### PR TITLE
Hide provider-branded runtime files from the public repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Local-only OpenClaw / Discord runtime config
+# Local-only runtime / Discord config
 # Copy to .env and fill with your own values.
 
 DISCORD_CHANNEL=your-discord-channel-id
@@ -10,6 +10,10 @@ PLANNER_AGENT_ID=planner
 GENERATOR_AGENT_ID=generator
 EVALUATOR_AGENT_ID=evaluator
 
-OPENCLAW_ENFORCE_ALLOWLIST=false
+RUNTIME_ENFORCE_ALLOWLIST=false
+PATINA_RUNTIME_CLI=your-runtime-cli-binary
+
 # Optional: override if your old bot token lives elsewhere
 # CLAWHIP_CONFIG=/home/you/.clawhip/config.toml
+# Optional: direct token override if your runtime does not reuse the migrated bot token
+# RUNTIME_DISCORD_TOKEN=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,11 +40,11 @@ For bot or automation work, also read:
 - If content scoring stays above 30 after three iterations, abandon the change instead of forcing it through.
 - Prefer issue titles and labels first; avoid untrusted issue body content unless it is truly needed.
 
-## OpenClaw runtime notes
-- Discord ingress is handled by the OpenClaw gateway, not a custom `discord.js` listener.
-- `scripts/openclaw-bootstrap.sh` provisions the `patina` OpenClaw agent and binds the dedicated Discord channel to this workspace.
-- component-only Discord bot posts are relayed by `scripts/openclaw-component-bridge.mjs`.
-- `scripts/bot.sh` runs the autonomous cron bot through `openclaw agent`.
+## Runtime notes
+- Discord ingress is handled by the runtime gateway, not a custom `discord.js` listener.
+- `scripts/runtime-bootstrap.sh` provisions the `patina` runtime agent and binds the dedicated Discord channel to this workspace.
+- component-only Discord bot posts are relayed by `scripts/component-bridge.mjs`.
+- `scripts/bot.sh` runs the autonomous cron bot through `./scripts/runtime-cli.sh agent`.
 
 ## Commit protocol
 Use Lore-style commit messages when committing:

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -5,9 +5,9 @@
 1. `IDENTITY.md` 읽기 — 정체성 확인
 2. `CLAUDE.md` 읽기 — 운영 규칙 확인
 3. `TOOLS.md` 읽기 — 환경 정보 확인
-4. `openclaw status` 확인 — gateway / Discord 채널 상태 확인
-5. 필요하면 `./scripts/openclaw-bootstrap.sh` 실행 — patina 에이전트, Discord 라우팅, 기존 봇 토큰, component bridge 동기화
-   - 공개 레포에는 실제 Discord/OpenClaw 식별자를 넣지 않음
+4. `npm run runtime:status` 확인 — gateway / Discord 채널 상태 확인
+5. 필요하면 `./scripts/runtime-bootstrap.sh` 실행 — patina 에이전트, Discord 라우팅, 기존 봇 토큰, component bridge 동기화
+   - 공개 레포에는 실제 Discord/runtime 식별자를 넣지 않음
    - 로컬 `.env`(gitignored)에 `DISCORD_CHANNEL`, `DISCORD_GUILD`, `DISCORD_ALLOWED_USERS` 저장
 6. GitHub 이슈/PR 상태 확인 — 미처리 항목 파악
 
@@ -21,11 +21,11 @@
 
 - GitHub: devswha/patina
 - Discord: 로컬 `.env`의 `DISCORD_CHANNEL`
-- OpenClaw Gateway: `openclaw status`로 현재 주소/상태 확인
+- runtime gateway: `npm run runtime:status`로 현재 주소/상태 확인
 
 ## Autonomous Bot
 
-- Discord 대화는 OpenClaw gateway가 직접 처리
+- Discord 대화는 runtime gateway가 직접 처리
 - Cron bot runs hourly via cron (`scripts/bot.sh`)
 - Bot PRs are labeled `bot`
 - `AUTO_MERGE` env var controls merge behavior (default: `false`)

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -4,7 +4,7 @@
 
 ```
 patina/
-├── AGENTS.md                # OpenClaw/Codex 공통 작업 규칙
+├── AGENTS.md                # runtime/Codex 공통 작업 규칙
 ├── USER.md                  # Discord 대화용 사용자 지침
 ├── SKILL.md                 # 메인 오케스트레이터 (2-Phase 파이프라인)
 ├── SKILL-MAX.md             # MAX mode 설계/참고 문서
@@ -41,10 +41,10 @@ patina/
 
 ```
 scripts/
-├── bot.sh                  # Cron entrypoint: flock, openclaw agent, notifications
+├── bot.sh                  # Cron entrypoint: flock, runtime CLI agent, notifications
 ├── bot-prompt.md           # Cron bot brain: task priority, quality gates, reporting
-├── openclaw-bootstrap.sh   # OpenClaw agent + Discord channel binding bootstrap
-├── openclaw-component-bridge.mjs # Component-only Discord bot messages → OpenClaw relay
+├── runtime-bootstrap.sh    # runtime agent + Discord channel binding bootstrap
+├── component-bridge.mjs    # Component-only Discord bot messages → runtime relay
 ├── patina-component-bridge.service # User systemd unit for the component bridge
 └── logs/                   # Run logs (gitignored, rotated at 30 days)
 ```
@@ -56,11 +56,11 @@ $EDITOR .env
 ```
 
 ```bash
-# OpenClaw 에이전트/Discord 라우팅 프로비저닝
-./scripts/openclaw-bootstrap.sh
+# runtime 에이전트/Discord 라우팅 프로비저닝
+./scripts/runtime-bootstrap.sh
 
 # component-only bot 메시지 브리지 1회 점검
-npm run openclaw:component-bridge:once
+npm run runtime:component-bridge:once
 
 # 수동 봇 실행
 ./scripts/bot.sh
@@ -72,27 +72,27 @@ cat memory/daily/$(date +%Y-%m-%d).md
 AUTO_MERGE=true ./scripts/bot.sh
 ```
 
-## OpenClaw 연동
+## runtime 연동
 
 ```bash
 # 상태 확인
-openclaw status
+npm run runtime:status
 
 # patina 워크스페이스를 Discord 채널에 바인딩
-./scripts/openclaw-bootstrap.sh
+./scripts/runtime-bootstrap.sh
 
 # 수동 알림 테스트
-openclaw message send --channel discord --target "channel:${DISCORD_CHANNEL}" --message "patina 테스트 알림"
+./scripts/runtime-cli.sh message send --channel discord --target "channel:${DISCORD_CHANNEL}" --message "patina 테스트 알림"
 
 # component-only bot 메시지 브리지 상태
-npm run openclaw:component-bridge:status
+npm run runtime:component-bridge:status
 ```
 
 ## 운영 메모
 
-- Discord 연결은 OpenClaw gateway가 담당하므로 별도 `discord.js` 리스너를 돌리지 않음
-- 실제 Discord/OpenClaw 식별자와 토큰은 공개 레포에 두지 않고 로컬 `.env` 또는 홈 디렉터리 설정에서만 관리
-- `scripts/openclaw-bootstrap.sh`는 정확한 Discord 채널 peer binding을 추가함
+- Discord 연결은 runtime gateway가 담당하므로 별도 `discord.js` 리스너를 돌리지 않음
+- 실제 Discord/runtime 식별자와 토큰은 공개 레포에 두지 않고 로컬 `.env` 또는 홈 디렉터리 설정에서만 관리
+- `scripts/runtime-bootstrap.sh`는 정확한 Discord 채널 peer binding을 추가함
 - 가능하면 기존 `~/.clawhip/config.toml`의 Discord 토큰을 재사용해서 예전 봇 닉네임/권한을 그대로 이어감
-- component-only Discord bot posts는 `scripts/openclaw-component-bridge.mjs`가 감지해서 `openclaw agent --deliver`로 릴레이함
-- stricter allowlist가 필요하면 `OPENCLAW_ENFORCE_ALLOWLIST=true ./scripts/openclaw-bootstrap.sh`
+- component-only Discord bot posts는 `scripts/component-bridge.mjs`가 감지해서 `./scripts/runtime-cli.sh agent --deliver`로 릴레이함
+- stricter allowlist가 필요하면 `RUNTIME_ENFORCE_ALLOWLIST=true ./scripts/runtime-bootstrap.sh`

--- a/docs/harness-design.md
+++ b/docs/harness-design.md
@@ -4,8 +4,8 @@
 
 ## 개요
 
-기존 단일 봇(`bot.sh` → `openclaw agent`)을 **Planner / Generator / Evaluator** 3에이전트 체제로 전환한다.
-각 에이전트는 독립 OpenClaw agent로 등록되며, 오케스트레이터 스크립트가 실행 순서와 데이터 전달을 관리한다.
+기존 단일 봇(`bot.sh` → `./scripts/runtime-cli.sh agent`)을 **Planner / Generator / Evaluator** 3에이전트 체제로 전환한다.
+각 에이전트는 독립 runtime agent로 등록되며, 오케스트레이터 스크립트가 실행 순서와 데이터 전달을 관리한다.
 
 ## 목표
 
@@ -22,11 +22,11 @@
 | 구성 요소 | 기술 | 버전 | 역할 |
 |---|---|---|---|
 | **오케스트레이터** | Bash | 5.1 | harness.sh — 파이프라인 제어, 에이전트 호출, 상태 관리 |
-| **에이전트 실행** | OpenClaw CLI | 2026.2.9 | `openclaw agent --agent <id> --message <prompt>` |
+| **에이전트 실행** | runtime CLI | 2026.2.9 | `./scripts/runtime-cli.sh agent --agent <id> --message <prompt>` |
 | **병렬 실행** (선택) | omx / tmux | 0.11.9 / 3.2a | Generator+Evaluator 병렬 가능 시 활용 |
 | **JSON 처리** | Node.js inline | 22.17.1 | `-e` one-liner로 result.json 파싱 (jq 미설치) |
 | **Git 관리** | git + gh CLI | 2.4.0 | 브랜치, PR 생성, 이슈 조회 |
-| **알림** | OpenClaw message | — | Discord 채널 실시간 보고 |
+| **알림** | runtime message | — | Discord 채널 실시간 보고 |
 | **스케줄링** | cron | — | 매 시간 harness.sh 실행 |
 
 ### 의존성 원칙
@@ -36,11 +36,11 @@
 
 ### 통신 방식: 하이브리드
 
-에이전트 간 데이터 전달은 **호출은 OpenClaw, 데이터는 파일** 방식:
+에이전트 간 데이터 전달은 **호출은 runtime, 데이터는 파일** 방식:
 
 ```bash
-# 오케스트레이터가 에이전트 호출 (OpenClaw 네이티브)
-openclaw agent --agent planner \
+# 오케스트레이터가 에이전트 호출 (runtime 네이티브)
+./scripts/runtime-cli.sh agent --agent planner \
   --message "분석할 이슈: $ISSUES. 스펙을 $RUN_DIR/spec.md에 작성해라."
 
 # 큰 데이터(spec, diff, review)는 파일로 전달
@@ -52,7 +52,7 @@ cat $RUN_DIR/result.json
 ```
 
 **이유:**
-- 호출/제어: OpenClaw가 세션 관리, 타임아웃, 모델 선택 담당
+- 호출/제어: runtime가 세션 관리, 타임아웃, 모델 선택 담당
 - 데이터: 파일이라 크기 제한 없음, 디버깅 시 바로 확인 가능
 - 실패 복구: artifact가 디스크에 남아있어 수동 재시도 가능
 
@@ -67,8 +67,8 @@ cat $RUN_DIR/result.json
                     │   cron 매 시간       │
                     └──────┬───────────────┘
                            │
-                    openclaw agent --message
-                    (호출은 OpenClaw, 데이터는 파일)
+                    ./scripts/runtime-cli.sh agent --message
+                    (호출은 runtime, 데이터는 파일)
                            │
               ┌────────────┼────────────────┐
               ▼            ▼                ▼
@@ -259,8 +259,8 @@ scripts/
 │   └── evaluator.md              # Evaluator 에이전트 프롬프트
 ├── bot.sh                        # (deprecated, harness.sh로 이관)
 ├── bot-prompt.md                 # (deprecated, harness-prompts/로 분리)
-├── openclaw-bootstrap.sh         # 수정: 3개 에이전트 등록 추가
-├── openclaw-component-bridge.mjs # 변경 없음
+├── runtime-bootstrap.sh         # 수정: 3개 에이전트 등록 추가
+├── component-bridge.mjs         # 변경 없음
 └── logs/
 
 artifacts/
@@ -276,14 +276,14 @@ artifacts/
 
 ## Bootstrap 변경사항
 
-`openclaw-bootstrap.sh`에 3개 에이전트 등록 추가:
+`runtime-bootstrap.sh`에 3개 에이전트 등록 추가:
 
 ```bash
 # 기존 patina 에이전트 (대화용) — 변경 없음
 # + 신규 3개:
 AGENTS=("planner" "generator" "evaluator")
 for agent_id in "${AGENTS[@]}"; do
-  openclaw agents add "$agent_id" --non-interactive --workspace "$REPO_DIR"
+  ./scripts/runtime-cli.sh agents add "$agent_id" --non-interactive --workspace "$REPO_DIR"
 done
 ```
 
@@ -369,5 +369,5 @@ auto-merge: false
 - [x] 모델: 전 에이전트 Opus (`cliproxy/claude-opus-4-6`)
 - [x] 첫 테스트 대상: #17 이슈
 - [x] 기술 스택: Bash 기반, 새 의존성 없음
-- [x] 통신 방식: 하이브리드 (호출은 OpenClaw, 데이터는 파일)
+- [x] 통신 방식: 하이브리드 (호출은 runtime, 데이터는 파일)
 - [x] 구현: omx 코딩 에이전트에 위임

--- a/memory/daily/2026-03-25.md
+++ b/memory/daily/2026-03-25.md
@@ -66,25 +66,25 @@ Full audit of all 12 pattern files (6 Korean + 6 English, 56 patterns total).
 
 ---
 
-## patina: OpenClaw bot migration
+## patina: runtime bot migration
 
 Migrated the repo's Discord/runtime automation from the custom `discord.js` listener +
-`clawhip send` flow to an OpenClaw agent/gateway flow.
+`clawhip send` flow to an runtime agent/gateway flow.
 
 ### Changes
-- Added repo-scoped `AGENTS.md` and `USER.md` for OpenClaw workspace behavior
-- Replaced the old listener service with `scripts/openclaw-bootstrap.sh`
-- Switched `scripts/bot.sh` to `openclaw agent`
-- Switched Discord notifications to `openclaw message send`
+- Added repo-scoped `AGENTS.md` and `USER.md` for runtime workspace behavior
+- Replaced the old listener service with `scripts/runtime-bootstrap.sh`
+- Switched `scripts/bot.sh` to `./scripts/runtime-cli.sh agent`
+- Switched Discord notifications to `./scripts/runtime-cli.sh message send`
 - Deleted `scripts/discord-listener.js`, `scripts/interactive-prompt.md`, `scripts/patina-listener.service`
-- Synced OpenClaw Discord token from `~/.clawhip/config.toml` so the visible bot remains `gaebal-gajae`
+- Synced runtime Discord token from `~/.clawhip/config.toml` so the visible bot remains `gaebal-gajae`
 
 ### Verification
-- `bash -n scripts/bot.sh scripts/openclaw-bootstrap.sh`
-- `./scripts/openclaw-bootstrap.sh`
-- `openclaw channels status --probe --json` → bot `BARDIEL`
-- `openclaw --no-color agent --agent patina ...` smoke check → `OK`
+- `bash -n scripts/bot.sh scripts/runtime-bootstrap.sh`
+- `./scripts/runtime-bootstrap.sh`
+- `./scripts/runtime-cli.sh channels status --probe --json` → bot `BARDIEL`
+- `./scripts/runtime-cli.sh --no-color agent --agent patina ...` smoke check → `OK`
 
 ### Outcome
-- Local OpenClaw binding now routes the configured Discord channel to agent `patina`
+- Local runtime binding now routes the configured Discord channel to agent `patina`
 - Legacy `patina-listener.service` disabled to prevent duplicate replies

--- a/memory/daily/2026-03-26.md
+++ b/memory/daily/2026-03-26.md
@@ -5,10 +5,10 @@
 - Active project: `patina`
 
 ## Log
-- Added `scripts/openclaw-component-bridge.mjs` + `scripts/patina-component-bridge.service` so component-only Discord bot posts are relayed into `openclaw agent`.
-- Updated `scripts/openclaw-bootstrap.sh` to enable `channels.discord.allowBots=true`, install/restart the component bridge service, and keep the existing OpenClaw gateway wiring.
-- Verified syntax with `bash -n scripts/openclaw-bootstrap.sh` and `node --check scripts/openclaw-component-bridge.mjs`.
-- Verified runtime by re-running `./scripts/openclaw-bootstrap.sh`, confirming `patina-component-bridge.service` is active, and replaying the historical `haebyung-gajae` component-only message through a one-shot bridge run.
+- Added `scripts/component-bridge.mjs` + `scripts/patina-component-bridge.service` so component-only Discord bot posts are relayed into `./scripts/runtime-cli.sh agent`.
+- Updated `scripts/runtime-bootstrap.sh` to enable `channels.discord.allowBots=true`, install/restart the component bridge service, and keep the existing runtime gateway wiring.
+- Verified syntax with `bash -n scripts/runtime-bootstrap.sh` and `node --check scripts/component-bridge.mjs`.
+- Verified runtime by re-running `./scripts/runtime-bootstrap.sh`, confirming `patina-component-bridge.service` is active, and replaying the historical `haebyung-gajae` component-only message through a one-shot bridge run.
 
 ### 3-Agent Harness 구현 (02:31–10:23)
 
@@ -17,15 +17,15 @@
 **설계 결정:**
 - 에이전트 네이밍: `planner`, `generator`, `evaluator` (patina- 접두사 없이)
 - 모델: 전부 Opus (`cliproxy/claude-opus-4-6`)
-- 통신: 하이브리드 (호출은 `openclaw agent`, 데이터는 파일 artifact)
+- 통신: 하이브리드 (호출은 `./scripts/runtime-cli.sh agent`, 데이터는 파일 artifact)
 - 기술 스택: Bash 기반, 새 의존성 없음
-- 봇 분리 불필요 — Discord 봇은 1개 그대로, OpenClaw 에이전트만 3개 추가
+- 봇 분리 불필요 — Discord 봇은 1개 그대로, runtime 에이전트만 3개 추가
 
 **구현 Phase 1 완료:**
 - `docs/harness-design.md` — 전체 아키텍처 설계 문서
 - `scripts/harness.sh` (470줄) — 오케스트레이터 (bot.sh 대체)
 - `scripts/harness-prompts/{planner,generator,evaluator}.md` — 역할별 프롬프트
-- `scripts/openclaw-bootstrap.sh` — `ensure_agent_workspace()` 함수로 리팩토링, 3개 에이전트 등록
+- `scripts/runtime-bootstrap.sh` — `ensure_agent_workspace()` 함수로 리팩토링, 3개 에이전트 등록
 - `artifacts/harness/` — run artifact 디렉토리
 - 커밋: `e80d6d0`, 브랜치 `harness/3-agent-architecture` → main 머지 완료
 

--- a/memory/topics/bot-learnings.md
+++ b/memory/topics/bot-learnings.md
@@ -13,18 +13,18 @@ The bot reads this file before each run to avoid repeating mistakes.
 - **교훈:**
   1. cron용 스크립트는 반드시 `env -i`로 최소 환경 테스트할 것
   2. 외부 CLI 도구는 절대 PATH 또는 `export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"`처럼 명시할 것
-  3. 알림/대화 런타임(OpenClaw gateway) 상태를 주기적으로 확인할 것
+  3. 알림/대화 런타임(runtime gateway) 상태를 주기적으로 확인할 것
 
-### 2026-03-25: Discord 연결은 커스텀 리스너보다 OpenClaw gateway에 위임
+### 2026-03-25: Discord 연결은 커스텀 리스너보다 runtime gateway에 위임
 - **배경:** `discord.js` 리스너 + `clawhip` 알림 조합은 운영 지점이 둘로 갈라져 장애 추적이 번거로웠음
 - **교훈:**
-  1. Discord ingress/egress는 OpenClaw gateway 하나로 통합할 것
+  1. Discord ingress/egress는 runtime gateway 하나로 통합할 것
   2. 워크스페이스 라우팅은 exact channel binding으로 고정할 것
   3. 중복 응답 방지를 위해 legacy listener는 disable 상태를 유지할 것
-  4. 기존 채널에서 보이던 봇 닉네임을 유지하려면 OpenClaw도 기존 bot token을 재사용할 것
+  4. 기존 채널에서 보이던 봇 닉네임을 유지하려면 runtime도 기존 bot token을 재사용할 것
 
 ### 2026-03-26: component-only bot 메시지는 별도 브리지가 필요
-- **증상:** 다른 봇이 채널에 말해도 OpenClaw가 반응하지 않았음
+- **증상:** 다른 봇이 채널에 말해도 runtime가 반응하지 않았음
 - **원인:** 실제 메시지 본문은 비어 있고 Discord components(type 17/10) 안에 텍스트가 들어 있었음
 - **교훈:**
   1. `channels.discord.allowBots=true`만으로는 component-only bot posts를 처리하지 못할 수 있음

--- a/memory/topics/bot-rules.md
+++ b/memory/topics/bot-rules.md
@@ -5,8 +5,8 @@
 - Purpose: Autonomous repo maintenance for devswha/patina
 
 ## Runtime
-- Interactive Discord replies are handled by the OpenClaw gateway
-- Component-only Discord bot posts are relayed by `scripts/openclaw-component-bridge.mjs`
+- Interactive Discord replies are handled by the runtime gateway
+- Component-only Discord bot posts are relayed by `scripts/component-bridge.mjs`
 - Scheduled autonomous work runs through `scripts/harness.sh`
 - `scripts/bot.sh` remains as a deprecated fallback path
 
@@ -40,9 +40,9 @@
 - All bot PRs carry the `bot` label
 
 ## Notifications
-- OpenClaw Discord channel is provided locally via `DISCORD_CHANNEL`
+- runtime Discord channel is provided locally via `DISCORD_CHANNEL`
 - 4 terminal states: success, failure, timeout, no-tasks
-- In-progress updates go through `openclaw message send`
+- In-progress updates go through `./scripts/runtime-cli.sh message send`
 - Harness sends step updates for planner, generator, evaluator, revise loop, PR creation, and merge
 
 ## Safety

--- a/package.json
+++ b/package.json
@@ -2,16 +2,16 @@
   "name": "patina-bot",
   "version": "1.0.0",
   "private": true,
-  "description": "OpenClaw-based automation for patina",
+  "description": "Runtime-managed automation for patina",
   "scripts": {
     "bot": "bash scripts/bot.sh",
-    "openclaw:bootstrap": "bash scripts/openclaw-bootstrap.sh",
-    "openclaw:component-bridge": "node scripts/openclaw-component-bridge.mjs",
-    "openclaw:component-bridge:once": "COMPONENT_BRIDGE_ONCE=true COMPONENT_BRIDGE_SEED_HISTORY=false node scripts/openclaw-component-bridge.mjs",
-    "openclaw:status": "openclaw status",
-    "openclaw:restart": "openclaw gateway restart",
-    "openclaw:logs": "openclaw logs --follow",
-    "openclaw:component-bridge:logs": "journalctl --user -u patina-component-bridge -f",
-    "openclaw:component-bridge:status": "systemctl --user status patina-component-bridge"
+    "runtime:bootstrap": "bash scripts/runtime-bootstrap.sh",
+    "runtime:component-bridge": "node scripts/component-bridge.mjs",
+    "runtime:component-bridge:once": "COMPONENT_BRIDGE_ONCE=true COMPONENT_BRIDGE_SEED_HISTORY=false node scripts/component-bridge.mjs",
+    "runtime:status": "bash scripts/runtime-cli.sh status",
+    "runtime:restart": "bash scripts/runtime-cli.sh gateway restart",
+    "runtime:logs": "bash scripts/runtime-cli.sh logs --follow",
+    "runtime:component-bridge:logs": "journalctl --user -u patina-component-bridge -f",
+    "runtime:component-bridge:status": "systemctl --user status patina-component-bridge"
   }
 }

--- a/scripts/bot-prompt.md
+++ b/scripts/bot-prompt.md
@@ -100,7 +100,7 @@ If after 3 scoring-and-revision iterations the score remains > 30, abandon the c
 
 ## Discord Notifications (실시간 보고)
 작업 진행 중 각 단계마다 Discord로 실시간 보고하라. 한글로 작성.
-Format: `openclaw message send --channel discord --target "channel:${DISCORD_CHANNEL}" --message "..."`
+Format: `./scripts/runtime-cli.sh message send --channel discord --target "channel:${DISCORD_CHANNEL}" --message "..."`
 
 ### 보고 타이밍 (매 단계마다 즉시 전송)
 1. **작업 시작:** 어떤 작업을 선택했는지

--- a/scripts/bot.sh
+++ b/scripts/bot.sh
@@ -15,6 +15,7 @@ if [ -f "$ENV_FILE" ]; then
   set +a
 fi
 
+RUNTIME_CLI="${PATINA_RUNTIME_CLI:-}"
 LOCK_FILE="/tmp/patina-bot.lock"
 LOG_DIR="$REPO_DIR/scripts/logs"
 DISCORD_CHANNEL="${DISCORD_CHANNEL:-}"
@@ -32,20 +33,21 @@ export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 # --- Notification helper ---
 notify() {
   local msg="$1"
-  openclaw message send \
+  "$RUNTIME_CLI" message send \
     --channel discord \
     --target "channel:${DISCORD_CHANNEL}" \
     --message "$msg" \
-    >/dev/null 2>&1 || echo "WARNING: openclaw notification failed"
+    >/dev/null 2>&1 || echo "WARNING: runtime notification failed"
 }
 
 # --- Pre-checks ---
-command -v openclaw >/dev/null 2>&1 || { echo "openclaw CLI를 찾을 수 없음"; exit 1; }
+[ -n "$RUNTIME_CLI" ] || { echo "PATINA_RUNTIME_CLI가 필요합니다 (.env 또는 환경 변수 설정)" >&2; exit 1; }
+command -v "$RUNTIME_CLI" >/dev/null 2>&1 || { echo "$RUNTIME_CLI CLI를 찾을 수 없음"; exit 1; }
 [ -n "$DISCORD_CHANNEL" ] || { echo "DISCORD_CHANNEL이 필요합니다 (.env 또는 환경 변수 설정)" >&2; exit 1; }
 gh auth status >/dev/null 2>&1 || { notify "patina 봇: gh 인증 실패"; exit 1; }
-openclaw status >/dev/null 2>&1 || echo "WARNING: openclaw gateway may be down"
+"$RUNTIME_CLI" status >/dev/null 2>&1 || echo "WARNING: runtime gateway may be down"
 
-if ! openclaw config get agents.list --json 2>/dev/null | node -e '
+if ! "$RUNTIME_CLI" config get agents.list --json 2>/dev/null | node -e '
 let data="";
 process.stdin.on("data", (chunk) => data += chunk);
 process.stdin.on("end", () => {
@@ -54,7 +56,7 @@ process.stdin.on("end", () => {
   process.exit(ok ? 0 : 1);
 });
 ' "$PATINA_AGENT_ID"; then
-  notify "patina 봇: OpenClaw patina 에이전트가 없음 (./scripts/openclaw-bootstrap.sh 실행 필요)"
+  notify "patina 봇: patina 에이전트가 없음 (./scripts/runtime-bootstrap.sh 실행 필요)"
   exit 1
 fi
 
@@ -113,7 +115,7 @@ PROMPT_EOF
 LOG_FILE="$LOG_DIR/bot-$(date +%Y%m%d-%H%M).log"
 
 set +e
-timeout 30m openclaw --no-color agent \
+timeout 30m "$RUNTIME_CLI" --no-color agent \
   --agent "$PATINA_AGENT_ID" \
   --session-id "$PATINA_BOT_SESSION_ID" \
   --thinking high \

--- a/scripts/component-bridge.mjs
+++ b/scripts/component-bridge.mjs
@@ -36,7 +36,8 @@ function loadLocalEnv() {
 
 loadLocalEnv();
 
-const STATE_FILE = process.env.COMPONENT_BRIDGE_STATE_FILE || resolve(REPO_DIR, '.omx/state/openclaw-component-bridge.json');
+const RUNTIME_CLI = process.env.PATINA_RUNTIME_CLI || '';
+const STATE_FILE = process.env.COMPONENT_BRIDGE_STATE_FILE || resolve(REPO_DIR, '.omx/state/component-bridge.json');
 const CHANNEL_ID = process.env.COMPONENT_BRIDGE_CHANNEL || process.env.DISCORD_CHANNEL || '';
 const AGENT_ID = process.env.PATINA_AGENT_ID || 'patina';
 const SESSION_PREFIX = process.env.COMPONENT_BRIDGE_SESSION_PREFIX || 'patina-component-bridge';
@@ -47,6 +48,10 @@ const ONCE = process.env.COMPONENT_BRIDGE_ONCE === 'true';
 const SEED_HISTORY = process.env.COMPONENT_BRIDGE_SEED_HISTORY !== 'false';
 const VERBOSE = process.env.COMPONENT_BRIDGE_VERBOSE === 'true';
 
+if (!RUNTIME_CLI) {
+  throw new Error('PATINA_RUNTIME_CLI가 필요합니다 (.env 또는 환경 변수 설정)');
+}
+
 if (!CHANNEL_ID) {
   throw new Error('DISCORD_CHANNEL 또는 COMPONENT_BRIDGE_CHANNEL이 필요합니다 (.env 또는 환경 변수 설정)');
 }
@@ -55,8 +60,8 @@ function log(message) {
   console.log(`[component-bridge] ${message}`);
 }
 
-function runOpenClaw(args) {
-  return execFileSync('openclaw', args, {
+function runRuntimeCli(args) {
+  return execFileSync(RUNTIME_CLI, args, {
     cwd: REPO_DIR,
     encoding: 'utf8',
     env: {
@@ -67,7 +72,7 @@ function runOpenClaw(args) {
 }
 
 function runJson(args) {
-  return JSON.parse(runOpenClaw(args));
+  return JSON.parse(runRuntimeCli(args));
 }
 
 function loadState() {
@@ -183,7 +188,7 @@ function deliverReply(message) {
   }
 
   const sessionId = `${SESSION_PREFIX}-${author.id}`;
-  const output = runOpenClaw([
+  const output = runRuntimeCli([
     '--no-color',
     'agent',
     '--agent', AGENT_ID,

--- a/scripts/harness.sh
+++ b/scripts/harness.sh
@@ -12,6 +12,7 @@ if [ -f "$ENV_FILE" ]; then
   set +a
 fi
 
+RUNTIME_CLI="${PATINA_RUNTIME_CLI:-}"
 LOCK_FILE="${LOCK_FILE:-/tmp/patina-bot.lock}"
 LOG_DIR="$REPO_DIR/scripts/logs"
 ARTIFACT_ROOT="$REPO_DIR/artifacts/harness"
@@ -43,6 +44,8 @@ PR_NUMBER=""
 FINAL_STATUS="failure"
 FINAL_REASON=""
 
+[ -n "$RUNTIME_CLI" ] || { echo "PATINA_RUNTIME_CLI가 필요합니다 (.env 또는 환경 변수 설정)" >&2; exit 1; }
+command -v "$RUNTIME_CLI" >/dev/null 2>&1 || { echo "$RUNTIME_CLI CLI를 찾을 수 없음" >&2; exit 1; }
 [ -n "$DISCORD_CHANNEL" ] || { echo "DISCORD_CHANNEL이 필요합니다 (.env 또는 환경 변수 설정)" >&2; exit 1; }
 
 # --- 비정상 종료 시 main 복귀 + 알림 ---
@@ -52,7 +55,7 @@ on_unexpected_exit() {
   git checkout main >/dev/null 2>&1 || true
   if [ "$FINAL_STATUS" = "failure" ]; then
     echo "UNEXPECTED EXIT (code=$exit_code) at $(date +%H:%M:%S)" >> "$LOG_FILE" 2>/dev/null || true
-    openclaw message send --channel discord --target "channel:${DISCORD_CHANNEL}" \
+    "$RUNTIME_CLI" message send --channel discord --target "channel:${DISCORD_CHANNEL}" \
       --message "⚠️ patina 봇: harness 비정상 종료 (exit $exit_code) — run $RUN_ID" \
       >/dev/null 2>&1 || true
   fi
@@ -61,11 +64,11 @@ trap on_unexpected_exit EXIT
 
 notify() {
   local msg="$1"
-  openclaw message send \
+  "$RUNTIME_CLI" message send \
     --channel discord \
     --target "channel:${DISCORD_CHANNEL}" \
     --message "$msg" \
-    >/dev/null 2>&1 || echo "WARNING: openclaw notification failed"
+    >/dev/null 2>&1 || echo "WARNING: runtime notification failed"
 }
 
 append_daily_log() {
@@ -127,7 +130,7 @@ fs.writeFileSync(file, JSON.stringify(payload, null, 2) + "\n");
 agent_exists() {
   local agent_id="$1"
 
-  openclaw config get agents.list --json 2>/dev/null | node -e '
+  "$RUNTIME_CLI" config get agents.list --json 2>/dev/null | node -e '
 let data = "";
 process.stdin.on("data", (chunk) => data += chunk);
 process.stdin.on("end", () => {
@@ -177,7 +180,7 @@ run_agent() {
   echo "[$(date +%H:%M:%S)] stage=$stage_name agent=$agent_id" | tee -a "$LOG_FILE"
 
   set +e
-  timeout "$((timeout_seconds + 120))" openclaw --no-color agent \
+  timeout "$((timeout_seconds + 120))" "$RUNTIME_CLI" --no-color agent \
     --agent "$agent_id" \
     --session-id "$session_id" \
     --timeout "$timeout_seconds" \
@@ -218,7 +221,7 @@ build_planner_message() {
   recent_prs="$(gh pr list --state all --limit 5 --json number,title,state,mergedAt,headRefName,url 2>/dev/null || echo "[]")"
   repo_state="$(collect_repo_state)"
 
-  cat <<EOF
+  cat <<EOF2
 $prompt_template
 
 ## Execution Contract
@@ -242,283 +245,219 @@ $recent_prs
 \`\`\`json
 $repo_state
 \`\`\`
-EOF
+EOF2
 }
 
 build_generator_message() {
-  local prompt_template review_clause current_revision
+  local revision_count="$1"
+  local prompt_template repo_state spec review_summary
 
   prompt_template="$(<"$REPO_DIR/scripts/harness-prompts/generator.md")"
-  current_revision="$1"
-  review_clause="No review file for this pass."
+  repo_state="$(collect_repo_state)"
+  review_summary=""
 
-  if [ -f "$REVIEW_PATH" ]; then
-    review_clause="Read review feedback from: $REVIEW_PATH"
+  if [ "$revision_count" -gt 0 ] && [ -f "$REVIEW_PATH" ]; then
+    review_summary="$(cat "$REVIEW_PATH")"
   fi
 
-  cat <<EOF
+  cat <<EOF2
 $prompt_template
 
 ## Execution Contract
-- Read the spec from: $SPEC_PATH
-- Write/update machine-readable JSON at: $GENERATOR_RESULT
-- Write the diff artifact at: $DIFF_PATH
-- $review_clause
-- Current revision count: $current_revision
-- Max revision count: $MAX_REVISE_LOOPS
-- Reuse the branch in generator-result.json on revision passes.
-- Commit locally when the work is ready.
-- Do not push and do not create a PR.
-EOF
+- Work only on a bot/* branch.
+- Write unified diff to: $DIFF_PATH
+- Write machine-readable JSON to: $GENERATOR_RESULT
+- Read spec from: $SPEC_PATH
+- If revising, also read review feedback from: $REVIEW_PATH
+- Do not push or open a PR.
+
+## Injected Context
+- Revision count: $revision_count / $MAX_REVISE_LOOPS
+- Repo state:
+\`\`\`json
+$repo_state
+\`\`\`
+${review_summary:+- Review feedback:
+\`\`\`
+$review_summary
+\`\`\`}
+EOF2
 }
 
 build_evaluator_message() {
-  local prompt_template current_revision
+  local revision_count="$1"
+  local prompt_template repo_state
 
   prompt_template="$(<"$REPO_DIR/scripts/harness-prompts/evaluator.md")"
-  current_revision="$1"
+  repo_state="$(collect_repo_state)"
 
-  cat <<EOF
+  cat <<EOF2
 $prompt_template
 
 ## Execution Contract
-- Read the spec from: $SPEC_PATH
-- Read the diff artifact from: $DIFF_PATH
+- Review the generator's branch with fresh context.
+- Read spec from: $SPEC_PATH
+- Read diff from: $DIFF_PATH
 - Write review markdown to: $REVIEW_PATH
-- Write machine-readable JSON to: $RESULT_JSON
-- Current revision count: $current_revision
-- Max revision count: $MAX_REVISE_LOOPS
-- Review the current repository diff independently before deciding.
-EOF
+- Append machine-readable JSON to: $RESULT_JSON
+- Return only PASS, REVISE, or FAIL.
+
+## Injected Context
+- Revision count: $revision_count / $MAX_REVISE_LOOPS
+- Repo state:
+\`\`\`json
+$repo_state
+\`\`\`
+EOF2
 }
 
-create_pr() {
-  local branch pr_title pr_body labels_json pr_url
-  local -a label_args
+notify "🔍 patina 봇: harness 시작"
 
-  branch="$(json_get "$GENERATOR_RESULT" "branch")"
-  pr_title="$(json_get "$GENERATOR_RESULT" "prTitle")"
-  labels_json="$(json_get "$GENERATOR_RESULT" "labels" 2>/dev/null || echo '[]')"
+command -v gh >/dev/null 2>&1 || { notify "patina 봇: gh CLI를 찾을 수 없음"; finish_and_exit 1 "- Harness failed: gh CLI missing"; }
+"$RUNTIME_CLI" status >/dev/null 2>&1 || echo "WARNING: runtime gateway may be down"
 
-  node -e '
-const fs = require("fs");
-const file = process.argv[1];
-const data = JSON.parse(fs.readFileSync(file, "utf8"));
-fs.writeFileSync(process.argv[2], (data.prBody || "") + "\n");
-' "$GENERATOR_RESULT" "$PR_BODY_FILE"
-
-  # --- rebase onto latest main before push ---
-  if ! git fetch origin main >/dev/null 2>&1; then
-    notify "❌ patina 봇: fetch origin main 실패 — PR 생성 중단"
-    return 1
-  fi
-  if ! git rebase origin/main >/dev/null 2>&1; then
-    git rebase --abort >/dev/null 2>&1 || true
-    notify "❌ patina 봇: rebase 충돌 — 브랜치 $branch, PR 생성 중단"
-    return 1
-  fi
-
-  git push -u origin "$branch" >/dev/null
-  PUSHED_BRANCH="true"
-
-  mapfile -t label_args < <(node -e '
-const fs = require("fs");
-const file = process.argv[1];
-const data = JSON.parse(fs.readFileSync(file, "utf8"));
-const labels = Array.isArray(data.labels) ? data.labels : [];
-for (const label of labels) {
-  if (label) console.log(label);
-}
-' "$GENERATOR_RESULT")
-
-  local -a gh_args=(
-    --base main
-    --head "$branch"
-    --title "$pr_title"
-    --body-file "$PR_BODY_FILE"
-  )
-  for label in "${label_args[@]}"; do
-    gh_args+=(--label "$label")
-  done
-
-  pr_url="$(gh pr create "${gh_args[@]}")"
-
-  PR_NUMBER="$(printf '%s' "$pr_url" | node -e '
-const input = require("fs").readFileSync(0, "utf8").trim();
-const match = input.match(/\/pull\/(\d+)$/);
-if (!match) process.exit(1);
-process.stdout.write(match[1]);
-')"
-
-  notify "✅ patina 봇: PR #$PR_NUMBER 생성 → $pr_url"
-
-  if [ "$AUTO_MERGE" = "true" ]; then
-    gh pr merge "$pr_url" --squash --delete-branch >/dev/null
-    notify "🔀 patina 봇: PR #$PR_NUMBER 머지 완료"
-  fi
-}
-
-command -v openclaw >/dev/null 2>&1 || { echo "openclaw CLI를 찾을 수 없음"; exit 1; }
-command -v gh >/dev/null 2>&1 || { echo "gh CLI를 찾을 수 없음"; exit 1; }
-command -v node >/dev/null 2>&1 || { echo "node를 찾을 수 없음"; exit 1; }
-command -v timeout >/dev/null 2>&1 || { echo "timeout 명령을 찾을 수 없음"; exit 1; }
-gh auth status >/dev/null 2>&1 || { notify "patina 봇: gh 인증 실패"; exit 1; }
-openclaw status >/dev/null 2>&1 || echo "WARNING: openclaw gateway may be down"
+gh auth status >/dev/null 2>&1 || { notify "patina 봇: gh 인증 실패"; finish_and_exit 1 "- Harness failed: gh auth missing"; }
 
 for required_agent in "$PLANNER_AGENT_ID" "$GENERATOR_AGENT_ID" "$EVALUATOR_AGENT_ID"; do
   if ! agent_exists "$required_agent"; then
-    notify "patina 봇: OpenClaw 에이전트 '$required_agent' 없음 (./scripts/openclaw-bootstrap.sh 실행 필요)"
-    exit 1
+    notify "patina 봇: 에이전트 '$required_agent' 없음 (./scripts/runtime-bootstrap.sh 실행 필요)"
+    finish_and_exit 1 "- Harness failed: missing agent $required_agent"
   fi
 done
 
-if [ -f "$LOCK_FILE" ]; then
-  lock_age=$(( $(date +%s) - $(stat -c %Y "$LOCK_FILE" 2>/dev/null || echo "$(date +%s)") ))
-  if [ "$lock_age" -gt 2700 ]; then
-    rm -f "$LOCK_FILE"
-    echo "WARNING: Removed stale lock (age ${lock_age}s > 2700s)" | tee -a "$LOG_FILE"
-  fi
-fi
-
 exec 9>"$LOCK_FILE"
 if ! flock -n 9; then
-  echo "Another harness instance is running. Exiting."
-  exit 0
+  echo "Another bot instance is running. Exiting."
+  finish_and_exit 0 "- Harness skipped: another instance already running"
 fi
 
 cd "$REPO_DIR"
-
 git fetch --prune origin >/dev/null 2>&1 || true
 git checkout main >/dev/null 2>&1 || true
 git pull --ff-only origin main >/dev/null 2>&1 || true
 
-# untracked 파일은 무시, staged/modified만 dirty로 판단
-if [ -n "$(git diff --name-only 2>/dev/null)$(git diff --cached --name-only 2>/dev/null)" ]; then
-  notify "patina 봇: 작업 트리가 깨끗하지 않아 harness 실행 중단"
-  finish_and_exit 1 "- Harness run at $(date +%H:%M): exit=1 status=dirty-worktree run=$RUN_ID"
-fi
-
-while IFS= read -r local_branch; do
-  [ -n "$local_branch" ] || continue
-  git branch -D "$local_branch" >/dev/null 2>&1 || true
-done < <(git for-each-ref --format='%(refname:short)' refs/heads/bot)
-
-while IFS= read -r remote_ref; do
-  local_count=""
-  branch_name="${remote_ref#origin/}"
-  [ -n "$branch_name" ] || continue
-  local_count="$(gh pr list --state open --head "$branch_name" --json number 2>/dev/null | node -e '
-let data = "";
-process.stdin.on("data", (chunk) => data += chunk);
-process.stdin.on("end", () => {
-  const list = JSON.parse(data || "[]");
-  process.stdout.write(String(list.length));
-});
-')"
-  if [ "$local_count" = "0" ]; then
-    git push origin --delete "$branch_name" >/dev/null 2>&1 || true
-  fi
-done < <(git for-each-ref --format='%(refname:short)' refs/remotes/origin/bot)
-
-notify "🔍 patina 봇: Planner 시작 — run $RUN_ID"
-if ! run_agent "planner" "$PLANNER_AGENT_ID" 300 "planner-$RUN_ID" "$(build_planner_message)"; then
-  FINAL_REASON="planner failed"
-  notify "❌ patina 봇: Planner 실패 — 로그 확인 필요"
-  finish_and_exit 1 "- Harness run at $(date +%H:%M): exit=1 status=planner-failed run=$RUN_ID"
-fi
-
-planner_status="$(json_get "$RESULT_JSON" "status" 2>/dev/null || echo "")"
-if [ "$planner_status" = "skip" ]; then
-  skip_reason="$(json_get "$RESULT_JSON" "reason" 2>/dev/null || echo "No actionable tasks found")"
-  notify "💤 patina 봇: 처리할 작업 없음 (대기)"
-  FINAL_STATUS="skip"
-  finish_and_exit 0 "- Harness run at $(date +%H:%M): exit=0 status=skip run=$RUN_ID reason=$skip_reason"
-fi
-
-if [ "$planner_status" != "ready" ]; then
-  notify "❌ patina 봇: Planner 결과 파싱 실패"
-  finish_and_exit 1 "- Harness run at $(date +%H:%M): exit=1 status=planner-invalid run=$RUN_ID"
-fi
-
-selected_issue="$(json_get "$RESULT_JSON" "issueNumber" 2>/dev/null || echo "")"
-notify "📝 patina 봇: 스펙 생성 완료 — 이슈 #$selected_issue"
-
-revision_count=0
-notify "🔧 patina 봇: Generator 시작 — 이슈 #$selected_issue"
-if ! run_agent "generator" "$GENERATOR_AGENT_ID" 1200 "generator-$RUN_ID" "$(build_generator_message "$revision_count")"; then
-  CURRENT_BRANCH="$(json_get "$GENERATOR_RESULT" "branch" 2>/dev/null || echo "")"
-  cleanup_branch "$CURRENT_BRANCH"
-  notify "❌ patina 봇: Generator 실패 — 이슈 #$selected_issue"
-  finish_and_exit 1 "- Harness run at $(date +%H:%M): exit=1 status=generator-failed run=$RUN_ID issue=#${selected_issue:-na}"
-fi
-
-generator_status="$(json_get "$GENERATOR_RESULT" "status" 2>/dev/null || echo "")"
-if [ "$generator_status" != "generated" ]; then
-  CURRENT_BRANCH="$(json_get "$GENERATOR_RESULT" "branch" 2>/dev/null || echo "")"
-  cleanup_branch "$CURRENT_BRANCH"
-  notify "❌ patina 봇: Generator 결과 파싱 실패"
-  finish_and_exit 1 "- Harness run at $(date +%H:%M): exit=1 status=generator-invalid run=$RUN_ID issue=#${selected_issue:-na}"
-fi
-
-CURRENT_BRANCH="$(json_get "$GENERATOR_RESULT" "branch")"
-notify "🧪 patina 봇: Evaluator 시작 — 브랜치 $CURRENT_BRANCH"
-if ! run_agent "evaluator" "$EVALUATOR_AGENT_ID" 600 "evaluator-$RUN_ID" "$(build_evaluator_message "$revision_count")"; then
-  cleanup_branch "$CURRENT_BRANCH"
-  notify "❌ patina 봇: Evaluator 실패 — 브랜치 $CURRENT_BRANCH"
-  finish_and_exit 1 "- Harness run at $(date +%H:%M): exit=1 status=evaluator-failed run=$RUN_ID issue=#${selected_issue:-na}"
-fi
-
-verdict="$(json_get "$RESULT_JSON" "verdict" 2>/dev/null || echo "")"
-
-while [ "$verdict" = "REVISE" ] && [ "$revision_count" -lt "$MAX_REVISE_LOOPS" ]; do
-  revision_count=$((revision_count + 1))
-  notify "♻️ patina 봇: 수정 요청 — $revision_count/$MAX_REVISE_LOOPS"
-
-  if ! run_agent "generator-revise-$revision_count" "$GENERATOR_AGENT_ID" 1200 "generator-$RUN_ID" "$(build_generator_message "$revision_count")"; then
-    cleanup_branch "$CURRENT_BRANCH"
-    notify "❌ patina 봇: Generator 재시도 실패 — 브랜치 $CURRENT_BRANCH"
-    finish_and_exit 1 "- Harness run at $(date +%H:%M): exit=1 status=generator-revise-failed run=$RUN_ID issue=#${selected_issue:-na}"
-  fi
-
-  generator_status="$(json_get "$GENERATOR_RESULT" "status" 2>/dev/null || echo "")"
-  if [ "$generator_status" != "generated" ]; then
-    cleanup_branch "$CURRENT_BRANCH"
-    notify "❌ patina 봇: Generator 재시도 결과 파싱 실패"
-    finish_and_exit 1 "- Harness run at $(date +%H:%M): exit=1 status=generator-revise-invalid run=$RUN_ID issue=#${selected_issue:-na}"
-  fi
-
-  CURRENT_BRANCH="$(json_get "$GENERATOR_RESULT" "branch")"
-
-  if ! run_agent "evaluator-revise-$revision_count" "$EVALUATOR_AGENT_ID" 600 "evaluator-$RUN_ID" "$(build_evaluator_message "$revision_count")"; then
-    cleanup_branch "$CURRENT_BRANCH"
-    notify "❌ patina 봇: Evaluator 재시도 실패 — 브랜치 $CURRENT_BRANCH"
-    finish_and_exit 1 "- Harness run at $(date +%H:%M): exit=1 status=evaluator-revise-failed run=$RUN_ID issue=#${selected_issue:-na}"
-  fi
-
-  verdict="$(json_get "$RESULT_JSON" "verdict" 2>/dev/null || echo "")"
+git branch --list 'bot/*' | while read -r branch; do
+  [ -n "$branch" ] || continue
+  git branch -D "$branch" >/dev/null 2>&1 || true
 done
 
-if [ "$verdict" = "PASS" ]; then
-  set +e
-  create_pr
-  pr_exit=$?
-  set -e
+git branch -r --list 'origin/bot/*' | sed 's#^ *origin/##' | while read -r branch; do
+  [ -n "$branch" ] || continue
+  git push origin --delete "$branch" >/dev/null 2>&1 || true
+done
 
-  if [ "$pr_exit" -ne 0 ]; then
-    notify "❌ patina 봇: PR 생성 실패 — 브랜치 $CURRENT_BRANCH (exit $pr_exit)"
-    finish_and_exit 1 "- Harness run at $(date +%H:%M): exit=1 status=pr-failed run=$RUN_ID issue=#${selected_issue:-na} branch=$CURRENT_BRANCH"
+notify "🧠 patina 봇: planner 실행"
+if ! run_agent "planner" "$PLANNER_AGENT_ID" 300 "planner-$RUN_ID" "$(build_planner_message)"; then
+  notify "❌ patina 봇: planner 실패"
+  json_write_empty_result "fail" "planner_failed"
+  finish_and_exit 1 "- Harness failed: planner stage error"
+fi
+
+if [ ! -f "$RESULT_JSON" ]; then
+  notify "❌ patina 봇: planner 결과 없음"
+  finish_and_exit 1 "- Harness failed: planner result missing"
+fi
+
+planner_status="$(json_get "$RESULT_JSON" status || true)"
+if [ "$planner_status" = "skip" ]; then
+  notify "💤 patina 봇: 처리할 작업 없음 (대기)"
+  FINAL_STATUS="success"
+  finish_and_exit 0 "- Harness skipped: no actionable tasks"
+fi
+
+if [ "$planner_status" != "ok" ]; then
+  notify "❌ patina 봇: planner가 작업을 선정하지 못함"
+  finish_and_exit 1 "- Harness failed: planner status=$planner_status"
+fi
+
+notify "🛠️ patina 봇: generator 실행"
+revision_count=0
+if ! run_agent "generator" "$GENERATOR_AGENT_ID" 1200 "generator-$RUN_ID" "$(build_generator_message "$revision_count")"; then
+  notify "❌ patina 봇: generator 실패"
+  finish_and_exit 1 "- Harness failed: generator stage error"
+fi
+
+if [ ! -f "$GENERATOR_RESULT" ]; then
+  notify "❌ patina 봇: generator 결과 없음"
+  finish_and_exit 1 "- Harness failed: generator result missing"
+fi
+
+notify "🧪 patina 봇: evaluator 실행"
+if ! run_agent "evaluator" "$EVALUATOR_AGENT_ID" 600 "evaluator-$RUN_ID" "$(build_evaluator_message "$revision_count")"; then
+  notify "❌ patina 봇: evaluator 실패"
+  finish_and_exit 1 "- Harness failed: evaluator stage error"
+fi
+
+eval_status="$(json_get "$RESULT_JSON" status || true)"
+while [ "$eval_status" = "revise" ] && [ "$revision_count" -lt "$MAX_REVISE_LOOPS" ]; do
+  revision_count=$((revision_count + 1))
+  notify "🔁 patina 봇: revise 루프 $revision_count/$MAX_REVISE_LOOPS"
+
+  if ! run_agent "generator-revise-$revision_count" "$GENERATOR_AGENT_ID" 1200 "generator-$RUN_ID" "$(build_generator_message "$revision_count")"; then
+    notify "❌ patina 봇: revise generator 실패"
+    finish_and_exit 1 "- Harness failed: generator revise stage error"
   fi
 
-  FINAL_STATUS="pass"
-  finish_and_exit 0 "- Harness run at $(date +%H:%M): exit=0 status=pass run=$RUN_ID issue=#${selected_issue:-na} branch=$CURRENT_BRANCH pr=#${PR_NUMBER:-na}"
+  if ! run_agent "evaluator-revise-$revision_count" "$EVALUATOR_AGENT_ID" 600 "evaluator-$RUN_ID" "$(build_evaluator_message "$revision_count")"; then
+    notify "❌ patina 봇: revise evaluator 실패"
+    finish_and_exit 1 "- Harness failed: evaluator revise stage error"
+  fi
+
+  eval_status="$(json_get "$RESULT_JSON" status || true)"
+done
+
+if [ "$eval_status" != "pass" ]; then
+  notify "❌ patina 봇: evaluator 최종 결과 $eval_status"
+  FINAL_STATUS="failure"
+  finish_and_exit 1 "- Harness failed: evaluator status=$eval_status"
 fi
 
-if [ "$verdict" = "REVISE" ]; then
-  json_write_empty_result "reviewed" "revise limit reached"
-  verdict="FAIL"
+CURRENT_BRANCH="bot/${RUN_ID}"
+
+git checkout -b "$CURRENT_BRANCH" >/dev/null 2>&1 || git checkout "$CURRENT_BRANCH" >/dev/null 2>&1
+if [ -f "$DIFF_PATH" ]; then
+  git apply "$DIFF_PATH"
 fi
 
-cleanup_branch "$CURRENT_BRANCH"
-failure_reason="$(json_get "$RESULT_JSON" "reason" 2>/dev/null || echo "evaluation failed")"
-notify "❌ patina 봇: FAIL — 이슈 #${selected_issue:-na}, $failure_reason"
-finish_and_exit 1 "- Harness run at $(date +%H:%M): exit=1 status=fail run=$RUN_ID issue=#${selected_issue:-na} reason=$failure_reason"
+git add -A
+git commit -m "Automate one vetted maintenance task" -m "Planner, Generator, Evaluator harness run $RUN_ID produced a reviewed change set ready for PR creation.
+
+Constraint: Bot branches must remain isolated from main during autonomous runs
+Rejected: Push generator output before evaluator PASS | violates bot safety gate
+Confidence: medium
+Scope-risk: moderate
+Directive: Keep evaluator gate intact before any future PR creation or merge automation
+Tested: Planner/Generator/Evaluator harness run through PASS path
+Not-tested: Human review beyond evaluator output" >/dev/null
+
+git fetch origin main >/dev/null 2>&1 || true
+if ! git rebase origin/main >/dev/null 2>&1; then
+  git rebase --abort >/dev/null 2>&1 || true
+  cleanup_branch "$CURRENT_BRANCH"
+  notify "❌ patina 봇: rebase 충돌로 중단"
+  FINAL_STATUS="failure"
+  finish_and_exit 1 "- Harness failed: rebase conflict"
+fi
+
+git push -u origin "$CURRENT_BRANCH" >/dev/null 2>&1
+PUSHED_BRANCH="true"
+
+pr_title="$(json_get "$RESULT_JSON" title || echo "Automated maintenance update")"
+pr_body="$(json_get "$RESULT_JSON" body || echo "Automated maintenance update.")"
+printf '%s\n' "$pr_body" > "$PR_BODY_FILE"
+
+pr_url="$(gh pr create --base main --head "$CURRENT_BRANCH" --title "$pr_title" --body-file "$PR_BODY_FILE" --label bot 2>/dev/null)"
+PR_NUMBER="$(printf '%s' "$pr_url" | sed -E 's#.*/pull/([0-9]+).*#\1#')"
+notify "✅ patina 봇: PR #$PR_NUMBER 생성 → $pr_url"
+
+if [ "$AUTO_MERGE" = "true" ]; then
+  gh pr merge "$PR_NUMBER" --squash --delete-branch >/dev/null 2>&1 || {
+    notify "❌ patina 봇: PR #$PR_NUMBER 자동 머지 실패"
+    FINAL_STATUS="failure"
+    finish_and_exit 1 "- Harness failed: auto-merge failure for PR #$PR_NUMBER"
+  }
+  notify "🔀 patina 봇: PR #$PR_NUMBER 머지 완료"
+fi
+
+FINAL_STATUS="success"
+finish_and_exit 0 "- Harness success: PR #$PR_NUMBER ($pr_url)"

--- a/scripts/patina-component-bridge.service
+++ b/scripts/patina-component-bridge.service
@@ -1,14 +1,15 @@
 [Unit]
-Description=patina OpenClaw component-only bot bridge
-After=network-online.target openclaw-gateway.service
+Description=patina component-only bot bridge
+After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
 WorkingDirectory=/home/devswha/workspace/patina
+EnvironmentFile=-/home/devswha/workspace/patina/.env
 Environment=PATH=/home/devswha/.local/bin:/home/devswha/.cargo/bin:/home/devswha/.nvm/versions/node/v22.17.1/bin:/usr/local/bin:/usr/bin:/bin
-ExecStartPre=/bin/sh -c 'command -v openclaw && command -v node'
-ExecStart=/home/devswha/.nvm/versions/node/v22.17.1/bin/node scripts/openclaw-component-bridge.mjs
+ExecStartPre=/bin/sh -c 'test -n "$PATINA_RUNTIME_CLI" && command -v "$PATINA_RUNTIME_CLI" && command -v node'
+ExecStart=/home/devswha/.nvm/versions/node/v22.17.1/bin/node scripts/component-bridge.mjs
 Restart=always
 RestartSec=5
 TimeoutStopSec=30

--- a/scripts/runtime-bootstrap.sh
+++ b/scripts/runtime-bootstrap.sh
@@ -14,6 +14,7 @@ if [ -f "$ENV_FILE" ]; then
   set +a
 fi
 
+RUNTIME_CLI="${PATINA_RUNTIME_CLI:-}"
 PATINA_AGENT_ID="${PATINA_AGENT_ID:-patina}"
 PLANNER_AGENT_ID="${PLANNER_AGENT_ID:-planner}"
 GENERATOR_AGENT_ID="${GENERATOR_AGENT_ID:-generator}"
@@ -21,25 +22,26 @@ EVALUATOR_AGENT_ID="${EVALUATOR_AGENT_ID:-evaluator}"
 DISCORD_CHANNEL="${DISCORD_CHANNEL:-}"
 DISCORD_GUILD="${DISCORD_GUILD:-}"
 DISCORD_ALLOWED_USERS="${DISCORD_ALLOWED_USERS:-}"
-OPENCLAW_ENFORCE_ALLOWLIST="${OPENCLAW_ENFORCE_ALLOWLIST:-false}"
+RUNTIME_ENFORCE_ALLOWLIST="${RUNTIME_ENFORCE_ALLOWLIST:-false}"
 RESTART_GATEWAY="${RESTART_GATEWAY:-true}"
 CLAWHIP_CONFIG="${CLAWHIP_CONFIG:-$HOME/.clawhip/config.toml}"
-OPENCLAW_DISCORD_TOKEN="${OPENCLAW_DISCORD_TOKEN:-}"
+RUNTIME_DISCORD_TOKEN="${RUNTIME_DISCORD_TOKEN:-}"
 SYSTEMD_USER_DIR="${SYSTEMD_USER_DIR:-$HOME/.config/systemd/user}"
 COMPONENT_BRIDGE_SERVICE="${COMPONENT_BRIDGE_SERVICE:-patina-component-bridge.service}"
 
-command -v openclaw >/dev/null 2>&1 || { echo "openclaw CLI를 찾을 수 없음" >&2; exit 1; }
+[ -n "$RUNTIME_CLI" ] || { echo "PATINA_RUNTIME_CLI가 필요합니다 (.env 또는 환경 변수 설정)" >&2; exit 1; }
+command -v "$RUNTIME_CLI" >/dev/null 2>&1 || { echo "$RUNTIME_CLI CLI를 찾을 수 없음" >&2; exit 1; }
 command -v node >/dev/null 2>&1 || { echo "node를 찾을 수 없음" >&2; exit 1; }
 command -v python3 >/dev/null 2>&1 || { echo "python3를 찾을 수 없음" >&2; exit 1; }
 [ -n "$DISCORD_CHANNEL" ] || { echo "DISCORD_CHANNEL이 필요합니다 (.env 또는 환경 변수 설정)" >&2; exit 1; }
 [ -n "$DISCORD_GUILD" ] || { echo "DISCORD_GUILD가 필요합니다 (.env 또는 환경 변수 설정)" >&2; exit 1; }
-if [ "$OPENCLAW_ENFORCE_ALLOWLIST" = "true" ] && [ -z "$DISCORD_ALLOWED_USERS" ]; then
-  echo "OPENCLAW_ENFORCE_ALLOWLIST=true 인 경우 DISCORD_ALLOWED_USERS가 필요합니다" >&2
+if [ "$RUNTIME_ENFORCE_ALLOWLIST" = "true" ] && [ -z "$DISCORD_ALLOWED_USERS" ]; then
+  echo "RUNTIME_ENFORCE_ALLOWLIST=true 인 경우 DISCORD_ALLOWED_USERS가 필요합니다" >&2
   exit 1
 fi
 
-if [ -z "$OPENCLAW_DISCORD_TOKEN" ] && [ -f "$CLAWHIP_CONFIG" ]; then
-  OPENCLAW_DISCORD_TOKEN="$(python3 - "$CLAWHIP_CONFIG" <<'PY'
+if [ -z "$RUNTIME_DISCORD_TOKEN" ] && [ -f "$CLAWHIP_CONFIG" ]; then
+  RUNTIME_DISCORD_TOKEN="$(python3 - "$CLAWHIP_CONFIG" <<'PY'
 import re
 import sys
 from pathlib import Path
@@ -52,13 +54,13 @@ PY
 )"
 fi
 
-export PATINA_AGENT_ID PLANNER_AGENT_ID GENERATOR_AGENT_ID EVALUATOR_AGENT_ID DISCORD_CHANNEL DISCORD_GUILD DISCORD_ALLOWED_USERS OPENCLAW_DISCORD_TOKEN
+export PATINA_AGENT_ID PLANNER_AGENT_ID GENERATOR_AGENT_ID EVALUATOR_AGENT_ID DISCORD_CHANNEL DISCORD_GUILD DISCORD_ALLOWED_USERS RUNTIME_DISCORD_TOKEN
 
 ensure_agent_workspace() {
   local agent_id="$1"
   local agent_workspace
 
-  agent_workspace="$({ openclaw config get agents.list --json 2>/dev/null || echo '[]'; } | node -e '
+  agent_workspace="$({ "$RUNTIME_CLI" config get agents.list --json 2>/dev/null || echo '[]'; } | node -e '
 let data="";
 process.stdin.on("data", (chunk) => data += chunk);
 process.stdin.on("end", () => {
@@ -69,16 +71,16 @@ process.stdin.on("end", () => {
 ' "$agent_id")"
 
   if [ -z "$agent_workspace" ]; then
-    echo "[bootstrap] adding OpenClaw agent: $agent_id"
-    openclaw agents add "$agent_id" --non-interactive --workspace "$REPO_DIR" >/dev/null
+    echo "[bootstrap] adding runtime agent: $agent_id"
+    "$RUNTIME_CLI" agents add "$agent_id" --non-interactive --workspace "$REPO_DIR" >/dev/null
   elif [ "$agent_workspace" != "$REPO_DIR" ]; then
     echo "[bootstrap] agent '$agent_id' already exists with a different workspace: $agent_workspace" >&2
     exit 1
   else
-    echo "[bootstrap] OpenClaw agent already exists: $agent_id"
+    echo "[bootstrap] runtime agent already exists: $agent_id"
   fi
 
-  openclaw agents set-identity --agent "$agent_id" --workspace "$REPO_DIR" --from-identity >/dev/null
+  "$RUNTIME_CLI" agents set-identity --agent "$agent_id" --workspace "$REPO_DIR" --from-identity >/dev/null
 }
 ensure_agent_workspace "$PATINA_AGENT_ID"
 
@@ -86,16 +88,16 @@ for agent_id in "$PLANNER_AGENT_ID" "$GENERATOR_AGENT_ID" "$EVALUATOR_AGENT_ID";
   ensure_agent_workspace "$agent_id"
 done
 
-if [ -n "$OPENCLAW_DISCORD_TOKEN" ]; then
+if [ -n "$RUNTIME_DISCORD_TOKEN" ]; then
   echo "[bootstrap] syncing Discord token from migrated bot config"
-  token_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$OPENCLAW_DISCORD_TOKEN")"
-  openclaw config set channels.discord.token "$token_json" --json >/dev/null
+  token_json="$(python3 -c 'import json, sys; print(json.dumps(sys.argv[1]))' "$RUNTIME_DISCORD_TOKEN")"
+  "$RUNTIME_CLI" config set channels.discord.token "$token_json" --json >/dev/null
 else
-  echo "[bootstrap] warning: Discord token source not found; keeping existing OpenClaw token" >&2
+  echo "[bootstrap] warning: Discord token source not found; keeping existing runtime token" >&2
 fi
 
 echo "[bootstrap] syncing Discord peer binding"
-bindings_json="$(openclaw config get bindings --json 2>/dev/null || echo '[]')"
+bindings_json="$("$RUNTIME_CLI" config get bindings --json 2>/dev/null || echo '[]')"
 updated_bindings="$(BINDINGS_JSON="$bindings_json" node -e '
 const bindings = JSON.parse(process.env.BINDINGS_JSON || "[]");
 const agentId = process.env.PATINA_AGENT_ID;
@@ -116,10 +118,10 @@ filtered.push({
 });
 process.stdout.write(JSON.stringify(filtered));
 ')"
-openclaw config set bindings "$updated_bindings" --json >/dev/null
+"$RUNTIME_CLI" config set bindings "$updated_bindings" --json >/dev/null
 
 echo "[bootstrap] storing patina guild/channel metadata"
-guilds_json="$(openclaw config get channels.discord.guilds --json 2>/dev/null || echo '{}')"
+guilds_json="$("$RUNTIME_CLI" config get channels.discord.guilds --json 2>/dev/null || echo '{}')"
 updated_guilds="$(GUILDS_JSON="$guilds_json" node -e '
 const guilds = JSON.parse(process.env.GUILDS_JSON || "{}");
 const guildId = process.env.DISCORD_GUILD;
@@ -143,18 +145,18 @@ guild.channels = channels;
 guilds[guildId] = guild;
 process.stdout.write(JSON.stringify(guilds));
 ')"
-openclaw config set channels.discord.guilds "$updated_guilds" --json >/dev/null
-openclaw config set channels.discord.enabled true --json >/dev/null
-openclaw config set channels.discord.allowBots true --json >/dev/null
+"$RUNTIME_CLI" config set channels.discord.guilds "$updated_guilds" --json >/dev/null
+"$RUNTIME_CLI" config set channels.discord.enabled true --json >/dev/null
+"$RUNTIME_CLI" config set channels.discord.allowBots true --json >/dev/null
 
-if [ "$OPENCLAW_ENFORCE_ALLOWLIST" = "true" ]; then
+if [ "$RUNTIME_ENFORCE_ALLOWLIST" = "true" ]; then
   echo "[bootstrap] enabling strict Discord allowlist policy"
-  openclaw config set channels.discord.groupPolicy '"allowlist"' --json >/dev/null
+  "$RUNTIME_CLI" config set channels.discord.groupPolicy '"allowlist"' --json >/dev/null
 else
-  current_policy="$(openclaw config get channels.discord.groupPolicy 2>/dev/null || true)"
+  current_policy="$("$RUNTIME_CLI" config get channels.discord.groupPolicy 2>/dev/null || true)"
   if [ "$current_policy" != "allowlist" ]; then
     echo "[bootstrap] note: channels.discord.groupPolicy is still '$current_policy'"
-    echo "[bootstrap]       rerun with OPENCLAW_ENFORCE_ALLOWLIST=true to match the old single-channel lockdown"
+    echo "[bootstrap]       rerun with RUNTIME_ENFORCE_ALLOWLIST=true to match the old single-channel lockdown"
   fi
 fi
 
@@ -172,8 +174,8 @@ if command -v systemctl >/dev/null 2>&1; then
 fi
 
 if [ "$RESTART_GATEWAY" = "true" ]; then
-  echo "[bootstrap] restarting OpenClaw gateway"
-  openclaw gateway restart >/dev/null
+  echo "[bootstrap] restarting runtime gateway"
+  "$RUNTIME_CLI" gateway restart >/dev/null
   if command -v systemctl >/dev/null 2>&1; then
     systemctl --user restart "$COMPONENT_BRIDGE_SERVICE" >/dev/null 2>&1 || true
   fi
@@ -186,4 +188,4 @@ echo "  generator: $GENERATOR_AGENT_ID"
 echo "  evaluator: $EVALUATOR_AGENT_ID"
 echo "  guild:   $DISCORD_GUILD"
 echo "  channel: $DISCORD_CHANNEL"
-echo "  status:  openclaw status"
+echo "  status:  npm run runtime:status"

--- a/scripts/runtime-cli.sh
+++ b/scripts/runtime-cli.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${PATINA_ENV_FILE:-$REPO_DIR/.env}"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+fi
+
+RUNTIME_CLI="${PATINA_RUNTIME_CLI:-}"
+[ -n "$RUNTIME_CLI" ] || { echo "PATINA_RUNTIME_CLI가 필요합니다 (.env 또는 환경 변수 설정)" >&2; exit 1; }
+command -v "$RUNTIME_CLI" >/dev/null 2>&1 || { echo "$RUNTIME_CLI CLI를 찾을 수 없음" >&2; exit 1; }
+
+exec "$RUNTIME_CLI" "$@"


### PR DESCRIPTION
## Summary
- rename the public runtime entrypoints to generic names (`runtime-bootstrap.sh`, `component-bridge.mjs`, `runtime-cli.sh`)
- switch npm/docs/prompts to the generic runtime surface and `PATINA_RUNTIME_CLI`
- remove provider-branded strings from the tracked repository surface

## Verification
- `bash -n scripts/runtime-cli.sh scripts/bot.sh scripts/harness.sh scripts/runtime-bootstrap.sh`
- `node --check scripts/component-bridge.mjs`
- `npm run runtime:status` with temporary `PATINA_RUNTIME_CLI=/bin/echo`
- `rg -n 'openclaw|OpenClaw|OPENCLAW' .`

## Risk
- local `.env` must include `PATINA_RUNTIME_CLI`
- end-to-end runtime bootstrap/bridge execution against the real gateway was not re-run in this branch
