### PR TITLE
security(pr1): scrub maintainer PII, parameterize ops paths, refresh lockfile

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+# Canonical author mapping for git shortlog / GitHub UI display.
+# All listed identities below belong to the maintainer (devswha).
+# Format: <canonical-name> <canonical-email> <historical-name> <historical-email>
+
+devswha <devswha@gmail.com> Sangwoo Ha <devswha@gmail.com>
+devswha <devswha@gmail.com> Hako <devswha@gmail.com>
+devswha <devswha@gmail.com> Calvin Ha <calvin-ha_Noul@noul.kr>

--- a/docs/harness-design.md
+++ b/docs/harness-design.md
@@ -100,7 +100,7 @@ cat $RUN_DIR/result.json
 | 항목 | 값 |
 |---|---|
 | Agent ID | `planner` |
-| Workspace | `/home/devswha/workspace/patina` |
+| Workspace | `${PATINA_REPO_DIR}` (default: repo checkout root) |
 | Model | `cliproxy/claude-opus-4-6` |
 | 트리거 | 오케스트레이터가 호출 |
 | 타임아웃 | 5분 |
@@ -148,7 +148,7 @@ cat $RUN_DIR/result.json
 | 항목 | 값 |
 |---|---|
 | Agent ID | `generator` |
-| Workspace | `/home/devswha/workspace/patina` |
+| Workspace | `${PATINA_REPO_DIR}` (default: repo checkout root) |
 | Model | `cliproxy/claude-opus-4-6` |
 | 트리거 | 오케스트레이터가 spec.md와 함께 호출 |
 | 타임아웃 | 20분 |
@@ -166,7 +166,7 @@ cat $RUN_DIR/result.json
 - 기존 패턴/코드 스타일 준수
 - 변경 완료 후 자체 검증 (lint, syntax check 등)
 - review.md가 있으면 피드백 반영하여 수정
-- 커밋 메시지는 Lore 스타일 + `Co-Authored-By: patina-bot <bot@devswha.dev>`
+- 커밋 메시지는 Lore 스타일 + `Co-Authored-By: patina-bot <patina-bot@example.com>`
 
 ---
 
@@ -177,7 +177,7 @@ cat $RUN_DIR/result.json
 | 항목 | 값 |
 |---|---|
 | Agent ID | `evaluator` |
-| Workspace | `/home/devswha/workspace/patina` |
+| Workspace | `${PATINA_REPO_DIR}` (default: repo checkout root) |
 | Model | `cliproxy/claude-opus-4-6` |
 | 트리거 | 오케스트레이터가 diff.patch와 함께 호출 |
 | 타임아웃 | 10분 |

--- a/ops/bot-prompt.md
+++ b/ops/bot-prompt.md
@@ -77,7 +77,7 @@ If after 3 scoring-and-revision iterations the score remains > 30, abandon the c
 1. Create branch: `bot/{issue-number}-{slug}` or `bot/{task-type}-{date}`
 2. Make changes (edit markdown, yaml, or scripts as needed)
 3. Apply the appropriate quality gate (see Quality Gates above)
-4. Commit using the repo's Lore commit protocol and append `Co-Authored-By: patina-bot <bot@devswha.dev>`
+4. Commit using the repo's Lore commit protocol and append `Co-Authored-By: patina-bot <patina-bot@example.com>`
 5. **Rebase before PR:**
    - Run: `git fetch origin main && git rebase origin/main`
    - If rebase fails: `git rebase --abort && git checkout main && git branch -D {branch}`

--- a/ops/bot.sh
+++ b/ops/bot.sh
@@ -6,7 +6,9 @@ set -euo pipefail
 
 export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 
-REPO_DIR="/home/devswha/workspace/patina"
+# Resolve repo dir from script location, allow PATINA_REPO_DIR override.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${PATINA_REPO_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 ENV_FILE="${PATINA_ENV_FILE:-$REPO_DIR/.env}"
 if [ -f "$ENV_FILE" ]; then
   set -a

--- a/ops/harness-prompts/generator.md
+++ b/ops/harness-prompts/generator.md
@@ -47,7 +47,7 @@ The harness message will provide:
 - Append this trailer exactly:
 
 ```text
-Co-Authored-By: patina-bot <bot@devswha.dev>
+Co-Authored-By: patina-bot <patina-bot@example.com>
 ```
 
 - Do not push.

--- a/ops/harness.sh
+++ b/ops/harness.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 
-REPO_DIR="/home/devswha/workspace/patina"
+# Resolve repo dir from script location, allow PATINA_REPO_DIR override.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${PATINA_REPO_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 ENV_FILE="${PATINA_ENV_FILE:-$REPO_DIR/.env}"
 if [ -f "$ENV_FILE" ]; then
   set -a

--- a/ops/patina-component-bridge.service
+++ b/ops/patina-component-bridge.service
@@ -5,11 +5,16 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/home/devswha/workspace/patina
-EnvironmentFile=-/home/devswha/workspace/patina/.env
-Environment=PATH=/home/devswha/.local/bin:/home/devswha/.cargo/bin:/home/devswha/.nvm/versions/node/v22.17.1/bin:/usr/local/bin:/usr/bin:/bin
+# %h expands to the user's home directory at runtime (user-mode systemd).
+# Adjust WorkingDirectory if your patina checkout lives elsewhere.
+WorkingDirectory=%h/workspace/patina
+EnvironmentFile=-%h/workspace/patina/.env
+# PATH must include a node binary. NVM users: replace `current` below with
+# the resolved version path (e.g. `%h/.nvm/versions/node/v22.17.1/bin`)
+# or symlink `current` to a maintained version.
+Environment=PATH=%h/.nvm/current/bin:%h/.local/bin:%h/.cargo/bin:/usr/local/bin:/usr/bin:/bin
 ExecStartPre=/bin/sh -c 'test -n "$PATINA_RUNTIME_CLI" && command -v "$PATINA_RUNTIME_CLI" && command -v node'
-ExecStart=/home/devswha/.nvm/versions/node/v22.17.1/bin/node ops/component-bridge.mjs
+ExecStart=/usr/bin/env node ops/component-bridge.mjs
 Restart=always
 RestartSec=5
 TimeoutStopSec=30

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "patina-cli",
-  "version": "3.3.0",
+  "version": "3.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "patina-cli",
-      "version": "3.3.0",
+      "version": "3.9.0",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"


### PR DESCRIPTION
## Summary

PR-1 of a 3-PR security pass. Two-reviewer audit (Claude `security-reviewer` + independent Codex via `omc ask`) found **no P0**, **no secrets in tracked tree**, **`.env` never committed historically**, **npm audit clean**. This PR addresses the highest-confidence PII / hygiene findings.

## Findings addressed

- **P1-PII-1** — `bot@devswha.dev` (maintainer's personal domain) appeared in 3 prompt/doc files. Replaced with the RFC 2606 reserved placeholder `patina-bot@example.com`.
- **P1-PII-2** — `/home/devswha/workspace/patina` and `/home/devswha/.nvm/versions/node/v22.17.1/bin/node` were hardcoded in 4 ops files and the systemd unit. Now derived from `BASH_SOURCE` (with `PATINA_REPO_DIR` override) or expanded via systemd `%h` specifier + `/usr/bin/env node`.
- **P1-DEP-2** — `package-lock.json` was at version `3.3.0` while `package.json` is `3.9.0`. Regenerated. No dep changes (`js-yaml@4.1.1` + `argparse@2.0.1`, audit clean).
- **P3-PII-1 (partial)** — historical commit metadata showed 4 author identities (`Sangwoo Ha`, `Hako`, `Calvin Ha <calvin-ha_Noul@noul.kr>`, `devswha`). Added `.mailmap` to canonicalize all four to `devswha <devswha@gmail.com>` for `git shortlog` / `%aN` / GitHub UI. Non-destructive: PR/fork SHAs unchanged.

## What's deferred (out of scope for PR-1)

| Finding | Severity | Why not here | Where it lands |
|---|---|---|---|
| `.env` file mode `0644` (world-readable) | P1 | Runtime ops change | PR-2 |
| `--api-key` argv leakage | P1 | CLI surface change, deprecation flow | PR-2 |
| SSRF blocklist in `validateBaseURL` | P1 | Network logic, needs careful test | PR-2 |
| systemd unit hardening (`NoNewPrivileges`, `ProtectSystem`, etc.) | P2 | Bigger ops change | PR-2 |
| Discord bot trust boundary | P1 | Subsystem isolation work | PR-3 |
| Marketing runtime auth isolation | P1 | Subsystem isolation work | PR-3 |
| MAX Codex dispatch sandbox / Gemini stdin | P1/P2 | Patina-max design | PR-3 |
| Git history rewrite (`git filter-repo`) | P3 | Destructive, invalidates every existing PR/fork SHA. Mailmap covers UI exposure non-destructively. Recommend only if `noul.kr` blob retention is unacceptable. | Separate coordinated effort |

## Verification needed from maintainer

**Calvin Ha mapping** — two old commits (v2.0 plugin architecture + v2.1.0 2-Phase pipeline) were authored as `Calvin Ha <calvin-ha_Noul@noul.kr>`. Treated as the maintainer (work email at Noul Inc.) based on commit content + pattern. If this is actually a different person, drop the line from `.mailmap` before merging.

## Test plan

- [x] `npm test` — 69/69 e2e tests pass
- [x] `bash -n ops/bot.sh` and `bash -n ops/harness.sh` — clean
- [x] REPO_DIR resolution test — returns correct repo root
- [x] `git log --pretty='%aN <%aE>' | sort -u` — returns 1 line (was 4)
- [x] `grep -rIn '/home/devswha\|devswha\.dev'` across tracked files — 0 hits
- [ ] Verify Calvin Ha mapping (see above)
- [ ] On a fresh checkout, run `systemctl --user daemon-reload && systemctl --user start patina-component-bridge` to confirm the parameterized unit still resolves correctly on the maintainer's machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)