### PR TITLE
chore(ci): add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 # patina
 
+[![Tests](https://github.com/devswha/patina/actions/workflows/test.yml/badge.svg)](https://github.com/devswha/patina/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Claude Code Skill](https://img.shields.io/badge/Claude%20Code-Skill-blueviolet)](https://docs.anthropic.com/en/docs/claude-code)
 [![Based on](https://img.shields.io/badge/Based%20on-blader%2Fhumanizer-blue)](https://github.com/blader/humanizer)

--- a/README_JA.md
+++ b/README_JA.md
@@ -2,6 +2,7 @@
 
 # patina
 
+[![Tests](https://github.com/devswha/patina/actions/workflows/test.yml/badge.svg)](https://github.com/devswha/patina/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Claude Code Skill](https://img.shields.io/badge/Claude%20Code-Skill-blueviolet)](https://docs.anthropic.com/en/docs/claude-code)
 [![Based on](https://img.shields.io/badge/Based%20on-blader%2Fhumanizer-blue)](https://github.com/blader/humanizer)

--- a/README_KR.md
+++ b/README_KR.md
@@ -2,6 +2,7 @@
 
 # patina
 
+[![Tests](https://github.com/devswha/patina/actions/workflows/test.yml/badge.svg)](https://github.com/devswha/patina/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Claude Code Skill](https://img.shields.io/badge/Claude%20Code-Skill-blueviolet)](https://docs.anthropic.com/en/docs/claude-code)
 [![Based on](https://img.shields.io/badge/Based%20on-blader%2Fhumanizer-blue)](https://github.com/blader/humanizer)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -2,6 +2,7 @@
 
 # patina
 
+[![Tests](https://github.com/devswha/patina/actions/workflows/test.yml/badge.svg)](https://github.com/devswha/patina/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Claude Code Skill](https://img.shields.io/badge/Claude%20Code-Skill-blueviolet)](https://docs.anthropic.com/en/docs/claude-code)
 [![Based on](https://img.shields.io/badge/Based%20on-blader%2Fhumanizer-blue)](https://github.com/blader/humanizer)


### PR DESCRIPTION
## Summary
Adds CI for \`npm test\`. Runs on every push to \`main\` and every PR. Uses GitHub-hosted \`ubuntu-latest\` (patina is a public repo, so unlimited free minutes). Matrix tests against Node 18, 20, 22 to cover the package.json \`engines\` range and the active LTS line.

## Why GitHub-hosted (not self-hosted)
The 2 self-hosted runners on the dev machine are bound to a different repo (\`devswha/magi-stock\`). User-account self-hosted runners can't be shared across repos. Setting up a third runner instance for patina would add disk + maintenance burden without any benefit — the test suite is 49 unit tests running in ~3s, no special hardware needed. GitHub-hosted is free, zero-maintenance, and uses the same Linux x86_64 environment.

## Workflow file
\`.github/workflows/test.yml\`:
- Triggers: push to main, PR to main, manual dispatch
- Matrix: Node 18 / 20 / 22 (fail-fast disabled)
- Steps: checkout → setup-node (with npm cache) → \`npm ci\` → \`npm test\`

## Other changes
- Tests badge added to top of all four READMEs (English, KR, JA, ZH).

## Verified locally
- \`npm ci --dry-run\` reports lockfile is in sync (no surprises in CI).
- \`npm test\` passes (49/49) on the dev machine's Node 22.

Once this lands, the next PR's CI run will exercise the workflow end-to-end against GitHub's runners.

## Test plan
- [x] Workflow YAML is syntactically valid
- [x] \`npm ci\` works against current lockfile
- [x] \`npm test\` passes locally (49/49)
- [ ] Workflow successfully completes on this PR (will verify after push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)