### PR TITLE
Add Patina logo and social preview assets

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,91 @@
+# Design
+
+## Source of truth
+- Status: Draft
+- Last refreshed: 2026-05-20
+- Primary product surfaces: README logo, app/repo icon, social preview image, launch posts.
+- Evidence reviewed:
+  - Local: `README.md`, `docs/ROADMAP.md`, `assets/brand/patina-icon.svg`, `assets/brand/patina-logo.svg`, `assets/social/patina-og.svg`.
+  - External pattern references: Vite, Astro, Bun, Deno, Tailwind CSS, shadcn/ui README presentation patterns.
+
+## Brand
+- Personality: precise, trustworthy, editorial, slightly mysterious, developer-friendly.
+- Trust signals: auditable changes, meaning preservation, benchmark visibility, clean docs.
+- Avoid: detector-bypass framing, generic AI sparkles, robot/brain motifs, purple crystal/Obsidian-like trade dress, eco-leaf ambiguity, unreadable tiny text.
+
+## Product goals
+- Goals:
+  - Make patina memorable at GitHub README, favicon, and social-card scale.
+  - Communicate “strip AI packaging, keep meaning” through one simple copper-to-teal transformation mark.
+  - Keep final production assets editable and reviewable as SVG.
+- Non-goals:
+  - Do not ship generated raster art as the only source asset.
+  - Do not imply proof of human authorship.
+- Success signals:
+  - Recognizable copper-to-teal core silhouette at 32px.
+  - Works on GitHub light and dark surfaces.
+  - Feels like a serious open-source developer tool, not a generic AI app.
+
+## Personas and jobs
+- Primary personas: LLM-assisted writers, engineers cleaning docs, Korean/English/Chinese/Japanese content editors, maintainers evaluating writing quality.
+- User jobs: detect AI-ish prose, rewrite without meaning loss, inspect what changed, trust benchmark/quality evidence.
+- Key contexts of use: GitHub README landing, package pages, social shares, terminal/CLI docs.
+
+## Information architecture
+- Primary navigation: README first, docs/examples/benchmark next.
+- Core routes/screens: N/A; current project is CLI/skill/docs-first.
+- Content hierarchy: logo/tagline → demo → trust metrics → quick start.
+
+## Design principles
+- Principle 1: One iconic transformation mark beats explanatory document details; prefer flat geometry over rendered texture.
+- Principle 2: Editorial trust first; visual drama should support credibility, not overpower it.
+- Tradeoffs: expressive color is useful for social preview, but the icon must stay flat, simple, and silhouette-first.
+
+## Visual language
+- Color: dark slate/near-black base, oxidized copper, verdigris green, warm cream text/meaning core; keep the production mark to a small flat palette.
+- Typography: system sans for README SVG lockup; no text inside app icon candidates.
+- Spacing/layout rhythm: centered hero, generous padding, compact badges/links below.
+- Shape/radius/elevation: rounded app tile, bold copper-to-teal pure mark, no shadows, no bevels, no pseudo-3D depth.
+- Motion: optional future demo can show wrapper peeling away from prose.
+- Imagery/iconography: copper becoming patina teal around a warm preserved-meaning core. Avoid text-line clutter, document-card literalism, 3D realism, gradients, glow, texture, and bevel language in final SVG assets.
+
+## Components
+- Existing components to reuse: `assets/brand/*.svg`, `assets/social/*.svg`.
+- New/changed components: optional AI concept references under `.omx/artifacts/visual-ralph/` before SVG reconstruction; production assets remain hand-authored SVG.
+- Variants and states: square pure-mark icon, horizontal logo lockup, social preview.
+- Token/component ownership: brand assets stay under `assets/brand/`; social cards under `assets/social/`.
+
+## Accessibility
+- Target standard: readable on GitHub light/dark backgrounds and package pages.
+- Keyboard/focus behavior: N/A for static assets.
+- Contrast/readability: logo lockup requires dark card/backplate or high-contrast text.
+- Screen-reader semantics: SVGs should keep `role="img"`, `<title>`, and `<desc>`.
+- Reduced motion and sensory considerations: no flashing or motion in static assets.
+
+## Responsive behavior
+- Supported breakpoints/devices: README desktop/mobile, favicon-scale icon, 1200x630 social preview.
+- Layout adaptations: icon must stand alone; wordmark can be omitted at small sizes.
+- Touch/hover differences: N/A.
+
+## Interaction states
+- Loading: N/A.
+- Empty: N/A.
+- Error: N/A.
+- Success: N/A.
+- Disabled: N/A.
+- Offline/slow network: SVG should be lightweight enough for README/package use.
+
+## Content voice
+- Tone: direct, auditable, non-hype.
+- Terminology: “AI packaging,” “meaning preservation,” “audit/diff/score.”
+- Microcopy rules: avoid “undetectable,” “bypass,” or “human proof.”
+
+## Implementation constraints
+- Framework/styling system: repo-native SVG/Markdown; no new runtime dependencies.
+- Design-token constraints: use explicit solid SVG fills; keep palette small and gradient-free for production logo assets.
+- Performance constraints: SVG should stay reasonably small and reviewable.
+- Compatibility constraints: relative links must work on GitHub and npm package pages.
+- Test/screenshot expectations: XML parse SVGs; `git diff --check`; `npm pack --dry-run` when package file list changes.
+
+## Open questions
+- [ ] Whether to add raster exports/favicons after final SVG approval / owner: maintainer / impact: launch polish.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 **[한국어](README_KR.md)** | **[中文](README_ZH.md)** | **[日本語](README_JA.md)** | English
 
+<p align="center">
+  <img src="assets/brand/patina-logo.svg" alt="patina — Strip the AI packaging. Keep the meaning." width="440">
+</p>
+
 # patina
 
 [![Tests](https://github.com/devswha/patina/actions/workflows/test.yml/badge.svg)](https://github.com/devswha/patina/actions/workflows/test.yml)
@@ -24,7 +28,9 @@ Unlike a generic paraphraser, patina is **pattern-based and auditable**: it show
 
 > **MPS = 100** · cultural transformation ✓ · community building ✓ · meaningful connections ✓ · cross-cultural dialogue ✓
 
-More examples: [Before/After Gallery](docs/EXAMPLES.md). Social preview asset: [patina-before-after.svg](assets/social/patina-before-after.svg).
+More examples: [Before/After Gallery](docs/EXAMPLES.md).
+Brand assets: [logo](assets/brand/patina-logo.svg), [icon](assets/brand/patina-icon.svg),
+[social preview](assets/social/patina-og.svg), and [before/after card](assets/social/patina-before-after.svg).
 
 ## At a Glance
 

--- a/assets/brand/patina-icon.svg
+++ b/assets/brand/patina-icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">patina icon</title>
+  <desc id="desc">A flat dark icon: copper transforms into patina teal around a warm preserved-meaning core.</desc>
+
+  <rect width="512" height="512" rx="112" fill="#020617"/>
+  <path d="M92 196C160 86 320 74 420 164L346 238C288 190 218 198 174 258Z" fill="#c46a2a"/>
+  <path d="M420 316C352 426 192 438 92 348L160 270C224 322 294 314 338 254Z" fill="#2dd4bf"/>
+  <circle cx="252" cy="248" r="54" fill="#ffe6a8" stroke="#020617" stroke-width="10"/>
+</svg>

--- a/assets/brand/patina-logo.svg
+++ b/assets/brand/patina-logo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 190" role="img" aria-labelledby="title desc">
+  <title id="title">patina logo</title>
+  <desc id="desc">patina wordmark with a flat copper-to-teal preserved-core mark.</desc>
+
+  <rect x="1" y="1" width="758" height="188" rx="48" fill="#020617" stroke="#1e293b" stroke-width="2"/>
+  <g transform="translate(24 24) scale(0.27734375)" aria-hidden="true">
+    <rect width="512" height="512" rx="112" fill="#020617"/>
+    <path d="M92 196C160 86 320 74 420 164L346 238C288 190 218 198 174 258Z" fill="#c46a2a"/>
+    <path d="M420 316C352 426 192 438 92 348L160 270C224 322 294 314 338 254Z" fill="#2dd4bf"/>
+    <circle cx="252" cy="248" r="54" fill="#ffe6a8" stroke="#020617" stroke-width="10"/>
+  </g>
+
+  <text x="212" y="102" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="82" font-weight="800" letter-spacing="-5">patina</text>
+  <text x="218" y="145" fill="#94a3b8" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="600" letter-spacing="0.8">Strip the AI packaging. Keep the meaning.</text>
+  <path d="M214 164h236" stroke="#34d399" stroke-width="3" stroke-linecap="round"/>
+  <path d="M462 164h82" stroke="#c46a2a" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/assets/social/patina-og.svg
+++ b/assets/social/patina-og.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">patina social preview</title>
+  <desc id="desc">patina social card with a flat copper-to-teal preserved-core mark and the tagline Strip the AI packaging. Keep the meaning.</desc>
+
+  <rect width="1200" height="630" fill="#020617"/>
+  <rect x="48" y="48" width="1104" height="534" rx="42" fill="#0b1120" stroke="#1e293b"/>
+
+  <g transform="translate(112 122) scale(0.5078125)" aria-hidden="true">
+    <rect width="512" height="512" rx="112" fill="#020617"/>
+    <path d="M92 196C160 86 320 74 420 164L346 238C288 190 218 198 174 258Z" fill="#c46a2a"/>
+    <path d="M420 316C352 426 192 438 92 348L160 270C224 322 294 314 338 254Z" fill="#2dd4bf"/>
+    <circle cx="252" cy="248" r="54" fill="#ffe6a8" stroke="#020617" stroke-width="10"/>
+  </g>
+
+  <text x="430" y="205" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="112" font-weight="850" letter-spacing="-7">patina</text>
+  <text x="436" y="276" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="38" font-weight="720" letter-spacing="-0.9">Strip the AI packaging. Keep the meaning.</text>
+  <text x="438" y="334" fill="#94a3b8" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="25" font-weight="530">Pattern-based cleanup for AI-sounding prose in KO / EN / ZH / JA.</text>
+
+  <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="23" font-weight="680">
+    <rect x="438" y="392" width="196" height="58" rx="29" fill="#064e3b" stroke="#34d399"/>
+    <text x="466" y="429" fill="#d1fae5">audit + diff</text>
+    <rect x="654" y="392" width="248" height="58" rx="29" fill="#0f172a" stroke="#475569"/>
+    <text x="682" y="429" fill="#e2e8f0">meaning checks</text>
+    <rect x="922" y="392" width="160" height="58" rx="29" fill="#451a03" stroke="#c46a2a"/>
+    <text x="950" y="429" fill="#fed7aa">CLI skill</text>
+  </g>
+
+  <path d="M438 494h330" stroke="#34d399" stroke-width="5" stroke-linecap="round"/>
+  <path d="M790 494h126" stroke="#c46a2a" stroke-width="5" stroke-linecap="round"/>
+  <text x="438" y="540" fill="#64748b" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace" font-size="22" font-weight="650">github.com/devswha/patina</text>
+</svg>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -135,7 +135,9 @@ Acceptance criteria:
 
 Goal: reduce the time from landing on README to seeing value.
 
-- Add a recognizable patina logo / app icon before launch. Aim for an Obsidian-like level of memorability: dark, faceted, tactile, and simple enough to work at favicon size, without copying Obsidian's trade dress.
+- Maintain the recognizable patina logo / app icon now in `assets/brand/`.
+  It should stay dark, faceted, tactile, and simple enough to work at favicon size,
+  without copying Obsidian's trade dress.
 - Add an animated terminal demo or short GIF.
 - Add copy-paste sample commands for the 4 most likely users:
   - writer/blogger
@@ -253,8 +255,7 @@ Recommended order:
 1. Link research notes and roadmap from README.
 2. Add GitHub issue/PR templates and community docs.
 3. Add benchmark report generation.
-4. Add a Patina logo/icon and social preview image.
+4. Add a Patina logo/icon and social preview image. **Done:** source SVGs live in `assets/brand/` and `assets/social/patina-og.svg`.
 5. Add a terminal demo asset.
 6. Prepare one focused launch post.
 7. Publish npm only after install/support policy is settled.
-

--- a/docs/social/patina-launch-copy.md
+++ b/docs/social/patina-launch-copy.md
@@ -18,6 +18,7 @@ Long tagline:
 
 - Run `npm run benchmark:report && npm test`.
 - Check the current benchmark: [`docs/benchmarks/latest.md`](../benchmarks/latest.md).
+- Use the launch social preview when the surface supports images: [`assets/social/patina-og.svg`](../../assets/social/patina-og.svg).
 - Keep claims to "editing signal" and "suspect-zone benchmark"; do not imply authorship proof.
 - Link issues for useful feedback: false positives, missing patterns, benchmark fixtures.
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "profiles/",
     "lexicon/",
     "docs/",
+    "assets/",
     "scripts/benchmark-report.mjs",
     "tests/quality/benchmark.mjs",
     "tests/quality/README.md",


### PR DESCRIPTION
## Summary
- Add editable SVG brand assets: square icon, README logo lockup, and 1200x630 social preview.
- Add `DESIGN.md` as the repo-local brand/design contract for future visual work.
- Use AI-generated concept exploration only as reference; final assets are hand-authored flat SVG.
- Replace the prior document/fold placeholder with the #16 pure-mark concept selected by Gemini + Claude consensus.
- Surface the logo in README and link the asset set from the demo section.
- Include `assets/` in the npm package so README/social asset links resolve after packing.
- Update launch-copy and roadmap docs to point at the new social preview and mark the logo task as done/maintained.

## Design notes
- Final assets deliberately avoid 3D/raster-like texture; the production mark is strictly flat and gradient-free.
- The new symbol is no longer a document icon: oxidized copper transforms into patina teal around a warm preserved-meaning core.
- Gemini and Claude both ranked #16 above #01/#12 for viral memorability and favicon readability.
- The selected mark includes the consensus tweaks: larger warm core, slight off-center placement, dark halo separation, and cleaner copper/teal seam.
- The palette stays constrained: dark slate + oxidized copper + verdigris + warm cream.
- The design explicitly avoids Obsidian-like purple crystal trade dress, generic AI sparkles, eco-leaf ambiguity, shadows, bevels, glow, and texture-heavy polish.

## Verification
- Candidate gallery: `.omx/artifacts/brand-concepts/patina-v4/index.html`
- Gemini consensus artifact: `.omx/artifacts/ask-gemini-patina-logo-candidate-consensus-20260520-045708.md`
- Claude consensus artifact: `.omx/artifacts/ask-claude-patina-logo-candidate-consensus-20260520-045708.md`
- Flatness token scan for gradients/glow/shadows/opacity pseudo-depth
- `git diff --check`
- SVG XML parse for `assets/brand/patina-icon.svg`, `assets/brand/patina-logo.svg`, `assets/social/patina-og.svg`, and existing `assets/social/patina-before-after.svg`
- SVG static scan for script/event/external href/foreignObject/data URLs
- `npm run benchmark` — 20/20 fixtures, 100.0%
- `npm test` — 144/144
- `npm pack --dry-run` — confirmed brand/social assets are included

## Notes / risks
- Source assets are SVG-only for now; no raster favicon/PNG export is included in this PR.
- Browser pixel-diff rendering across social platforms was not available in this environment.
- Core rewrite/skill pipeline is untouched.
