### PR TITLE
chore(ci): bump actions/checkout and actions/setup-node to v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm


### PR DESCRIPTION
## Why
v3.4.0 CI runs (#80, #83) emitted Node.js 20 deprecation warnings — \`actions/checkout@v4\` and \`actions/setup-node@v4\` still ship with Node.js 20 internally, which GitHub will remove from runners on **2026-09-16**.

Both actions have a v6 release that uses the current Node.js LTS:
- \`actions/checkout@v6.0.2\`
- \`actions/setup-node@v6.4.0\`

Bumping to v6 (skipping past v5) clears the warnings without needing the \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24\` escape hatch.

## Validation
This PR's own CI run is the validation — if the workflow completes without deprecation annotations, the upgrade is good. Will report once CI finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)