### PR TITLE
refactor(prompt-builder): skip Phase 3 self-audit in Ouroboros mode

### DIFF
--- a/src/prompt-builder.js
+++ b/src/prompt-builder.js
@@ -63,8 +63,9 @@ export function buildPrompt({ config, patterns, profile, voice, scoring, text, m
   return prompt;
 }
 
-function buildRewriteInstructions(structurePacks, lexicalPacks) {
-  let inst = `Follow the 3-Phase pipeline:\n\n`;
+function buildRewriteInstructions(structurePacks, lexicalPacks, { includeSelfAudit = true } = {}) {
+  const phaseCount = includeSelfAudit ? 3 : 2;
+  let inst = `Follow the ${phaseCount}-Phase pipeline:\n\n`;
 
   if (structurePacks.length > 0) {
     inst += `### Phase 1: Structure Scan\n\n`;
@@ -91,15 +92,23 @@ function buildRewriteInstructions(structurePacks, lexicalPacks) {
   inst += `5. Inject personality per voice guidelines\n`;
   inst += `6. Respect blocklist/allowlist and pattern overrides\n\n`;
 
-  inst += `### Phase 3: Self-Audit\n\n`;
-  inst += `1. Scan for remaining AI tells\n`;
-  inst += `2. Verify no polarity inversions (negation → positive or vice versa)\n`;
-  inst += `3. Ensure Phase 1 corrections were not reverted in Phase 2\n`;
-  inst += `4. Final check: meaning preserved?\n\n`;
+  if (includeSelfAudit) {
+    inst += `### Phase 3: Self-Audit\n\n`;
+    inst += `1. Scan for remaining AI tells\n`;
+    inst += `2. Verify no polarity inversions (negation → positive or vice versa)\n`;
+    inst += `3. Ensure Phase 1 corrections were not reverted in Phase 2\n`;
+    inst += `4. Final check: meaning preserved?\n\n`;
 
-  inst += `Provide:\n`;
-  inst += `1. A brief list of what still looks AI-written (if anything)\n`;
-  inst += `2. The final humanized text\n`;
+    inst += `Provide:\n`;
+    inst += `1. A brief list of what still looks AI-written (if anything)\n`;
+    inst += `2. The final humanized text\n`;
+  } else {
+    // Self-audit suppressed: external evaluators (scoreText, scoreMPS,
+    // scoreFidelity) handle AI-tell detection, polarity, and meaning checks
+    // downstream. Output only the rewritten text so iterations stay clean.
+    inst += `Output ONLY the final humanized text. Do not include analysis, ` +
+      `pattern lists, or commentary — downstream evaluators handle that.\n`;
+  }
 
   return inst;
 }
@@ -171,7 +180,10 @@ function buildOuroborosInstructions(config, structurePacks, lexicalPacks) {
   inst += `      - fidelity < ${fidelityFloor} → fidelity violation → rollback\n`;
   inst += `      - MPS < ${mpsFloor} → MPS violation → rollback\n`;
   inst += `4. Output iteration log and final text\n\n`;
-  inst += buildRewriteInstructions(structurePacks, lexicalPacks);
+  // Skip Phase 3 self-audit: each iteration runs through external evaluators
+  // (scoreText, scoreMPS, scoreFidelity) in src/ouroboros.js, so an in-prompt
+  // self-audit duplicates work and inflates token cost.
+  inst += buildRewriteInstructions(structurePacks, lexicalPacks, { includeSelfAudit: false });
 
   return inst;
 }


### PR DESCRIPTION
## Summary

In Ouroboros mode, every iteration's output already runs through three external evaluators (`scoreText`, `scoreMPS`, `scoreFidelity`). The in-prompt Phase 3 self-audit duplicates that work — re-scanning AI tells, re-checking polarity, re-verifying meaning preservation — and pollutes the iteration's text payload with an analysis preamble ("brief list of what still looks AI-written") that has to be stripped or scored alongside the rewritten text.

This change adds an `includeSelfAudit` option to `buildRewriteInstructions` (default `true`, preserves pure rewrite-mode behavior) and threads `includeSelfAudit: false` through `buildOuroborosInstructions`. When suppressed, the rewrite block instructs the model to output ONLY the final humanized text.

Pure `patina foo.md` (rewrite mode) is unchanged — Phase 3 is still its only QA layer.

## Why

Follow-up to #96. Audit finding: Phase 3 self-audit is the LLM grading its own output, which is exactly what the external evaluators are for. In Ouroboros loops it runs N times for no marginal QA benefit, while inflating tokens and forcing downstream parsing to skip past the self-audit preamble.

## Test plan

- [x] `npm test` — 69/69 e2e tests pass
- [x] `node --check src/prompt-builder.js`
- [ ] Manual smoke: `--ouroboros` run — verify iteration outputs no longer contain the "what still looks AI-written" preamble
- [ ] Manual smoke: `patina foo.md` (no flags) — verify Phase 3 still runs and full audit output preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)