### PR TITLE
docs(readme): sharpen hero positioning across 4 languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
 [![Version](https://img.shields.io/badge/version-3.8.0-blue)](CHANGELOG.md)
 
-> **Make AI text sound like a human wrote it.**
+> **Strip the AI packaging. Keep the meaning.**
 
-Detects and rewrites AI writing patterns in Korean, English, Chinese, and Japanese. Available as a skill for [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), [Cursor](https://cursor.sh), and OpenCode, or as a standalone Node.js CLI. Pattern-based and auditable — not a black-box LLM paraphraser. The scoring formula is deterministic; LLM severity assignment is the only stochastic step (±8–10 pt variance per run, see [scoring.md §8](core/scoring.md)).
+Detects and rewrites AI writing patterns in Korean, English, Chinese, and Japanese. Runs as a skill for [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), [Cursor](https://cursor.sh), and OpenCode, or as a standalone Node.js CLI.
+
+Unlike a generic paraphraser, patina is **pattern-based and auditable**: it shows what it changed, why it changed it, and whether the original claims were preserved.
 
 ## Demo
 
@@ -31,6 +33,7 @@ Detects and rewrites AI writing patterns in Korean, English, Chinese, and Japane
 | **False positives** | 13–25% on human prose *(boundary intrinsic to encyclopedic register, [documented](core/stylometry.md))* |
 | **Modes** | rewrite · audit · score · diff · ouroboros |
 | **Free tier** | Yes — via `codex` CLI (no API key) |
+| **Determinism** | Scoring formula is deterministic; LLM severity assignment ±8–10 pt per run ([scoring.md §8](core/scoring.md)) |
 | **License** | MIT |
 
 ## Quick Start

--- a/README_JA.md
+++ b/README_JA.md
@@ -8,9 +8,11 @@
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
 [![Version](https://img.shields.io/badge/version-3.8.0-blue)](CHANGELOG.md)
 
-> **AI が書いた文章を、人間が書いたように変えます。**
+> **AI の装飾だけを剥がし、意味はそのまま。**
 
-韓国語・英語・中国語・日本語のテキストから AI 特有の文体パターンを検出して書き換えます。[Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex CLI](https://github.com/openai/codex)、[Cursor](https://cursor.sh)、OpenCode 向けスキル + スタンドアロン Node.js CLI として利用可能。パターンベース・監査可能 — ブラックボックス LLM パラフレーザーではありません。スコアリング式は決定的ですが LLM の severity 判定段階に ±8–10pt の変動があります（[scoring.md §8](core/scoring.md) 参照）。
+韓国語・英語・中国語・日本語のテキストから AI 特有の文体パターンを検出して書き換えます。[Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex CLI](https://github.com/openai/codex)、[Cursor](https://cursor.sh)、OpenCode 向けのスキル、またはスタンドアロン Node.js CLI として動作します。
+
+一般的なパラフレーザーとは違い、patina は **パターンベースで監査可能**です。何を、なぜ変更し、原文の主張が保たれているかを示します。
 
 ## デモ
 
@@ -31,6 +33,7 @@
 | **誤検出率** | 人間文章で 13–25% *(百科事典体の本質的限界、[文書化済み](core/stylometry.md))* |
 | **モード** | rewrite · audit · score · diff · ouroboros |
 | **無料利用** | 可能 — `codex` CLI 経由 (API キー不要) |
+| **決定性** | スコアリング式は決定的、LLM の severity 判定段階に ±8–10pt の変動 ([scoring.md §8](core/scoring.md)) |
 | **ライセンス** | MIT |
 
 ## クイックスタート

--- a/README_KR.md
+++ b/README_KR.md
@@ -8,9 +8,11 @@
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
 [![Version](https://img.shields.io/badge/version-3.8.0-blue)](CHANGELOG.md)
 
-> **AI가 쓴 글을 사람이 쓴 것처럼 바꿔줍니다.**
+> **AI 포장만 벗기고, 의미는 그대로.**
 
-한국어, 영어, 중국어, 일본어 텍스트에서 AI 특유의 글쓰기 패턴을 탐지하고 교정합니다. [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), [Cursor](https://cursor.sh), OpenCode 용 스킬 + 독립형 Node.js CLI 로 사용. 패턴 기반, 감사 가능 — 블랙박스 LLM 패러프레이저가 아닙니다. 스코어링 공식은 결정적이지만 LLM severity 부여 단계는 ±8–10pt 변동이 있습니다 ([scoring.md §8](core/scoring.md) 참조).
+한국어, 영어, 중국어, 일본어 텍스트에서 AI 특유의 글쓰기 패턴을 탐지하고 교정합니다. [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), [Cursor](https://cursor.sh), OpenCode 용 스킬 또는 독립형 Node.js CLI 로 동작합니다.
+
+일반적인 패러프레이저와 달리 patina는 **패턴 기반이고 감사 가능**합니다. 무엇을, 왜 바꿨는지, 그리고 원문의 주장이 보존됐는지를 보여줍니다.
 
 ## 데모
 
@@ -31,6 +33,7 @@
 | **오탐율** | 사람 글에 13–25% *(백과사전체의 본질적 한계, [문서화](core/stylometry.md))* |
 | **모드** | rewrite · audit · score · diff · ouroboros |
 | **무료 사용** | 가능 — `codex` CLI 로그인 시 API 키 불필요 |
+| **결정성** | 스코어링 공식은 결정적이지만 LLM severity 부여 단계는 ±8–10pt 변동 ([scoring.md §8](core/scoring.md)) |
 | **라이선스** | MIT |
 
 ## 빠른 시작

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -8,9 +8,11 @@
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
 [![Version](https://img.shields.io/badge/version-3.8.0-blue)](CHANGELOG.md)
 
-> **让 AI 生成的文字读起来像人写的。**
+> **只剥掉 AI 包装，保留原意。**
 
-检测并改写中文、韩文、英文及日文文本中的 AI 写作痕迹。可作为 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex CLI](https://github.com/openai/codex)、[Cursor](https://cursor.sh)、OpenCode 技能使用，或作为独立的 Node.js CLI 运行。基于模式、可审计 — 不是黑箱式 LLM 改写器。评分公式是确定性的，但 LLM 严重程度判定阶段有 ±8–10pt 的波动（参见 [scoring.md §8](core/scoring.md)）。
+检测并改写中文、韩文、英文及日文文本中的 AI 写作痕迹。可作为 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex CLI](https://github.com/openai/codex)、[Cursor](https://cursor.sh)、OpenCode 的技能使用，或作为独立的 Node.js CLI 运行。
+
+不同于一般的改写器，patina **基于模式且可审计**：会展示改了什么、为什么改、以及原文的主张是否被保留。
 
 ## 效果展示
 
@@ -31,6 +33,7 @@
 | **误检率** | 人类写作 13–25% *(百科风格本质局限，[已记录](core/stylometry.md))* |
 | **模式** | rewrite · audit · score · diff · ouroboros |
 | **免费层** | 支持 — 通过 `codex` CLI（无需 API 密钥） |
+| **确定性** | 评分公式是确定性的；LLM 严重度判定阶段 ±8–10pt 波动（[scoring.md §8](core/scoring.md)） |
 | **许可证** | MIT |
 
 ## 快速开始


### PR DESCRIPTION
## Summary

Adopts the launch-positioning tagline from `.omc/drafts/patina-promo-pack-2026-05-05.md` §2 and applies it consistently across all four READMEs.

- **Tagline**: "Make AI text sound like a human wrote it" → **"Strip the AI packaging. Keep the meaning."** Concrete, benefit-led, and matches the X / Reddit / HN copy in the promo pack so the hero and community posts give the same first impression.
- **Positioning paragraph**: split the dense one-paragraph intro into two — runtime line first, then a clear "unlike a paraphraser" differentiator. Auditability is the actual selling point vs generic rewriters; promote it.
- **Determinism caveat**: moved from the lead paragraph into the At a Glance table. Above-the-fold real estate goes to the differentiator, not the variance footnote.

### Intentionally kept
- Demo block with `MPS = 100 · cultural transformation ✓ · …` — this single line is the entire differentiator vs paraphrasers; the promo §2 draft dropped it but I think keeping it is correct.
- 🆓 free-tier callout — it's the most product-visible win from the recent codex-cli + free-provider PRs.
- `git clone` install path. The promo draft suggested `npm install -g patina-ai` but the package isn't published under that name (current `package.json#name` is `patina-cli`); flagging as a separate decision rather than misleading users.

## Files

- README.md, README_KR.md, README_JA.md, README_ZH.md (synced)

## Out of scope (separate work)
- Promo pack §13 assets (terminal GIF, before/after social card) — manual.
- Promo pack §12 launch order — should wait until assets exist (HN gets one shot).

## Test plan

- [x] All four READMEs render the new tagline + paragraph structure
- [x] At a Glance table now has a Determinism row
- [x] MPS demo line preserved
- [x] Free-tier row preserved
- [ ] preview on github.com to confirm markdown table renders cleanly with the extra row

🤖 Generated with [Claude Code](https://claude.com/claude-code)