### PR TITLE
docs: sync Standalone CLI section to KR/JA/ZH READMEs

### DIFF
--- a/README_JA.md
+++ b/README_JA.md
@@ -45,6 +45,43 @@ curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | ba
 
 スキルディレクトリの作成、リポジトリのクローン、patina-max シンボリックリンクの設定をすべて自動で行います。更新時に再実行しても安全です。
 
+### スタンドアロン CLI
+
+Patina は Node.js ベースのスタンドアロン CLI としても動作します。ターミナル、シェルスクリプト、CI/CD パイプラインなど、どこでも利用できます。
+
+**要件:** Node.js ≥ 18
+
+**ローカルインストール:**
+```bash
+git clone https://github.com/devswha/patina.git
+cd patina
+npm install
+npm link        # `patina` コマンドをグローバルで使えるようにします
+```
+
+**インストールせずに実行:**
+```bash
+node bin/patina.js --lang en input.txt
+```
+
+**環境変数:**
+```bash
+export PATINA_API_KEY="your-api-key"
+export PATINA_API_BASE="https://api.openai.com/v1"  # またはプロキシ
+export PATINA_MODEL="gpt-4o"                        # デフォルトモデル
+```
+
+**CLI の使い方:**
+```bash
+patina --lang en --profile blog input.txt
+patina --lang ko --score input.txt
+patina --lang en --ouroboros input.txt
+patina --lang en --models gpt-4o,claude-sonnet input.txt  # MAX モード
+patina --batch docs/*.md --suffix .humanized
+```
+
+全オプションは `patina --help` で確認できます。
+
 ## 使い方
 
 Claude Code で以下のように入力します：

--- a/README_KR.md
+++ b/README_KR.md
@@ -45,6 +45,43 @@ curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | ba
 
 스킬 디렉토리 생성, 저장소 클론, patina-max 심볼릭 링크 설정까지 한 번에 처리합니다. 업데이트할 때 다시 실행해도 안전합니다.
 
+### 독립형 CLI
+
+Patina는 Node.js 기반 독립형 CLI로도 동작합니다. 터미널, 셸 스크립트, CI/CD 파이프라인 어디서든 쓸 수 있습니다.
+
+**요구사항:** Node.js ≥ 18
+
+**로컬 설치:**
+```bash
+git clone https://github.com/devswha/patina.git
+cd patina
+npm install
+npm link        # `patina` 명령어를 전역에서 사용 가능하게 만듭니다
+```
+
+**설치 없이 바로 실행:**
+```bash
+node bin/patina.js --lang en input.txt
+```
+
+**환경 변수:**
+```bash
+export PATINA_API_KEY="your-api-key"
+export PATINA_API_BASE="https://api.openai.com/v1"  # 또는 프록시 주소
+export PATINA_MODEL="gpt-4o"                        # 기본 모델
+```
+
+**CLI 사용 예시:**
+```bash
+patina --lang en --profile blog input.txt
+patina --lang ko --score input.txt
+patina --lang en --ouroboros input.txt
+patina --lang en --models gpt-4o,claude-sonnet input.txt  # MAX 모드
+patina --batch docs/*.md --suffix .humanized
+```
+
+전체 옵션은 `patina --help`로 확인하세요.
+
 ## 사용법
 
 Claude Code에서 다음과 같이 입력하세요:

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -45,6 +45,43 @@ curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | ba
 
 一键完成：创建技能目录、克隆仓库、设置 patina-max 符号链接。已安装的情况下再次运行即可更新到最新版本。
 
+### 独立 CLI
+
+Patina 也可以作为独立的 Node.js CLI 工具使用，可在任意终端、Shell 脚本或 CI/CD 流水线中调用。
+
+**环境要求：** Node.js ≥ 18
+
+**本地安装：**
+```bash
+git clone https://github.com/devswha/patina.git
+cd patina
+npm install
+npm link        # 让 `patina` 命令全局可用
+```
+
+**无需安装直接运行：**
+```bash
+node bin/patina.js --lang en input.txt
+```
+
+**环境变量：**
+```bash
+export PATINA_API_KEY="your-api-key"
+export PATINA_API_BASE="https://api.openai.com/v1"  # 或自建代理
+export PATINA_MODEL="gpt-4o"                        # 默认模型
+```
+
+**CLI 用法：**
+```bash
+patina --lang en --profile blog input.txt
+patina --lang ko --score input.txt
+patina --lang en --ouroboros input.txt
+patina --lang en --models gpt-4o,claude-sonnet input.txt  # MAX 模式
+patina --batch docs/*.md --suffix .humanized
+```
+
+完整选项请运行 `patina --help` 查看。
+
 ## 使用方法
 
 在 Claude Code 中输入：


### PR DESCRIPTION
## Summary
- Add the `### Standalone CLI` section (npm install + npm link, env vars, CLI usage examples, batch mode) to `README_KR.md`, `README_JA.md`, `README_ZH.md`
- Translations match the English original (lines 48-83) — same structure, faithful wording in Korean / Japanese / Chinese
- Closes the doc-sync gap flagged by the project rule in CLAUDE.md: *"When updating an English doc, always sync its `_KR` counterpart"*

## Test plan
- [x] All 4 READMEs now contain the Standalone CLI section (verified via grep)
- [x] Section inserted between `### Quick Install` and `## Use` — same position as English README
- [x] No other content changed (only +37 lines per translated file)
- [ ] Spot-check translation tone (KR / JA / ZH speakers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)