### PR TITLE
cli: add help usage examples

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -606,6 +606,11 @@ Subcommands:
   patina auth status   Show backend availability and authentication status
   patina auth login    Print per-backend instructions for authenticating
 
+Examples:
+  echo "Text to rewrite" | patina --lang en --backend codex-cli
+  patina --audit --lang ko draft.md
+  patina --score --gate 35 --lang en report.md
+
 If no API key is set, pass --backend codex-cli to use a logged-in codex CLI
 (no key required). Auto-fallback was removed in v3.9 to keep agent-mode
 backends opt-in (issue #88).

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -154,7 +154,10 @@ describe('CLI End-to-End with Mock API', () => {
     assert.ok(help.includes('Core options:'), 'help should group core options');
     assert.ok(help.includes('Modes:'), 'help should group modes');
     assert.ok(help.includes('Model / auth / backend:'), 'help should group backend options');
+    assert.ok(help.includes('Examples:'), 'help should include usage examples');
     assert.ok(help.includes('--gate <n>'), 'help should document score gate');
+    assert.ok(help.includes('patina --audit --lang ko draft.md'));
+    assert.ok(help.includes('patina --score --gate 35 --lang en report.md'));
     assert.ok(
       help.includes('openai-http, codex-cli, claude-cli, gemini-cli'),
       'help should list every backend name'


### PR DESCRIPTION
Closes #176.

## Summary
- add an Examples block to `patina --help`
- include pipe, audit, and score-gate examples
- extend the existing help-output e2e test to cover the examples

## Verification
- npm run lint
- npm test
- node bin/patina.js --help
- git diff --check