### PR TITLE
feat(auth): patina auth subcommands + codex-cli auto-fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,15 @@ patina --batch docs/*.md --suffix .humanized
 
 **Backends (run without an API key):**
 ```bash
-patina --list-backends                                    # list backends + availability
-patina --backend codex-cli --lang ko input.txt            # uses local codex CLI
+patina auth status                                        # show backend availability + authentication
+patina auth login                                         # per-backend instructions for authenticating
+patina --backend codex-cli --lang ko input.txt            # uses local codex CLI explicitly
 patina --model codex --lang ko input.txt                  # same — auto-routes by model name
+patina --lang ko input.txt                                # auto-fallback: if no PATINA_API_KEY and
+                                                          # codex is logged in, patina uses it for free
 ```
 
-> `codex-cli` backend dispatches via the local [`codex`](https://github.com/openai/codex) CLI, which authenticates via OpenAI/ChatGPT OAuth — no `PATINA_API_KEY` needed. Single-mode rewrites only (`--audit`, `--score`, `--diff`, `--ouroboros`, `--models`/MAX still go through the HTTP backend in v1).
+> `codex-cli` backend dispatches via the local [`codex`](https://github.com/openai/codex) CLI, which authenticates via OpenAI/ChatGPT OAuth — no `PATINA_API_KEY` needed. Run `codex login` once and patina picks it up automatically. Single-mode rewrites only (`--audit`, `--score`, `--diff`, `--ouroboros`, `--models`/MAX still go through the HTTP backend in v1).
 
 See `patina --help` for all options.
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -88,12 +88,15 @@ patina --batch docs/*.md --suffix .humanized
 
 **バックエンド（API キーなしで実行）:**
 ```bash
-patina --list-backends                                    # バックエンド一覧と可用性を表示
-patina --backend codex-cli --lang ko input.txt            # ローカル codex CLI を使用
+patina auth status                                        # バックエンドの可用性 + 認証状態を表示
+patina auth login                                         # バックエンド別の認証手順
+patina --backend codex-cli --lang ko input.txt            # ローカル codex CLI を明示的に使用
 patina --model codex --lang ko input.txt                  # 同上 — モデル名から自動ルーティング
+patina --lang ko input.txt                                # 自動フォールバック: PATINA_API_KEY が未設定で
+                                                          # codex がログイン済みなら無料で使用
 ```
 
-> `codex-cli` バックエンドはローカルの [`codex`](https://github.com/openai/codex) CLI 経由でディスパッチします。codex は OpenAI/ChatGPT OAuth で認証するため、`PATINA_API_KEY` は不要です。v1 では単一モードの書き換えのみ対応し、`--audit`、`--score`、`--diff`、`--ouroboros`、`--models`/MAX は引き続き HTTP バックエンドを使用します。
+> `codex-cli` バックエンドはローカルの [`codex`](https://github.com/openai/codex) CLI 経由でディスパッチします。codex は OpenAI/ChatGPT OAuth で認証するため、`PATINA_API_KEY` は不要です。一度 `codex login` を実行すれば patina が自動で認識します。v1 では単一モードの書き換えのみ対応し、`--audit`、`--score`、`--diff`、`--ouroboros`、`--models`/MAX は引き続き HTTP バックエンドを使用します。
 
 全オプションは `patina --help` で確認できます。
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -88,12 +88,15 @@ patina --batch docs/*.md --suffix .humanized
 
 **백엔드 (API 키 없이 실행):**
 ```bash
-patina --list-backends                                    # 백엔드 목록과 가용성 표시
-patina --backend codex-cli --lang ko input.txt            # 로컬 codex CLI 사용
+patina auth status                                        # 백엔드 가용성 + 인증 상태 표시
+patina auth login                                         # 백엔드별 인증 안내
+patina --backend codex-cli --lang ko input.txt            # 로컬 codex CLI 명시적 사용
 patina --model codex --lang ko input.txt                  # 동일 — 모델명으로 자동 라우팅
+patina --lang ko input.txt                                # 자동 fallback: PATINA_API_KEY가 없고
+                                                          # codex가 로그인돼 있으면 무료로 사용
 ```
 
-> `codex-cli` 백엔드는 로컬 [`codex`](https://github.com/openai/codex) CLI로 디스패치합니다. codex는 OpenAI/ChatGPT OAuth로 인증하므로 `PATINA_API_KEY`가 필요 없습니다. v1에서는 단일 모드 재작성만 지원하며, `--audit`, `--score`, `--diff`, `--ouroboros`, `--models`/MAX는 여전히 HTTP 백엔드를 사용합니다.
+> `codex-cli` 백엔드는 로컬 [`codex`](https://github.com/openai/codex) CLI로 디스패치합니다. codex는 OpenAI/ChatGPT OAuth로 인증하므로 `PATINA_API_KEY`가 필요 없습니다. `codex login`을 한 번 하면 patina가 자동으로 인식합니다. v1에서는 단일 모드 재작성만 지원하며, `--audit`, `--score`, `--diff`, `--ouroboros`, `--models`/MAX는 여전히 HTTP 백엔드를 사용합니다.
 
 전체 옵션은 `patina --help`로 확인하세요.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -88,12 +88,15 @@ patina --batch docs/*.md --suffix .humanized
 
 **后端（无需 API 密钥即可运行）：**
 ```bash
-patina --list-backends                                    # 列出后端及其可用性
-patina --backend codex-cli --lang ko input.txt            # 使用本地 codex CLI
-patina --model codex --lang ko input.txt                  # 同上 — 根据模型名称自动路由
+patina auth status                                        # 显示后端可用性 + 认证状态
+patina auth login                                         # 各后端的认证指引
+patina --backend codex-cli --lang ko input.txt            # 显式使用本地 codex CLI
+patina --model codex --lang ko input.txt                  # 同上 — 按模型名自动路由
+patina --lang ko input.txt                                # 自动回退：未设置 PATINA_API_KEY
+                                                          # 且 codex 已登录时免费使用
 ```
 
-> `codex-cli` 后端通过本地 [`codex`](https://github.com/openai/codex) CLI 调度，由 OpenAI/ChatGPT OAuth 完成认证，因此无需 `PATINA_API_KEY`。v1 仅支持单模式改写，`--audit`、`--score`、`--diff`、`--ouroboros`、`--models`/MAX 仍走 HTTP 后端。
+> `codex-cli` 后端通过本地 [`codex`](https://github.com/openai/codex) CLI 调度，由 OpenAI/ChatGPT OAuth 完成认证，因此无需 `PATINA_API_KEY`。运行一次 `codex login` 之后 patina 会自动识别。v1 仅支持单模式改写，`--audit`、`--score`、`--diff`、`--ouroboros`、`--models`/MAX 仍走 HTTP 后端。
 
 完整选项请运行 `patina --help` 查看。
 

--- a/src/backends/codex-cli.js
+++ b/src/backends/codex-cli.js
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 export const name = 'codex-cli';
@@ -12,6 +12,14 @@ export function isAvailable() {
   } catch {
     return false;
   }
+}
+
+export function isAuthenticated() {
+  return existsSync(join(homedir(), '.codex', 'auth.json'));
+}
+
+export function authHint() {
+  return 'Run `codex login` to authenticate (uses your ChatGPT Plus account, no API key needed).';
 }
 
 export async function invoke({ prompt, timeout = 180000 } = {}) {

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -4,6 +4,9 @@ import * as codexCli from './codex-cli.js';
 const openaiHttp = {
   name: 'openai-http',
   isAvailable: () => true,
+  isAuthenticated: () => Boolean(process.env.PATINA_API_KEY),
+  authHint: () =>
+    'Set PATINA_API_KEY (or pass --api-key). Get a key at https://platform.openai.com/api-keys.',
   invoke: ({ prompt, apiKey, baseURL, model, timeout }) =>
     callLLM({ prompt, apiKey, baseURL, model, timeout }),
 };
@@ -14,24 +17,35 @@ const REGISTRY = {
 };
 
 export function listBackends() {
-  return Object.keys(REGISTRY).map((key) => ({
-    name: key,
-    available: REGISTRY[key].isAvailable(),
-  }));
+  return Object.keys(REGISTRY).map((key) => {
+    const b = REGISTRY[key];
+    return {
+      name: key,
+      available: b.isAvailable(),
+      authenticated: b.isAuthenticated(),
+      authHint: b.authHint(),
+    };
+  });
 }
 
-export function selectBackend({ name, model } = {}) {
+export function selectBackend({ name, model, hasApiKey } = {}) {
   if (name) {
     const backend = REGISTRY[name];
     if (!backend) {
       throw new Error(`Unknown backend: ${name}. Available: ${Object.keys(REGISTRY).join(', ')}`);
     }
-    return backend;
+    return { backend, autoSelected: false, reason: 'explicit' };
   }
 
   if (model && /^codex(-|$)/i.test(model)) {
-    return REGISTRY['codex-cli'];
+    return { backend: REGISTRY['codex-cli'], autoSelected: false, reason: 'model heuristic' };
   }
 
-  return REGISTRY['openai-http'];
+  // Auto-fallback: no API key, but codex is installed and authenticated
+  const noKey = hasApiKey === false || (hasApiKey === undefined && !process.env.PATINA_API_KEY);
+  if (noKey && REGISTRY['codex-cli'].isAvailable() && REGISTRY['codex-cli'].isAuthenticated()) {
+    return { backend: REGISTRY['codex-cli'], autoSelected: true, reason: 'no API key; codex authenticated' };
+  }
+
+  return { backend: REGISTRY['openai-http'], autoSelected: false, reason: 'default' };
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,6 +9,10 @@ import { writeFileSync } from 'node:fs';
 import { resolve, basename, extname } from 'node:path';
 
 export async function main(args) {
+  if (args[0] === 'auth') {
+    return handleAuth(args.slice(1));
+  }
+
   const parsed = parseArgs(args);
 
   if (parsed.help) {
@@ -22,9 +26,7 @@ export async function main(args) {
   }
 
   if (parsed.listBackends) {
-    for (const b of listBackends()) {
-      console.log(`${b.name}\t${b.available ? 'available' : 'not installed'}`);
-    }
+    printBackendStatus();
     return;
   }
 
@@ -87,10 +89,31 @@ export async function main(args) {
       });
     } else {
       const model = parsed.model || process.env.PATINA_MODEL || 'gpt-4o';
-      const backend = selectBackend({ name: parsed.backend, model });
+      const apiKey = parsed.apiKey || process.env.PATINA_API_KEY;
+      const { backend, autoSelected, reason } = selectBackend({
+        name: parsed.backend,
+        model,
+        hasApiKey: Boolean(apiKey),
+      });
+
+      if (autoSelected) {
+        console.error(`[patina] Using ${backend.name} backend (${reason}). Run \`patina auth status\` for details.`);
+      }
+
+      if (backend.name === 'openai-http' && !apiKey) {
+        const msg = ['No API key found. Set PATINA_API_KEY or pass --api-key.'];
+        const codex = listBackends().find((b) => b.name === 'codex-cli');
+        if (codex && codex.available && !codex.authenticated) {
+          msg.push('Or run `codex login` to use the free codex-cli backend (no key needed).');
+        } else if (codex && !codex.available) {
+          msg.push('Or install `codex` from https://github.com/openai/codex to use the free codex-cli backend.');
+        }
+        throw new Error(msg.join('\n'));
+      }
+
       result = await backend.invoke({
         prompt,
-        apiKey: parsed.apiKey || process.env.PATINA_API_KEY,
+        apiKey,
         baseURL: parsed.baseURL || process.env.PATINA_API_BASE || 'https://api.openai.com/v1',
         model,
       });
@@ -292,5 +315,58 @@ Environment Variables:
   PATINA_API_KEY       API authentication key
   PATINA_API_BASE      API base URL (default: https://api.openai.com/v1)
   PATINA_MODEL         Default model ID
+
+Subcommands:
+  patina auth status   Show backend availability and authentication status
+  patina auth login    Print per-backend instructions for authenticating
+
+If no API key is set and the codex CLI is installed and authenticated,
+patina automatically uses the codex-cli backend (no key required).
 `);
+}
+
+function printBackendStatus() {
+  const list = listBackends();
+  const rows = list.map((b) => ({
+    name: b.name,
+    available: b.available ? 'yes' : 'no',
+    authenticated: b.authenticated ? 'yes' : 'no',
+    note: b.authenticated ? '' : b.authHint,
+  }));
+  const widths = {
+    name: Math.max('Backend'.length, ...rows.map((r) => r.name.length)),
+    available: Math.max('Available'.length, ...rows.map((r) => r.available.length)),
+    authenticated: Math.max('Authenticated'.length, ...rows.map((r) => r.authenticated.length)),
+  };
+  const pad = (s, w) => s + ' '.repeat(Math.max(0, w - s.length));
+  console.log(
+    `${pad('Backend', widths.name)}  ${pad('Available', widths.available)}  ${pad('Authenticated', widths.authenticated)}  Notes`
+  );
+  console.log(
+    `${'-'.repeat(widths.name)}  ${'-'.repeat(widths.available)}  ${'-'.repeat(widths.authenticated)}  -----`
+  );
+  for (const r of rows) {
+    console.log(
+      `${pad(r.name, widths.name)}  ${pad(r.available, widths.available)}  ${pad(r.authenticated, widths.authenticated)}  ${r.note}`
+    );
+  }
+}
+
+function handleAuth(subArgs) {
+  const sub = subArgs[0] || 'status';
+  if (sub === 'status') {
+    printBackendStatus();
+    return;
+  }
+  if (sub === 'login') {
+    console.log('To authenticate a backend, follow the per-backend instructions:\n');
+    for (const b of listBackends()) {
+      const status = b.authenticated ? '✓ already authenticated' : '✗ not authenticated';
+      console.log(`  ${b.name}: ${status}`);
+      if (!b.authenticated) console.log(`    → ${b.authHint}`);
+    }
+    return;
+  }
+  console.error(`Unknown auth subcommand: ${sub}. Try \`patina auth status\` or \`patina auth login\`.`);
+  process.exit(1);
 }

--- a/tests/e2e/backends.test.js
+++ b/tests/e2e/backends.test.js
@@ -1,51 +1,76 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { selectBackend, listBackends } from '../../src/backends/index.js';
-import { isAvailable as codexAvailable } from '../../src/backends/codex-cli.js';
+import { isAvailable as codexAvailable, isAuthenticated as codexAuthd } from '../../src/backends/codex-cli.js';
 
 describe('Backend Selection', () => {
-  it('selects openai-http by default when no model and no name given', () => {
-    const b = selectBackend({});
-    assert.strictEqual(b.name, 'openai-http');
+  it('selects openai-http by default when API key is present', () => {
+    const { backend, autoSelected } = selectBackend({ hasApiKey: true });
+    assert.strictEqual(backend.name, 'openai-http');
+    assert.strictEqual(autoSelected, false);
   });
 
-  it('selects openai-http for unrelated models like gpt-4o', () => {
-    const b = selectBackend({ model: 'gpt-4o' });
-    assert.strictEqual(b.name, 'openai-http');
+  it('selects openai-http for unrelated models when API key is present', () => {
+    const { backend } = selectBackend({ model: 'gpt-4o', hasApiKey: true });
+    assert.strictEqual(backend.name, 'openai-http');
   });
 
   it('selects codex-cli when --backend codex-cli is explicit', () => {
-    const b = selectBackend({ name: 'codex-cli' });
-    assert.strictEqual(b.name, 'codex-cli');
+    const { backend, autoSelected, reason } = selectBackend({ name: 'codex-cli' });
+    assert.strictEqual(backend.name, 'codex-cli');
+    assert.strictEqual(autoSelected, false);
+    assert.strictEqual(reason, 'explicit');
   });
 
-  it('selects openai-http when --backend openai-http is explicit', () => {
-    const b = selectBackend({ name: 'openai-http' });
-    assert.strictEqual(b.name, 'openai-http');
+  it('selects openai-http when --backend openai-http is explicit even without key', () => {
+    const { backend, autoSelected } = selectBackend({ name: 'openai-http', hasApiKey: false });
+    assert.strictEqual(backend.name, 'openai-http');
+    assert.strictEqual(autoSelected, false);
   });
 
   it('routes --model codex to codex-cli via heuristic', () => {
-    const b = selectBackend({ model: 'codex' });
-    assert.strictEqual(b.name, 'codex-cli');
+    const { backend, reason } = selectBackend({ model: 'codex', hasApiKey: true });
+    assert.strictEqual(backend.name, 'codex-cli');
+    assert.strictEqual(reason, 'model heuristic');
   });
 
   it('routes --model codex-mini-latest to codex-cli via prefix', () => {
-    const b = selectBackend({ model: 'codex-mini-latest' });
-    assert.strictEqual(b.name, 'codex-cli');
+    const { backend } = selectBackend({ model: 'codex-mini-latest', hasApiKey: true });
+    assert.strictEqual(backend.name, 'codex-cli');
   });
 
   it('does not match `codexa` or other false positives', () => {
-    const b = selectBackend({ model: 'codexa-1.0' });
-    assert.strictEqual(b.name, 'openai-http');
+    const { backend } = selectBackend({ model: 'codexa-1.0', hasApiKey: true });
+    assert.strictEqual(backend.name, 'openai-http');
   });
 
   it('explicit --backend overrides --model heuristic', () => {
-    const b = selectBackend({ name: 'openai-http', model: 'codex' });
-    assert.strictEqual(b.name, 'openai-http');
+    const { backend } = selectBackend({ name: 'openai-http', model: 'codex' });
+    assert.strictEqual(backend.name, 'openai-http');
   });
 
   it('throws on unknown backend name', () => {
     assert.throws(() => selectBackend({ name: 'invented-backend' }), /Unknown backend/);
+  });
+});
+
+describe('Auto-fallback to codex-cli', () => {
+  it('auto-selects codex-cli when no API key and codex is authenticated', { skip: !(codexAvailable() && codexAuthd()) }, () => {
+    const { backend, autoSelected, reason } = selectBackend({ hasApiKey: false });
+    assert.strictEqual(backend.name, 'codex-cli');
+    assert.strictEqual(autoSelected, true);
+    assert.match(reason, /no API key/);
+  });
+
+  it('does NOT auto-select when API key is present', () => {
+    const { backend, autoSelected } = selectBackend({ hasApiKey: true });
+    assert.strictEqual(backend.name, 'openai-http');
+    assert.strictEqual(autoSelected, false);
+  });
+
+  it('does NOT auto-select when name is explicit', () => {
+    const { autoSelected } = selectBackend({ name: 'openai-http', hasApiKey: false });
+    assert.strictEqual(autoSelected, false);
   });
 });
 
@@ -67,5 +92,13 @@ describe('Backend Listing', () => {
     const list = listBackends();
     const codex = list.find((b) => b.name === 'codex-cli');
     assert.strictEqual(codex.available, codexAvailable());
+  });
+
+  it('reports authenticated status for each backend', () => {
+    const list = listBackends();
+    for (const b of list) {
+      assert.strictEqual(typeof b.authenticated, 'boolean');
+      assert.strictEqual(typeof b.authHint, 'string');
+    }
   });
 });


### PR DESCRIPTION
## Why
PR #72's OAuth research concluded that implementing ChatGPT OAuth directly is **not advisable** (scope-limited third-party tokens hitting 401s in the wild as of April 2026, ToS gray-zone, Anthropic and Google killed equivalent flows). This PR takes the recommended Track C: make the existing codex-cli backend feel native — `patina` handles auth-status UX without owning OAuth implementation, security, or ToS risk.

## Changes
- **`isAuthenticated()` per backend**: codex-cli checks `~/.codex/auth.json`, openai-http checks `PATINA_API_KEY`.
- **`patina auth status`** subcommand: backend availability + authentication table.
- **`patina auth login`**: per-backend authentication instructions (no actual OAuth, just guidance — `codex login` for codex, `platform.openai.com` link for openai-http).
- **Auto-fallback**: if no API key and codex is authenticated, `selectBackend()` picks codex-cli automatically. One-line stderr notice when this fires so the user knows what happened.
- **Better error**: `--backend openai-http` without a key now suggests `codex login` if codex is installed-but-not-authenticated, or installing codex if missing.
- **README × 4 langs**: documents the new subcommands and auto-fallback.

## Verified end-to-end (zero cost)
```
$ unset PATINA_API_KEY
$ patina --lang ko /tmp/sample.txt
[patina] Using codex-cli backend (no API key; codex authenticated). Run `patina auth status` for details.
한국 스타트업 생태계가 빠르게 큰 배경에는 ...
```

`patina auth status`:
```
Backend      Available  Authenticated  Notes
-----------  ---------  -------------  -----
openai-http  yes        no             Set PATINA_API_KEY (or pass --api-key). Get a key at https://platform.openai.com/api-keys.
codex-cli    yes        yes
```

## Test plan
- [x] `npm test` — 37 / 37 pass (3 new auto-fallback unit tests + 1 listing test on top of the 33 from PR #71)
- [x] `patina auth status` and `patina auth login` produce expected output
- [x] Real e2e auto-fallback works end-to-end with codex (no key, no `--backend`)
- [x] Explicit `--backend openai-http` without key throws helpful error
- [x] All 4 README translations synced

## Out of scope
- Patina implementing OAuth directly (PR #72 research → not advisable)
- Track E: adding Gemini / Groq / Together AI free-tier backends (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)