### PR TITLE
chore: clarify standalone CLI MAX mode and quality-test.js dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ npm install
 npm link        # makes `patina` available globally
 ```
 
+> Already ran the quick install above? The repo is already at `~/.claude/skills/patina`. Just `cd ~/.claude/skills/patina && npm install && npm link` instead of cloning again.
+
 **Or use without installing:**
 ```bash
 node bin/patina.js --lang en input.txt
@@ -76,9 +78,11 @@ export PATINA_MODEL="gpt-4o"                        # default model
 patina --lang en --profile blog input.txt
 patina --lang ko --score input.txt
 patina --lang en --ouroboros input.txt
-patina --lang en --models gpt-4o,claude-sonnet input.txt  # MAX mode
+patina --lang en --models gpt-4o,gpt-4o-mini input.txt  # MAX mode
 patina --batch docs/*.md --suffix .humanized
 ```
+
+> `--models` calls each listed model via the same `--base-url` endpoint, so all models must be served by that endpoint. To mix providers (OpenAI + Anthropic + Google), point `--base-url` at a multi-provider gateway like OpenRouter. The separate `/patina-max` Claude Code skill dispatches via local `claude`, `codex`, and `gemini` CLIs instead — no API key needed.
 
 See `patina --help` for all options.
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -59,6 +59,8 @@ npm install
 npm link        # `patina` コマンドをグローバルで使えるようにします
 ```
 
+> 既に上のクイックインストールを実行済みの場合、リポジトリは `~/.claude/skills/patina` にあります。再クローンせずに `cd ~/.claude/skills/patina && npm install && npm link` を実行してください。
+
 **インストールせずに実行:**
 ```bash
 node bin/patina.js --lang en input.txt
@@ -76,9 +78,11 @@ export PATINA_MODEL="gpt-4o"                        # デフォルトモデル
 patina --lang en --profile blog input.txt
 patina --lang ko --score input.txt
 patina --lang en --ouroboros input.txt
-patina --lang en --models gpt-4o,claude-sonnet input.txt  # MAX モード
+patina --lang en --models gpt-4o,gpt-4o-mini input.txt  # MAX モード
 patina --batch docs/*.md --suffix .humanized
 ```
+
+> `--models` は列挙したすべてのモデルを同じ `--base-url` エンドポイントに対して呼び出します。複数プロバイダ（OpenAI + Anthropic + Google）を混在させたい場合は、OpenRouter のようなマルチプロバイダゲートウェイに `--base-url` を向けてください。別パスの `/patina-max` Claude Code スキルはローカルの `claude`、`codex`、`gemini` CLI 経由でディスパッチするため、API キーは不要です。
 
 全オプションは `patina --help` で確認できます。
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -59,6 +59,8 @@ npm install
 npm link        # `patina` 명령어를 전역에서 사용 가능하게 만듭니다
 ```
 
+> 이미 위의 빠른 설치를 실행했다면 `~/.claude/skills/patina`에 저장소가 있습니다. 다시 클론하지 말고 `cd ~/.claude/skills/patina && npm install && npm link`로 진행하세요.
+
 **설치 없이 바로 실행:**
 ```bash
 node bin/patina.js --lang en input.txt
@@ -76,9 +78,11 @@ export PATINA_MODEL="gpt-4o"                        # 기본 모델
 patina --lang en --profile blog input.txt
 patina --lang ko --score input.txt
 patina --lang en --ouroboros input.txt
-patina --lang en --models gpt-4o,claude-sonnet input.txt  # MAX 모드
+patina --lang en --models gpt-4o,gpt-4o-mini input.txt  # MAX 모드
 patina --batch docs/*.md --suffix .humanized
 ```
+
+> `--models`는 나열된 모든 모델을 같은 `--base-url` 엔드포인트로 호출합니다. 여러 프로바이더(OpenAI + Anthropic + Google)를 섞으려면 OpenRouter 같은 멀티 프로바이더 게이트웨이로 `--base-url`을 가리키세요. 별도의 `/patina-max` Claude Code 스킬은 로컬 `claude`, `codex`, `gemini` CLI로 디스패치하므로 API 키가 필요하지 않습니다.
 
 전체 옵션은 `patina --help`로 확인하세요.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -59,6 +59,8 @@ npm install
 npm link        # 让 `patina` 命令全局可用
 ```
 
+> 如果已经执行过上方的快速安装，仓库位于 `~/.claude/skills/patina`，无需再次克隆。直接 `cd ~/.claude/skills/patina && npm install && npm link` 即可。
+
 **无需安装直接运行：**
 ```bash
 node bin/patina.js --lang en input.txt
@@ -76,9 +78,11 @@ export PATINA_MODEL="gpt-4o"                        # 默认模型
 patina --lang en --profile blog input.txt
 patina --lang ko --score input.txt
 patina --lang en --ouroboros input.txt
-patina --lang en --models gpt-4o,claude-sonnet input.txt  # MAX 模式
+patina --lang en --models gpt-4o,gpt-4o-mini input.txt  # MAX 模式
 patina --batch docs/*.md --suffix .humanized
 ```
+
+> `--models` 通过同一个 `--base-url` 端点调用所列出的全部模型，因此该端点必须支持所有模型。要混用多家提供商（OpenAI + Anthropic + Google），请将 `--base-url` 指向 OpenRouter 等多提供商网关。另一条路径 `/patina-max` Claude Code 技能通过本地 `claude`、`codex`、`gemini` CLI 调度，无需 API 密钥。
 
 完整选项请运行 `patina --help` 查看。
 

--- a/tests/e2e/quality-test.js
+++ b/tests/e2e/quality-test.js
@@ -1,6 +1,18 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync } from 'node:fs';
+/**
+ * Quality test — opt-in script (NOT part of `npm test`).
+ *
+ * Builds a patina prompt for an AI-generated paragraph, runs it through
+ * `opencode run -m opencode/hy3-preview-free`, and grades the rewrite on
+ * AI-buzzword removal, fact preservation, length sanity, personal voice,
+ * and sentence variety.
+ *
+ * Requires the `opencode` CLI to be installed and authenticated.
+ * Run with: `node tests/e2e/quality-test.js`
+ */
+
+import { writeFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';


### PR DESCRIPTION
## Summary
Post-merge verification of the new standalone CLI (PR #66 + earlier `b276dbe`) surfaced three documentation gaps. No behavior changes — code/tests untouched.

- **README MAX mode example**: `--models gpt-4o,claude-sonnet` implied OpenAI's endpoint serves both, which it doesn't. Switched to `gpt-4o,gpt-4o-mini` (both real OpenAI models) and added a note about multi-provider gateways. Also pointed at the separate `/patina-max` Claude Code skill as the no-API-key local-CLI path.
- **README "Standalone CLI" section**: `git clone` instructions ignored that the quick-install script already cloned the repo to `~/.claude/skills/patina`. Added a hint about reusing that checkout (`cd ~/.claude/skills/patina && npm install && npm link`).
- **`tests/e2e/quality-test.js`**: opt-in script that requires the `opencode` CLI (not in `npm test` glob, not in CI). Added a header docstring documenting the dependency. Drive-by: removed an unused `readFileSync` import flagged by the linter.

KR/JA/ZH READMEs synced to match.

## Test plan
- [x] `npm test` — 21/21 pass
- [x] `git diff --stat` — 5 files, +33 -5
- [x] All 4 READMEs have consistent MAX/`--models` mentions (13 each)
- [x] `bin/patina.js --help` and `--version` still respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)