### PR TITLE
feat(quality): add deterministic stylometry benchmark layer + unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ memory/
 
 # Marketing bot workspace template (internal ops)
 ops/marketing-workspace-template/
+
+# Generated benchmark artifacts (regenerated per `npm run benchmark`)
+tests/quality/results.json

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "patina": "bin/patina.js"
   },
   "scripts": {
-    "test": "node --test tests/e2e/*.test.js",
+    "test": "node --test tests/unit/*.test.js tests/e2e/*.test.js",
+    "test:unit": "node --test tests/unit/*.test.js",
+    "test:e2e": "node --test tests/e2e/*.test.js",
+    "benchmark": "node tests/quality/benchmark.mjs",
     "bot": "bash ops/harness.sh",
     "marketing:runtime:bootstrap": "bash ops/marketing-runtime-bootstrap.sh",
     "marketing:runtime:status": "bash ops/marketing-runtime-cli.sh status",

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -26,7 +26,11 @@ export function analyzeText(text, opts = {}) {
     lexicon: providedLexicon,
   } = opts;
 
-  const paragraphs = splitParagraphs(text);
+  // Normalize to NFC at the boundary so downstream tokenization and lexicon
+  // comparison see canonical form. Mixed NFC/NFD inputs (e.g. "café" composed
+  // vs decomposed) would otherwise yield different MATTR/lexicon hits.
+  const normalized = text ? text.normalize('NFC') : '';
+  const paragraphs = splitParagraphs(normalized);
   const lexicon =
     providedLexicon ??
     (repoRoot ? loadLexicon(lang, repoRoot) : { strict: [], phrases: [] });

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -1,0 +1,92 @@
+// Top-level analyzer: runs the deterministic stylometry + lexicon signals
+// described in core/stylometry.md and returns a per-paragraph result. This
+// is the in-tree port of the algorithm previously delegated to the LLM via
+// SKILL.md Step 4.6/4.7. It does not call any LLM.
+
+import { splitParagraphs, splitSentences, tokenize } from './segment.js';
+import {
+  burstinessCV,
+  mattr,
+  classifyBurstiness,
+  classifyMattr,
+  DEFAULT_BURSTINESS_BANDS,
+  DEFAULT_MATTR_BANDS,
+  DEFAULT_MATTR_WINDOW,
+} from './stylometry.js';
+import { loadLexicon, computeDensity, DEFAULT_LEXICON_DENSITY_THRESHOLD } from './lexicon.js';
+
+export function analyzeText(text, opts = {}) {
+  const {
+    lang = 'en',
+    repoRoot,
+    burstinessBands = DEFAULT_BURSTINESS_BANDS,
+    mattrBands = DEFAULT_MATTR_BANDS,
+    mattrWindow = DEFAULT_MATTR_WINDOW,
+    lexiconDensityThreshold = DEFAULT_LEXICON_DENSITY_THRESHOLD,
+    lexicon: providedLexicon,
+  } = opts;
+
+  const paragraphs = splitParagraphs(text);
+  const lexicon =
+    providedLexicon ??
+    (repoRoot ? loadLexicon(lang, repoRoot) : { strict: [], phrases: [] });
+
+  // §8 skip conditions are advisory only — production callers (SKILL.md 4.6/4.7)
+  // can suppress meta-block emission, but the benchmark wants raw signals on
+  // single-paragraph fixtures so we compute them unconditionally.
+  const totalSentences = paragraphs.reduce(
+    (n, p) => n + splitSentences(p).length,
+    0
+  );
+  const skipReason =
+    paragraphs.length <= 2 ? 'paragraphs<=2' :
+    totalSentences <= 2 ? 'sentences<=2' :
+    null;
+
+  const analyzed = paragraphs.map((paragraph, idx) => {
+    const sentences = splitSentences(paragraph);
+    const sentenceTokens = sentences.map(tokenize);
+    const sentenceTokenCounts = sentenceTokens.map((t) => t.length);
+    const allTokens = sentenceTokens.flat();
+
+    const cv = burstinessCV(sentenceTokenCounts);
+    const cvBand = classifyBurstiness(cv, burstinessBands);
+    const mattrValue = mattr(allTokens, mattrWindow);
+    const mattrBand = classifyMattr(mattrValue, mattrBands);
+    const lex = computeDensity(paragraph, allTokens, lexicon);
+
+    const lexiconHot = lex.density > lexiconDensityThreshold;
+    const hot =
+      cvBand === 'low' || mattrBand === 'low' || lexiconHot;
+
+    return {
+      id: `P${idx + 1}`,
+      sentenceCount: sentences.length,
+      tokenCount: allTokens.length,
+      burstiness: { cv, band: cvBand },
+      mattr: { value: mattrValue, band: mattrBand },
+      lexicon: { ...lex, hot: lexiconHot },
+      hot,
+    };
+  });
+
+  return {
+    lang,
+    skipped: Boolean(skipReason),
+    skipReason,
+    paragraphs: analyzed,
+    hot: analyzed.some((p) => p.hot),
+  };
+}
+
+export {
+  splitParagraphs,
+  splitSentences,
+  tokenize,
+  burstinessCV,
+  mattr,
+  classifyBurstiness,
+  classifyMattr,
+  loadLexicon,
+  computeDensity,
+};

--- a/src/features/lexicon.js
+++ b/src/features/lexicon.js
@@ -24,7 +24,9 @@ function parseLexiconBody(body) {
       continue;
     }
     if (mode && line.startsWith('- ')) {
-      const entry = line.slice(2).trim();
+      // Normalize to NFC so visually identical entries don't fail to match
+      // tokens that arrive in a different normalization form.
+      const entry = line.slice(2).trim().normalize('NFC');
       if (entry) (mode === 'strict' ? strict : phrases).push(entry);
     }
   }
@@ -63,13 +65,19 @@ export function computeDensity(paragraphText, tokens, lexicon) {
   const hits = [];
   const tokenSet = new Set(tokens.map((t) => t.toLowerCase()));
 
+  // §16: English strict entries match whole-word; Korean strict entries are
+  // approximated by substring (어절 inflection means `자리매김` should also
+  // hit `자리매김했다`, `자리매김으로`, etc.). Punctuated entries always need
+  // substring fallback because tokenization strips edge punct.
+  const koSubstring = lexicon.lang === 'ko';
   for (const entry of lexicon.strict) {
     const lowerEntry = entry.toLowerCase();
     if (tokenSet.has(lowerEntry)) {
       hits.push(entry);
-    } else if (/[^\p{L}\p{N}]/u.test(lowerEntry) && lowerText.includes(lowerEntry)) {
-      // Hyphenated or otherwise punctuated entries can't sit in tokenSet
-      // because tokenization strips edge punct only.
+      continue;
+    }
+    const hasInternalPunct = /[^\p{L}\p{N}]/u.test(lowerEntry);
+    if ((koSubstring || hasInternalPunct) && lowerText.includes(lowerEntry)) {
       hits.push(entry);
     }
   }

--- a/src/features/lexicon.js
+++ b/src/features/lexicon.js
@@ -1,0 +1,82 @@
+// AI-lexicon loading and density per core/stylometry.md §16.
+// Loads the markdown lexicon at lexicon/ai-{lang}.md and computes
+// hits-per-1000-tokens density. Custom lexicons under custom/lexicon/
+// take precedence when present.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export const DEFAULT_LEXICON_DENSITY_THRESHOLD = 2.0;
+
+// Parses the two well-known sections out of a lexicon markdown file.
+// Returns { strict: string[], phrases: string[] }.
+function parseLexiconBody(body) {
+  const strict = [];
+  const phrases = [];
+  let mode = null;
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.trim();
+    if (line.startsWith('## ')) {
+      const heading = line.toLowerCase();
+      if (heading.includes('strict matches')) mode = 'strict';
+      else if (heading.includes('multi-word phrases')) mode = 'phrases';
+      else mode = null;
+      continue;
+    }
+    if (mode && line.startsWith('- ')) {
+      const entry = line.slice(2).trim();
+      if (entry) (mode === 'strict' ? strict : phrases).push(entry);
+    }
+  }
+  return { strict, phrases };
+}
+
+export function loadLexicon(lang, repoRoot) {
+  const candidates = [
+    resolve(repoRoot, 'custom', 'lexicon', `ai-${lang}.md`),
+    resolve(repoRoot, 'lexicon', `ai-${lang}.md`),
+  ];
+  for (const path of candidates) {
+    if (existsSync(path)) {
+      const raw = readFileSync(path, 'utf8');
+      const body = raw.replace(/^---[\s\S]*?---\s*/, '');
+      return { lang, path, ...parseLexiconBody(body) };
+    }
+  }
+  return { lang, path: null, strict: [], phrases: [] };
+}
+
+// Phrases may include `~` as a wildcard standing in for up to 40 chars.
+function phraseToRegex(phrase) {
+  const escaped = phrase
+    .toLowerCase()
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const withWildcard = escaped.replace(/~/g, '.{0,40}');
+  return new RegExp(withWildcard);
+}
+
+// Counts paragraph-level lexicon hits. Strict entries match whole-word
+// (Unicode-aware boundaries via \p{L}\p{N}); phrases match as substrings
+// with `~` wildcard support. Each entry counts at most once per paragraph.
+export function computeDensity(paragraphText, tokens, lexicon) {
+  const lowerText = paragraphText.toLowerCase();
+  const hits = [];
+  const tokenSet = new Set(tokens.map((t) => t.toLowerCase()));
+
+  for (const entry of lexicon.strict) {
+    const lowerEntry = entry.toLowerCase();
+    if (tokenSet.has(lowerEntry)) {
+      hits.push(entry);
+    } else if (/[^\p{L}\p{N}]/u.test(lowerEntry) && lowerText.includes(lowerEntry)) {
+      // Hyphenated or otherwise punctuated entries can't sit in tokenSet
+      // because tokenization strips edge punct only.
+      hits.push(entry);
+    }
+  }
+  for (const phrase of lexicon.phrases) {
+    if (phraseToRegex(phrase).test(lowerText)) hits.push(phrase);
+  }
+
+  const density = tokens.length > 0 ? (hits.length / tokens.length) * 1000 : 0;
+  return { matches: hits.length, density, hits };
+}

--- a/src/features/segment.js
+++ b/src/features/segment.js
@@ -1,0 +1,35 @@
+// Paragraph / sentence / token splitting per core/stylometry.md §2 §3.
+//
+// Tokenization is intentionally simple: whitespace split + edge-punctuation
+// strip, no morphological analysis. Sentence splitting is regex-only and
+// accepts known false splits on abbreviations / decimals (documented limit).
+
+const SENTENCE_SPLIT_RE = /[.!?。…]+\s+|\n+/;
+const PARAGRAPH_SPLIT_RE = /\n\s*\n/;
+// \W in Unicode-aware mode. Strips edge punctuation but keeps internal
+// hyphens / apostrophes (e.g. "don't", "좋은-도구") as a single token.
+const EDGE_PUNCT_RE = /^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu;
+
+export function splitParagraphs(text) {
+  if (!text) return [];
+  return text
+    .split(PARAGRAPH_SPLIT_RE)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
+
+export function splitSentences(paragraph) {
+  if (!paragraph) return [];
+  return paragraph
+    .split(SENTENCE_SPLIT_RE)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export function tokenize(text) {
+  if (!text) return [];
+  return text
+    .split(/\s+/)
+    .map((chunk) => chunk.replace(EDGE_PUNCT_RE, ''))
+    .filter((t) => t.length > 0);
+}

--- a/src/features/stylometry.js
+++ b/src/features/stylometry.js
@@ -1,0 +1,50 @@
+// Burstiness CV + MATTR per core/stylometry.md §4 §5.
+// Pure functions over token arrays; no I/O.
+
+export const DEFAULT_BURSTINESS_BANDS = { low: 0.30, high: 0.50 };
+export const DEFAULT_MATTR_BANDS = { low: 0.55, high: 0.70 };
+export const DEFAULT_MATTR_WINDOW = 50;
+
+// Coefficient of variation of sentence token counts.
+// Returns null when the paragraph has fewer than 2 sentences or mean is 0.
+export function burstinessCV(sentenceTokenCounts) {
+  if (!Array.isArray(sentenceTokenCounts) || sentenceTokenCounts.length < 2) return null;
+  const n = sentenceTokenCounts.length;
+  const mean = sentenceTokenCounts.reduce((a, b) => a + b, 0) / n;
+  if (mean === 0) return null;
+  const variance =
+    sentenceTokenCounts.reduce((acc, x) => acc + (x - mean) ** 2, 0) / n;
+  return Math.sqrt(variance) / mean;
+}
+
+// Moving Average Type-Token Ratio (window default 50).
+// Falls back to simple TTR when token count < window.
+export function mattr(tokens, window = DEFAULT_MATTR_WINDOW) {
+  if (!Array.isArray(tokens) || tokens.length === 0) return null;
+  const lower = tokens.map((t) => t.toLowerCase());
+  if (lower.length < window) {
+    return new Set(lower).size / lower.length;
+  }
+  let sum = 0;
+  let count = 0;
+  for (let i = 0; i + window <= lower.length; i++) {
+    const slice = lower.slice(i, i + window);
+    sum += new Set(slice).size / window;
+    count++;
+  }
+  return sum / count;
+}
+
+export function classifyBurstiness(cv, bands = DEFAULT_BURSTINESS_BANDS) {
+  if (cv == null) return null;
+  if (cv < bands.low) return 'low';
+  if (cv > bands.high) return 'high';
+  return 'mid';
+}
+
+export function classifyMattr(value, bands = DEFAULT_MATTR_BANDS) {
+  if (value == null) return null;
+  if (value < bands.low) return 'low';
+  if (value > bands.high) return 'high';
+  return 'mid';
+}

--- a/tests/quality/README.md
+++ b/tests/quality/README.md
@@ -1,0 +1,81 @@
+# Quality Benchmark
+
+Deterministic measurement of patina's stylometry / lexicon signal layer
+against a labeled fixture set. Runs with no LLM calls, no API key, no
+network — fast enough to run on every CI build.
+
+## Run it
+
+```bash
+npm run benchmark
+```
+
+Outputs:
+- A markdown table per language (accuracy, precision, recall, F1, confusion matrix)
+- A list of any misclassified fixtures with their feature values
+- `tests/quality/results.json` — full per-fixture log (gitignored)
+
+## What it measures
+
+Every fixture under `tests/fixtures/suspect-zones/{lang}/{ai|natural}/*.md`
+carries an `expected_hot` label in its frontmatter. The benchmark runs
+`analyzeText()` (defined in `src/features/index.js`) on the body and
+compares the predicted hot/cold decision against that label. The decision
+follows the 3-signal OR rule from `core/stylometry.md` §16:
+
+```
+paragraph is SUSPECT iff
+  burstiness_band == "low"  OR
+  MATTR_band == "low"       OR
+  lexicon_density > threshold
+```
+
+Per-language metrics use `expected_hot=true` as the positive class.
+
+## What it does NOT measure
+
+- LLM-based scoring (`src/scoring.js`). The LLM is non-deterministic by
+  design and adds API cost / latency, so it stays out of this layer.
+  A separate live-mode benchmark would be its own follow-up.
+- Rewrite quality (does the rewritten text read better?). That requires
+  human or LLM grading and lives in `tests/e2e/quality-test.js`.
+- AUROC against a ranked score — the current decision is binary
+  (hot/cold), so we report accuracy + F1 instead.
+
+## Extending the corpus
+
+1. Add a new fixture markdown with frontmatter:
+
+   ```yaml
+   ---
+   fixture_id: ko-ai-06
+   language: ko
+   class: ai
+   expected_hot: true
+   why_designed_this_way: |
+     Brief note on which signals you expect to fire.
+   topic: <subject>
+   ---
+
+   <one paragraph of text>
+   ```
+
+2. Drop it under `tests/fixtures/suspect-zones/{lang}/{ai|natural}/`.
+
+3. Re-run `npm run benchmark` and confirm it classifies as expected.
+
+## Tuning the thresholds
+
+If a real-world corpus produces too many misclassifications, the bands
+in `.patina.default.yaml` (`stylometry.burstiness.bands`,
+`stylometry.ttr.bands`, `lexicon.density_threshold`) drive the
+classification. Sweep against this benchmark + your own corpus and
+update thresholds; the shipped values come from the v3.5.1 / v3.7
+calibration documented in `core/stylometry.md` §13 §16.
+
+## Languages
+
+Currently runs on `ko` and `en` fixtures. `zh` and `ja` are tracked in
+[issue #104](https://github.com/devswha/patina/issues/104) — they
+require lexicon curation and tokenization-policy decisions before the
+benchmark can be extended.

--- a/tests/quality/benchmark.mjs
+++ b/tests/quality/benchmark.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// Quality benchmark for the deterministic stylometry layer.
+//
+// Iterates every fixture under tests/fixtures/suspect-zones/{lang}/{class}/*.md,
+// runs the in-tree analyzer (no LLM), and compares the predicted hot/cold
+// decision against the fixture's expected_hot label. Emits a per-language
+// confusion matrix + accuracy and writes the full per-fixture log to
+// tests/quality/results.json.
+//
+// Usage: node tests/quality/benchmark.mjs [--quiet]
+
+import { readFileSync, readdirSync, writeFileSync, statSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+import { analyzeText } from '../../src/features/index.js';
+import { loadLexicon } from '../../src/features/lexicon.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../..');
+const FIXTURES_ROOT = resolve(REPO_ROOT, 'tests/fixtures/suspect-zones');
+const RESULTS_PATH = resolve(__dirname, 'results.json');
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
+
+function parseFixture(path) {
+  const raw = readFileSync(path, 'utf8');
+  const m = raw.match(FRONTMATTER_RE);
+  if (!m) throw new Error(`Missing frontmatter: ${path}`);
+  return { meta: yaml.load(m[1]), body: m[2].trim(), path };
+}
+
+function listFixtures() {
+  const out = [];
+  for (const lang of readdirSync(FIXTURES_ROOT)) {
+    const langDir = resolve(FIXTURES_ROOT, lang);
+    if (!statSync(langDir).isDirectory()) continue;
+    for (const cls of readdirSync(langDir)) {
+      const clsDir = resolve(langDir, cls);
+      if (!statSync(clsDir).isDirectory()) continue;
+      for (const file of readdirSync(clsDir)) {
+        if (!file.endsWith('.md')) continue;
+        out.push(resolve(clsDir, file));
+      }
+    }
+  }
+  return out.sort();
+}
+
+function emptyMetrics() {
+  return { tp: 0, fp: 0, fn: 0, tn: 0, total: 0 };
+}
+
+function updateMetrics(m, predicted, expected) {
+  m.total++;
+  if (predicted && expected) m.tp++;
+  else if (predicted && !expected) m.fp++;
+  else if (!predicted && expected) m.fn++;
+  else m.tn++;
+}
+
+function summarize(m) {
+  const accuracy = m.total ? (m.tp + m.tn) / m.total : 0;
+  const precision = m.tp + m.fp ? m.tp / (m.tp + m.fp) : 0;
+  const recall = m.tp + m.fn ? m.tp / (m.tp + m.fn) : 0;
+  const f1 = precision + recall ? (2 * precision * recall) / (precision + recall) : 0;
+  return {
+    ...m,
+    accuracy: round(accuracy),
+    precision: round(precision),
+    recall: round(recall),
+    f1: round(f1),
+  };
+}
+
+function round(n, digits = 3) {
+  return Math.round(n * 10 ** digits) / 10 ** digits;
+}
+
+function main() {
+  const quiet = process.argv.includes('--quiet');
+  const fixtures = listFixtures();
+
+  if (fixtures.length === 0) {
+    console.error('No fixtures found under', FIXTURES_ROOT);
+    process.exit(2);
+  }
+
+  const lexicons = {};
+  const perLanguage = {};
+  const fixtureLog = [];
+
+  for (const path of fixtures) {
+    const { meta, body } = parseFixture(path);
+    const lang = meta.language;
+    if (!lexicons[lang]) lexicons[lang] = loadLexicon(lang, REPO_ROOT);
+    if (!perLanguage[lang]) perLanguage[lang] = emptyMetrics();
+
+    const result = analyzeText(body, {
+      lang,
+      lexicon: lexicons[lang],
+    });
+    const predicted = result.hot;
+    const expected = Boolean(meta.expected_hot);
+    updateMetrics(perLanguage[lang], predicted, expected);
+
+    const p = result.paragraphs[0] || {};
+    fixtureLog.push({
+      fixture_id: meta.fixture_id,
+      lang,
+      class: meta.class,
+      expected_hot: expected,
+      predicted_hot: predicted,
+      correct: predicted === expected,
+      cv: round(p.burstiness?.cv ?? 0),
+      cv_band: p.burstiness?.band,
+      mattr: round(p.mattr?.value ?? 0),
+      mattr_band: p.mattr?.band,
+      lexicon_density: round(p.lexicon?.density ?? 0),
+      lexicon_hits: p.lexicon?.hits ?? [],
+    });
+  }
+
+  const summary = {};
+  let totalCorrect = 0;
+  let totalCount = 0;
+  for (const [lang, m] of Object.entries(perLanguage)) {
+    summary[lang] = summarize(m);
+    totalCorrect += m.tp + m.tn;
+    totalCount += m.total;
+  }
+  const overallAccuracy = totalCount ? totalCorrect / totalCount : 0;
+
+  const results = {
+    generatedAt: new Date().toISOString(),
+    fixtureCount: fixtureLog.length,
+    overallAccuracy: round(overallAccuracy),
+    perLanguage: summary,
+    fixtures: fixtureLog,
+  };
+
+  writeFileSync(RESULTS_PATH, JSON.stringify(results, null, 2) + '\n');
+
+  if (!quiet) {
+    console.log(`# Quality benchmark — ${fixtureLog.length} fixtures`);
+    console.log(`Overall accuracy: ${(overallAccuracy * 100).toFixed(1)}%`);
+    console.log();
+    console.log('| lang | n | accuracy | precision | recall | f1 | TP | FP | FN | TN |');
+    console.log('|------|---|----------|-----------|--------|----|----|----|----|----|');
+    for (const [lang, s] of Object.entries(summary)) {
+      console.log(
+        `| ${lang} | ${s.total} | ${(s.accuracy * 100).toFixed(1)}% | ${(s.precision * 100).toFixed(1)}% | ${(s.recall * 100).toFixed(1)}% | ${s.f1.toFixed(2)} | ${s.tp} | ${s.fp} | ${s.fn} | ${s.tn} |`
+      );
+    }
+    console.log();
+    const wrong = fixtureLog.filter((f) => !f.correct);
+    if (wrong.length > 0) {
+      console.log(`Misclassified (${wrong.length}):`);
+      for (const f of wrong) {
+        console.log(
+          `  ${f.fixture_id} (${f.class}) → predicted=${f.predicted_hot}, expected=${f.expected_hot} | cv=${f.cv} ${f.cv_band}, mattr=${f.mattr} ${f.mattr_band}, lex=${f.lexicon_density}/1000`
+        );
+      }
+    } else {
+      console.log('All fixtures classified correctly.');
+    }
+    console.log(`\nFull log: ${RESULTS_PATH}`);
+  }
+}
+
+main();

--- a/tests/quality/benchmark.mjs
+++ b/tests/quality/benchmark.mjs
@@ -94,6 +94,11 @@ function main() {
   for (const path of fixtures) {
     const { meta, body } = parseFixture(path);
     const lang = meta.language;
+    if (typeof meta.expected_hot !== 'boolean') {
+      throw new Error(
+        `${path}: \`expected_hot\` must be a literal boolean (got ${typeof meta.expected_hot}: ${JSON.stringify(meta.expected_hot)})`
+      );
+    }
     if (!lexicons[lang]) lexicons[lang] = loadLexicon(lang, REPO_ROOT);
     if (!perLanguage[lang]) perLanguage[lang] = emptyMetrics();
 
@@ -102,7 +107,7 @@ function main() {
       lexicon: lexicons[lang],
     });
     const predicted = result.hot;
-    const expected = Boolean(meta.expected_hot);
+    const expected = meta.expected_hot;
     updateMetrics(perLanguage[lang], predicted, expected);
 
     const p = result.paragraphs[0] || {};
@@ -142,6 +147,8 @@ function main() {
 
   writeFileSync(RESULTS_PATH, JSON.stringify(results, null, 2) + '\n');
 
+  const wrong = fixtureLog.filter((f) => !f.correct);
+
   if (!quiet) {
     console.log(`# Quality benchmark — ${fixtureLog.length} fixtures`);
     console.log(`Overall accuracy: ${(overallAccuracy * 100).toFixed(1)}%`);
@@ -154,7 +161,6 @@ function main() {
       );
     }
     console.log();
-    const wrong = fixtureLog.filter((f) => !f.correct);
     if (wrong.length > 0) {
       console.log(`Misclassified (${wrong.length}):`);
       for (const f of wrong) {
@@ -167,6 +173,9 @@ function main() {
     }
     console.log(`\nFull log: ${RESULTS_PATH}`);
   }
+
+  // Non-zero exit on any misclassification so CI catches regressions even in --quiet mode.
+  if (wrong.length > 0) process.exitCode = 1;
 }
 
 main();

--- a/tests/unit/stylometry.test.js
+++ b/tests/unit/stylometry.test.js
@@ -67,25 +67,36 @@ test('classifyMattr uses default bands (low<0.55, high>0.70)', () => {
   assert.equal(classifyMattr(0.80), 'high');
 });
 
-test('§10 English worked example is hot (low burstiness AND low MATTR)', () => {
+test('§10 English worked example: exact CV/MATTR/token counts', () => {
   const text =
     'The tool is innovative. The tool is efficient. The tool is reliable. The tool is scalable. The tool is essential.';
   const result = analyzeText(text, { lang: 'en' });
   const p = result.paragraphs[0];
+  // 5 sentences × 4 tokens (the, tool, is, X) → uniform → CV=0
   assert.equal(p.sentenceCount, 5);
+  assert.equal(p.tokenCount, 20);
+  assert.equal(p.burstiness.cv, 0);
   assert.equal(p.burstiness.band, 'low');
+  // 8 unique (the, tool, is, innovative, efficient, reliable, scalable, essential) / 20 = 0.40
+  assert.equal(p.mattr.value, 8 / 20);
   assert.equal(p.mattr.band, 'low');
   assert.equal(p.hot, true);
 });
 
-test('§10 Korean worked example is hot via burstiness (uniform 어절 counts)', () => {
+test('§10 Korean worked example: exact CV/MATTR/token counts', () => {
   const text =
     '이 도구는 단순한 자동완성을 넘어선다. 이 도구는 사용자의 의도를 이해한다. ' +
     '이 도구는 효율적인 협업을 가능하게 한다. 이 도구는 혁신적인 생산성을 제공한다. ' +
     '이 도구는 다양한 언어를 지원한다.';
   const result = analyzeText(text, { lang: 'ko' });
   const p = result.paragraphs[0];
+  // 어절 counts: [5, 5, 6, 5, 5] → mean=5.2, stddev=0.4, CV=0.4/5.2≈0.0769
   assert.equal(p.sentenceCount, 5);
+  assert.equal(p.tokenCount, 26);
+  assert.ok(Math.abs(p.burstiness.cv - 0.4 / 5.2) < 1e-9);
   assert.equal(p.burstiness.band, 'low');
+  // 18 unique tokens / 26 total → 0.6923...
+  assert.ok(Math.abs(p.mattr.value - 18 / 26) < 1e-9);
+  assert.equal(p.mattr.band, 'mid');
   assert.equal(p.hot, true);
 });

--- a/tests/unit/stylometry.test.js
+++ b/tests/unit/stylometry.test.js
@@ -1,0 +1,91 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { splitParagraphs, splitSentences, tokenize } from '../../src/features/segment.js';
+import {
+  burstinessCV,
+  mattr,
+  classifyBurstiness,
+  classifyMattr,
+} from '../../src/features/stylometry.js';
+import { analyzeText } from '../../src/features/index.js';
+
+test('splitParagraphs returns trimmed non-empty paragraphs', () => {
+  assert.deepEqual(splitParagraphs(''), []);
+  assert.deepEqual(splitParagraphs('one\n\ntwo\n\n\nthree'), ['one', 'two', 'three']);
+});
+
+test('splitSentences handles ., !, ?, 。, … and newlines', () => {
+  assert.deepEqual(
+    splitSentences('First. Second! Third? Fourth。 Fifth…\nSixth'),
+    ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth']
+  );
+});
+
+test('tokenize strips edge punctuation but keeps internal hyphens / apostrophes', () => {
+  assert.deepEqual(
+    tokenize(`The tool acts like autocomplete.`),
+    ['The', 'tool', 'acts', 'like', 'autocomplete']
+  );
+  assert.deepEqual(tokenize(`don't 좋은-도구`), [`don't`, '좋은-도구']);
+  assert.deepEqual(tokenize('이 도구는 자동완성처럼 동작한다'), ['이', '도구는', '자동완성처럼', '동작한다']);
+});
+
+test('burstinessCV returns 0 when all sentences have identical token counts', () => {
+  assert.equal(burstinessCV([5, 5, 5, 5, 5]), 0);
+});
+
+test('burstinessCV returns null on degenerate input', () => {
+  assert.equal(burstinessCV([]), null);
+  assert.equal(burstinessCV([5]), null);
+  assert.equal(burstinessCV([0, 0]), null);
+});
+
+test('mattr falls back to simple TTR when token count < window', () => {
+  // 6 unique tokens out of 6 total → TTR = 1.0
+  assert.equal(mattr(['a', 'b', 'c', 'd', 'e', 'f']), 1);
+  // 8 unique out of 20 → TTR = 0.4 (matches stylometry.md §10 worked example)
+  const tokens = 'the tool is innovative the tool is efficient the tool is reliable the tool is scalable the tool is essential'
+    .split(/\s+/);
+  const value = mattr(tokens);
+  assert.equal(value, 8 / 20);
+});
+
+test('classifyBurstiness uses default bands (low<0.30, high>0.50)', () => {
+  assert.equal(classifyBurstiness(0.20), 'low');
+  assert.equal(classifyBurstiness(0.30), 'mid');
+  assert.equal(classifyBurstiness(0.40), 'mid');
+  assert.equal(classifyBurstiness(0.50), 'mid');
+  assert.equal(classifyBurstiness(0.60), 'high');
+  assert.equal(classifyBurstiness(null), null);
+});
+
+test('classifyMattr uses default bands (low<0.55, high>0.70)', () => {
+  assert.equal(classifyMattr(0.40), 'low');
+  assert.equal(classifyMattr(0.55), 'mid');
+  assert.equal(classifyMattr(0.70), 'mid');
+  assert.equal(classifyMattr(0.80), 'high');
+});
+
+test('§10 English worked example is hot (low burstiness AND low MATTR)', () => {
+  const text =
+    'The tool is innovative. The tool is efficient. The tool is reliable. The tool is scalable. The tool is essential.';
+  const result = analyzeText(text, { lang: 'en' });
+  const p = result.paragraphs[0];
+  assert.equal(p.sentenceCount, 5);
+  assert.equal(p.burstiness.band, 'low');
+  assert.equal(p.mattr.band, 'low');
+  assert.equal(p.hot, true);
+});
+
+test('§10 Korean worked example is hot via burstiness (uniform 어절 counts)', () => {
+  const text =
+    '이 도구는 단순한 자동완성을 넘어선다. 이 도구는 사용자의 의도를 이해한다. ' +
+    '이 도구는 효율적인 협업을 가능하게 한다. 이 도구는 혁신적인 생산성을 제공한다. ' +
+    '이 도구는 다양한 언어를 지원한다.';
+  const result = analyzeText(text, { lang: 'ko' });
+  const p = result.paragraphs[0];
+  assert.equal(p.sentenceCount, 5);
+  assert.equal(p.burstiness.band, 'low');
+  assert.equal(p.hot, true);
+});


### PR DESCRIPTION
## Summary

Adds the **quality benchmark layer** the deep-research audit identified as P1 — a way to measure regressions in scoring/stylometry on every CI run, without LLM calls or API keys.

Until now, `core/stylometry.md` defined the burstiness CV / MATTR / lexicon-density algorithm but only the LLM ran it (via prompt instructions in `prompt-builder.js`). This PR ports the deterministic parts into JavaScript under `src/features/`, adds unit tests on the §10 worked examples, and wires up a benchmark that scores the `tests/fixtures/suspect-zones/` corpus the maintainer already curated.

## What's measured

For every fixture under `tests/fixtures/suspect-zones/{ko,en}/{ai,natural}/`:

- Predicted `hot` flag using the §16 3-signal OR rule:
  ```
  paragraph SUSPECT iff
    burstiness_band == "low"  OR  MATTR_band == "low"  OR  lexicon_density > threshold
  ```
- Compared against the fixture's `expected_hot` frontmatter label
- Per-language confusion matrix + accuracy / precision / recall / F1

Run: `npm run benchmark`

## Current baseline

```
# Quality benchmark — 20 fixtures
Overall accuracy: 100.0%

| lang | n | accuracy | precision | recall | f1 | TP | FP | FN | TN |
|------|---|----------|-----------|--------|----|----|----|----|----|
| en   | 10 | 100.0% | 100.0% | 100.0% | 1.00 | 5 | 0 | 0 | 5 |
| ko   | 10 | 100.0% | 100.0% | 100.0% | 1.00 | 5 | 0 | 0 | 5 |
```

This is the **self-consistency baseline** — fixtures were authored alongside the spec, so 100% is expected. Real-world calibration is documented at `core/stylometry.md` §13 (HC3 / Wikipedia, AI catch 76% / human FP 25%) and §14 (NamuWiki, KO catch 91% / human FP 13%). Running this benchmark against external corpora is a follow-up — the in-tree fixtures serve as the regression baseline.

## Modules added

| File | Purpose |
|---|---|
| `src/features/segment.js` | paragraph / sentence / token splitting (§2 §3) |
| `src/features/stylometry.js` | burstinessCV, mattr, band classifiers (§4 §5) |
| `src/features/lexicon.js` | loadLexicon (`lexicon/ai-{lang}.md`) + density (§16) |
| `src/features/index.js` | `analyzeText()` — ties signals together |
| `tests/unit/stylometry.test.js` | 10 deterministic cases including §10 worked examples |
| `tests/quality/benchmark.mjs` | corpus-driven benchmark runner |
| `tests/quality/README.md` | how to run / extend / tune |

## Wiring

- `npm test` now runs both `tests/unit/` and `tests/e2e/`
- `npm run test:unit` / `test:e2e` for targeted runs
- `npm run benchmark` for the quality benchmark
- `tests/quality/results.json` is gitignored — regenerated per run

## Verification

- [x] `npm test` — 79/79 (69 e2e unchanged + 10 new unit)
- [x] `npm run benchmark` — 100% accuracy on all 20 fixtures
- [x] `node --check` on every new module

## Out of scope (explicit follow-ups)

- **LLM-based scoring benchmark** (live + cached fixtures replay). Adds API cost / non-determinism; needs its own design.
- **AUROC against ranked scores**. The decision is currently binary (hot/cold); ranking would require per-fixture continuous score export.
- **zh/ja fixtures and lexicons**. Tracked in #104 — needs lexicon curation + tokenization policy decisions before fixtures can be scored deterministically.
- **External corpus runner** (HC3 / NamuWiki / Wikipedia). The reference Python implementations live in `.omc/research/` (gitignored); a JS port is its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)