### PR TITLE
Refresh README logo URL after crop fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **[한국어](README_KR.md)** | **[中文](README_ZH.md)** | **[日本語](README_JA.md)** | English
 
 <p align="center">
-  <img src="assets/brand/patina-logo.svg" alt="patina — Strip the AI packaging. Keep the meaning." width="440">
+  <img src="assets/brand/patina-logo.svg?v=20260520" alt="patina — Strip the AI packaging. Keep the meaning." width="440">
 </p>
 
 # patina


### PR DESCRIPTION
## Summary\n- add a versioned query to the README logo image URL\n- forces GitHub's README/raw image cache to pick up the widened SVG that prevents tagline clipping\n\n## Verification\n- git diff --check\n- README local link/image check with query stripping\n- Playwright local preview at width=440