### PR TITLE
Serve README logo from a fresh asset path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **[한국어](README_KR.md)** | **[中文](README_ZH.md)** | **[日本語](README_JA.md)** | English
 
 <p align="center">
-  <img src="assets/brand/patina-logo.svg?v=20260520" alt="patina — Strip the AI packaging. Keep the meaning." width="440">
+  <img src="assets/brand/patina-readme-logo.svg" alt="patina — Strip the AI packaging. Keep the meaning." width="440">
 </p>
 
 # patina

--- a/assets/brand/patina-readme-logo.svg
+++ b/assets/brand/patina-readme-logo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 190" role="img" aria-labelledby="title desc">
+  <title id="title">patina logo</title>
+  <desc id="desc">patina wordmark with a flat copper-to-teal preserved-core mark.</desc>
+
+  <rect x="1" y="1" width="938" height="188" rx="48" fill="#020617" stroke="#1e293b" stroke-width="2"/>
+  <g transform="translate(24 24) scale(0.27734375)" aria-hidden="true">
+    <rect width="512" height="512" rx="112" fill="#020617"/>
+    <path d="M92 196C160 86 320 74 420 164L346 238C288 190 218 198 174 258Z" fill="#c46a2a"/>
+    <path d="M420 316C352 426 192 438 92 348L160 270C224 322 294 314 338 254Z" fill="#2dd4bf"/>
+    <circle cx="252" cy="248" r="54" fill="#ffe6a8" stroke="#020617" stroke-width="10"/>
+  </g>
+
+  <text x="212" y="102" fill="#f8fafc" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="82" font-weight="800" letter-spacing="-5">patina</text>
+  <text x="218" y="145" fill="#94a3b8" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="600" letter-spacing="0.8">Strip the AI packaging. Keep the meaning.</text>
+  <path d="M214 164h318" stroke="#34d399" stroke-width="3" stroke-linecap="round"/>
+  <path d="M548 164h110" stroke="#c46a2a" stroke-width="3" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary\n- add a README-specific logo lockup file using the widened SVG\n- point the README hero image at the fresh path so GitHub's raw-image CDN stops serving the old clipped file\n- keep the canonical brand logo asset available\n\n## Verification\n- git diff --check\n- SVG XML parse\n- SVG active-content scan\n- README local link/image check\n- npm pack --dry-run asset check