### PR TITLE
feat(api): smarter retries, retry-after support, MAX-mode concurrency cap

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -2,6 +2,92 @@ import { validateBaseURL } from './security.js';
 
 const DEFAULT_TIMEOUT = 120000;
 const DEFAULT_MAX_RETRIES = 2;
+const DEFAULT_BASE_BACKOFF_MS = 1000;
+const DEFAULT_MAX_BACKOFF_MS = 30000;
+
+// Status codes that warrant a retry. Network errors (no status, AbortError)
+// are also retryable; auth / validation 4xxs are not.
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+// Subclassed error so the retry loop can read `.status` + `.retryAfter`
+// without re-parsing strings.
+export class HttpError extends Error {
+  constructor(status, body, retryAfter) {
+    super(`HTTP ${status}: ${truncate(body)}`);
+    this.name = 'HttpError';
+    this.status = status;
+    this.body = body;
+    this.retryAfter = retryAfter;
+  }
+}
+
+function truncate(text, max = 256) {
+  if (typeof text !== 'string') return '';
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+export function isRetryable(err) {
+  if (!err) return false;
+  if (err.name === 'AbortError') return true;
+  if (typeof err.status === 'number') return RETRYABLE_STATUS.has(err.status);
+  // Heuristic for fetch network errors (no status set).
+  return err.name === 'TypeError' || err.code === 'ECONNRESET' || err.code === 'ECONNREFUSED';
+}
+
+// Honors Retry-After (seconds or HTTP-date). Falls back to exponential
+// backoff with up to 50% jitter, capped at maxDelay.
+export function computeBackoffMs(attempt, retryAfter, opts = {}) {
+  const {
+    base = DEFAULT_BASE_BACKOFF_MS,
+    max = DEFAULT_MAX_BACKOFF_MS,
+    now = () => Date.now(),
+    random = Math.random,
+  } = opts;
+
+  if (retryAfter) {
+    const asNumber = Number(retryAfter);
+    if (Number.isFinite(asNumber) && asNumber >= 0) {
+      return Math.min(asNumber * 1000, max);
+    }
+    const asDateMs = Date.parse(retryAfter);
+    if (Number.isFinite(asDateMs)) {
+      return Math.max(0, Math.min(asDateMs - now(), max));
+    }
+  }
+
+  const exp = Math.min(base * 2 ** attempt, max);
+  const jitter = random() * exp * 0.5;
+  return Math.min(exp + jitter, max);
+}
+
+// Bounded-concurrency semaphore. `max <= 0` (or undefined) yields a
+// no-op gate so the existing parallel-fanout behavior is unchanged when
+// the caller doesn't ask for a limit.
+export function createSemaphore(max) {
+  if (!max || max <= 0) {
+    return { acquire: () => Promise.resolve(() => {}) };
+  }
+  let active = 0;
+  const queue = [];
+  const drain = () => {
+    if (active < max && queue.length) {
+      active++;
+      const resolve = queue.shift();
+      resolve(() => {
+        active--;
+        drain();
+      });
+    }
+  };
+  return {
+    acquire() {
+      return new Promise((resolve) => {
+        queue.push(resolve);
+        if (active < max) drain();
+      });
+    },
+  };
+}
 
 export async function callLLM({
   prompt,
@@ -12,6 +98,8 @@ export async function callLLM({
   timeout = DEFAULT_TIMEOUT,
   maxRetries = DEFAULT_MAX_RETRIES,
   allowInsecureBaseURL = false,
+  // Allows tests to inject a deterministic delay function.
+  sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
 }) {
   validateBaseURL(baseURL, { allowInsecure: allowInsecureBaseURL });
   const url = `${baseURL}/chat/completions`;
@@ -40,7 +128,11 @@ export async function callLLM({
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`HTTP ${response.status}: ${errorText}`);
+        throw new HttpError(
+          response.status,
+          errorText,
+          response.headers.get('retry-after')
+        );
       }
 
       const data = await response.json();
@@ -52,16 +144,19 @@ export async function callLLM({
       return content;
     } catch (err) {
       lastError = err;
-      if (attempt < maxRetries) {
-        const delay = 1000 * (attempt + 1);
-        await new Promise((r) => setTimeout(r, delay));
+      if (attempt < maxRetries && isRetryable(err)) {
+        const delay = computeBackoffMs(attempt, err.retryAfter);
+        await sleep(delay);
+        continue;
       }
+      // Non-retryable or out of attempts — bail out.
+      break;
     } finally {
       clearTimeout(timer);
     }
   }
 
-  throw new Error(`LLM API failed after ${maxRetries + 1} attempts: ${lastError.message}`);
+  throw new Error(`LLM API failed after ${maxRetries + 1} attempts: ${lastError?.message ?? 'unknown'}`);
 }
 
 export async function callLLMMultiple({
@@ -72,11 +167,14 @@ export async function callLLMMultiple({
   temperature = 0.7,
   timeout = DEFAULT_TIMEOUT,
   allowInsecureBaseURL = false,
+  maxConcurrency = 0, // 0 = unlimited (preserves prior behavior)
   onStart,
   onComplete,
 }) {
   validateBaseURL(baseURL, { allowInsecure: allowInsecureBaseURL });
+  const sem = createSemaphore(maxConcurrency);
   const promises = models.map(async (model) => {
+    const release = await sem.acquire();
     if (onStart) onStart(model);
     try {
       const result = await callLLM({
@@ -93,6 +191,8 @@ export async function callLLMMultiple({
     } catch (err) {
       if (onComplete) onComplete(model, false);
       return { model, error: err.message, ok: false };
+    } finally {
+      release();
     }
   });
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -97,6 +97,7 @@ export async function main(args) {
         baseURL: resolved.baseURL,
         config,
         patterns,
+        maxConcurrency: parsed.maxConcurrency,
       });
     } else if (parsed.ouroboros) {
       result = await runOuroboros({
@@ -208,6 +209,14 @@ function parseArgs(args) {
       case '--models':
         parsed.models = args[++i].split(',').map((m) => m.trim());
         break;
+      case '--max-concurrency': {
+        const n = Number(args[++i]);
+        if (!Number.isFinite(n) || n < 0) {
+          throw new Error(`--max-concurrency expects a non-negative integer, got ${args[i]}`);
+        }
+        parsed.maxConcurrency = n;
+        break;
+      }
       case '--model':
         parsed.model = args[++i];
         break;
@@ -385,6 +394,7 @@ Options:
   --suffix <ext>       Save as {name}{ext}{extname}
   --outdir <dir>       Save results to directory
   --models <list>      MAX mode: comma-separated model list
+  --max-concurrency <n>  Cap parallel MAX-mode requests (default: unlimited)
   --model <id>         Single model ID (default: gpt-4o)
   --api-key <key>      API key (DEPRECATED: leaks via ps/shell history; prefer
                        PATINA_API_KEY env or --api-key-file)

--- a/src/max-mode.js
+++ b/src/max-mode.js
@@ -1,7 +1,7 @@
 import { callLLMMultiple } from './api.js';
 import { scoreText, scoreMPS } from './scoring.js';
 
-export async function runMaxMode({ prompt, sourceText, models, apiKey, baseURL, config, patterns }) {
+export async function runMaxMode({ prompt, sourceText, models, apiKey, baseURL, config, patterns, maxConcurrency }) {
   console.error(`[patina-max] Dispatching to ${models.length} models: ${models.join(', ')}`);
 
   const results = await callLLMMultiple({
@@ -9,6 +9,7 @@ export async function runMaxMode({ prompt, sourceText, models, apiKey, baseURL, 
     models,
     apiKey,
     baseURL,
+    maxConcurrency,
     onStart: (model) => console.error(`[patina-max] Starting ${model}...`),
     onComplete: (model, ok) => console.error(`[patina-max] ${model} ${ok ? 'completed' : 'failed'}`),
   });

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -1,0 +1,107 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  HttpError,
+  isRetryable,
+  computeBackoffMs,
+  createSemaphore,
+} from '../../src/api.js';
+
+test('HttpError captures status, body, and Retry-After', () => {
+  const err = new HttpError(503, 'service down', '5');
+  assert.equal(err.name, 'HttpError');
+  assert.equal(err.status, 503);
+  assert.equal(err.body, 'service down');
+  assert.equal(err.retryAfter, '5');
+  assert.match(err.message, /^HTTP 503: /);
+});
+
+test('HttpError truncates long bodies in the message', () => {
+  const long = 'x'.repeat(1024);
+  const err = new HttpError(500, long);
+  assert.ok(err.message.length < long.length, 'message should be truncated');
+  assert.equal(err.body, long); // raw body preserved on the error
+});
+
+test('isRetryable: 5xx, 429, 408, 425 are retryable', () => {
+  for (const status of [500, 502, 503, 504, 429, 408, 425]) {
+    assert.equal(isRetryable(new HttpError(status, '')), true, `status ${status}`);
+  }
+});
+
+test('isRetryable: auth/validation 4xxs are NOT retryable', () => {
+  for (const status of [400, 401, 403, 404, 422]) {
+    assert.equal(isRetryable(new HttpError(status, '')), false, `status ${status}`);
+  }
+});
+
+test('isRetryable: AbortError (timeout) is retryable', () => {
+  const err = new Error('aborted');
+  err.name = 'AbortError';
+  assert.equal(isRetryable(err), true);
+});
+
+test('isRetryable: network TypeError / ECONNRESET are retryable', () => {
+  const typeErr = new TypeError('fetch failed');
+  assert.equal(isRetryable(typeErr), true);
+  const econn = new Error('connection reset');
+  econn.code = 'ECONNRESET';
+  assert.equal(isRetryable(econn), true);
+});
+
+test('computeBackoffMs honors numeric Retry-After in seconds', () => {
+  const ms = computeBackoffMs(0, '5');
+  assert.equal(ms, 5000);
+});
+
+test('computeBackoffMs honors HTTP-date Retry-After', () => {
+  const now = 1_700_000_000_000;
+  const future = new Date(now + 7000).toUTCString();
+  const ms = computeBackoffMs(0, future, { now: () => now });
+  assert.equal(ms, 7000);
+});
+
+test('computeBackoffMs falls back to exponential + jitter', () => {
+  // Jitter held constant (0.5) to make the assertion deterministic.
+  const ms = computeBackoffMs(2, null, { random: () => 0.5 });
+  // base = min(1000 * 2^2, 30000) = 4000; jitter = 0.5 * 4000 * 0.5 = 1000
+  assert.equal(ms, 5000);
+});
+
+test('computeBackoffMs caps backoff at maxDelay', () => {
+  const ms = computeBackoffMs(20, null, { random: () => 1, max: 30000 });
+  assert.equal(ms, 30000);
+});
+
+test('computeBackoffMs caps Retry-After at maxDelay too', () => {
+  const ms = computeBackoffMs(0, '600', { max: 30000 });
+  assert.equal(ms, 30000);
+});
+
+test('createSemaphore(0) is a no-op (existing parallel behavior)', async () => {
+  const sem = createSemaphore(0);
+  const r1 = await sem.acquire();
+  const r2 = await sem.acquire();
+  assert.equal(typeof r1, 'function');
+  assert.equal(typeof r2, 'function');
+  r1();
+  r2();
+});
+
+test('createSemaphore enforces concurrency cap and drains the queue', async () => {
+  const sem = createSemaphore(2);
+  let active = 0;
+  let peak = 0;
+  const work = async () => {
+    const release = await sem.acquire();
+    active++;
+    peak = Math.max(peak, active);
+    await new Promise((r) => setTimeout(r, 5));
+    active--;
+    release();
+  };
+  await Promise.all([work(), work(), work(), work(), work()]);
+  assert.equal(peak, 2, 'never exceeds cap');
+  assert.equal(active, 0, 'all releases run');
+});


### PR DESCRIPTION
## Summary

Backend hardening from the deep-research audit P1. The previous `src/api.js` retry loop treated every error the same and used linear 1s/2s backoff — wasted attempts on non-retryable 4xxs, ignored rate-limit hints on 429s. MAX mode also fan-fired all candidate models with no upper bound, so a 5-model dispatch on a flaky provider would pile against the rate limiter.

No new dependencies; everything implemented inline.

## Changes

### `src/api.js`
- **`HttpError`** — captures `status`, `body`, `retryAfter`. Retry loop reads structured fields instead of regex-matching error strings.
- **`isRetryable(err)`** — retries 5xx + {429, 408, 425} + `AbortError` + fetch network errors. Auth/validation 4xxs (400, 401, 403, 404, 422) bail immediately.
- **`computeBackoffMs(attempt, retryAfter, opts)`** — honors numeric and HTTP-date `Retry-After`, otherwise exponential (base 1s → cap 30s) with up to 50% jitter. `Retry-After` is also capped at 30s to bound waits.
- **`createSemaphore(max)`** — queue-based concurrency gate. `max<=0` is a no-op so existing parallel-fanout MAX behavior remains the default unless the caller opts in.
- **`callLLMMultiple`** now accepts `maxConcurrency`.

### `src/cli.js`
- Adds `--max-concurrency <n>` (default unlimited).
- Threads through `runMaxMode → callLLMMultiple`.
- Help text updated.

### `src/max-mode.js`
- Accepts and forwards `maxConcurrency`.

### Tests (`tests/unit/api.test.js`, 13 cases)
- `HttpError` carries fields; long bodies truncated in `.message`
- `isRetryable` covers retryable 5xx/429/408/425, non-retryable 4xxs, `AbortError`, `TypeError` (fetch), `ECONNRESET`
- `computeBackoffMs` covers numeric `Retry-After`, HTTP-date `Retry-After`, exponential fallback with deterministic jitter (`random: () => 0.5`), and `maxDelay` cap
- `createSemaphore(0)` is a no-op; `createSemaphore(2)` caps peak concurrency and drains the queue

## Verification

- [x] `npm test` — 92/92 (69 e2e + 23 unit; 13 new + 10 stylometry)
- [x] `npm run benchmark` — unchanged (100%, no regression)
- [x] `node --check` on `src/api.js`, `src/cli.js`, `src/max-mode.js` — clean

## Behavior changes (callers should know)

- **A 401/403 fails on attempt 1**, not after 2 retries. Saves ~3s and one wasted call on a misconfigured key.
- **MAX mode without `--max-concurrency`** keeps the existing all-at-once fanout — the flag is opt-in. To use a cap: `patina --models claude,codex,gemini --max-concurrency 2 input.txt`.

## Out of scope (future)

- Provider capability map (structured output support, per-provider timeouts, free-tier rate caps)
- `--budget-tokens` / `--budget-cost` / `--fail-open` / `--fail-closed` runtime flags
- `applyInsecureBaseURLOptIn` env-mutation cleanup (cosmetic; tracked in #108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)