### PR TITLE
feat: Add one-liner install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ ln -snf ~/.claude/skills/patina/patina-max ~/.claude/skills/patina-max
 
 Claude Code will detect `/patina` automatically. Add the symlink step as well if you want `/patina-max` exposed as a separate skill.
 
+### Quick Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
+```
+
+This handles everything: creates the skills directory, clones the repo, and sets up the patina-max symlink. Safe to run again to update.
+
 ## Use
 
 In Claude Code, type:

--- a/README_KR.md
+++ b/README_KR.md
@@ -35,6 +35,14 @@ ln -snf ~/.claude/skills/patina/patina-max ~/.claude/skills/patina-max
 
 Claude Code는 `/patina`를 자동 인식합니다. `/patina-max`까지 쓰려면 symlink 단계도 함께 실행하세요.
 
+### 빠른 설치
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
+```
+
+스킬 디렉토리 생성, 저장소 클론, patina-max 심링크 설정까지 한 번에 처리합니다. 이미 설치된 경우 다시 실행하면 최신 버전으로 업데이트됩니다.
+
 ## 사용법
 
 Claude Code에서 입력:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# install.sh - Install patina as a Claude Code skill
+# Usage: curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
+set -e
+
+SKILLS_DIR="${HOME}/.claude/skills"
+PATINA_DIR="${SKILLS_DIR}/patina"
+REPO_URL="https://github.com/devswha/patina.git"
+
+# Colors (only when outputting to a terminal)
+if [ -t 1 ]; then
+  GREEN='\033[0;32m'
+  RED='\033[0;31m'
+  BOLD='\033[1m'
+  RESET='\033[0m'
+else
+  GREEN=''
+  RED=''
+  BOLD=''
+  RESET=''
+fi
+
+info() {
+  printf "%b\n" "${BOLD}$1${RESET}"
+}
+
+success() {
+  printf "%b\n" "${GREEN}$1${RESET}"
+}
+
+error() {
+  printf "%b\n" "${RED}Error: $1${RESET}" >&2
+  exit 1
+}
+
+# Check prerequisites
+command -v git >/dev/null 2>&1 || error "git is not installed. Please install git first."
+
+# Create skills directory
+if [ ! -d "${SKILLS_DIR}" ]; then
+  info "Creating ${SKILLS_DIR}..."
+  mkdir -p "${SKILLS_DIR}"
+fi
+
+# Clone or pull patina
+if [ -d "${PATINA_DIR}/.git" ]; then
+  info "Updating existing patina installation..."
+  cd "${PATINA_DIR}"
+  git pull --ff-only || error "Failed to update patina. You may have local changes."
+else
+  if [ -d "${PATINA_DIR}" ]; then
+    error "${PATINA_DIR} exists but is not a git repo. Remove it and try again."
+  fi
+  info "Cloning patina..."
+  git clone "${REPO_URL}" "${PATINA_DIR}" || error "Failed to clone patina. Check your network connection."
+fi
+
+# Create symlink for patina-max
+info "Linking patina-max skill..."
+ln -snf "${PATINA_DIR}/patina-max" "${SKILLS_DIR}/patina-max"
+
+# Done
+printf "\n"
+success "patina installed successfully!"
+printf "\n"
+info "Usage:"
+printf "  /patina              Humanize Korean text\n"
+printf "  /patina --lang en    Humanize English text\n"
+printf "  /patina-max          Multi-model humanization\n"
+printf "\n"


### PR DESCRIPTION
## Summary

- Add `install.sh` for one-liner installation via `curl -fsSL ... | bash`
- POSIX-compatible (`sh`), idempotent (safe to run multiple times -- clones on first run, pulls on subsequent runs)
- Handles errors gracefully: checks for git, validates directories, reports network failures
- Add "Quick Install" section to both `README.md` and `README_KR.md`

## What the script does

```bash
curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
```

1. Creates `~/.claude/skills` if it doesn't exist
2. Clones patina to `~/.claude/skills/patina` (or `git pull` if already installed)
3. Creates symlink: `~/.claude/skills/patina-max` -> `~/.claude/skills/patina/patina-max`
4. Prints usage instructions

## Test plan

- [ ] Run `sh -n install.sh` to verify POSIX syntax (passed)
- [ ] Fresh install: remove `~/.claude/skills/patina` and run the script
- [ ] Update path: run the script again with existing installation
- [ ] Verify `install.sh` has executable permission (`chmod +x`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)