### PR TITLE
feat(cli): --config and --save-run for reproducible runs

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -7,6 +7,7 @@ import { validateBaseURL, applyInsecureBaseURLOptIn, applyPrivateBaseURLOptIn } 
 import { formatOutput } from './output.js';
 import { runMaxMode } from './max-mode.js';
 import { runOuroboros } from './ouroboros.js';
+import { buildManifest, appendResult, writeManifest } from './manifest.js';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, basename, extname } from 'node:path';
 
@@ -53,7 +54,10 @@ export async function main(args) {
   applyPrivateBaseURLOptIn(parsed);
   validateBaseURL(resolved.baseURL);
 
-  const config = loadConfig();
+  const configPath = parsed.config ? resolve(process.cwd(), parsed.config) : undefined;
+  const config = loadConfig(configPath);
+  const startedAt = new Date().toISOString();
+  const manifestResults = [];
 
   if (parsed.lang) config.language = parsed.lang;
   if (parsed.profile) config.profile = parsed.profile;
@@ -151,11 +155,45 @@ export async function main(args) {
       output = formatOutput(result, mode, parsed);
     }
 
+    if (parsed.saveRun) {
+      const idx = manifestResults.length + 1;
+      const outputName = `output-${idx}.txt`;
+      appendResult(manifestResults, {
+        inputPath: path,
+        prompt,
+        outputRef: { kind: 'file', name: outputName },
+      });
+      manifestResults[manifestResults.length - 1]._content = output;
+    }
+
     if (parsed.batch) {
       await writeBatchOutput(parsed, path, output);
     } else {
       console.log(output);
     }
+  }
+
+  if (parsed.saveRun) {
+    const manifest = buildManifest({
+      patinaVersion: PACKAGE_VERSION,
+      mode,
+      lang,
+      profile: profileName,
+      provider: provider?.name,
+      backend: parsed.backend ?? 'openai-http',
+      model: resolved.model,
+      configPath: configPath ?? null,
+      config,
+      patterns,
+      results: manifestResults.map(({ _content, ...r }) => r),
+      startedAt,
+    });
+    const outputs = manifestResults.map(({ outputRef, _content }) => ({
+      name: outputRef.name,
+      content: _content,
+    }));
+    const manifestPath = writeManifest(resolve(process.cwd(), parsed.saveRun), manifest, outputs);
+    console.error(`[patina] wrote manifest to ${manifestPath}`);
   }
 }
 
@@ -237,6 +275,12 @@ function parseArgs(args) {
         break;
       case '--allow-insecure-base-url':
         parsed.allowInsecureBaseURL = true;
+        break;
+      case '--config':
+        parsed.config = args[++i];
+        break;
+      case '--save-run':
+        parsed.saveRun = args[++i];
         break;
       default:
         if (!arg.startsWith('-')) {
@@ -397,6 +441,10 @@ Options:
   --list-providers     List provider presets and which keys are set
   --allow-insecure-base-url  Permit plaintext http:// to non-localhost endpoints
                        (also enabled by PATINA_ALLOW_INSECURE_BASE_URL=1)
+  --config <path>      Load config from <path> instead of .patina.default.yaml
+  --save-run <dir>     Write manifest.json + output-N.txt under <dir> after the
+                       run (records version, prompt/config hashes, patterns,
+                       provider/model — useful for reproducibility / audit)
   --allow-private-base-url   Permit base URL pointing at private/IMDS IPs
                        (also enabled by PATINA_ALLOW_PRIVATE_BASE_URL=1).
                        Default: refuse to send the API key to RFC 1918 / link-local

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -1,0 +1,72 @@
+// Reproducibility manifest writer — captures enough metadata about a run
+// to reproduce it later (config hash, prompt hash, selected patterns,
+// provider/model, package version, results). Schema is versioned so
+// callers and tooling can detect breaking shape changes.
+
+import { createHash } from 'node:crypto';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export const MANIFEST_SCHEMA_VERSION = '1';
+
+export function hashSha256(input) {
+  if (input == null) return null;
+  const data = typeof input === 'string' ? input : JSON.stringify(input);
+  return `sha256:${createHash('sha256').update(data).digest('hex')}`;
+}
+
+// Build the manifest body. Caller passes the already-resolved run state;
+// this function is pure (no I/O) so it's easy to unit-test.
+export function buildManifest({
+  patinaVersion,
+  mode,
+  lang,
+  profile,
+  provider,
+  backend,
+  model,
+  configPath,
+  config,
+  patterns,
+  results,
+  startedAt,
+  finishedAt = new Date().toISOString(),
+}) {
+  return {
+    manifestVersion: MANIFEST_SCHEMA_VERSION,
+    patina: patinaVersion,
+    startedAt,
+    finishedAt,
+    mode,
+    lang,
+    profile,
+    provider: provider ?? null,
+    backend: backend ?? null,
+    model: model ?? null,
+    configPath: configPath ?? null,
+    configHash: hashSha256(config),
+    patterns: (patterns ?? []).map((p) => p.frontmatter?.pack || p.file),
+    results: results ?? [],
+  };
+}
+
+// Add one input/output pair's hash + ref to the running results array.
+// Mutates the input array for convenience.
+export function appendResult(results, { inputPath, prompt, outputRef }) {
+  results.push({
+    input: inputPath,
+    promptHash: hashSha256(prompt),
+    output: outputRef,
+  });
+  return results;
+}
+
+export function writeManifest(dir, manifest, outputs = []) {
+  mkdirSync(dir, { recursive: true });
+  const manifestPath = resolve(dir, 'manifest.json');
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+  for (const { name, content } of outputs) {
+    writeFileSync(resolve(dir, name), content);
+  }
+  return manifestPath;
+}

--- a/tests/unit/manifest.test.js
+++ b/tests/unit/manifest.test.js
@@ -1,0 +1,109 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+import {
+  hashSha256,
+  buildManifest,
+  appendResult,
+  writeManifest,
+  MANIFEST_SCHEMA_VERSION,
+} from '../../src/manifest.js';
+
+test('hashSha256 returns deterministic sha256-prefixed hex', () => {
+  const a = hashSha256('hello');
+  const b = hashSha256('hello');
+  assert.equal(a, b, 'same input → same hash');
+  assert.match(a, /^sha256:[0-9a-f]{64}$/);
+});
+
+test('hashSha256 stringifies non-string inputs', () => {
+  const a = hashSha256({ x: 1 });
+  const b = hashSha256({ x: 1 });
+  assert.equal(a, b);
+  assert.notEqual(hashSha256({ x: 1 }), hashSha256({ x: 2 }));
+});
+
+test('hashSha256 returns null for null/undefined input', () => {
+  assert.equal(hashSha256(null), null);
+  assert.equal(hashSha256(undefined), null);
+});
+
+test('buildManifest captures core run metadata + schema version', () => {
+  const m = buildManifest({
+    patinaVersion: '3.9.0',
+    mode: 'rewrite',
+    lang: 'ko',
+    profile: 'default',
+    provider: 'openai',
+    backend: 'openai-http',
+    model: 'gpt-4o',
+    configPath: '/tmp/config.yaml',
+    config: { language: 'ko' },
+    patterns: [
+      { file: 'ko-structure.md', frontmatter: { pack: 'ko-structure' }, body: '' },
+      { file: 'ko-content.md', frontmatter: {}, body: '' },
+    ],
+    startedAt: '2026-05-06T00:00:00Z',
+    finishedAt: '2026-05-06T00:00:01Z',
+  });
+
+  assert.equal(m.manifestVersion, MANIFEST_SCHEMA_VERSION);
+  assert.equal(m.patina, '3.9.0');
+  assert.equal(m.mode, 'rewrite');
+  assert.equal(m.lang, 'ko');
+  assert.equal(m.provider, 'openai');
+  assert.deepEqual(m.patterns, ['ko-structure', 'ko-content.md']); // falls back to file when no pack
+  assert.match(m.configHash, /^sha256:[0-9a-f]{64}$/);
+  assert.deepEqual(m.results, []);
+});
+
+test('buildManifest tolerates missing optional fields', () => {
+  const m = buildManifest({
+    patinaVersion: '3.9.0',
+    mode: 'rewrite',
+    lang: 'en',
+    profile: 'default',
+    config: {},
+  });
+  assert.equal(m.provider, null);
+  assert.equal(m.backend, null);
+  assert.equal(m.model, null);
+  assert.equal(m.configPath, null);
+  assert.deepEqual(m.patterns, []);
+});
+
+test('appendResult records input + prompt hash + output ref', () => {
+  const results = [];
+  appendResult(results, {
+    inputPath: 'foo.md',
+    prompt: 'PROMPT BODY',
+    outputRef: { kind: 'file', name: 'output-1.txt' },
+  });
+  assert.equal(results.length, 1);
+  assert.equal(results[0].input, 'foo.md');
+  assert.match(results[0].promptHash, /^sha256:[0-9a-f]{64}$/);
+  assert.deepEqual(results[0].output, { kind: 'file', name: 'output-1.txt' });
+});
+
+test('writeManifest creates dir, writes manifest.json + outputs', () => {
+  const dir = mkdtempSync(resolve(tmpdir(), 'patina-manifest-'));
+  const manifest = buildManifest({
+    patinaVersion: '3.9.0',
+    mode: 'rewrite',
+    lang: 'ko',
+    profile: 'default',
+    config: {},
+    results: [{ input: 'a.md', promptHash: 'sha256:abc', output: { kind: 'file', name: 'out.txt' } }],
+    startedAt: '2026-05-06T00:00:00Z',
+  });
+  const path = writeManifest(dir, manifest, [{ name: 'out.txt', content: 'rendered output' }]);
+  assert.equal(path, resolve(dir, 'manifest.json'));
+  assert.ok(existsSync(path));
+  assert.equal(readFileSync(resolve(dir, 'out.txt'), 'utf8'), 'rendered output');
+  const onDisk = JSON.parse(readFileSync(path, 'utf8'));
+  assert.equal(onDisk.manifestVersion, MANIFEST_SCHEMA_VERSION);
+  assert.equal(onDisk.results[0].output.name, 'out.txt');
+});


### PR DESCRIPTION
## Summary

Audit P1 reproducibility item. Adds `--config <path>` and `--save-run <dir>` so any patina invocation can be explicitly described and replayed later. Also creates `src/manifest.js` — the schema future scoring / MPS / fidelity work can attach result metadata to.

Branched off `main` independently of #110 (backend hardening). Both touch `src/cli.js` `parseArgs`, but the touched regions are different switch cases — trivial conflict resolution at merge time. No code overlap with #110's `src/api.js` work.

## CLI surfaces

| Flag | Effect |
|---|---|
| `--config <path>` | Override the default `.patina.default.yaml` lookup. User-config layer (`~/.patina.yaml`, `./.patina.yaml`) still merges on top. |
| `--save-run <dir>` | After the run, write `<dir>/manifest.json` + one `<dir>/output-N.txt` per input. Directory is created if missing. Path goes to stderr. |

## Manifest schema (v1)

```json
{
  "manifestVersion": "1",
  "patina": "3.9.0",
  "startedAt": "2026-05-06T...",
  "finishedAt": "2026-05-06T...",
  "mode": "rewrite",
  "lang": "ko",
  "profile": "default",
  "provider": "openai",
  "backend": "openai-http",
  "model": "gpt-4o",
  "configPath": "/abs/path/to/.patina.yaml",
  "configHash": "sha256:...",
  "patterns": ["ko-structure", "ko-content", ...],
  "results": [
    { "input": "foo.md", "promptHash": "sha256:...", "output": { "kind": "file", "name": "output-1.txt" } }
  ]
}
```

`promptHash` makes it cheap to detect when a config edit actually changed what the LLM saw. `configHash` does the same for the resolved config (after `~/.patina.yaml` and `./.patina.yaml` merge).

## Implementation

`src/manifest.js`:
- `hashSha256(input)` — deterministic `sha256:<hex>` for strings or JSON-stringified objects
- `buildManifest(opts)` — pure (no I/O), returns the JSON object
- `appendResult(results, opts)` — pushes one result entry
- `writeManifest(dir, manifest, outputs)` — `mkdir -p` + writes `manifest.json` + each named output file

`src/cli.js` plumbs `parsed.config` to `loadConfig()`, captures `startedAt` once, accumulates per-input results, and writes the manifest after the loop if `--save-run` is set.

## Test plan

- [x] `npm test` — 86/86 (69 e2e + 17 unit; 7 new manifest + 10 stylometry)
- [x] `node --check src/manifest.js src/cli.js` — clean
- [x] `tests/unit/manifest.test.js` — round-trip writeManifest writes the schema and the named output file to a tmpdir
- [ ] Manual smoke: `patina --save-run /tmp/run-1 --backend codex-cli foo.md` produces a manifest pointing at `output-1.txt` (skipped here because it requires a live `codex` invocation)

## Out of scope (future)

- `--patterns-dir` / `--profiles-dir` / `--lexicon-dir` / `--voice-file` overrides
- `--json` output mode
- Token usage and score breakdown inside `manifest.results` (gated on the scoring re-calibration work — manifest schema can extend without bumping `manifestVersion` for additive fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)