### PR TITLE
Keep README logo from clipping on GitHub

### DIFF
--- a/assets/brand/patina-logo.svg
+++ b/assets/brand/patina-logo.svg
@@ -1,8 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 190" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 190" role="img" aria-labelledby="title desc">
   <title id="title">patina logo</title>
   <desc id="desc">patina wordmark with a flat copper-to-teal preserved-core mark.</desc>
 
-  <rect x="1" y="1" width="758" height="188" rx="48" fill="#020617" stroke="#1e293b" stroke-width="2"/>
+  <rect x="1" y="1" width="938" height="188" rx="48" fill="#020617" stroke="#1e293b" stroke-width="2"/>
   <g transform="translate(24 24) scale(0.27734375)" aria-hidden="true">
     <rect width="512" height="512" rx="112" fill="#020617"/>
     <path d="M92 196C160 86 320 74 420 164L346 238C288 190 218 198 174 258Z" fill="#c46a2a"/>
@@ -12,6 +12,6 @@
 
   <text x="212" y="102" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="82" font-weight="800" letter-spacing="-5">patina</text>
   <text x="218" y="145" fill="#94a3b8" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="600" letter-spacing="0.8">Strip the AI packaging. Keep the meaning.</text>
-  <path d="M214 164h236" stroke="#34d399" stroke-width="3" stroke-linecap="round"/>
-  <path d="M462 164h82" stroke="#c46a2a" stroke-width="3" stroke-linecap="round"/>
+  <path d="M214 164h318" stroke="#34d399" stroke-width="3" stroke-linecap="round"/>
+  <path d="M548 164h110" stroke="#c46a2a" stroke-width="3" stroke-linecap="round"/>
 </svg>


### PR DESCRIPTION
## Summary\n- expand the Patina logo SVG lockup viewBox so the README tagline does not clip in GitHub's renderer\n- keep the selected icon mark unchanged\n\n## Evidence\n- Before: .omx/artifacts/readme-review-20260520-050912/github-readme-logo.png showed the tagline clipped on the live GitHub README\n- After local preview: .omx/artifacts/readme-review-20260520-051001-local-fix/local-logo.png shows the same width=440 render without clipping\n\n## Verification\n- git diff --check\n- SVG XML parse\n- SVG active-content static scan\n- README local link/image check\n- npm pack --dry-run asset check\n- npm test