### PR TITLE
docs: add before/after promo gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Unlike a generic paraphraser, patina is **pattern-based and auditable**: it show
 
 > **MPS = 100** · cultural transformation ✓ · community building ✓ · meaningful connections ✓ · cross-cultural dialogue ✓
 
+More examples: [Before/After Gallery](docs/EXAMPLES.md). Social preview asset: [patina-before-after.svg](assets/social/patina-before-after.svg).
+
 ## At a Glance
 
 |  |  |

--- a/assets/social/patina-before-after.svg
+++ b/assets/social/patina-before-after.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="patina before and after example">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1020"/>
+      <stop offset="55%" stop-color="#111827"/>
+      <stop offset="100%" stop-color="#1f2937"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#000" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <text x="72" y="78" fill="#f9fafb" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="46" font-weight="800">patina</text>
+  <text x="72" y="118" fill="#a7f3d0" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="24" font-weight="600">Strip the AI packaging. Keep the meaning.</text>
+
+  <g filter="url(#shadow)">
+    <rect x="72" y="158" width="500" height="330" rx="26" fill="#111827" stroke="#374151" stroke-width="2"/>
+    <text x="104" y="210" fill="#fca5a5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="24" font-weight="800">Before</text>
+    <text x="104" y="258" fill="#e5e7eb" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="25">
+      <tspan x="104" dy="0">Coffee has emerged as a pivotal</tspan>
+      <tspan x="104" dy="38">cultural phenomenon that has</tspan>
+      <tspan x="104" dy="38">fundamentally transformed</tspan>
+      <tspan x="104" dy="38">social interactions across the</tspan>
+      <tspan x="104" dy="38">globe.</tspan>
+    </text>
+  </g>
+
+  <text x="596" y="332" fill="#93c5fd" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="42" font-weight="800">→</text>
+
+  <g filter="url(#shadow)">
+    <rect x="628" y="158" width="500" height="330" rx="26" fill="#ecfdf5" stroke="#34d399" stroke-width="2"/>
+    <text x="660" y="210" fill="#047857" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="24" font-weight="800">After</text>
+    <text x="660" y="258" fill="#064e3b" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="25">
+      <tspan x="660" dy="0">Coffee has quietly changed how</tspan>
+      <tspan x="660" dy="38">people meet. Sit across from</tspan>
+      <tspan x="660" dy="38">someone long enough, and</tspan>
+      <tspan x="660" dy="38">something like a real connection</tspan>
+      <tspan x="660" dy="38">tends to form.</tspan>
+    </text>
+  </g>
+
+  <text x="72" y="548" fill="#d1d5db" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="23">Pattern-based · auditable · KO/EN/ZH/JA · Claude Code · Codex CLI · Cursor · OpenCode · Node CLI</text>
+  <text x="72" y="586" fill="#93c5fd" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700">github.com/devswha/patina</text>
+</svg>

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1,0 +1,60 @@
+# Before/After Gallery
+
+patina is easiest to understand with examples: the claims stay, the AI packaging goes.
+
+## English: inflated product copy
+
+**Before**
+
+> AI coding tools represent a transformative leap forward in the software development lifecycle, enabling teams to streamline workflows, enhance collaboration, and unlock unprecedented levels of productivity across the organization.
+
+**After**
+
+> AI coding tools are useful for the boring parts: test stubs, config files, small refactors. They do not fix a messy codebase, but they can save time when someone still checks the output.
+
+**Patterns removed**: inflated stakes, corporate abstractions, three-part benefit stack.
+
+## Korean: benefit stacking
+
+**Before**
+
+> 본 솔루션은 사용자의 업무 효율성을 극대화하고, 생산성 향상을 도모하며, 더 나은 협업 경험을 제공하는 혁신적인 도구입니다.
+
+**After**
+
+> 이 도구는 반복 작업을 줄여준다. 문서 정리, 초안 작성, 간단한 협업 흐름처럼 사람이 굳이 매번 손으로 할 필요 없는 일에 잘 맞는다.
+
+**Patterns removed**: `혁신적인`, `도모`, abstract benefit stacking, stiff noun-heavy phrasing.
+
+## English: vague balance
+
+**Before**
+
+> While there are challenges to consider, it is important to recognize that this technology has the potential to create meaningful value when implemented thoughtfully.
+
+**After**
+
+> The tool is useful, but only if someone checks the output. Without tests or review, it just makes wrong answers arrive faster.
+
+**Patterns removed**: generic caveat, vague upside, empty balance.
+
+## Technical: architecture claims
+
+**Before**
+
+> This architecture provides a robust and scalable foundation for future enhancements, ensuring that teams can effectively adapt to evolving requirements while maintaining operational excellence.
+
+**After**
+
+> The architecture leaves room for new backends without touching the CLI entry point. That is the useful part. The tradeoff is more config surface, so the defaults need to stay boring and safe.
+
+**Patterns removed**: `robust and scalable foundation`, future-proofing claims, operational-excellence filler.
+
+## What patina is checking
+
+- Did the rewrite remove AI-writing patterns?
+- Did the rewrite keep the original claims?
+- Did the rewrite introduce anything that was not in the source?
+- Can the change be inspected through `--audit`, `--diff`, or `--score`?
+
+The goal is editing quality, not detector evasion. AI detectors are noisy; patina treats the score as a rough signal and the diff as the useful artifact.


### PR DESCRIPTION
## Summary
- add a before/after gallery for English, Korean, and technical examples
- add a reusable social preview SVG asset
- link the gallery and asset from the README demo section

## Verification
- npm test
- git diff --check
- SVG XML parse check