### PR TITLE
cli: standardize input error messages

### DIFF
--- a/bin/patina.js
+++ b/bin/patina.js
@@ -3,6 +3,6 @@
 import { main } from '../src/cli.js';
 
 main(process.argv.slice(2)).catch((err) => {
-  console.error(err);
+  console.error(err?.message || err);
   process.exit(1);
 });

--- a/src/cli.js
+++ b/src/cli.js
@@ -163,19 +163,29 @@ export async function main(args) {
       }
 
       if (backend.name === 'openai-http' && !resolved.apiKey) {
-        const msg = ['No API key found. Set PATINA_API_KEY or pass --api-key.'];
+        const next = [
+          provider
+            ? `Set ${provider.apiKeyEnv} or PATINA_API_KEY, or pass --api-key-file <path>.`
+            : 'Set PATINA_API_KEY or pass --api-key-file <path>.',
+        ];
         if (provider) {
-          msg.push(`(--provider ${provider.name} expects ${provider.apiKeyEnv} or PATINA_API_KEY.)`);
+          next.unshift(
+            `--provider ${provider.name} expects ${provider.apiKeyEnv} or PATINA_API_KEY.`
+          );
         }
         const codex = listBackends().find((b) => b.name === 'codex-cli');
         if (codex && codex.available && codex.authenticated) {
-          msg.push('Or pass `--backend codex-cli` to use the codex-cli backend (no key needed).');
+          next.push('Or pass `--backend codex-cli` to use the codex-cli backend.');
         } else if (codex && codex.available && !codex.authenticated) {
-          msg.push('Or run `codex login`, then pass `--backend codex-cli`.');
+          next.push('Or run `codex login`, then pass `--backend codex-cli`.');
         } else if (codex && !codex.available) {
-          msg.push('Or install `codex` from https://github.com/openai/codex and pass `--backend codex-cli`.');
+          next.push('Or install `codex` and pass `--backend codex-cli`.');
         }
-        throw new Error(msg.join('\n'));
+        throw new Error(formatCliError(
+          'no API key found',
+          'openai-http needs an API key before it can call the provider.',
+          next.join(' ')
+        ));
       }
 
       result = await backend.invoke({
@@ -437,18 +447,29 @@ function resolveApiKey(parsed) {
   return undefined;
 }
 
+export function formatCliError(what, why, nextAction) {
+  return `[patina] Error: ${what}\n         ${why}\n         → ${nextAction}`;
+}
+
 async function loadInputs(parsed) {
   if (parsed.files.length === 0) {
     // No file args. If stdin is a TTY (interactive terminal), there is no input
-    // to read — print help instead of hanging or sending empty text to the LLM.
+    // to read; fail instead of hanging or sending empty text to the LLM.
     if (process.stdin.isTTY) {
-      printHelp();
-      console.error('\nNo input provided. Pass a file path, pipe text via stdin, or run `patina --help`.');
+      console.error(formatCliError(
+        'no input provided',
+        'patina needs a file path or piped stdin before it can run.',
+        'Pass a file path, pipe text via stdin, or run `patina --help`.'
+      ));
       process.exit(2);
     }
     const stdin = await readStdin();
     if (!stdin.trim()) {
-      console.error('Error: empty input on stdin. Pipe text via stdin or pass a file path.');
+      console.error(formatCliError(
+        'empty input on stdin',
+        'stdin was present but contained only whitespace.',
+        'Try: echo "..." | patina --lang en'
+      ));
       process.exit(2);
     }
     return [{ path: '-', text: stdin }];

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -1,7 +1,8 @@
 import { createServer } from 'node:http';
+import { spawnSync } from 'node:child_process';
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
-import { main } from '../../src/cli.js';
+import { formatCliError, main } from '../../src/cli.js';
 import { getRepoRoot } from '../../src/config.js';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -55,6 +56,23 @@ async function captureConsole(fn) {
     console.error = originalError;
   }
   return { logs, errors };
+}
+
+async function captureProcessExit(fn) {
+  const originalExit = process.exit;
+  let exitCode;
+  process.exit = (code) => {
+    exitCode = code;
+    throw new Error(`process.exit:${code}`);
+  };
+  try {
+    await fn();
+  } catch (err) {
+    if (!String(err.message).startsWith('process.exit:')) throw err;
+  } finally {
+    process.exit = originalExit;
+  }
+  return exitCode;
 }
 
 describe('CLI End-to-End with Mock API', () => {
@@ -158,6 +176,91 @@ describe('CLI End-to-End with Mock API', () => {
     assert.ok(
       help.includes('openai-http, codex-cli, claude-cli, gemini-cli'),
       'help should list every backend name'
+    );
+  });
+
+  it('should format no-input TTY errors without dumping help', async () => {
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: true,
+    });
+
+    try {
+      const { logs, errors } = await captureConsole(async () => {
+        const exitCode = await captureProcessExit(() =>
+          main(['--backend', 'codex-cli'])
+        );
+        assert.strictEqual(exitCode, 2);
+      });
+
+      assert.deepStrictEqual(logs, []);
+      assert.deepStrictEqual(errors, [
+        formatCliError(
+          'no input provided',
+          'patina needs a file path or piped stdin before it can run.',
+          'Pass a file path, pipe text via stdin, or run `patina --help`.'
+        ),
+      ]);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        configurable: true,
+        value: originalIsTTY,
+      });
+    }
+  });
+
+  it('should format empty stdin errors with a concrete pipe example', () => {
+    const result = spawnSync(
+      process.execPath,
+      ['bin/patina.js', '--backend', 'codex-cli'],
+      {
+        cwd: REPO_ROOT,
+        input: '',
+        encoding: 'utf8',
+      }
+    );
+
+    assert.strictEqual(result.status, 2);
+    assert.strictEqual(result.stdout, '');
+    assert.strictEqual(
+      result.stderr.trim(),
+      formatCliError(
+        'empty input on stdin',
+        'stdin was present but contained only whitespace.',
+        'Try: echo "..." | patina --lang en'
+      )
+    );
+  });
+
+  it('should format missing API key errors without a stack trace', () => {
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+    const result = spawnSync(
+      process.execPath,
+      ['bin/patina.js', '--backend', 'openai-http', testFile],
+      {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          PATINA_API_KEY: '',
+          PATINA_API_KEY_FILE: '',
+        },
+        encoding: 'utf8',
+      }
+    );
+
+    assert.strictEqual(result.status, 1);
+    assert.strictEqual(result.stdout, '');
+    assert.ok(result.stderr.includes('[patina] Error: no API key found'));
+    assert.ok(
+      result.stderr.includes(
+        '         openai-http needs an API key before it can call the provider.'
+      )
+    );
+    assert.ok(result.stderr.includes('         → Set PATINA_API_KEY'));
+    assert.ok(
+      !result.stderr.includes('\n    at '),
+      'should not print a stack trace'
     );
   });
 


### PR DESCRIPTION
Closes #184.

## Summary
- add a shared formatter for contextual three-line CLI errors
- replace no-input TTY and empty-stdin messages with the requested `[patina] Error` format
- bring missing API-key errors into the same format and avoid stack traces from the bin wrapper
- cover TTY, empty stdin, and missing API-key paths in e2e tests

## Verification
- npm run lint
- npm test
- printf '' | node bin/patina.js --backend codex-cli
- env PATINA_API_KEY= PATINA_API_KEY_FILE= node bin/patina.js --backend openai-http tests/e2e/test-input-en.txt
- git diff --check