### PR TITLE
chore: tighten audit/diff prompts to require exact pattern + pack names

### DIFF
--- a/src/prompt-builder.js
+++ b/src/prompt-builder.js
@@ -48,7 +48,7 @@ export function buildPrompt({ config, patterns, profile, voice, scoring, text, m
   if (mode === 'rewrite') {
     prompt += buildRewriteInstructions(structurePacks, lexicalPacks);
   } else if (mode === 'diff') {
-    prompt += buildDiffInstructions(structurePacks, lexicalPacks);
+    prompt += buildDiffInstructions();
   } else if (mode === 'audit') {
     prompt += buildAuditInstructions();
   } else if (mode === 'score') {
@@ -104,16 +104,26 @@ function buildRewriteInstructions(structurePacks, lexicalPacks) {
   return inst;
 }
 
-function buildDiffInstructions(structurePacks, lexicalPacks) {
+function buildDiffInstructions() {
   return `Show what changed and why, pattern by pattern. For each change:\n` +
     `- Show the original text\n` +
     `- Show the corrected text\n` +
-    `- Name the pattern that triggered the change\n` +
+    `- Name the pattern that triggered the change (use exact \`N. Pattern Name\` from the loaded packs)\n` +
     `- Explain why it was changed\n`;
 }
 
 function buildAuditInstructions() {
-  return `Detect AI patterns ONLY — do not rewrite. Output a table:\n\n` +
+  return `Detect AI patterns ONLY — do not rewrite. Output a table.\n\n` +
+    `**Strict requirements:**\n` +
+    `- Use the EXACT pattern name AND number from the loaded Pattern Packs above. ` +
+    `Format: \`N. Pattern Name\` (e.g., \`30. Rhetorical Question Openers\` or \`13. Em Dash Overuse\`). ` +
+    `Do not paraphrase, abbreviate, or invent names.\n` +
+    `- The Category column must be the exact pack name from the loaded packs ` +
+    `(e.g., \`en-structure\`, \`ko-filler\`, \`zh-content\`). Do not use generic ` +
+    `category names like "Style", "Filler", or "Content".\n` +
+    `- If you suspect an AI tell that doesn't match any loaded pattern exactly, ` +
+    `omit it from the table rather than coining a new name.\n\n` +
+    `Output format:\n` +
     `| Pattern | Category | Severity | Location |\n` +
     `|---------|----------|----------|----------|\n`;
 }


### PR DESCRIPTION
## Why
During the cross-language audit work that produced PRs #71/#75/#76, codex was paraphrasing pattern names and inventing generic category labels in \`--audit\` output:
- "Promotional/Inflated Language" instead of \`4. Promotional Language\`
- "Formulaic Conclusion" — not a real pattern; no match in any pack
- "Em Dash Overuse" with category \`Style\` instead of \`13. Em Dash Overuse\` with category \`en-style\`

These don't break anything (audit is human-readable), but they make it impossible to programmatically map detections back to pattern files, and they are a low-trust signal for users — seeing made-up pattern names erodes confidence in the tool.

## What changed
- **\`buildAuditInstructions()\`** now requires:
  - Exact \`N. Pattern Name\` from the loaded packs (no paraphrase or abbreviation)
  - Exact pack name in the Category column (\`en-style\`, \`ko-filler\`, etc.) — no generic "Style" / "Filler"
  - Omit detections that don't match a loaded pattern rather than coining new names
- **\`buildDiffInstructions()\`** got the same exact-name requirement and a drive-by removal of unused \`structurePacks\`/\`lexicalPacks\` params (linter flagged).

## Verified end-to-end
Re-audited \`ko-tutorial.txt\` (which previously returned mixed "Style"/"Filler" generic categories from codex). Output now:
\`\`\`
| 31. 결론 신호어 남용  | ko-filler    | LOW | ... |
| 26. 번역체           | ko-structure | LOW | ... |
| 13. 과도한 연결 표현 | ko-style     | MEDIUM | ... |
| 16. ~고 있다 진행형  | ko-style     | MEDIUM | ... |
| 1. 과도한 중요성 부여 | ko-content  | HIGH | ... |
\`\`\`

All categories now use exact pack names, all patterns include their numbers, and nothing invented showed up.

## Test plan
- [x] \`npm test\` — 49/49 pass (no behavior change to API surface, just prompt strings)
- [x] Real e2e \`--audit\` run produces clean output with exact names
- [x] Linter warning on \`structurePacks\`/\`lexicalPacks\` cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)