### PR TITLE
chore: fix malformed frontmatter in 18 EN example files

### DIFF
--- a/examples/en-03-failure-01.md
+++ b/examples/en-03-failure-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 3
 type: failure
 name: Superficial -ing Analyses
 pack: en-content
-ENDFRONT
+language: en
+---
 
 # Pattern 3: Superficial -ing Analyses — Failure (False Positive)
 

--- a/examples/en-03-success-01.md
+++ b/examples/en-03-success-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 3
 type: success
 name: Superficial -ing Analyses
 pack: en-content
-ENDFRONT
+language: en
+---
 
 # Pattern 3: Superficial -ing Analyses — Success
 

--- a/examples/en-04-failure-01.md
+++ b/examples/en-04-failure-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 4
 type: failure
 name: Promotional Language
 pack: en-content
-ENDFRONT
+language: en
+---
 
 # Pattern 4: Promotional Language — Failure (False Positive)
 

--- a/examples/en-04-success-01.md
+++ b/examples/en-04-success-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 4
 type: success
 name: Promotional Language
 pack: en-content
-ENDFRONT
+language: en
+---
 
 # Pattern 4: Promotional Language — Success
 

--- a/examples/en-08-failure-01.md
+++ b/examples/en-08-failure-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 8
 type: failure
 name: Copula Avoidance
 pack: en-language
-ENDFRONT
+language: en
+---
 
 # Pattern 8: Copula Avoidance — Failure (False Positive)
 

--- a/examples/en-08-success-01.md
+++ b/examples/en-08-success-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 8
 type: success
 name: Copula Avoidance
 pack: en-language
-ENDFRONT
+language: en
+---
 
 # Pattern 8: Copula Avoidance — Success
 

--- a/examples/en-13-failure-01.md
+++ b/examples/en-13-failure-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 13
 type: failure
 name: Em Dash Overuse
 pack: en-style
-ENDFRONT
+language: en
+---
 
 # Pattern 13: Em Dash Overuse — Failure (False Positive)
 

--- a/examples/en-13-success-01.md
+++ b/examples/en-13-success-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 13
 type: success
 name: Em Dash Overuse
 pack: en-style
-ENDFRONT
+language: en
+---
 
 # Pattern 13: Em Dash Overuse — Success
 

--- a/examples/en-19-failure-01.md
+++ b/examples/en-19-failure-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 19
 type: failure
 name: Collaborative Communication Artifacts
 pack: en-communication
-ENDFRONT
+language: en
+---
 
 # Pattern 19: Collaborative Communication Artifacts — Failure (False Positive)
 

--- a/examples/en-19-success-01.md
+++ b/examples/en-19-success-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 19
 type: success
 name: Collaborative Communication Artifacts
 pack: en-communication
-ENDFRONT
+language: en
+---
 
 # Pattern 19: Collaborative Communication Artifacts — Success
 

--- a/examples/en-21-failure-01.md
+++ b/examples/en-21-failure-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 21
 type: failure
 name: Sycophantic/Servile Tone
 pack: en-communication
-ENDFRONT
+language: en
+---
 
 # Pattern 21: Sycophantic/Servile Tone — Failure (False Positive)
 

--- a/examples/en-21-success-01.md
+++ b/examples/en-21-success-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 21
 type: success
 name: Sycophantic/Servile Tone
 pack: en-communication
-ENDFRONT
+language: en
+---
 
 # Pattern 21: Sycophantic/Servile Tone — Success
 

--- a/examples/en-22-failure-01.md
+++ b/examples/en-22-failure-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 22
 type: failure
 name: Filler Phrases
 pack: en-filler
-ENDFRONT
+language: en
+---
 
 # Pattern 22: Filler Phrases — Failure (False Positive)
 

--- a/examples/en-22-success-01.md
+++ b/examples/en-22-success-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 22
 type: success
 name: Filler Phrases
 pack: en-filler
-ENDFRONT
+language: en
+---
 
 # Pattern 22: Filler Phrases — Success
 

--- a/examples/en-25-failure-01.md
+++ b/examples/en-25-failure-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 25
 type: failure
 name: Metronomic Paragraph Structure
 pack: en-structure
-ENDFRONT
+language: en
+---
 
 # Pattern 25: Metronomic Paragraph Structure — Failure (False Positive)
 

--- a/examples/en-25-success-01.md
+++ b/examples/en-25-success-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 25
 type: success
 name: Metronomic Paragraph Structure
 pack: en-structure
-ENDFRONT
+language: en
+---
 
 # Pattern 25: Metronomic Paragraph Structure — Success
 

--- a/examples/en-26-failure-01.md
+++ b/examples/en-26-failure-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 26
 type: failure
 name: Passive Nominalization Chains
 pack: en-structure
-ENDFRONT
+language: en
+---
 
 # Pattern 26: Passive Nominalization Chains — Failure (False Positive)
 

--- a/examples/en-26-success-01.md
+++ b/examples/en-26-success-01.md
@@ -1,10 +1,10 @@
-language: en
 ---
 pattern: 26
 type: success
 name: Passive Nominalization Chains
 pack: en-structure
-ENDFRONT
+language: en
+---
 
 # Pattern 26: Passive Nominalization Chains — Success
 


### PR DESCRIPTION
## Summary
Found during the audit work for PR #71 — 18 EN example files had broken YAML frontmatter (missing opening \`---\`, stray \`language: en\` above, \`ENDFRONT\` instead of closing \`---\`). Normalized to match the standard format used elsewhere in \`examples/\`.

## Before
```
language: en
---
pattern: 25
type: failure
name: Metronomic Paragraph Structure
pack: en-structure
ENDFRONT

# Pattern 25...
```

## After
```
---
pattern: 25
type: failure
name: Metronomic Paragraph Structure
pack: en-structure
language: en
---

# Pattern 25...
```

## Affected files
en-03/04/08/13/19/21/22/25/26 × {success,failure} = 18 files. (The other EN examples — including the 4 from PR #71 / #75 — already used correct YAML frontmatter.)

## Why this matters (a little)
Examples are reference material, not loaded by patina at runtime, so this had no functional impact today. But the broken frontmatter would silently fail any tool that parses examples (auto-generated pattern catalogs, contributor docs site, etc.). Easier to fix now than later.

## Test plan
- [x] \`npm test\` — 49/49 pass (examples aren't in the test loader)
- [x] All 18 files now have valid YAML frontmatter
- [x] No \`ENDFRONT\` markers remain (\`grep -l ENDFRONT examples/*.md\` → empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)