### PR TITLE
Relay component-only Discord bot posts into patina

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ For bot or automation work, also read:
 ## OpenClaw runtime notes
 - Discord ingress is handled by the OpenClaw gateway, not a custom `discord.js` listener.
 - `scripts/openclaw-bootstrap.sh` provisions the `patina` OpenClaw agent and binds the dedicated Discord channel to this workspace.
+- component-only Discord bot posts are relayed by `scripts/openclaw-component-bridge.mjs`.
 - `scripts/bot.sh` runs the autonomous cron bot through `openclaw agent`.
 
 ## Commit protocol

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -6,7 +6,7 @@
 2. `CLAUDE.md` 읽기 — 운영 규칙 확인
 3. `TOOLS.md` 읽기 — 환경 정보 확인
 4. `openclaw status` 확인 — gateway / Discord 채널 상태 확인
-5. 필요하면 `./scripts/openclaw-bootstrap.sh` 실행 — patina 에이전트, Discord 라우팅, 기존 봇 토큰 동기화
+5. 필요하면 `./scripts/openclaw-bootstrap.sh` 실행 — patina 에이전트, Discord 라우팅, 기존 봇 토큰, component bridge 동기화
 6. GitHub 이슈/PR 상태 확인 — 미처리 항목 파악
 
 ## 프로젝트 경로

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -44,12 +44,17 @@ scripts/
 ├── bot.sh                  # Cron entrypoint: flock, openclaw agent, notifications
 ├── bot-prompt.md           # Cron bot brain: task priority, quality gates, reporting
 ├── openclaw-bootstrap.sh   # OpenClaw agent + Discord channel binding bootstrap
+├── openclaw-component-bridge.mjs # Component-only Discord bot messages → OpenClaw relay
+├── patina-component-bridge.service # User systemd unit for the component bridge
 └── logs/                   # Run logs (gitignored, rotated at 30 days)
 ```
 
 ```bash
 # OpenClaw 에이전트/Discord 라우팅 프로비저닝
 ./scripts/openclaw-bootstrap.sh
+
+# component-only bot 메시지 브리지 1회 점검
+npm run openclaw:component-bridge:once
 
 # 수동 봇 실행
 ./scripts/bot.sh
@@ -72,6 +77,9 @@ openclaw status
 
 # 수동 알림 테스트
 openclaw message send --channel discord --target channel:1484400552262762496 --message "patina 테스트 알림"
+
+# component-only bot 메시지 브리지 상태
+npm run openclaw:component-bridge:status
 ```
 
 ## 운영 메모
@@ -79,4 +87,5 @@ openclaw message send --channel discord --target channel:1484400552262762496 --m
 - Discord 연결은 OpenClaw gateway가 담당하므로 별도 `discord.js` 리스너를 돌리지 않음
 - `scripts/openclaw-bootstrap.sh`는 정확한 Discord 채널 peer binding을 추가함
 - 가능하면 기존 `~/.clawhip/config.toml`의 Discord 토큰을 재사용해서 예전 봇 닉네임/권한을 그대로 이어감
+- component-only Discord bot posts는 `scripts/openclaw-component-bridge.mjs`가 감지해서 `openclaw agent --deliver`로 릴레이함
 - stricter allowlist가 필요하면 `OPENCLAW_ENFORCE_ALLOWLIST=true ./scripts/openclaw-bootstrap.sh`

--- a/memory/daily/2026-03-26.md
+++ b/memory/daily/2026-03-26.md
@@ -1,0 +1,11 @@
+# 2026-03-26
+
+## Summary
+
+- Active project: `patina`
+
+## Log
+- Added `scripts/openclaw-component-bridge.mjs` + `scripts/patina-component-bridge.service` so component-only Discord bot posts are relayed into `openclaw agent`.
+- Updated `scripts/openclaw-bootstrap.sh` to enable `channels.discord.allowBots=true`, install/restart the component bridge service, and keep the existing OpenClaw gateway wiring.
+- Verified syntax with `bash -n scripts/openclaw-bootstrap.sh` and `node --check scripts/openclaw-component-bridge.mjs`.
+- Verified runtime by re-running `./scripts/openclaw-bootstrap.sh`, confirming `patina-component-bridge.service` is active, and replaying the historical `haebyung-gajae` component-only message through a one-shot bridge run.

--- a/memory/topics/bot-learnings.md
+++ b/memory/topics/bot-learnings.md
@@ -22,3 +22,11 @@ The bot reads this file before each run to avoid repeating mistakes.
   2. 워크스페이스 라우팅은 exact channel binding으로 고정할 것
   3. 중복 응답 방지를 위해 legacy listener는 disable 상태를 유지할 것
   4. 기존 채널에서 보이던 봇 닉네임을 유지하려면 OpenClaw도 기존 bot token을 재사용할 것
+
+### 2026-03-26: component-only bot 메시지는 별도 브리지가 필요
+- **증상:** 다른 봇이 채널에 말해도 OpenClaw가 반응하지 않았음
+- **원인:** 실제 메시지 본문은 비어 있고 Discord components(type 17/10) 안에 텍스트가 들어 있었음
+- **교훈:**
+  1. `channels.discord.allowBots=true`만으로는 component-only bot posts를 처리하지 못할 수 있음
+  2. 최신 메시지 payload를 직접 읽어 `components[].content`까지 확인해야 함
+  3. 브리지 서비스는 component-only bot posts만 릴레이해서 bot-to-bot 루프를 최소화할 것

--- a/memory/topics/bot-rules.md
+++ b/memory/topics/bot-rules.md
@@ -6,6 +6,7 @@
 
 ## Runtime
 - Interactive Discord replies are handled by the OpenClaw gateway
+- Component-only Discord bot posts are relayed by `scripts/openclaw-component-bridge.mjs`
 - Scheduled autonomous work runs through `scripts/bot.sh` via `openclaw agent`
 
 ## Schedule

--- a/package.json
+++ b/package.json
@@ -6,8 +6,12 @@
   "scripts": {
     "bot": "bash scripts/bot.sh",
     "openclaw:bootstrap": "bash scripts/openclaw-bootstrap.sh",
+    "openclaw:component-bridge": "node scripts/openclaw-component-bridge.mjs",
+    "openclaw:component-bridge:once": "COMPONENT_BRIDGE_ONCE=true COMPONENT_BRIDGE_SEED_HISTORY=false node scripts/openclaw-component-bridge.mjs",
     "openclaw:status": "openclaw status",
     "openclaw:restart": "openclaw gateway restart",
-    "openclaw:logs": "openclaw logs --follow"
+    "openclaw:logs": "openclaw logs --follow",
+    "openclaw:component-bridge:logs": "journalctl --user -u patina-component-bridge -f",
+    "openclaw:component-bridge:status": "systemctl --user status patina-component-bridge"
   }
 }

--- a/scripts/openclaw-bootstrap.sh
+++ b/scripts/openclaw-bootstrap.sh
@@ -14,6 +14,8 @@ OPENCLAW_ENFORCE_ALLOWLIST="${OPENCLAW_ENFORCE_ALLOWLIST:-false}"
 RESTART_GATEWAY="${RESTART_GATEWAY:-true}"
 CLAWHIP_CONFIG="${CLAWHIP_CONFIG:-$HOME/.clawhip/config.toml}"
 OPENCLAW_DISCORD_TOKEN="${OPENCLAW_DISCORD_TOKEN:-}"
+SYSTEMD_USER_DIR="${SYSTEMD_USER_DIR:-$HOME/.config/systemd/user}"
+COMPONENT_BRIDGE_SERVICE="${COMPONENT_BRIDGE_SERVICE:-patina-component-bridge.service}"
 
 command -v openclaw >/dev/null 2>&1 || { echo "openclaw CLI를 찾을 수 없음" >&2; exit 1; }
 command -v node >/dev/null 2>&1 || { echo "node를 찾을 수 없음" >&2; exit 1; }
@@ -116,6 +118,7 @@ process.stdout.write(JSON.stringify(guilds));
 ')"
 openclaw config set channels.discord.guilds "$updated_guilds" --json >/dev/null
 openclaw config set channels.discord.enabled true --json >/dev/null
+openclaw config set channels.discord.allowBots true --json >/dev/null
 
 if [ "$OPENCLAW_ENFORCE_ALLOWLIST" = "true" ]; then
   echo "[bootstrap] enabling strict Discord allowlist policy"
@@ -133,9 +136,20 @@ if systemctl --user list-unit-files 2>/dev/null | grep -q '^patina-listener\.ser
   systemctl --user disable --now patina-listener.service >/dev/null 2>&1 || true
 fi
 
+if command -v systemctl >/dev/null 2>&1; then
+  echo "[bootstrap] installing component-only bot bridge service"
+  mkdir -p "$SYSTEMD_USER_DIR"
+  install -m 644 "$REPO_DIR/scripts/patina-component-bridge.service" "$SYSTEMD_USER_DIR/$COMPONENT_BRIDGE_SERVICE"
+  systemctl --user daemon-reload
+  systemctl --user enable --now "$COMPONENT_BRIDGE_SERVICE" >/dev/null
+fi
+
 if [ "$RESTART_GATEWAY" = "true" ]; then
   echo "[bootstrap] restarting OpenClaw gateway"
   openclaw gateway restart >/dev/null
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl --user restart "$COMPONENT_BRIDGE_SERVICE" >/dev/null 2>&1 || true
+  fi
 fi
 
 echo "[bootstrap] done"

--- a/scripts/openclaw-component-bridge.mjs
+++ b/scripts/openclaw-component-bridge.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_DIR = resolve(__dirname, '..');
+const STATE_FILE = process.env.COMPONENT_BRIDGE_STATE_FILE || resolve(REPO_DIR, '.omx/state/openclaw-component-bridge.json');
+const CHANNEL_ID = process.env.COMPONENT_BRIDGE_CHANNEL || process.env.DISCORD_CHANNEL || '1484400552262762496';
+const AGENT_ID = process.env.PATINA_AGENT_ID || 'patina';
+const SESSION_PREFIX = process.env.COMPONENT_BRIDGE_SESSION_PREFIX || 'patina-component-bridge';
+const POLL_MS = Number.parseInt(process.env.COMPONENT_BRIDGE_POLL_MS || '4000', 10);
+const MAX_SEEN_IDS = Number.parseInt(process.env.COMPONENT_BRIDGE_MAX_SEEN_IDS || '200', 10);
+const TIMEOUT_SEC = Number.parseInt(process.env.COMPONENT_BRIDGE_TIMEOUT_SEC || '180', 10);
+const ONCE = process.env.COMPONENT_BRIDGE_ONCE === 'true';
+const SEED_HISTORY = process.env.COMPONENT_BRIDGE_SEED_HISTORY !== 'false';
+const VERBOSE = process.env.COMPONENT_BRIDGE_VERBOSE === 'true';
+
+function log(message) {
+  console.log(`[component-bridge] ${message}`);
+}
+
+function runOpenClaw(args) {
+  return execFileSync('openclaw', args, {
+    cwd: REPO_DIR,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${process.env.HOME}/.local/bin:${process.env.HOME}/.cargo/bin:${process.env.PATH}`,
+    },
+  });
+}
+
+function runJson(args) {
+  return JSON.parse(runOpenClaw(args));
+}
+
+function loadState() {
+  if (!existsSync(STATE_FILE)) {
+    return {
+      seenIds: [],
+      selfBotId: process.env.COMPONENT_BRIDGE_SELF_BOT_ID || '',
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(STATE_FILE, 'utf8'));
+    return {
+      seenIds: Array.isArray(parsed.seenIds) ? parsed.seenIds.map(String) : [],
+      selfBotId: typeof parsed.selfBotId === 'string' ? parsed.selfBotId : (process.env.COMPONENT_BRIDGE_SELF_BOT_ID || ''),
+    };
+  } catch (error) {
+    log(`state load failed; resetting (${error.message})`);
+    return {
+      seenIds: [],
+      selfBotId: process.env.COMPONENT_BRIDGE_SELF_BOT_ID || '',
+    };
+  }
+}
+
+function saveState(state) {
+  mkdirSync(dirname(STATE_FILE), { recursive: true });
+  writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+function getSelfBotId() {
+  const configured = process.env.COMPONENT_BRIDGE_SELF_BOT_ID;
+  if (configured) return configured;
+
+  const status = runJson(['channels', 'status', '--probe', '--json']);
+  return String(
+    status?.channelAccounts?.discord?.[0]?.bot?.id
+      || status?.channels?.discord?.probe?.bot?.id
+      || ''
+  );
+}
+
+function readMessages(limit = 20) {
+  const result = runJson([
+    'message', 'read',
+    '--channel', 'discord',
+    '--target', `channel:${CHANNEL_ID}`,
+    '--limit', String(limit),
+    '--json',
+  ]);
+  return result?.payload?.messages || [];
+}
+
+function collectComponentText(components, sink = []) {
+  for (const component of components || []) {
+    for (const key of ['content', 'label', 'title', 'value']) {
+      if (typeof component?.[key] === 'string') {
+        const value = component[key].trim();
+        if (value) sink.push(value);
+      }
+    }
+
+    if (Array.isArray(component?.components)) {
+      collectComponentText(component.components, sink);
+    }
+  }
+  return sink;
+}
+
+function extractComponentOnlyText(message) {
+  const content = (message?.content || '').trim();
+  if (content) return '';
+
+  const parts = collectComponentText(message?.components || []);
+  const unique = [];
+  for (const part of parts) {
+    if (!unique.includes(part)) unique.push(part);
+  }
+  return unique.join('\n').trim();
+}
+
+function shouldBridge(message, selfBotId) {
+  const author = message?.author || {};
+  if (!author.bot) return false;
+  if (selfBotId && String(author.id) === String(selfBotId)) return false;
+  return Boolean(extractComponentOnlyText(message));
+}
+
+function markSeen(state, messageId) {
+  const seen = state.seenIds.filter((id) => id !== String(messageId));
+  seen.push(String(messageId));
+  state.seenIds = seen.slice(-MAX_SEEN_IDS);
+}
+
+function alreadySeen(state, messageId) {
+  return state.seenIds.includes(String(messageId));
+}
+
+function deliverReply(message) {
+  const author = message.author || {};
+  const extracted = extractComponentOnlyText(message);
+  const prompt = [
+    `[Bridge note: This Discord message came from bot ${author.username || author.id} as component-only content.]`,
+    'Respond naturally in Korean.',
+    '',
+    extracted,
+  ].join('\n');
+
+  if (VERBOSE) {
+    log(`forwarding ${message.id} from ${author.username || author.id}: ${JSON.stringify(extracted)}`);
+  } else {
+    log(`forwarding component-only bot message ${message.id} from ${author.username || author.id}`);
+  }
+
+  const sessionId = `${SESSION_PREFIX}-${author.id}`;
+  const output = runOpenClaw([
+    '--no-color',
+    'agent',
+    '--agent', AGENT_ID,
+    '--session-id', sessionId,
+    '--timeout', String(TIMEOUT_SEC),
+    '--message', prompt,
+    '--deliver',
+    '--reply-channel', 'discord',
+    '--reply-to', `channel:${CHANNEL_ID}`,
+  ]).trim();
+
+  if (output) {
+    log(`agent output: ${output.slice(0, 200)}`);
+  }
+}
+
+async function sleep(ms) {
+  await new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}
+
+async function main() {
+  const state = loadState();
+  if (!state.selfBotId) {
+    try {
+      state.selfBotId = getSelfBotId();
+      saveState(state);
+    } catch (error) {
+      log(`self bot lookup deferred: ${error.message}`);
+    }
+  }
+
+  log(`watching channel ${CHANNEL_ID} as self bot ${state.selfBotId || 'unknown'}${ONCE ? ' (once)' : ''}`);
+
+  if (SEED_HISTORY && state.seenIds.length === 0) {
+    const initialMessages = readMessages(30);
+    for (const message of initialMessages) {
+      markSeen(state, message.id);
+    }
+    saveState(state);
+    log(`seeded ${initialMessages.length} recent messages`);
+  }
+
+  while (true) {
+    try {
+      if (!state.selfBotId) {
+        state.selfBotId = getSelfBotId();
+        saveState(state);
+        log(`resolved self bot id: ${state.selfBotId}`);
+      }
+
+      const messages = readMessages(20).slice().reverse();
+      for (const message of messages) {
+        if (alreadySeen(state, message.id)) continue;
+        markSeen(state, message.id);
+        saveState(state);
+
+        if (!shouldBridge(message, state.selfBotId)) continue;
+        deliverReply(message);
+      }
+    } catch (error) {
+      log(`poll failed: ${error.message}`);
+    }
+
+    if (ONCE) break;
+    await sleep(POLL_MS);
+  }
+}
+
+main().catch((error) => {
+  console.error(`[component-bridge] fatal: ${error.stack || error.message}`);
+  process.exit(1);
+});

--- a/scripts/patina-component-bridge.service
+++ b/scripts/patina-component-bridge.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=patina OpenClaw component-only bot bridge
+After=network-online.target openclaw-gateway.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/devswha/workspace/patina
+Environment=PATH=/home/devswha/.local/bin:/home/devswha/.cargo/bin:/home/devswha/.nvm/versions/node/v22.17.1/bin:/usr/local/bin:/usr/bin:/bin
+ExecStartPre=/bin/sh -c 'command -v openclaw && command -v node'
+ExecStart=/home/devswha/.nvm/versions/node/v22.17.1/bin/node scripts/openclaw-component-bridge.mjs
+Restart=always
+RestartSec=5
+TimeoutStopSec=30
+KillSignal=SIGINT
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
- add a small OpenClaw bridge service for Discord bot messages whose text lives only in components
- install and restart that bridge through `scripts/openclaw-bootstrap.sh`, alongside `channels.discord.allowBots=true`
- document the bridge in repo guidance and add a 2026-03-26 migration log entry

## Testing
- `bash -n scripts/openclaw-bootstrap.sh`
- `node --check scripts/openclaw-component-bridge.mjs`
- `./scripts/openclaw-bootstrap.sh`
- `systemctl --user is-active/is-enabled patina-component-bridge.service`
- `COMPONENT_BRIDGE_ONCE=true COMPONENT_BRIDGE_SEED_HISTORY=false COMPONENT_BRIDGE_STATE_FILE=/tmp/patina-component-bridge-once.json node scripts/openclaw-component-bridge.mjs`

## Notes
- keeps OpenClaw as the primary Discord ingress; the bridge only relays component-only bot posts
- still ignores patina's own bot id to reduce bot-to-bot loop risk
