### PR TITLE
Make launch-readiness backlog safer to trust

### DIFF
--- a/.github/ISSUE_TEMPLATE/calibration_concern.yml
+++ b/.github/ISSUE_TEMPLATE/calibration_concern.yml
@@ -1,0 +1,40 @@
+name: Calibration concern
+description: Report a scoring threshold, false-positive, or false-negative concern
+title: "calibration: "
+labels: [benchmark]
+body:
+  - type: dropdown
+    id: concern_type
+    attributes:
+      label: Concern type
+      options: [false positive, false negative, score too high, score too low, threshold, benchmark method, other]
+    validations:
+      required: true
+  - type: dropdown
+    id: language
+    attributes:
+      label: Language
+      options: [ko, en, zh, ja, mixed]
+    validations:
+      required: true
+  - type: textarea
+    id: safe_sample
+    attributes:
+      label: Safe sample or fixture reference
+      description: Paste only text you are allowed to share publicly, or link to a repo fixture.
+    validations:
+      required: true
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed patina output
+      description: Include score, audit findings, mode, and command/config if available.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected calibration behavior
+      description: Explain what score range or pattern behavior would be more appropriate.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Propose a CLI, integration, docs, or workflow improvement
+title: "feature: "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Keep the request focused on the user workflow. Avoid pasting private writing samples.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options: [cli, skill, max-mode, benchmark, docs, integration, distribution, other]
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is hard, confusing, slow, or missing today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the smallest behavior or documentation change that would help.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Mention workarounds or simpler variants.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/research_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/research_proposal.yml
@@ -1,0 +1,40 @@
+name: Research proposal
+description: Propose an evaluation, corpus, detector comparison, or methodology study
+title: "research: "
+labels: [research, benchmark]
+body:
+  - type: dropdown
+    id: research_type
+    attributes:
+      label: Research type
+      options: [human evaluation, detector comparison, corpus study, metric validation, multilingual study, adversarial audit, other]
+    validations:
+      required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: Research question
+      description: What should this study prove, disprove, or calibrate?
+    validations:
+      required: true
+  - type: textarea
+    id: method
+    attributes:
+      label: Proposed method
+      description: Include sample size, languages, data source, and validation idea if known.
+    validations:
+      required: true
+  - type: textarea
+    id: data_rights
+    attributes:
+      label: Data rights / privacy notes
+      description: State whether the data can be redistributed or only summarized.
+    validations:
+      required: true
+  - type: textarea
+    id: success
+    attributes:
+      label: Success criteria
+      description: What artifact should land in the repo when this is done?
+    validations:
+      required: true

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,29 @@
+# Governance
+
+Patina uses lightweight maintainer governance until the contributor base grows.
+
+## Decision model
+
+- Routine docs, tests, examples, and small CLI fixes can be merged after one maintainer review or an equivalent verified maintainer run.
+- Pattern, scoring, benchmark, installer, provider, and release changes need explicit maintainer approval.
+- Changes that affect the core skill pipeline should explain the meaning-preservation impact and include before/after examples when practical.
+
+## Triage labels
+
+Suggested label groups:
+
+- `bug` — incorrect behavior or broken documented workflow
+- `enhancement` — product, CLI, integration, or distribution improvement
+- `documentation` — docs-only update
+- `patterns` — pattern catalog or rewrite-rule change
+- `benchmark` — corpus, metrics, calibration, or quality gate work
+- `research` — evaluation methodology or external comparison
+- `false-positive` — human prose flagged too strongly
+- `good first issue` — bounded and low-risk contributor task
+- `help wanted` — useful but not on the immediate maintainer path
+
+## Safety notes
+
+- Do not position patina as an AI-detector bypass tool. The accepted framing is auditable editing with meaning-preservation checks.
+- Do not include private user text in issues, fixtures, or benchmarks unless the contributor has explicit redistribution rights.
+- Prefer small, reversible changes over broad rewrites.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -5,7 +5,7 @@
 > **Goal:** Make `/patina` and `/patina-max` available as a skill in the host agent, with no API key required when the host machine has [`codex`](https://github.com/openai/codex) logged in.
 
 **Repository:** `https://github.com/devswha/patina.git`
-**Version pinned by this guide:** v3.11.0 (any later tag also works — patina is backwards compatible within v3.x)
+**Version pinning:** the installer resolves remote `HEAD` once and checks out that concrete commit. For strict reproducibility, set `PATINA_REF=<tag-or-full-sha>`.
 **Languages supported:** Korean (ko), English (en), Chinese (zh), Japanese (ja)
 
 ---
@@ -26,10 +26,17 @@ Do not mix paths. Do not invent extra steps. If a step fails, stop and surface t
 
 ## Path A — One-liner installer (recommended)
 
-Run this command. It installs into Claude Code, Codex CLI, Cursor, and OpenCode in one shot.
+Run this command. It installs into Claude Code, Codex CLI, Cursor, and OpenCode in one shot. The installer resolves remote `HEAD` to a commit SHA before checkout so the local skill does not track a moving `main` branch.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
+```
+
+For a fully explicit install, pin the checked-out repo ref yourself:
+
+```bash
+PATINA_REF=<tag-or-full-sha> \
+  curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
 ```
 
 **What it does** (so you can explain to the user):
@@ -39,6 +46,7 @@ curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | ba
   - `~/.codex/skills/` (Codex CLI)
   - `~/.cursor/rules/` (Cursor)
   - `~/.config/opencode/skills/` (OpenCode)
+- Checks out a detached commit resolved from `PATINA_REF`, or from remote `HEAD` when `PATINA_REF` is unset.
 - Skips any target whose corresponding env var is set to `false` (e.g. `INSTALL_CURSOR=false`).
 
 **Skip a target:**
@@ -60,7 +68,10 @@ Use this when `curl` is unavailable or the user explicitly wants to install for 
 
 ```bash
 mkdir -p ~/.claude/skills
-git clone https://github.com/devswha/patina.git ~/.claude/skills/patina
+PATINA_REF="$(git ls-remote https://github.com/devswha/patina.git HEAD | awk 'NR == 1 { print $1 }')"
+git clone --depth=1 https://github.com/devswha/patina.git ~/.claude/skills/patina
+git -C ~/.claude/skills/patina fetch --depth=1 origin "${PATINA_REF}"
+git -C ~/.claude/skills/patina checkout --detach FETCH_HEAD
 ```
 
 If `~/.claude/skills/patina` already exists but is not a git repo, **stop and ask the user** — do not delete it.
@@ -91,11 +102,15 @@ Requires Node.js ≥ 18. After this, `patina --help` works as a shell command.
 
 ## Path C — Update existing install
 
+Use the installer again, or fetch and check out a pinned ref. Do not leave the skill tracking a moving branch.
+
 ```bash
-cd ~/.claude/skills/patina && git pull --ff-only
+PATINA_REF="$(git ls-remote https://github.com/devswha/patina.git HEAD | awk 'NR == 1 { print $1 }')"
+git -C ~/.claude/skills/patina fetch --depth=1 origin "${PATINA_REF}"
+git -C ~/.claude/skills/patina checkout --detach FETCH_HEAD
 ```
 
-If the pull fails because of local changes, **stop and report to the user**. Do not run `git reset --hard` — that would discard work the user might want.
+If the fetch or checkout fails because of local changes, **stop and report to the user**. Do not run `git reset --hard` — that would discard work the user might want.
 
 ---
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,17 @@
+# Maintainers
+
+Patina is currently maintained by:
+
+- `@devswha` — project owner, release authority, and final reviewer for security-sensitive changes.
+
+## Maintainer responsibilities
+
+- Keep the core skill pipeline aligned with the project mission: remove AI-sounding packaging while preserving meaning.
+- Require before/after examples for pattern edits.
+- Keep version-bearing files synchronized when preparing a release.
+- Review benchmark, corpus, and false-positive changes with extra care because they affect public quality claims.
+- Avoid merging security-sensitive installer or provider changes without local verification.
+
+## Handoff rule
+
+If a new maintainer is added, update this file in the same PR that grants repository permissions.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,15 @@ Unlike a generic paraphraser, patina is **pattern-based and auditable**: it show
 
 > **MPS = 100** · cultural transformation ✓ · community building ✓ · meaningful connections ✓ · cross-cultural dialogue ✓
 
-More examples: [Before/After Gallery](docs/EXAMPLES.md).
+**More demo slices**
+
+| Input type | AI packaging removed | Preserved meaning |
+|---|---|---|
+| Korean marketing | “혁신적인 솔루션”, “새로운 패러다임” | 30 Notion templates, workflow fit, copy-and-edit usage |
+| Academic | “획기적인 성과”, broad significance claims | 60 GitHub projects, 72h→10m setup time, p<0.01, limits noted |
+| Technical | “핵심적인 역할”, future-standard hype | GPU management, one-command provisioning, 5× result caveat |
+
+Try it quickly: [30-second terminal demo](docs/DEMO.md). More examples: [Before/After Gallery](docs/EXAMPLES.md).
 Brand assets: [logo](assets/brand/patina-logo.svg), [icon](assets/brand/patina-icon.svg),
 [social preview](assets/social/patina-og.svg), and [before/after card](assets/social/patina-before-after.svg).
 
@@ -53,7 +61,7 @@ Brand assets: [logo](assets/brand/patina-logo.svg), [icon](assets/brand/patina-i
 curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
 ```
 
-The installer wires patina into Claude Code, [Codex CLI](https://github.com/openai/codex), Cursor, and OpenCode. Then:
+The installer wires patina into Claude Code, [Codex CLI](https://github.com/openai/codex), Cursor, and OpenCode. It resolves the repository HEAD to a concrete commit before checkout; set `PATINA_REF=<tag-or-full-sha>` when you need a fully pinned install. Then:
 
 ```
 /patina --lang en
@@ -107,6 +115,7 @@ patina --lang <ko|en|zh|ja> [mode] [--profile <name>] input.txt
 | *(default)* | Rewrite |
 | `--audit` | Detect AI patterns only |
 | `--score` | 0–100 AI-likeness score with category breakdown |
+| `--score --gate <n>` | Keep CI strict: exit code `3` when `overall > n` |
 | `--diff` | Show changes pattern by pattern |
 | `--ouroboros` | Iterate the rewrite until score converges (with MPS rollback) |
 | `--lang <ko\|en\|zh\|ja>` | Select language (default: `ko`) |
@@ -201,8 +210,10 @@ Pattern packs are auto-discovered by language prefix. `.patina.yaml` in the work
 ## Documentation
 
 - **[Glossary](docs/GLOSSARY.md)** — short definitions for MPS, fidelity, burstiness, MATTR, modes, and other recurring terms
+- **[Demo](docs/DEMO.md)** — terminal transcript and multi-genre before/after snapshots
 - **[Patterns](docs/PATTERNS.md)** — full 146-pattern catalog
 - **[Authentication](docs/AUTHENTICATION.md)** — backends, providers, free-tier setup
+- **[CLI Contract](docs/CLI.md)** — score gate, exit codes, and automation-safe surfaces
 - **[FAQ](docs/FAQ.md)** — detector-bypass concerns, MPS, false positives, contribution starting points
 - **[Roadmap](docs/ROADMAP.md)** — quality, benchmark, product, community, and launch priorities
 - **[Benchmark Report](docs/benchmarks/latest.md)** — latest reproducible suspect-zone benchmark summary
@@ -212,6 +223,7 @@ Pattern packs are auto-discovered by language prefix. `.patina.yaml` in the work
 - **[Scoring](core/scoring.md)** — AI-likeness + fidelity + MPS
 - **[Changelog](CHANGELOG.md)** — release notes and methodology
 - **[Contributing](CONTRIBUTING.md)** — pattern submissions, staleness reports
+- **[Governance](GOVERNANCE.md)** / **[Maintainers](MAINTAINERS.md)** — lightweight project decision rules
 
 ## Acknowledgements
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,32 @@
+# CLI Contract
+
+patina's CLI is optimized for interactive editing, but a few surfaces are stable enough for automation.
+
+## Score gate
+
+Use `--score --gate <n>` when CI should fail if a text still reads too AI-like.
+
+```bash
+patina --lang en --score --gate 30 draft.md
+```
+
+- `--score` still prints the model's score output.
+- If the parsed `overall` score is greater than the gate, patina prints a `[patina] score gate failed` warning to stderr and exits with code `3`.
+- The gate is intentionally limited to `--score`; rewrite/audit/diff modes should not fail a pipeline based on an output shape they do not own.
+
+## Exit codes
+
+| Code | Meaning |
+|---:|---|
+| `0` | Command completed; for `--score --gate`, the score was at or below the gate. |
+| `1` | Runtime or backend error, including API/auth/backend failures. |
+| `2` | Input/usage error from no interactive input or empty stdin. |
+| `3` | `--score --gate` completed, but the score exceeded the configured gate. |
+
+## Current machine-readable surfaces
+
+- `--score` asks the backend to emit a JSON-like score with an `overall` field; `--gate` parses that field for exit-code decisions.
+- `--save-run <dir>` writes `manifest.json` plus `output-N.txt` files for reproducible audit trails.
+- `--list-backends` and `--list-providers` print tabular status for auth/debugging.
+
+Future output-format work should keep these contracts backward-compatible instead of changing existing stdout by surprise.

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -1,0 +1,40 @@
+# Demo
+
+A copy/paste demo for showing what patina does: remove AI packaging while keeping the claims intact.
+
+## 30-second terminal transcript
+
+This transcript uses the checked-in short marketing fixture so the example is reviewable without screenshots or a live model run.
+
+```bash
+$ cat examples/short/marketing-launch.md
+새롭게 출시된 노션 템플릿 팩은 생산성 향상을 위한 혁신적인 솔루션입니다. 다양한 워크플로우에 최적화된 30개의 템플릿을 제공하며, 사용자 친화적인 디자인으로 누구나 손쉽게 활용 가능합니다. 본 제품은 업무 효율성을 극대화하는 새로운 패러다임을 제시합니다.
+
+$ patina --lang ko --tone marketing examples/short/marketing-launch.md
+새로 나온 노션 템플릿 팩에는 업무 흐름별로 바로 쓸 수 있는 템플릿 30개가 들어 있습니다. 복잡한 설정 없이 복제해서 쓰고, 팀이나 개인 작업 방식에 맞게 손보면 됩니다.
+
+노션을 매번 빈 페이지에서 시작했다면, 이제 그 시간부터 줄이세요.
+```
+
+Full source/expected pair:
+[`examples/short/marketing-launch.md`](../examples/short/marketing-launch.md) →
+[`examples/short/marketing-launch-rewritten.md`](../examples/short/marketing-launch-rewritten.md).
+
+## Before/after snapshots
+
+| Genre | Before | After |
+|---|---|---|
+| Korean marketing | “생산성 향상을 위한 혁신적인 솔루션… 업무 효율성을 극대화하는 새로운 패러다임” | “업무 흐름별로 바로 쓸 수 있는 템플릿 30개… 빈 페이지에서 시작했다면, 이제 그 시간부터 줄이세요.” |
+| Academic | “획기적인 성과가 관찰되었으며… 중요한 역할을 수행할 수 있음을 시사한다” | “평균 구축 시간은 72시간에서 10분 이내로 줄었다… 일반화하기에는 주의가 필요하다.” |
+| Technical | “핵심적인 역할을 수행… 차세대 AI 인프라 환경의 표준” | “GPU 자원 관리는 배포 속도와 운영 비용에 직접 영향을 준다… 검토할 만한 선택지다.” |
+
+Reference files:
+
+- Academic: [`examples/genres/academic.md`](../examples/genres/academic.md) → [`examples/genres/academic-rewritten.md`](../examples/genres/academic-rewritten.md)
+- Technical: [`examples/genres/technical.md`](../examples/genres/technical.md) → [`examples/genres/technical-rewritten.md`](../examples/genres/technical-rewritten.md)
+
+## What to point out in a live demo
+
+1. The output removes inflated claims like “혁신적인 솔루션” and “새로운 패러다임.”
+2. Concrete facts survive: 30 templates, workflow fit, setup simplicity, and the user action.
+3. The rewrite is auditable because the source fixture, expected rewrite, and pattern catalog all live in the repo.

--- a/docs/benchmarks/latest.json
+++ b/docs/benchmarks/latest.json
@@ -3,27 +3,27 @@
   "benchmarkCommand": "node tests/quality/benchmark.mjs --quiet",
   "benchmarkStatus": 0,
   "note": "Deterministic suspect-zone benchmark; not an authorship detector.",
-  "generatedAt": "2026-05-19T18:12:26.135Z",
-  "fixtureCount": 20,
+  "generatedAt": "2026-05-20T02:23:17.955Z",
+  "fixtureCount": 22,
   "overallAccuracy": 1,
   "perLanguage": {
     "en": {
-      "tp": 5,
+      "tp": 6,
       "fp": 0,
       "fn": 0,
       "tn": 5,
-      "total": 10,
+      "total": 11,
       "accuracy": 1,
       "precision": 1,
       "recall": 1,
       "f1": 1
     },
     "ko": {
-      "tp": 5,
+      "tp": 6,
       "fp": 0,
       "fn": 0,
       "tn": 5,
-      "total": 10,
+      "total": 11,
       "accuracy": 1,
       "precision": 1,
       "recall": 1,
@@ -43,7 +43,8 @@
       "mattr": 0.928,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     },
     {
       "fixture_id": "en-ai-02",
@@ -57,7 +58,8 @@
       "mattr": 0.841,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     },
     {
       "fixture_id": "en-ai-03",
@@ -71,7 +73,8 @@
       "mattr": 0.828,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     },
     {
       "fixture_id": "en-ai-04",
@@ -85,7 +88,8 @@
       "mattr": 0.84,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     },
     {
       "fixture_id": "en-ai-05",
@@ -99,7 +103,28 @@
       "mattr": 0.879,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
+    },
+    {
+      "fixture_id": "en-ai-06-chat-register",
+      "lang": "en",
+      "class": "ai",
+      "expected_hot": true,
+      "predicted_hot": true,
+      "correct": true,
+      "cv": 0.034,
+      "cv_band": "low",
+      "mattr": 0.814,
+      "mattr_band": "high",
+      "lexicon_density": 0,
+      "lexicon_hits": [],
+      "expected_metrics": {
+        "cv_band": "low",
+        "mattr_band": "high",
+        "lexicon_density_min": 0,
+        "lexicon_density_max": 80
+      }
     },
     {
       "fixture_id": "en-nat-01",
@@ -113,7 +138,8 @@
       "mattr": 0.898,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     },
     {
       "fixture_id": "en-nat-02",
@@ -127,7 +153,8 @@
       "mattr": 0.884,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     },
     {
       "fixture_id": "en-nat-03",
@@ -141,7 +168,8 @@
       "mattr": 0.882,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     },
     {
       "fixture_id": "en-nat-04",
@@ -155,7 +183,8 @@
       "mattr": 0.854,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     },
     {
       "fixture_id": "en-nat-05",
@@ -169,7 +198,8 @@
       "mattr": 0.875,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     },
     {
       "fixture_id": "ko-ai-01",
@@ -185,7 +215,8 @@
       "lexicon_density": 23.256,
       "lexicon_hits": [
         "추세"
-      ]
+      ],
+      "expected_metrics": null
     },
     {
       "fixture_id": "ko-ai-02",
@@ -201,7 +232,8 @@
       "lexicon_density": 19.608,
       "lexicon_hits": [
         "환경"
-      ]
+      ],
+      "expected_metrics": null
     },
     {
       "fixture_id": "ko-ai-03",
@@ -217,7 +249,8 @@
       "lexicon_density": 19.608,
       "lexicon_hits": [
         "추세"
-      ]
+      ],
+      "expected_metrics": null
     },
     {
       "fixture_id": "ko-ai-04",
@@ -231,7 +264,8 @@
       "mattr": 0.853,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     },
     {
       "fixture_id": "ko-ai-05",
@@ -245,7 +279,30 @@
       "mattr": 0.853,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
+    },
+    {
+      "fixture_id": "ko-ai-06-chat-register",
+      "lang": "ko",
+      "class": "ai",
+      "expected_hot": true,
+      "predicted_hot": true,
+      "correct": true,
+      "cv": 0.081,
+      "cv_band": "low",
+      "mattr": 1,
+      "mattr_band": "high",
+      "lexicon_density": 21.739,
+      "lexicon_hits": [
+        "흐름"
+      ],
+      "expected_metrics": {
+        "cv_band": "low",
+        "mattr_band": "high",
+        "lexicon_density_min": 0,
+        "lexicon_density_max": 80
+      }
     },
     {
       "fixture_id": "ko-nat-01",
@@ -259,7 +316,8 @@
       "mattr": 1,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     },
     {
       "fixture_id": "ko-nat-02",
@@ -273,7 +331,8 @@
       "mattr": 1,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     },
     {
       "fixture_id": "ko-nat-03",
@@ -287,7 +346,8 @@
       "mattr": 1,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     },
     {
       "fixture_id": "ko-nat-04",
@@ -301,7 +361,8 @@
       "mattr": 0.975,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     },
     {
       "fixture_id": "ko-nat-05",
@@ -315,7 +376,18 @@
       "mattr": 0.998,
       "mattr_band": "high",
       "lexicon_density": 0,
-      "lexicon_hits": []
+      "lexicon_hits": [],
+      "expected_metrics": null
     }
-  ]
+  ],
+  "sampleSizes": {
+    "en": {
+      "ai": 6,
+      "natural": 5
+    },
+    "ko": {
+      "ai": 6,
+      "natural": 5
+    }
+  }
 }

--- a/docs/benchmarks/latest.md
+++ b/docs/benchmarks/latest.md
@@ -7,8 +7,8 @@ This is the latest checked-in report for patina's deterministic suspect-zone ben
 ## Current result
 
 - Status: **passing**
-- Generated at: 2026-05-19T18:12:26.135Z
-- Fixtures: 20
+- Generated at: 2026-05-20T02:23:17.955Z
+- Fixtures: 22
 - Languages: 2
 - Overall accuracy: **100.0%**
 - Source fixtures: `tests/fixtures/suspect-zones/**`
@@ -19,8 +19,17 @@ This is the latest checked-in report for patina's deterministic suspect-zone ben
 
 | lang | fixtures | accuracy | precision | recall | f1 | TP | FP | FN | TN |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| en | 10 | 100.0% | 100.0% | 100.0% | 1 | 5 | 0 | 0 | 5 |
-| ko | 10 | 100.0% | 100.0% | 100.0% | 1 | 5 | 0 | 0 | 5 |
+| en | 11 | 100.0% | 100.0% | 100.0% | 1 | 6 | 0 | 0 | 5 |
+| ko | 11 | 100.0% | 100.0% | 100.0% | 1 | 6 | 0 | 0 | 5 |
+
+## Sample sizes
+
+| lang | class | fixtures |
+|---|---|---:|
+| en | ai | 6 |
+| en | natural | 5 |
+| ko | ai | 6 |
+| ko | natural | 5 |
 
 ## Misclassifications
 
@@ -35,6 +44,7 @@ All fixtures classified correctly.
 | en-ai-03 | en | ai | hot | hot | ✓ | 0.065 low | 0.828 high | 0 | — |
 | en-ai-04 | en | ai | hot | hot | ✓ | 0.07 low | 0.84 high | 0 | — |
 | en-ai-05 | en | ai | hot | hot | ✓ | 0.093 low | 0.879 high | 0 | — |
+| en-ai-06-chat-register | en | ai | hot | hot | ✓ | 0.034 low | 0.814 high | 0 | — |
 | en-nat-01 | en | natural | cold | cold | ✓ | 0.881 high | 0.898 high | 0 | — |
 | en-nat-02 | en | natural | cold | cold | ✓ | 0.886 high | 0.884 high | 0 | — |
 | en-nat-03 | en | natural | cold | cold | ✓ | 0.914 high | 0.882 high | 0 | — |
@@ -45,6 +55,7 @@ All fixtures classified correctly.
 | ko-ai-03 | ko | ai | hot | hot | ✓ | 0.073 low | 0.79 high | 19.608 | 추세 |
 | ko-ai-04 | ko | ai | hot | hot | ✓ | 0.098 low | 0.853 high | 0 | — |
 | ko-ai-05 | ko | ai | hot | hot | ✓ | 0.098 low | 0.853 high | 0 | — |
+| ko-ai-06-chat-register | ko | ai | hot | hot | ✓ | 0.081 low | 1 high | 21.739 | 흐름 |
 | ko-nat-01 | ko | natural | cold | cold | ✓ | 0.717 high | 1 high | 0 | — |
 | ko-nat-02 | ko | natural | cold | cold | ✓ | 0.552 high | 1 high | 0 | — |
 | ko-nat-03 | ko | natural | cold | cold | ✓ | 0.68 high | 1 high | 0 | — |
@@ -56,4 +67,6 @@ All fixtures classified correctly.
 - **Hot** means at least one deterministic signal crossed the benchmark threshold: low burstiness CV, low MATTR, or AI-lexicon density.
 - **Cold** means the fixture did not cross those thresholds.
 - The report is meant for regression tracking and contributor discussion, not for authorship accusation.
+- This deterministic corpus is intentionally small (22 fixtures) and currently covers only checked-in ko/en suspect-zone fixtures; do not treat 100% fixture accuracy as generalization to new models, genres, or edited AI text.
+- Confidence intervals, threshold sweeps, and 2025+ model rebaselines are tracked as benchmark follow-ups, not claimed by this report yet.
 - Broader methodology notes live in [AI/Human Metrics Research](../research/ai-human-metrics.md) and [Quality Checks](../../tests/quality/README.md).

--- a/docs/research/ai-human-metrics.md
+++ b/docs/research/ai-human-metrics.md
@@ -31,7 +31,18 @@ paragraph is SUSPECT iff
   OR lexicon_density > threshold
 ```
 
-현재 레포의 로컬 `tests/quality/results.json` 스냅샷은 fixture 20개 기준 전체 accuracy 1.0이다. 다만 이 corpus는 작고 설계된 synthetic fixture이므로, 일반화 성능 증거로 과신하면 안 된다.
+현재 레포의 로컬 `tests/quality/results.json` 스냅샷은 fixture 22개 기준 전체 accuracy 1.0이다. 다만 이 corpus는 작고 설계된 synthetic/curated fixture이므로, 일반화 성능 증거로 과신하면 안 된다.
+
+### 2.1 단기 benchmark 한계와 rebaseline 계획 (#155/#162)
+
+현재 체크인된 deterministic report는 회귀 테스트로는 유용하지만, 공개 성능 주장으로 쓰기에는 아직 좁다.
+
+- 표본 수: ko/en suspect-zone fixture 22개. 언어·장르·출처별 신뢰구간을 낼 만큼 크지 않다.
+- 모델 시대성: 2025+ GPT/Claude/Gemini/Llama/Qwen 계열 생성문 rebaseline은 아직 별도 follow-up이다.
+- 통계 보고: `docs/benchmarks/latest.md`는 fixture 수와 lang/class sample size를 공개하지만, Wilson 95% CI, bootstrap interval, threshold sweep은 아직 없다.
+- 범위: 현재 수치는 stylometry/lexicon hot 판정 회귀이며, rewrite 품질·MPS·fidelity의 live 품질 점수가 아니다.
+
+따라서 README/benchmark 문구는 “현재 fixture에서 회귀가 통과했다”로 해석해야 하며, “새 모델·새 장르에서도 100% 탐지한다”는 의미가 아니다. 다음 rebaseline에서는 최소한 언어 × class × register별 sample size를 고정하고, confidence interval과 threshold sweep을 함께 게시한다.
 
 ## 3. 문헌/실무에서 반복되는 지표 축
 
@@ -299,7 +310,7 @@ notes: |
 
 ### Phase 2 — corpus 확장
 
-- synthetic fixture 20개에서 real-world sampled fixture로 확장
+- synthetic/curated fixture 22개에서 real-world sampled fixture로 확장
 - human false positive register를 먼저 늘린다
 - 목표: 언어별 최소 100 human + 100 AI paragraph
 

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,9 @@ CURSOR_RULES_DIR="${HOME}/.cursor/rules"
 OPCODE_SKILLS_DIR="${HOME}/.config/opencode/skills"
 PATINA_DIR="${CLAUDE_SKILLS_DIR}/patina"
 REPO_URL="https://github.com/devswha/patina.git"
+# Pin the installed checkout to a concrete ref. If unset, resolve the current
+# remote HEAD once and check out that commit instead of tracking main.
+PATINA_REF="${PATINA_REF:-}"
 
 # Colors (only when outputting to a terminal)
 if [ -t 1 ]; then
@@ -51,6 +54,43 @@ error() {
 # Check prerequisites
 command -v git >/dev/null 2>&1 || error "git is not installed. Please install git first."
 
+resolve_install_ref() {
+  if [ -n "${PATINA_REF}" ]; then
+    printf "%s" "${PATINA_REF}"
+    return 0
+  fi
+
+  git ls-remote "${REPO_URL}" HEAD 2>/dev/null | awk 'NR == 1 { print $1 }'
+}
+
+checkout_install_ref() {
+  dir="$1"
+  ref="$2"
+
+  set +e
+  (
+    cd "${dir}"
+    git fetch --depth=1 origin "${ref}" || exit 10
+    git checkout --detach FETCH_HEAD >/dev/null 2>&1 || exit 11
+  )
+  rc="$?"
+  set -e
+  if [ "${rc}" = "10" ]; then
+    error "Failed to fetch patina ref '${ref}'. Use PATINA_REF=<tag-or-full-sha>."
+  fi
+  if [ "${rc}" = "11" ]; then
+    error "Failed to check out patina ref '${ref}'."
+  fi
+  if [ "${rc}" != "0" ]; then
+    error "Failed to install patina ref '${ref}'."
+  fi
+}
+
+INSTALL_REF="$(resolve_install_ref)"
+if [ -z "${INSTALL_REF}" ]; then
+  error "Failed to resolve patina install ref. Set PATINA_REF=<tag-or-full-sha> and retry."
+fi
+
 # --- Claude Code ---
 if [ "${INSTALL_CLAUDE}" = "true" ]; then
   info "Installing for Claude Code..."
@@ -62,14 +102,14 @@ if [ "${INSTALL_CLAUDE}" = "true" ]; then
 
   if [ -d "${PATINA_DIR}/.git" ]; then
     info "Updating existing patina installation..."
-    cd "${PATINA_DIR}"
-    git pull --ff-only || error "Failed to update patina. You may have local changes."
+    checkout_install_ref "${PATINA_DIR}" "${INSTALL_REF}"
   else
     if [ -d "${PATINA_DIR}" ]; then
       error "${PATINA_DIR} exists but is not a git repo. Remove it and try again."
     fi
-    info "Cloning patina..."
-    git clone "${REPO_URL}" "${PATINA_DIR}" || error "Failed to clone patina. Check your network connection."
+    info "Cloning patina at ${INSTALL_REF}..."
+    git clone --depth=1 "${REPO_URL}" "${PATINA_DIR}" || error "Failed to clone patina. Check your network connection."
+    checkout_install_ref "${PATINA_DIR}" "${INSTALL_REF}"
   fi
 
   ln -snf "${PATINA_DIR}/patina-max" "${CLAUDE_SKILLS_DIR}/patina-max"
@@ -170,8 +210,9 @@ if [ "${INSTALL_OPCODE}" = "true" ]; then
 fi
 printf "\n"
 info "Environment variables to control installation:"
-printf "  INSTALL_CLAUDE=true|false   (default: true)\n"
-printf "  INSTALL_CODEX=true|false    (default: true)\n"
-printf "  INSTALL_CURSOR=true|false   (default: true)\n"
-printf "  INSTALL_OPCODE=true|false   (default: true)\n"
+printf "  PATINA_REF=<tag-or-full-sha>  Pin installed checkout (default: resolved remote HEAD SHA)\n"
+printf "  INSTALL_CLAUDE=true|false    (default: true)\n"
+printf "  INSTALL_CODEX=true|false     (default: true)\n"
+printf "  INSTALL_CURSOR=true|false    (default: true)\n"
+printf "  INSTALL_OPCODE=true|false    (default: true)\n"
 printf "\n"

--- a/scripts/benchmark-report.mjs
+++ b/scripts/benchmark-report.mjs
@@ -71,6 +71,30 @@ function languageRows(perLanguage = {}) {
     );
 }
 
+function classRows(fixtures = []) {
+  const counts = new Map();
+  for (const f of fixtures) {
+    const key = `${f.lang}\0${f.class}`;
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, count]) => {
+      const [lang, klass] = key.split('\0');
+      return `| ${cell(lang)} | ${cell(klass)} | ${count} |`;
+    });
+}
+
+function sampleSizeSummary(fixtures = []) {
+  return fixtures.reduce((acc, f) => {
+    const lang = f.lang || 'unknown';
+    const klass = f.class || 'unknown';
+    acc[lang] ||= {};
+    acc[lang][klass] = (acc[lang][klass] || 0) + 1;
+    return acc;
+  }, {});
+}
+
 function fixtureRows(fixtures = []) {
   return fixtures.map((f) => {
     const hits = cell((f.lexicon_hits || []).slice(0, 4).join(', '));
@@ -119,6 +143,12 @@ This is the latest checked-in report for patina's deterministic suspect-zone ben
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 ${languageRows(results.perLanguage).join('\n')}
 
+## Sample sizes
+
+| lang | class | fixtures |
+|---|---|---:|
+${classRows(results.fixtures).join('\n')}
+
 ## Misclassifications
 
 ${misclassificationSection(results.fixtures)}
@@ -134,6 +164,8 @@ ${fixtureRows(results.fixtures).join('\n')}
 - **Hot** means at least one deterministic signal crossed the benchmark threshold: low burstiness CV, low MATTR, or AI-lexicon density.
 - **Cold** means the fixture did not cross those thresholds.
 - The report is meant for regression tracking and contributor discussion, not for authorship accusation.
+- This deterministic corpus is intentionally small (${results.fixtureCount} fixtures) and currently covers only checked-in ko/en suspect-zone fixtures; do not treat 100% fixture accuracy as generalization to new models, genres, or edited AI text.
+- Confidence intervals, threshold sweeps, and 2025+ model rebaselines are tracked as benchmark follow-ups, not claimed by this report yet.
 - Broader methodology notes live in [AI/Human Metrics Research](../research/ai-human-metrics.md) and [Quality Checks](../../tests/quality/README.md).
 `;
 }
@@ -151,6 +183,7 @@ function main() {
     benchmarkStatus,
     note: 'Deterministic suspect-zone benchmark; not an authorship detector.',
     ...results,
+    sampleSizes: sampleSizeSummary(results.fixtures),
   };
 
   mkdirSync(REPORT_DIR, { recursive: true });

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -47,6 +47,10 @@ export function listBackends() {
   });
 }
 
+export function listBackendNames() {
+  return Object.keys(REGISTRY);
+}
+
 export function selectBackend({ name, model } = {}) {
   if (name) {
     const backend = REGISTRY[name];

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
 import { loadConfig, getRepoRoot, resolveTone } from './config.js';
 import { loadPatterns, loadProfile, loadCoreFile, loadInputText, toneToBackboneProfile } from './loader.js';
 import { buildPrompt } from './prompt-builder.js';
-import { selectBackend, listBackends } from './backends/index.js';
+import { selectBackend, listBackends, listBackendNames } from './backends/index.js';
 import { selectProvider, resolveProviderConfig, PROVIDERS } from './providers.js';
 import { validateBaseURL, applyInsecureBaseURLOptIn, applyPrivateBaseURLOptIn } from './security.js';
 import { formatOutput, validateScoreWeights } from './output.js';
@@ -31,6 +31,14 @@ export async function main(args) {
   if (parsed.version) {
     console.log(`patina ${PACKAGE_VERSION}`);
     return;
+  }
+
+  if (parsed.models && parsed.variants && parsed.variants > 1) {
+    throw new Error('--variants is not supported with --models/MAX mode yet. Omit --variants or run one model at a time.');
+  }
+
+  if (parsed.gate !== undefined && !parsed.score) {
+    throw new Error('--gate can only be used with --score.');
   }
 
   if (parsed.listBackends) {
@@ -194,6 +202,10 @@ export async function main(args) {
       for (const w of warnings) {
         console.error(`[patina] ${w}`);
       }
+
+      if (parsed.gate !== undefined) {
+        applyScoreGate(result, output, parsed.gate);
+      }
     }
 
     if (parsed.saveRun) {
@@ -281,6 +293,14 @@ function parseArgs(args) {
       case '--score':
         parsed.score = true;
         break;
+      case '--gate': {
+        const n = Number(args[++i]);
+        if (!Number.isFinite(n) || n < 0 || n > 100) {
+          throw new Error(`--gate expects a number from 0 to 100, got ${args[i]}`);
+        }
+        parsed.gate = n;
+        break;
+      }
       case '--ouroboros':
         parsed.ouroboros = true;
         break;
@@ -502,11 +522,12 @@ function formatOuroborosOutput(result) {
 }
 
 function printHelp() {
+  const backendChoices = listBackendNames().join(', ');
   console.log(`patina — AI text humanizer CLI
 
 Usage: patina [options] [file...]
 
-Options:
+Core options:
   -h, --help           Show this help message
   -v, --version        Show version
   --lang <code>        Language: ko, en, zh, ja (default: ko)
@@ -517,46 +538,57 @@ Options:
                        narrative, marketing, instructional, auto.
                        Resolution: --tone > config tone > config profile.
                        zh/ja with explicit tone → warns + profile-only fallback.
+
+Modes:
   --diff               Show changes pattern by pattern
   --audit              Detect patterns only (no rewrite)
   --score              Output AI-likeness score (0-100)
+  --gate <n>           With --score, set exit code 3 when overall score > n
   --ouroboros          Iterative self-improvement loop
+
+Batch / output:
   --batch              Process multiple files
   --in-place           Overwrite original files (with --batch)
   --suffix <ext>       Save as {name}{ext}{extname}
   --outdir <dir>       Save results to directory
+  --save-run <dir>     Write manifest.json + output-N.txt under <dir> after the
+                       run (records version, prompt/config hashes, patterns,
+                       provider/model — useful for reproducibility / audit)
+
+MAX / variants:
   --models <list>      MAX mode: comma-separated model list
   --max-concurrency <n>  Cap parallel MAX-mode requests (default: unlimited)
+  --variants <n>       Generate N stylistic variants of the rewrite (1-5,
+                       default 1). Each variant preserves facts/numbers but
+                       differs in voice (V1 casual, V2 direct, V3 measured…).
+                       Output prints each as ## Variant N. Only --rewrite mode.
+
+Model / auth / backend:
   --model <id>         Single model ID (default: gpt-4o)
   --api-key <key>      API key (DEPRECATED: leaks via ps/shell history; prefer
                        PATINA_API_KEY env or --api-key-file)
   --api-key-file <path>  Read API key from file (recommended for shared hosts)
   --base-url <url>     API base URL (or PATINA_API_BASE env)
-  --backend <name>     Backend: openai-http (default), codex-cli (no API key)
+  --backend <name>     Backend: ${backendChoices} (default: openai-http)
   --list-backends      List available backends and their availability
   --provider <name>    Provider preset: openai, gemini, groq, together
                        (sets base-url + default model + reads <PROVIDER>_API_KEY)
   --list-providers     List provider presets and which keys are set
   --allow-insecure-base-url  Permit plaintext http:// to non-localhost endpoints
                        (also enabled by PATINA_ALLOW_INSECURE_BASE_URL=1)
+  --allow-private-base-url   Permit base URL pointing at private/IMDS IPs
+                       (also enabled by PATINA_ALLOW_PRIVATE_BASE_URL=1).
+                       Default: refuse to send the API key to RFC 1918 / link-local
+                       hosts to block SSRF to cloud metadata endpoints.
+
+Prompt / config:
   --config <path>      Load config from <path> instead of .patina.default.yaml
-  --save-run <dir>     Write manifest.json + output-N.txt under <dir> after the
-                       run (records version, prompt/config hashes, patterns,
-                       provider/model — useful for reproducibility / audit)
   --prompt-mode <m>    Rewrite prompt mode: strict | minimal | auto.
                        strict (default): full pattern packs (~34KB).
                        minimal: compressed watch-words + casual instruction (~3KB).
                        auto: pick by backend — gemini → minimal, others → strict.
                        case-05 finding: minimal helps Gemini, hurts Claude,
                        neutral for Codex. Only affects --rewrite mode.
-  --variants <n>       Generate N stylistic variants of the rewrite (1-5,
-                       default 1). Each variant preserves facts/numbers but
-                       differs in voice (V1 casual, V2 direct, V3 measured…).
-                       Output prints each as ## Variant N. Only --rewrite mode.
-  --allow-private-base-url   Permit base URL pointing at private/IMDS IPs
-                       (also enabled by PATINA_ALLOW_PRIVATE_BASE_URL=1).
-                       Default: refuse to send the API key to RFC 1918 / link-local
-                       hosts to block SSRF to cloud metadata endpoints.
 
 Environment Variables:
   PATINA_API_KEY       API authentication key (any provider)
@@ -578,6 +610,52 @@ If no API key is set, pass --backend codex-cli to use a logged-in codex CLI
 (no key required). Auto-fallback was removed in v3.9 to keep agent-mode
 backends opt-in (issue #88).
 `);
+}
+
+function applyScoreGate(result, output, gate) {
+  const overall = extractScoreOverall(result, output);
+  if (overall === null) {
+    throw new Error('--gate could not find a numeric `overall` value in --score output.');
+  }
+  if (overall > gate) {
+    console.error(`[patina] score gate failed: overall ${overall} > ${gate}`);
+    process.exitCode = Math.max(Number(process.exitCode) || 0, 3);
+  }
+}
+
+function extractScoreOverall(result, output) {
+  const resultOverall = toFiniteScore(result?.overall);
+  if (resultOverall !== null) return resultOverall;
+
+  const text = String(output ?? result ?? '');
+  const parsed = parseJsonScore(text);
+  const parsedOverall = toFiniteScore(parsed?.overall);
+  if (parsedOverall !== null) return parsedOverall;
+
+  const match = text.match(/(?:^|[\s|{,"])overall(?:["\s]*[:|]|\s+score\s*[:|]?)\s*(\d+(?:\.\d+)?)/i);
+  if (!match) return null;
+  return Number(match[1]);
+}
+
+function toFiniteScore(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function parseJsonScore(text) {
+  const trimmed = text.trim();
+  const candidates = [
+    trimmed,
+    trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1],
+    trimmed.match(/\{[\s\S]*\}/)?.[0],
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate);
+    } catch {}
+  }
+  return null;
 }
 
 function printBackendStatus() {

--- a/src/max-mode.js
+++ b/src/max-mode.js
@@ -27,7 +27,7 @@ export async function runMaxMode({ prompt, sourceText, models, apiKey, baseURL, 
       patterns,
       apiKey,
       baseURL,
-      model: models[0],
+      model: r.model,
     });
 
     const mpsResult = await scoreMPS({
@@ -35,7 +35,7 @@ export async function runMaxMode({ prompt, sourceText, models, apiKey, baseURL, 
       rewritten: r.result,
       apiKey,
       baseURL,
-      model: models[0],
+      model: r.model,
     });
 
     candidates.push({

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -41,6 +41,22 @@ function stopMockServer() {
   });
 }
 
+async function captureConsole(fn) {
+  const logs = [];
+  const errors = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (...args) => logs.push(args.join(' '));
+  console.error = (...args) => errors.push(args.join(' '));
+  try {
+    await fn();
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+  return { logs, errors };
+}
+
 describe('CLI End-to-End with Mock API', () => {
   before(async () => {
     await startMockServer('This is the humanized result.');
@@ -131,23 +147,89 @@ describe('CLI End-to-End with Mock API', () => {
     await startMockServer('This is the humanized result.');
   });
 
-  it('should handle MAX mode with multiple models', async () => {
+  it('should group help output and list current backend names', async () => {
+    const { logs } = await captureConsole(() => main(['--help']));
+    const help = logs.join('\n');
+
+    assert.ok(help.includes('Core options:'), 'help should group core options');
+    assert.ok(help.includes('Modes:'), 'help should group modes');
+    assert.ok(help.includes('Model / auth / backend:'), 'help should group backend options');
+    assert.ok(help.includes('--gate <n>'), 'help should document score gate');
+    assert.ok(
+      help.includes('openai-http, codex-cli, claude-cli, gemini-cli'),
+      'help should list every backend name'
+    );
+  });
+
+  it('should set exit code 3 when --score gate fails', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+    await stopMockServer();
+    await startMockServer('{ "overall": 42, "interpretation": "mixed" }');
+
+    const oldExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+    try {
+      const { errors } = await captureConsole(() => main([
+        '--lang', 'en',
+        '--score',
+        '--gate', '30',
+        '--api-key', 'test-key',
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        testFile,
+      ]));
+
+      assert.strictEqual(process.exitCode, 3);
+      assert.ok(errors.some((line) => line.includes('score gate failed')));
+    } finally {
+      process.exitCode = oldExitCode;
+    }
+    await stopMockServer();
+    await startMockServer('This is the humanized result.');
+  });
+
+  it('should reject --gate outside score mode', async () => {
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+
+    await assert.rejects(
+      () => main([
+        '--gate', '30',
+        '--api-key', 'test-key',
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        testFile,
+      ]),
+      /--gate can only be used with --score/
+    );
+  });
+
+  it('should score each MAX candidate with its own model', async () => {
     callCount = 0;
     lastRequestBody = null;
     await stopMockServer();
 
-    let callNum = 0;
+    const requests = [];
     mockServer = createServer((req, res) => {
       callCount++;
       let body = '';
       req.on('data', (chunk) => { body += chunk; });
       req.on('end', () => {
         lastRequestBody = JSON.parse(body);
-        callNum++;
+        requests.push(lastRequestBody);
         const model = lastRequestBody.model;
+        const prompt = lastRequestBody.messages[0].content;
         res.writeHead(200, { 'Content-Type': 'application/json' });
 
-        if (model === 'model-a') {
+        if (prompt.includes('AI-likeness scoring engine')) {
+          const overall = prompt.includes('Result from model B') ? 20 : 40;
+          res.end(JSON.stringify({
+            choices: [{ message: { content: `{ "overall": ${overall}, "interpretation": "mostly human" }` } }],
+          }));
+        } else if (prompt.includes('Meaning Preservation evaluator')) {
+          res.end(JSON.stringify({
+            choices: [{ message: { content: '{ "anchors": [], "pass_count": 1, "total_count": 1, "polarity_pass_count": 0, "polarity_total_count": 0, "mps": 90 }' } }],
+          }));
+        } else if (model === 'model-a') {
           res.end(JSON.stringify({
             choices: [{ message: { content: 'Result from model A' } }],
           }));
@@ -157,7 +239,7 @@ describe('CLI End-to-End with Mock API', () => {
           }));
         } else {
           res.end(JSON.stringify({
-            choices: [{ message: { content: 'Score result' } }],
+            choices: [{ message: { content: 'Unexpected model' } }],
           }));
         }
       });
@@ -180,9 +262,33 @@ describe('CLI End-to-End with Mock API', () => {
       testFile,
     ]);
 
-    assert.ok(callCount >= 2, `Should make multiple API calls, got ${callCount}`);
+    const scoringModelsForB = requests
+      .filter((request) => request.messages[0].content.includes('Result from model B'))
+      .map((request) => request.model);
+
+    assert.deepStrictEqual(
+      scoringModelsForB,
+      ['model-b', 'model-b'],
+      'model-b candidate should be scored for AI-likeness and MPS by model-b'
+    );
+    assert.ok(callCount >= 6, `Should make rewrite + scoring calls, got ${callCount}`);
     await stopMockServer();
     await startMockServer('This is the humanized result.');
+  });
+
+  it('should reject --variants with MAX mode instead of ignoring it', async () => {
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+
+    await assert.rejects(
+      () => main([
+        '--models', 'model-a,model-b',
+        '--variants', '2',
+        '--api-key', 'test-key',
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        testFile,
+      ]),
+      /--variants is not supported with --models\/MAX mode yet/
+    );
   });
 
   it('should handle API errors gracefully', async () => {

--- a/tests/fixtures/suspect-zones/en/ai/en-ai-06-chat-register.md
+++ b/tests/fixtures/suspect-zones/en/ai/en-ai-06-chat-register.md
@@ -1,0 +1,16 @@
+---
+fixture_id: en-ai-06-chat-register
+language: en
+class: ai
+expected_hot: true
+expected_metrics:
+  cv_band: low
+  mattr_band: high
+  lexicon_density_min: 0
+  lexicon_density_max: 80
+why_designed_this_way: |
+  Sanitized Discord-style assistant prose. The claims are harmless and redistributable, while the sentence lengths stay deliberately even to pin a chat-register AI hot fixture.
+topic: Discord bot project update
+---
+
+The runtime bridge now forwards component-only bot messages into the workspace queue. The scheduler records each handoff before the generator starts a branch. The evaluator then checks the diff, the tests, and the repository status. This flow keeps the Discord thread readable while preserving the audit trail. Future runs should reuse the same channel binding and avoid duplicate listeners.

--- a/tests/fixtures/suspect-zones/ko/ai/ko-ai-06-chat-register.md
+++ b/tests/fixtures/suspect-zones/ko/ai/ko-ai-06-chat-register.md
@@ -1,0 +1,16 @@
+---
+fixture_id: ko-ai-06-chat-register
+language: ko
+class: ai
+expected_hot: true
+expected_metrics:
+  cv_band: low
+  mattr_band: high
+  lexicon_density_min: 0
+  lexicon_density_max: 80
+why_designed_this_way: |
+  공개 가능한 형태로 재작성한 Discord 봇 응답체 fixture. 실제 운영 맥락을 반영하되 개인 메시지나 비공개 내용을 포함하지 않는다.
+topic: Discord bot project update
+---
+
+런타임 브리지는 컴포넌트 전용 봇 메시지를 작업 큐로 전달합니다. 스케줄러는 생성기가 브랜치를 만들기 전에 각 핸드오프를 기록합니다. 평가기는 변경 diff와 테스트 결과와 저장소 상태를 함께 확인합니다. 이 흐름은 디스코드 스레드를 읽기 쉽게 유지하면서 감사 기록을 남깁니다. 다음 실행에서도 같은 채널 바인딩을 재사용하고 중복 리스너를 피해야 합니다.

--- a/tests/quality/README.md
+++ b/tests/quality/README.md
@@ -52,6 +52,11 @@ Per-language metrics use `expected_hot=true` as the positive class.
    language: ko
    class: ai
    expected_hot: true
+   expected_metrics:
+     cv_band: low              # optional regression pin
+     mattr_band: high          # optional regression pin
+     lexicon_density_min: 0    # optional regression pin
+     lexicon_density_max: 80   # optional regression pin
    why_designed_this_way: |
      Brief note on which signals you expect to fire.
    topic: <subject>
@@ -62,7 +67,9 @@ Per-language metrics use `expected_hot=true` as the positive class.
 
 2. Drop it under `tests/fixtures/suspect-zones/{lang}/{ai|natural}/`.
 
-3. Re-run `npm run benchmark` and confirm it classifies as expected.
+3. Add `expected_metrics` when a fixture is meant to pin a specific deterministic signal. This is useful for real-world chat-register fixtures where a future tokenizer or threshold change should fail loudly instead of silently changing the benchmark meaning.
+
+4. Re-run `npm run benchmark` and confirm it classifies as expected.
 
 ## Tuning the thresholds
 

--- a/tests/quality/benchmark.mjs
+++ b/tests/quality/benchmark.mjs
@@ -78,6 +78,25 @@ function round(n, digits = 3) {
   return Math.round(n * 10 ** digits) / 10 ** digits;
 }
 
+function validateExpectedMetrics(path, expected = {}, observed = {}) {
+  const failures = [];
+  if (expected.cv_band && observed.cv_band !== expected.cv_band) {
+    failures.push(`cv_band expected ${expected.cv_band}, got ${observed.cv_band}`);
+  }
+  if (expected.mattr_band && observed.mattr_band !== expected.mattr_band) {
+    failures.push(`mattr_band expected ${expected.mattr_band}, got ${observed.mattr_band}`);
+  }
+  if (typeof expected.lexicon_density_min === 'number' && observed.lexicon_density < expected.lexicon_density_min) {
+    failures.push(`lexicon_density expected >= ${expected.lexicon_density_min}, got ${observed.lexicon_density}`);
+  }
+  if (typeof expected.lexicon_density_max === 'number' && observed.lexicon_density > expected.lexicon_density_max) {
+    failures.push(`lexicon_density expected <= ${expected.lexicon_density_max}, got ${observed.lexicon_density}`);
+  }
+  if (failures.length) {
+    throw new Error(`${path}: expected_metrics regression failed: ${failures.join('; ')}`);
+  }
+}
+
 function main() {
   const quiet = process.argv.includes('--quiet');
   const fixtures = listFixtures();
@@ -111,6 +130,15 @@ function main() {
     updateMetrics(perLanguage[lang], predicted, expected);
 
     const p = result.paragraphs[0] || {};
+    const observed = {
+      cv: round(p.burstiness?.cv ?? 0),
+      cv_band: p.burstiness?.band,
+      mattr: round(p.mattr?.value ?? 0),
+      mattr_band: p.mattr?.band,
+      lexicon_density: round(p.lexicon?.density ?? 0),
+      lexicon_hits: p.lexicon?.hits ?? [],
+    };
+    if (meta.expected_metrics) validateExpectedMetrics(path, meta.expected_metrics, observed);
     fixtureLog.push({
       fixture_id: meta.fixture_id,
       lang,
@@ -118,12 +146,8 @@ function main() {
       expected_hot: expected,
       predicted_hot: predicted,
       correct: predicted === expected,
-      cv: round(p.burstiness?.cv ?? 0),
-      cv_band: p.burstiness?.band,
-      mattr: round(p.mattr?.value ?? 0),
-      mattr_band: p.mattr?.band,
-      lexicon_density: round(p.lexicon?.density ?? 0),
-      lexicon_hits: p.lexicon?.hits ?? [],
+      ...observed,
+      expected_metrics: meta.expected_metrics ?? null,
     });
   }
 


### PR DESCRIPTION
## Summary

- Make `install.sh` resolve and checkout a concrete ref (`PATINA_REF` or remote HEAD SHA) instead of updating a moving branch.
- Fix MAX candidate scoring so each candidate is scored with its own model, and reject unsupported `--models` + `--variants` combinations explicitly.
- Add launch-readiness docs: 30-second demo, CLI contract/exit codes, issue templates, governance/maintainers.
- Add two chat-register benchmark fixtures plus `expected_metrics` regression checks, sample-size reporting, and benchmark limitation notes.
- Group `patina --help` output and add `--score --gate <n>` for CI-style automation.

## Verification

- `npm test` (148 pass)
- `npm run benchmark` (22 fixtures, 100% deterministic fixture accuracy)
- `npm run benchmark:report`
- `sh -n install.sh`
- `git diff --check`
- `node --check src/cli.js scripts/benchmark-report.mjs src/backends/index.js`
- Issue-template YAML parse smoke
- Local Markdown link check for changed docs
- Pinned install smoke with detached checkout and update path

## Notes

- Core skill pipeline unchanged.
- No new dependencies.
- Ultragoal ledger checkpointing is still blocked in this Codex thread by an older completed goal snapshot; repo work is complete and verified.
