### PR TITLE
release: v3.4.0

### DIFF
--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "3.3.0"
+version: "3.4.0"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Some pattern slots have different implementations per language, targeting each l
 Edit `.patina.default.yaml`:
 
 ```yaml
-version: "3.3.0"
+version: "3.4.0"
 language: ko              # ko | en | zh | ja (or use --lang flag)
 profile: default
 output: rewrite           # rewrite | diff | audit | score
@@ -504,6 +504,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add patterns, improve examples
 
 | Version | Changes |
 |---------|---------|
+| **3.4.0** | Free-tier ergonomics + 4 new patterns. New: codex-cli backend (no API key — uses local `codex` CLI's ChatGPT OAuth), `patina auth status/login` with auto-fallback when no key set, `--provider` shortcuts for Gemini / Groq / Together AI free tiers. Pattern additions: #30 (rhetorical question openers) and #31 (conclusion signal words) across all 4 languages, plus #32 (comparative adverb overuse) for KO `보다` and JA `より`. Default profile expanded to match other profiles' structure. GitHub Actions CI workflow added. |
 | **3.3.0** | Meaning Preservation System (MPS): ensures humanized text maintains original intent and claims |
 | **3.2.0** | Ouroboros scoring system: pattern-based AI-likeness scoring (0-100), `--score` mode with category breakdown, `--ouroboros` iterative self-improvement loop with configurable termination (target/plateau/regression/max-iterations) |
 | **3.1.1** | MAX mode reliability fixes: per-run temp dir, model-scoped wait loop + timeout handling, Gemini stdin dispatch, Codex CLI compatibility (`--output-last-message`, no `-q`) |

--- a/README_JA.md
+++ b/README_JA.md
@@ -400,7 +400,7 @@ ouroboros:
 `.patina.default.yaml` を編集します：
 
 ```yaml
-version: "3.3.0"
+version: "3.4.0"
 language: ko              # ko | en | zh | ja（または --lang フラグを使用）
 profile: default
 output: rewrite           # rewrite | diff | audit | score
@@ -498,6 +498,7 @@ patina/
 
 | バージョン | 変更内容 |
 |---------|---------|
+| **3.4.0** | 無料利用オプションの拡張 + 4つの新規パターン。新機能：codex-cli バックエンド（API キー不要 — ローカル `codex` CLI の ChatGPT OAuth を使用）、`patina auth status/login` サブコマンドと API キー未設定時の自動フォールバック、Gemini/Groq/Together AI 無料ティア向け `--provider` ショートカット。パターン追加：#30（修辞疑問の段落冒頭）と #31（結論シグナルワード）を4言語すべてに追加、KO `보다` / JA `より` 比較副詞の濫用 (#32)。デフォルトプロファイルを他のプロファイルと同等の構造に拡張。GitHub Actions CI ワークフロー追加。 |
 | **3.3.0** | 意味保持システム（MPS）：人間化後のテキストが原文の意図と主張を維持することを保証 |
 | **3.2.0** | Ouroboros スコアリングシステム：パターンベースのAI類似度スコアリング（0-100）、カテゴリ別内訳付き `--score` モード、設定可能な終了条件（目標/停滞/後退/最大イテレーション数）付き `--ouroboros` 反復自己改善ループ |
 | **3.1.1** | MAX モード信頼性修正：実行ごとの一時ディレクトリ、モデル単位の待機ループ＋タイムアウト処理、Gemini stdin ディスパッチ、Codex CLI 互換性（`--output-last-message`、`-q` なし） |

--- a/README_KR.md
+++ b/README_KR.md
@@ -400,7 +400,7 @@ ouroboros:
 `.patina.default.yaml`을 편집하세요:
 
 ```yaml
-version: "3.3.0"
+version: "3.4.0"
 language: ko              # ko | en | zh | ja (또는 --lang 플래그 사용)
 profile: default
 output: rewrite           # rewrite | diff | audit | score
@@ -504,6 +504,7 @@ patina/
 
 | 버전 | 변경 사항 |
 |---------|---------|
+| **3.4.0** | 무료 사용 옵션 확장 + 4개 신규 패턴. 신규: codex-cli 백엔드 (API 키 불필요 — 로컬 `codex` CLI의 ChatGPT OAuth 사용), `patina auth status/login` 서브커맨드 + API 키 없을 때 자동 fallback, Gemini/Groq/Together AI 무료 티어용 `--provider` 단축. 패턴 추가: #30(수사적 질문 단락 시작)과 #31(결론 신호어 남용)을 4개 언어 모두에 추가, KO `보다` / JA `より` 비교부사 남용 (#32). 기본 프로필을 다른 프로필과 동일한 구조로 확장. GitHub Actions CI 워크플로우 추가. |
 | **3.3.0** | 의미 보존 시스템(MPS): 사람화된 텍스트가 원문의 의도와 주장을 유지하도록 보장 |
 | **3.2.0** | 우로보로스 스코어링 시스템: 패턴 기반 AI 유사도 점수(0-100), 카테고리별 상세 내역의 `--score` 모드, 설정 가능한 종료 조건(목표/정체/퇴행/최대 반복)의 `--ouroboros` 반복 자기개선 루프 |
 | **3.1.1** | MAX 모드 안정성 개선: 실행별 임시 디렉토리, 모델별 대기 루프 + 타임아웃 처리, Gemini stdin 전달, Codex CLI 호환성 (`--output-last-message`, `-q` 제거) |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -400,7 +400,7 @@ ouroboros:
 编辑 `.patina.default.yaml`：
 
 ```yaml
-version: "3.3.0"
+version: "3.4.0"
 language: ko              # ko | en | zh | ja（或使用 --lang 参数）
 profile: default
 output: rewrite           # rewrite | diff | audit | score
@@ -498,6 +498,7 @@ patina/
 
 | 版本 | 变更内容 |
 |------|----------|
+| **3.4.0** | 免费使用选项扩展 + 4 个新模式。新增：codex-cli 后端（无需 API 密钥 — 通过本地 `codex` CLI 的 ChatGPT OAuth 认证），`patina auth status/login` 子命令及未设置 API 密钥时的自动回退，Gemini/Groq/Together AI 免费层的 `--provider` 快捷方式。模式新增：#30（修辞性疑问句段首）与 #31（结论信号词滥用）扩展到全部 4 种语言，KO `보다` / JA `より` 比较副词滥用 (#32)。默认配置文件扩充至与其他配置文件同等结构。新增 GitHub Actions CI 工作流。 |
 | **3.3.0** | 语义保留系统（MPS）：确保人性化后的文本保持原文的意图和主张 |
 | **3.2.0** | Ouroboros 评分系统：基于模式的 AI 相似度评分（0-100）、`--score` 模式含类别细分、`--ouroboros` 迭代自我优化循环，支持可配置的终止条件（目标值/平台期/退化/最大迭代次数） |
 | **3.1.1** | MAX 模式可靠性修复：独立运行临时目录、模型级等待循环 + 超时处理、Gemini stdin 分发、Codex CLI 兼容性（`--output-last-message`，移除 `-q`） |

--- a/SKILL-MAX.md
+++ b/SKILL-MAX.md
@@ -1,6 +1,6 @@
 ---
 name: patina-max
-version: 3.3.0
+version: 3.4.0
 description: |
   Multi-model humanization. Runs the same humanization task on multiple
   local model CLIs, scores each result, and selects the best

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: patina
-version: 3.3.0
+version: 3.4.0
 description: |
   AI가 생성한 텍스트에서 AI 특유의 글쓰기 패턴을 제거하여 자연스럽고
-  사람이 쓴 것처럼 만듭니다. 다국어 지원(한국어 29개, 영어 29개, 중국어 29개, 일본어 29개 패턴).
+  사람이 쓴 것처럼 만듭니다. 다국어 지원(한국어 32개, 영어 31개, 중국어 31개, 일본어 32개 패턴).
   2-Phase 처리 파이프라인(구조→문장/어휘)과 플러그인 기반 구조로
   패턴 팩과 프로필을 조합합니다. 의미 보존 시스템(MPS) 내장.
   Based on blader/humanizer, oh-my-zsh inspired plugin architecture.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",

--- a/patina-max/SKILL.md
+++ b/patina-max/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina-max
-version: 3.3.0
+version: 3.4.0
 description: |
   Multi-model humanization. Runs the same humanization task on multiple
   local model CLIs, scores each result, and selects the best

--- a/src/cli.js
+++ b/src/cli.js
@@ -22,7 +22,7 @@ export async function main(args) {
   }
 
   if (parsed.version) {
-    console.log('patina 3.3.0');
+    console.log('patina 3.4.0');
     return;
   }
 

--- a/tests/e2e/cli.test.js
+++ b/tests/e2e/cli.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { loadConfig, getRepoRoot } from '../../src/config.js';
+import { loadConfig } from '../../src/config.js';
 import { loadPatterns, loadProfile, loadCoreFile, splitFrontmatter } from '../../src/loader.js';
 import { buildPrompt } from '../../src/prompt-builder.js';
 import { fileURLToPath } from 'node:url';
@@ -13,7 +13,7 @@ describe('Config Loading', () => {
   it('should load .patina.default.yaml', () => {
     const config = loadConfig(resolve(REPO_ROOT, '.patina.default.yaml'));
     assert.ok(config);
-    assert.strictEqual(config.version, '3.3.0');
+    assert.strictEqual(config.version, '3.4.0');
     assert.ok(config.language);
     assert.ok(config.profile);
     assert.ok(config.patterns);


### PR DESCRIPTION
## Why
Cumulative session work since v3.3.0 has reached a coherent minor release boundary. No breaking changes — every v3.3.0 behavior still works the same; v3.4.0 only adds backends, providers, patterns, and quality-of-life.

## Highlights since v3.3.0

**Backends + auth UX**
- codex-cli backend (no API key — uses local \`codex\` CLI's ChatGPT OAuth) — PR #70
- \`patina auth status\` / \`patina auth login\`, auto-fallback when no key + codex authenticated — PR #73
- \`--provider\` shortcuts (OpenAI, Gemini, Groq, Together AI free tiers) — PR #74

**Pattern coverage**
- #30 rhetorical question openers — KO/EN (#71), ZH/JA (#77)
- #31 conclusion signal words — KO/EN (#75), ZH/JA (#77)
- #32 comparative adverb overuse — KO 보다 (#76), JA より (#82)
- Total: 116 → 126 patterns (KO 32, EN 31, ZH 31, JA 32)

**Quality + infra**
- default profile fleshed out to match other profiles' structure — PR #81
- GitHub Actions test workflow + Tests badge — PR #80
- Audit/diff prompts tightened (exact pattern + pack names) — PR #79
- 18 EN example files normalized from broken frontmatter — PR #78
- Test count: 21 → 49

## Files synchronized to v3.4.0
Per project rule:
- \`package.json\`, \`SKILL.md\`, \`SKILL-MAX.md\`, \`patina-max/SKILL.md\`, \`.patina.default.yaml\`
- \`src/cli.js\` (console.log), \`tests/e2e/cli.test.js\` (assertion)
- README.md + KR/JA/ZH yaml example block + Version History row

## Test plan
- [x] \`npm test\` — 49/49 pass with new version assertion
- [x] \`patina --version\` reports \`patina 3.4.0\`
- [x] No leftover \`3.3.0\` references outside the Version History row
- [x] All 4 READMEs synced (KR/JA/ZH translations of release note)
- [ ] CI runs successfully on this PR (will verify after push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)