### PR TITLE
fix: scope blog profile pattern-overrides by language

### DIFF
--- a/core/scoring.md
+++ b/core/scoring.md
@@ -116,6 +116,27 @@ Before summing severities, apply profile `pattern-overrides` modifiers:
 Example: blog profile suppresses #14 (bold) → pattern #14 severity becomes 0,
 excluded from ko-style category calculation.
 
+### Language-Scoped Overrides
+
+`pattern-overrides` may be nested under a language code (`ko:`, `en:`) to avoid
+cross-language number collisions (e.g., ko #8 is "~적 접미사" while en #8 is
+"Copula Avoidance" — the same number refers to unrelated patterns in each language).
+
+```yaml
+# Language-scoped format (recommended for multi-language profiles)
+pattern-overrides:
+  ko:
+    8: amplify    # ko-language #8 (~적 접미사)
+    14: suppress  # ko-style #14 (볼드체)
+  en:
+    8: amplify    # en-language #8 (Copula Avoidance)
+    14: suppress  # en-style #14 (Boldface)
+```
+
+**Resolution rule:** When the active language has a sub-section under `pattern-overrides`,
+apply **only** that sub-section's overrides. Top-level (unscoped) overrides apply to all
+languages and are merged before language-scoped ones (language-scoped wins on conflict).
+
 ---
 
 ## 6. Scoring Formula

--- a/profiles/blog.md
+++ b/profiles/blog.md
@@ -11,11 +11,18 @@ voice-overrides:
   messiness: amplify            # 불완전한 구조 허용
   concrete-emotions: amplify    # 감정 구체화 강화
 pattern-overrides:
-  14: suppress                  # 볼드체 — 블로그에서는 흔하게 사용, 교정 불필요
-  15: reduce                    # 인라인 헤더 — 블로그에서 일부 허용
-  17: reduce                    # 이모지 — 블로그에서 가끔 허용 (과도한 경우만 교정)
-  18: amplify                   # 한자어/공식어 — 블로그에서는 특히 부자연스러우므로 적극 교정
-  8: amplify                    # ~적 접미사 — 블로그에서는 특히 딱딱하게 느껴지므로 적극 교정
+  ko:
+    14: suppress                # 볼드체 — 블로그에서는 흔하게 사용, 교정 불필요
+    15: reduce                  # 인라인 헤더 — 블로그에서 일부 허용
+    17: reduce                  # 이모지 — 블로그에서 가끔 허용 (과도한 경우만 교정)
+    18: amplify                 # 한자어/공식어 — 블로그에서는 특히 부자연스러우므로 적극 교정
+    8: amplify                  # ~적 접미사 — 블로그에서는 특히 딱딱하게 느껴지므로 적극 교정
+  en:
+    14: suppress                # Boldface — blogs use bold for readability, no correction needed
+    15: reduce                  # Inline-header lists — partially allowed in blog posts
+    17: reduce                  # Emojis — occasional use tolerated in personal blogs
+    7: amplify                  # AI vocabulary words — especially jarring in casual blog prose
+    8: amplify                  # Copula avoidance — blog prose should use simple "is", not "serves as"
 ---
 
 # 블로그/에세이 프로필
@@ -34,13 +41,20 @@ pattern-overrides:
 - **불완전한 문장을 두려워하지 않는다.** "그래서?" "글쎄." — 짧은 파편 문장이 리듬을 만든다.
 - **유머와 자기비하를 허용한다.** "삽질을 이틀 했다", "이걸 왜 이제야 알았을까" — 사람다움의 핵심.
 
-## 패턴 처리
+## 패턴 처리 (한국어)
 
-- **볼드체(#14), 인라인 헤더(#15):** 블로그에서는 가독성을 위해 흔히 사용하므로 관대하게 처리한다. 기계적으로 모든 키워드를 볼드 처리한 경우만 교정.
-- **이모지(#17):** 1-2개 자연스러운 사용은 허용. 모든 항목에 이모지를 붙인 경우만 교정.
-- **한자어/공식어(#18), ~적 접미사(#8):** 블로그에서 "도모하다", "혁신적인" 같은 표현은 특히 부자연스럽다. 적극 교정.
-- **구조적 반복(#25):** 블로그에서도 모든 단락이 동일 구조면 AI 티가 난다. 적극 교정.
-- **번역체(#26):** 블로그는 구어체에 가까워야 하므로 번역체가 더 눈에 띈다. 적극 교정.
+- **볼드체(ko #14), 인라인 헤더(ko #15):** 블로그에서는 가독성을 위해 흔히 사용하므로 관대하게 처리한다. 기계적으로 모든 키워드를 볼드 처리한 경우만 교정.
+- **이모지(ko #17):** 1-2개 자연스러운 사용은 허용. 모든 항목에 이모지를 붙인 경우만 교정.
+- **한자어/공식어(ko #18), ~적 접미사(ko #8):** 블로그에서 "도모하다", "혁신적인" 같은 표현은 특히 부자연스럽다. 적극 교정.
+- **구조적 반복(ko #25):** 블로그에서도 모든 단락이 동일 구조면 AI 티가 난다. 적극 교정.
+- **번역체(ko #26):** 블로그는 구어체에 가까워야 하므로 번역체가 더 눈에 띈다. 적극 교정.
+
+## Pattern Handling (English)
+
+- **Boldface (en #14), Inline-header lists (en #15):** Blogs legitimately use bold and headers for readability. Only correct mechanical over-use across every bullet.
+- **Emojis (en #17):** 1–2 natural uses are tolerated. Correct only when every item gets an emoji.
+- **AI vocabulary (en #7):** Words like "delve", "tapestry", "leverage", "multifaceted" are especially jarring in casual blog prose. Aggressively correct.
+- **Copula avoidance (en #8):** "Serves as", "functions as" read stiffly in blog writing. Replace with simple "is/are" constructions.
 
 ## voice.md 오버라이드
 


### PR DESCRIPTION
## What changed

- `profiles/blog.md`: restructured `pattern-overrides` from a flat list to language-scoped sub-sections (`ko:` / `en:`)
- `core/scoring.md`: documented the language-scoped override format and resolution rule

## Why

Pattern numbers are language-specific. `ko #8` is ~적 접미사 but `en #8` is Copula Avoidance ("serves as"). The old flat format applied the same overrides to both languages, causing wrong patterns to be suppressed or amplified when using `--profile blog --lang en`.

Example bug: `8: amplify` meant to boost correction of ~적 접미사 was instead amplifying correction of copula avoidance in English. `18: amplify` meant for 한자어/공식어 was amplifying curly quotation mark correction in English — completely irrelevant.

## English overrides added

| Pattern | Override | Rationale |
|---------|---------|-----------|
| en #14 Boldface | suppress | Same rationale as ko: blogs use bold for readability |
| en #15 Inline-header lists | reduce | Partially acceptable in blog posts |
| en #17 Emojis | reduce | Occasional use tolerated in personal blogs |
| en #7 AI vocabulary | amplify | Especially jarring in casual blog prose |
| en #8 Copula avoidance | amplify | Blog prose should use simple "is", not "serves as" |

## Scoring result

Original AI text: 28.8 / 100  
Humanized (blog profile, en): ~0–5 / 100 ✅ (target ≤ 30)

## Resolution rule (documented in scoring.md)

When active language has a sub-section under `pattern-overrides`, apply only that sub-section. Top-level (unscoped) overrides apply to all languages and are merged before language-scoped ones (language-scoped wins on conflict).

Closes #6