### PR TITLE
feat: add codex-cli backend to standalone CLI (Issue #69 v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ patina --batch docs/*.md --suffix .humanized
 
 > `--models` calls each listed model via the same `--base-url` endpoint, so all models must be served by that endpoint. To mix providers (OpenAI + Anthropic + Google), point `--base-url` at a multi-provider gateway like OpenRouter. The separate `/patina-max` Claude Code skill dispatches via local `claude`, `codex`, and `gemini` CLIs instead — no API key needed.
 
+**Backends (run without an API key):**
+```bash
+patina --list-backends                                    # list backends + availability
+patina --backend codex-cli --lang ko input.txt            # uses local codex CLI
+patina --model codex --lang ko input.txt                  # same — auto-routes by model name
+```
+
+> `codex-cli` backend dispatches via the local [`codex`](https://github.com/openai/codex) CLI, which authenticates via OpenAI/ChatGPT OAuth — no `PATINA_API_KEY` needed. Single-mode rewrites only (`--audit`, `--score`, `--diff`, `--ouroboros`, `--models`/MAX still go through the HTTP backend in v1).
+
 See `patina --help` for all options.
 
 ## Use

--- a/README_JA.md
+++ b/README_JA.md
@@ -84,6 +84,15 @@ patina --batch docs/*.md --suffix .humanized
 
 > `--models` は列挙したすべてのモデルを同じ `--base-url` エンドポイントに対して呼び出します。複数プロバイダ（OpenAI + Anthropic + Google）を混在させたい場合は、OpenRouter のようなマルチプロバイダゲートウェイに `--base-url` を向けてください。別パスの `/patina-max` Claude Code スキルはローカルの `claude`、`codex`、`gemini` CLI 経由でディスパッチするため、API キーは不要です。
 
+**バックエンド（API キーなしで実行）:**
+```bash
+patina --list-backends                                    # バックエンド一覧と可用性を表示
+patina --backend codex-cli --lang ko input.txt            # ローカル codex CLI を使用
+patina --model codex --lang ko input.txt                  # 同上 — モデル名から自動ルーティング
+```
+
+> `codex-cli` バックエンドはローカルの [`codex`](https://github.com/openai/codex) CLI 経由でディスパッチします。codex は OpenAI/ChatGPT OAuth で認証するため、`PATINA_API_KEY` は不要です。v1 では単一モードの書き換えのみ対応し、`--audit`、`--score`、`--diff`、`--ouroboros`、`--models`/MAX は引き続き HTTP バックエンドを使用します。
+
 全オプションは `patina --help` で確認できます。
 
 ## 使い方

--- a/README_KR.md
+++ b/README_KR.md
@@ -84,6 +84,15 @@ patina --batch docs/*.md --suffix .humanized
 
 > `--models`는 나열된 모든 모델을 같은 `--base-url` 엔드포인트로 호출합니다. 여러 프로바이더(OpenAI + Anthropic + Google)를 섞으려면 OpenRouter 같은 멀티 프로바이더 게이트웨이로 `--base-url`을 가리키세요. 별도의 `/patina-max` Claude Code 스킬은 로컬 `claude`, `codex`, `gemini` CLI로 디스패치하므로 API 키가 필요하지 않습니다.
 
+**백엔드 (API 키 없이 실행):**
+```bash
+patina --list-backends                                    # 백엔드 목록과 가용성 표시
+patina --backend codex-cli --lang ko input.txt            # 로컬 codex CLI 사용
+patina --model codex --lang ko input.txt                  # 동일 — 모델명으로 자동 라우팅
+```
+
+> `codex-cli` 백엔드는 로컬 [`codex`](https://github.com/openai/codex) CLI로 디스패치합니다. codex는 OpenAI/ChatGPT OAuth로 인증하므로 `PATINA_API_KEY`가 필요 없습니다. v1에서는 단일 모드 재작성만 지원하며, `--audit`, `--score`, `--diff`, `--ouroboros`, `--models`/MAX는 여전히 HTTP 백엔드를 사용합니다.
+
 전체 옵션은 `patina --help`로 확인하세요.
 
 ## 사용법

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -84,6 +84,15 @@ patina --batch docs/*.md --suffix .humanized
 
 > `--models` 通过同一个 `--base-url` 端点调用所列出的全部模型，因此该端点必须支持所有模型。要混用多家提供商（OpenAI + Anthropic + Google），请将 `--base-url` 指向 OpenRouter 等多提供商网关。另一条路径 `/patina-max` Claude Code 技能通过本地 `claude`、`codex`、`gemini` CLI 调度，无需 API 密钥。
 
+**后端（无需 API 密钥即可运行）：**
+```bash
+patina --list-backends                                    # 列出后端及其可用性
+patina --backend codex-cli --lang ko input.txt            # 使用本地 codex CLI
+patina --model codex --lang ko input.txt                  # 同上 — 根据模型名称自动路由
+```
+
+> `codex-cli` 后端通过本地 [`codex`](https://github.com/openai/codex) CLI 调度，由 OpenAI/ChatGPT OAuth 完成认证，因此无需 `PATINA_API_KEY`。v1 仅支持单模式改写，`--audit`、`--score`、`--diff`、`--ouroboros`、`--models`/MAX 仍走 HTTP 后端。
+
 完整选项请运行 `patina --help` 查看。
 
 ## 使用方法

--- a/src/backends/codex-cli.js
+++ b/src/backends/codex-cli.js
@@ -1,0 +1,77 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export const name = 'codex-cli';
+
+export function isAvailable() {
+  try {
+    const result = spawnSync('codex', ['--version'], { stdio: 'ignore' });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function invoke({ prompt, timeout = 180000 } = {}) {
+  if (!prompt || typeof prompt !== 'string') {
+    throw new Error('codex-cli backend: prompt must be a non-empty string');
+  }
+
+  const dir = mkdtempSync(join(tmpdir(), 'patina-codex-'));
+  const outFile = join(dir, 'last-message.txt');
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn('codex', [
+      'exec',
+      '--skip-git-repo-check',
+      '--output-last-message', outFile,
+    ], { stdio: ['pipe', 'pipe', 'pipe'] });
+
+    let stderr = '';
+    proc.stderr.on('data', (chunk) => { stderr += chunk; });
+
+    const timer = setTimeout(() => {
+      proc.kill('SIGKILL');
+      cleanup();
+      reject(new Error(`codex-cli backend: timed out after ${timeout}ms`));
+    }, timeout);
+
+    proc.on('error', (err) => {
+      clearTimeout(timer);
+      cleanup();
+      if (err.code === 'ENOENT') {
+        reject(new Error('codex-cli backend: `codex` CLI not found. Install it from https://github.com/openai/codex'));
+      } else {
+        reject(new Error(`codex-cli backend: failed to spawn codex (${err.message})`));
+      }
+    });
+
+    proc.on('close', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        cleanup();
+        reject(new Error(`codex-cli backend: codex exited with code ${code}\n${stderr}`));
+        return;
+      }
+
+      try {
+        const content = readFileSync(outFile, 'utf8');
+        cleanup();
+        resolve(content);
+      } catch (err) {
+        cleanup();
+        reject(new Error(`codex-cli backend: failed to read output file (${err.message})`));
+      }
+    });
+
+    proc.stdin.write(prompt);
+    proc.stdin.end();
+
+    function cleanup() {
+      try { rmSync(dir, { recursive: true, force: true }); } catch {}
+    }
+  });
+}
+

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -1,0 +1,37 @@
+import { callLLM } from '../api.js';
+import * as codexCli from './codex-cli.js';
+
+const openaiHttp = {
+  name: 'openai-http',
+  isAvailable: () => true,
+  invoke: ({ prompt, apiKey, baseURL, model, timeout }) =>
+    callLLM({ prompt, apiKey, baseURL, model, timeout }),
+};
+
+const REGISTRY = {
+  'openai-http': openaiHttp,
+  'codex-cli': codexCli,
+};
+
+export function listBackends() {
+  return Object.keys(REGISTRY).map((key) => ({
+    name: key,
+    available: REGISTRY[key].isAvailable(),
+  }));
+}
+
+export function selectBackend({ name, model } = {}) {
+  if (name) {
+    const backend = REGISTRY[name];
+    if (!backend) {
+      throw new Error(`Unknown backend: ${name}. Available: ${Object.keys(REGISTRY).join(', ')}`);
+    }
+    return backend;
+  }
+
+  if (model && /^codex(-|$)/i.test(model)) {
+    return REGISTRY['codex-cli'];
+  }
+
+  return REGISTRY['openai-http'];
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
 import { loadConfig, getRepoRoot } from './config.js';
 import { loadPatterns, loadProfile, loadCoreFile, loadInputText } from './loader.js';
 import { buildPrompt } from './prompt-builder.js';
-import { callLLM, callLLMMultiple } from './api.js';
+import { selectBackend, listBackends } from './backends/index.js';
 import { formatOutput } from './output.js';
 import { runMaxMode } from './max-mode.js';
 import { runOuroboros } from './ouroboros.js';
@@ -18,6 +18,13 @@ export async function main(args) {
 
   if (parsed.version) {
     console.log('patina 3.3.0');
+    return;
+  }
+
+  if (parsed.listBackends) {
+    for (const b of listBackends()) {
+      console.log(`${b.name}\t${b.available ? 'available' : 'not installed'}`);
+    }
     return;
   }
 
@@ -80,7 +87,8 @@ export async function main(args) {
       });
     } else {
       const model = parsed.model || process.env.PATINA_MODEL || 'gpt-4o';
-      result = await callLLM({
+      const backend = selectBackend({ name: parsed.backend, model });
+      result = await backend.invoke({
         prompt,
         apiKey: parsed.apiKey || process.env.PATINA_API_KEY,
         baseURL: parsed.baseURL || process.env.PATINA_API_BASE || 'https://api.openai.com/v1',
@@ -163,6 +171,12 @@ function parseArgs(args) {
         break;
       case '--dispatch':
         parsed.dispatch = args[++i];
+        break;
+      case '--backend':
+        parsed.backend = args[++i];
+        break;
+      case '--list-backends':
+        parsed.listBackends = true;
         break;
       default:
         if (!arg.startsWith('-')) {
@@ -271,6 +285,8 @@ Options:
   --api-key <key>      API key (or PATINA_API_KEY env)
   --base-url <url>     API base URL (or PATINA_API_BASE env)
   --dispatch <mode>    MAX dispatch: omc, direct, api
+  --backend <name>     Backend: openai-http (default), codex-cli (no API key)
+  --list-backends      List available backends and their availability
 
 Environment Variables:
   PATINA_API_KEY       API authentication key

--- a/tests/e2e/backends.test.js
+++ b/tests/e2e/backends.test.js
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { selectBackend, listBackends } from '../../src/backends/index.js';
+import { isAvailable as codexAvailable } from '../../src/backends/codex-cli.js';
+
+describe('Backend Selection', () => {
+  it('selects openai-http by default when no model and no name given', () => {
+    const b = selectBackend({});
+    assert.strictEqual(b.name, 'openai-http');
+  });
+
+  it('selects openai-http for unrelated models like gpt-4o', () => {
+    const b = selectBackend({ model: 'gpt-4o' });
+    assert.strictEqual(b.name, 'openai-http');
+  });
+
+  it('selects codex-cli when --backend codex-cli is explicit', () => {
+    const b = selectBackend({ name: 'codex-cli' });
+    assert.strictEqual(b.name, 'codex-cli');
+  });
+
+  it('selects openai-http when --backend openai-http is explicit', () => {
+    const b = selectBackend({ name: 'openai-http' });
+    assert.strictEqual(b.name, 'openai-http');
+  });
+
+  it('routes --model codex to codex-cli via heuristic', () => {
+    const b = selectBackend({ model: 'codex' });
+    assert.strictEqual(b.name, 'codex-cli');
+  });
+
+  it('routes --model codex-mini-latest to codex-cli via prefix', () => {
+    const b = selectBackend({ model: 'codex-mini-latest' });
+    assert.strictEqual(b.name, 'codex-cli');
+  });
+
+  it('does not match `codexa` or other false positives', () => {
+    const b = selectBackend({ model: 'codexa-1.0' });
+    assert.strictEqual(b.name, 'openai-http');
+  });
+
+  it('explicit --backend overrides --model heuristic', () => {
+    const b = selectBackend({ name: 'openai-http', model: 'codex' });
+    assert.strictEqual(b.name, 'openai-http');
+  });
+
+  it('throws on unknown backend name', () => {
+    assert.throws(() => selectBackend({ name: 'invented-backend' }), /Unknown backend/);
+  });
+});
+
+describe('Backend Listing', () => {
+  it('returns at least openai-http and codex-cli', () => {
+    const list = listBackends();
+    const names = list.map((b) => b.name);
+    assert.ok(names.includes('openai-http'));
+    assert.ok(names.includes('codex-cli'));
+  });
+
+  it('reports openai-http as always available (HTTP, no install check)', () => {
+    const list = listBackends();
+    const http = list.find((b) => b.name === 'openai-http');
+    assert.strictEqual(http.available, true);
+  });
+
+  it('reports codex-cli availability based on actual install', () => {
+    const list = listBackends();
+    const codex = list.find((b) => b.name === 'codex-cli');
+    assert.strictEqual(codex.available, codexAvailable());
+  });
+});


### PR DESCRIPTION
Closes the v1 phase of #69.

## Summary
- New `src/backends/` abstraction with two implementations: `openai-http` (wraps existing `api.js`, default) and `codex-cli` (spawns local `codex exec --skip-git-repo-check --output-last-message <tmpfile>`, pipes prompt via stdin).
- New CLI flags: `--backend <name>` (explicit selection) and `--list-backends` (lists registered backends + availability check).
- Heuristic in `selectBackend`: explicit `--backend` wins → else `--model codex*` routes to `codex-cli` → else `openai-http`.
- v1 scope: only single-mode rewrites use the backend abstraction. `--audit`, `--score`, `--diff`, `--ouroboros`, and `--models`/MAX still go through the HTTP backend (documented in READMEs and the issue phasing).

## Verified end-to-end
Real run on a 189-char Korean AI sample (no API key, codex OAuth):
```
$ patina --backend codex-cli --lang ko /tmp/sample.txt
요즘 커피는 그냥 마시는 걸로 끝나지 않는다. 누군가에겐 출근 전 루틴이고,
누군가에겐 친구를 만나는 핑계다. 카페는 조용히 일하는 사람, 오래 수다 떠는
사람, 잠깐 숨 돌리러 들어온 사람이 뒤섞이는 공간이 됐다.
...
```
~9s wall, all canonical AI patterns removed (`~다는 점`, `주목할 만`, `의미 있는 교류`, `지속될 것으로 전망`, 격식체→평어체, 추상→구체).

## Test plan
- [x] `npm test` — 33 / 33 pass (12 new unit tests in `backends.test.js` + 21 existing)
- [x] `node bin/patina.js --help` shows new flags
- [x] `node bin/patina.js --list-backends` shows `openai-http available` + `codex-cli available`
- [x] Real e2e run with `--backend codex-cli` produces valid humanized output
- [x] README + KR / JA / ZH translations synced

## Out of scope (v2+, tracked in #69)
- claude-cli, gemini-cli backends
- Mixed-backend MAX mode
- `patina doctor` health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)