### PR TITLE
fix(cli): correct manifest output keys, drop _content sneak channel

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -58,6 +58,7 @@ export async function main(args) {
   const config = loadConfig(configPath);
   const startedAt = new Date().toISOString();
   const manifestResults = [];
+  const manifestOutputs = [];
 
   if (parsed.lang) config.language = parsed.lang;
   if (parsed.profile) config.profile = parsed.profile;
@@ -164,7 +165,7 @@ export async function main(args) {
         prompt,
         outputRef: { kind: 'file', name: outputName },
       });
-      manifestResults[manifestResults.length - 1]._content = output;
+      manifestOutputs.push({ name: outputName, content: output });
     }
 
     if (parsed.batch) {
@@ -186,14 +187,14 @@ export async function main(args) {
       configPath: configPath ?? null,
       config,
       patterns,
-      results: manifestResults.map(({ _content, ...r }) => r),
+      results: manifestResults,
       startedAt,
     });
-    const outputs = manifestResults.map(({ outputRef, _content }) => ({
-      name: outputRef.name,
-      content: _content,
-    }));
-    const manifestPath = writeManifest(resolve(process.cwd(), parsed.saveRun), manifest, outputs);
+    const manifestPath = writeManifest(
+      resolve(process.cwd(), parsed.saveRun),
+      manifest,
+      manifestOutputs
+    );
     console.error(`[patina] wrote manifest to ${manifestPath}`);
   }
 }


### PR DESCRIPTION
## Summary

Hot-fix for #111: `--save-run` crashed with `TypeError: Cannot read properties of undefined (reading 'name')` right before the manifest hit disk. The rewrite itself succeeded, but the manifest was never written.

## Root cause

The cli.js plumbing read `outputRef` from each result entry — but `appendResult()` stores that field as `output`, not `outputRef`. The destructure resolved to `undefined`, and `outputRef.name` blew up.

The bug was hidden by a parallel sneak channel: cli.js stuffed `_content` onto each result entry to carry the rendered output text into a later `.map()`, and that strip-on-write step was the same code that tripped on the missing key.

## Fix

Drop the `_content` side channel. Track results and outputs as two parallel arrays:

```js
const manifestResults = [];   // schema entries: { input, promptHash, output }
const manifestOutputs = [];   // { name, content } pairs

// inside the per-input loop:
appendResult(manifestResults, { inputPath, prompt, outputRef: { kind: 'file', name } });
manifestOutputs.push({ name, content: output });

// after the loop:
writeManifest(saveRunDir, buildManifest({ ..., results: manifestResults }), manifestOutputs);
```

## Verification

End-to-end demo with the codex-cli backend:

```
$ rm -rf /tmp/patina-demo-run
$ patina --backend codex-cli --lang ko --save-run /tmp/patina-demo-run input.md
[patina-cli] Using codex-cli backend (...)
<rewritten paragraph printed to stdout>
[patina] wrote manifest to /tmp/patina-demo-run/manifest.json

$ ls /tmp/patina-demo-run/
manifest.json  output-1.txt

$ cat /tmp/patina-demo-run/manifest.json | jq '{patina, configHash, results}'
{
  "patina": "3.9.0",
  "configHash": "sha256:8049df5fc...",
  "results": [{
    "input": "/tmp/patina-demo-input.md",
    "promptHash": "sha256:eb8fe0922c...",
    "output": { "kind": "file", "name": "output-1.txt" }
  }]
}
```

Exit code 0. No TypeError.

## Test plan

- [x] `node --check src/cli.js` — clean
- [x] `npm test` — 86/86 (no regression)
- [x] Manual: `patina --save-run` with codex-cli backend now produces both `manifest.json` and `output-N.txt` at the requested directory
- [ ] Integration test that exercises `--save-run` end-to-end with a mock backend — gated on backend-mocking infra; tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)