### PR TITLE
refactor(scoring): harden evaluator paths in MAX, scoring, and Ouroboros

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -89,6 +89,7 @@ export async function main(args) {
     if (parsed.models) {
       result = await runMaxMode({
         prompt,
+        sourceText: text,
         models: parsed.models,
         apiKey: resolved.apiKey,
         baseURL: resolved.baseURL,

--- a/src/max-mode.js
+++ b/src/max-mode.js
@@ -1,7 +1,7 @@
 import { callLLMMultiple } from './api.js';
 import { scoreText, scoreMPS } from './scoring.js';
 
-export async function runMaxMode({ prompt, models, apiKey, baseURL, config, patterns }) {
+export async function runMaxMode({ prompt, sourceText, models, apiKey, baseURL, config, patterns }) {
   console.error(`[patina-max] Dispatching to ${models.length} models: ${models.join(', ')}`);
 
   const results = await callLLMMultiple({
@@ -30,7 +30,7 @@ export async function runMaxMode({ prompt, models, apiKey, baseURL, config, patt
     });
 
     const mpsResult = await scoreMPS({
-      original: prompt.split('## Input Text')[1] || '',
+      original: sourceText,
       rewritten: r.result,
       apiKey,
       baseURL,

--- a/src/ouroboros.js
+++ b/src/ouroboros.js
@@ -55,6 +55,14 @@ export async function runOuroboros({
   let previousScore = initialScore;
   let bestText = text;
   let bestScore = initialScore;
+  // Original is identical to itself, so its fidelity is 100 by definition.
+  // This gives iteration 1 a valid combined baseline to detect regressions against.
+  let previousCombined = combinedScore({
+    aiLikeness: initialScore,
+    fidelity: 100,
+    profile: config.profile,
+    config,
+  });
 
   for (let iteration = 1; iteration <= maxIterations; iteration++) {
     const prompt = buildPrompt({
@@ -99,6 +107,7 @@ export async function runOuroboros({
       profile: config.profile,
       config,
     });
+    const combinedDelta = previousCombined - combined;
 
     let reason = '';
     let shouldStop = false;
@@ -107,8 +116,8 @@ export async function runOuroboros({
     if (currentScore <= targetScore) {
       reason = 'Target met';
       shouldStop = true;
-    } else if (delta < 0) {
-      reason = 'Regression';
+    } else if (combinedDelta < 0) {
+      reason = `Regression (combined ${previousCombined} → ${combined})`;
       shouldStop = true;
       shouldRollback = true;
     } else if (fidelity < fidelityFloor) {
@@ -135,6 +144,7 @@ export async function runOuroboros({
       fidelity,
       mps,
       combined,
+      combinedDelta,
       reason: shouldStop ? reason : '',
     });
 
@@ -144,6 +154,7 @@ export async function runOuroboros({
     } else {
       currentText = humanized;
       previousScore = currentScore;
+      previousCombined = combined;
 
       if (currentScore < bestScore) {
         bestText = humanized;

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,22 +1,50 @@
 import { callLLM } from './api.js';
 
-function extractJson(text) {
-  if (!text) return null;
+class SchemaError extends Error {
+  constructor(message, raw) {
+    super(message);
+    this.name = 'SchemaError';
+    this.raw = raw;
+  }
+}
 
+function parseStrictJson(text) {
+  if (!text) throw new SchemaError('Empty response', text);
+
+  let body = text;
   const codeBlockMatch = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
-  if (codeBlockMatch) {
-    text = codeBlockMatch[1];
+  if (codeBlockMatch) body = codeBlockMatch[1];
+  body = body.trim();
+
+  const firstBrace = body.indexOf('{');
+  const lastBrace = body.lastIndexOf('}');
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
+    throw new SchemaError('No JSON object found', text);
   }
 
-  text = text.trim();
-
-  const firstBrace = text.indexOf('{');
-  const lastBrace = text.lastIndexOf('}');
-  if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
-    return text.slice(firstBrace, lastBrace + 1);
+  try {
+    return JSON.parse(body.slice(firstBrace, lastBrace + 1));
+  } catch (e) {
+    throw new SchemaError(`JSON parse failed: ${e.message}`, text);
   }
+}
 
-  return null;
+// Call LLM and parse strict JSON. On schema failure, retry once at temperature 0.
+async function callAndParseJson({ prompt, apiKey, baseURL, model, temperature = 0.1 }) {
+  let lastError;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const t = attempt === 0 ? temperature : 0;
+    const result = await callLLM({ prompt, apiKey, baseURL, model, temperature: t });
+    try {
+      return { parsed: parseStrictJson(result), raw: result };
+    } catch (e) {
+      lastError = e;
+      if (attempt === 0) {
+        console.error(`[patina] score JSON parse failed (${e.message}); retrying at temperature 0`);
+      }
+    }
+  }
+  throw lastError;
 }
 
 export async function scoreText({ text, config, patterns, apiKey, baseURL, model }) {
@@ -53,22 +81,12 @@ Return ONLY a JSON object in this exact format (no markdown, no explanation):
 ${text}
 `;
 
-  const result = await callLLM({
-    prompt,
-    apiKey,
-    baseURL,
-    model,
-    temperature: 0.1,
-  });
-
   try {
-    const cleaned = extractJson(result);
-    if (cleaned) {
-      return JSON.parse(cleaned);
-    }
-    return { raw: result, overall: null };
-  } catch {
-    return { raw: result, overall: null };
+    const { parsed } = await callAndParseJson({ prompt, apiKey, baseURL, model });
+    return parsed;
+  } catch (e) {
+    console.error(`[patina] scoreText schema failure after retry: ${e.message}`);
+    return { overall: null, error: 'schema-failure', raw: e.raw };
   }
 }
 
@@ -104,22 +122,12 @@ ${original}
 ${rewritten}
 `;
 
-  const result = await callLLM({
-    prompt,
-    apiKey,
-    baseURL,
-    model,
-    temperature: 0.1,
-  });
-
   try {
-    const cleaned = extractJson(result);
-    if (cleaned) {
-      return JSON.parse(cleaned);
-    }
-    return { mps: null, raw: result };
-  } catch {
-    return { mps: null, raw: result };
+    const { parsed } = await callAndParseJson({ prompt, apiKey, baseURL, model });
+    return parsed;
+  } catch (e) {
+    console.error(`[patina] scoreMPS schema failure after retry: ${e.message}`);
+    return { mps: null, error: 'schema-failure', raw: e.raw };
   }
 }
 
@@ -174,12 +182,13 @@ ${rewritten}
 `;
 
   let parsed = null;
+  let schemaError = null;
   try {
-    const result = await callLLM({ prompt, apiKey, baseURL, model, temperature: 0.1 });
-    const cleaned = extractJson(result);
-    if (cleaned) parsed = JSON.parse(cleaned);
-  } catch {
-    parsed = null;
+    const result = await callAndParseJson({ prompt, apiKey, baseURL, model });
+    parsed = result.parsed;
+  } catch (e) {
+    console.error(`[patina] scoreFidelity schema failure after retry: ${e.message}`);
+    schemaError = e;
   }
 
   const claims = clamp03(parsed?.claims_preserved);
@@ -197,6 +206,7 @@ ${rewritten}
     length_ratio_pct: lengthRatio,
     rationale: parsed?.rationale ?? null,
     fidelity: Math.round(fidelity * 10) / 10,
+    ...(schemaError ? { error: 'schema-failure', raw: schemaError.raw } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

Three judgment-layer fixes from a deep-research audit of patina's evaluator paths. All P0 in scope, low-blast-radius, backward-compatible.

- **MAX source text passing** — `runMaxMode` now accepts `sourceText` directly. Removes the brittle `prompt.split('## Input Text')[1]` reverse-extraction that silently breaks if prompt-builder's headers ever change.
- **Strict JSON parsing with retry** — `scoreText` / `scoreMPS` / `scoreFidelity` now use `parseStrictJson` + a single retry at temperature 0 on schema failure. Failures surface as `error: 'schema-failure'` and log to stderr instead of silently returning null.
- **Ouroboros regression on combined score** — Iteration regression detection now uses `combinedScore` delta (AI-likeness + inverted fidelity, profile-weighted) instead of raw AI-likeness delta. Original is treated as fidelity=100 for a valid iteration-1 baseline. `target-score` semantics unchanged.

## Why

Audit findings, by file:line:

- `src/max-mode.js:33` — original recovered via prompt-string slicing
- `src/scoring.js:69,120` — schema failures returned `null`, hiding partial breakage
- `src/ouroboros.js:96-101` — `combinedScore` was computed but never used in decision logic

## Test plan

- [x] `npm test` — 69/69 e2e tests pass
- [x] `node --check` on all modified files
- [x] Grep for stale references (`extractJson`, `prompt.split`) — none remain
- [ ] Manual smoke: `--ouroboros` with intentional regression to verify combined-delta rollback path
- [ ] Manual smoke: `--models` MAX path with a long source to confirm MPS evaluator receives original

## Out of scope (follow-ups)

- zh/ja lexicon files
- Phase 3 self-audit simplification (depends on this PR's MPS path)
- Evaluator model separation (cost question)
- `--api-key-stdin`, `--config`, manifest output

🤖 Generated with [Claude Code](https://claude.com/claude-code)