### PR TITLE
Add distribution and CI adoption surfaces

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+.omc
+.omx
+.claude
+.openclaw
+.workclaw
+node_modules
+artifacts
+custom
+memory
+.env
+npm-debug.log*
+.DS_Store
+tests
+docs/benchmarks/latest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish npm packages and GHCR image instead of running a dry-run.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Release metadata check
+        run: npm run release:check
+
+      - name: Unit and e2e tests
+        run: npm test
+
+      - name: Benchmark report schema
+        run: npm run benchmark:report
+
+      - name: Dogfood public docs
+        run: npm run dogfood
+
+      - name: Root npm package dry run
+        run: npm pack --dry-run
+
+      - name: Alias npm package dry run
+        run: cd packages/patina-humanizer && npm pack --dry-run
+
+  npm:
+    needs: verify
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node 20 for npm
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify release metadata
+        run: npm run release:check
+
+      - name: Publish patina-cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance
+
+      - name: Publish patina-humanizer alias
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: cd packages/patina-humanizer && npm publish --access public --provenance
+
+  ghcr:
+    needs: verify
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/devswha/patina
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Release metadata
+        run: npm run release:check
+
       - name: Syntax lint
         run: npm run lint
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: patina-score
+  name: patina prose score
+  description: Flag AI-sounding prose hotspots in Markdown without rewriting files.
+  entry: patina-score --gate 30 --lang auto
+  language: node
+  files: \.(md|mdx)$
+  pass_filenames: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
+## 3.11.0 — 2026-05-20
+
+**Launch-readiness polish for trust, benchmarks, and distribution.**
+
+Semver rationale: minor — adds CI/release/distribution surfaces and documentation, while preserving the core rewrite pipeline and existing CLI behavior.
+
+### New
+
+- Prepared npm release metadata for `patina-cli` plus the `patina-humanizer` alias package.
+- Added a release workflow for npm provenance publishing and GHCR image publishing.
+- Added deterministic GitHub Action and pre-commit scoring surfaces for Markdown review.
+- Added Dockerfile-based container runtime for API-backed CLI use.
+
+### Quality
+
+- Added release metadata checks so package/config/skill/changelog versions stay synchronized.
+- Added deterministic prose-score tests and pre-commit E2E coverage.
+
 ## 3.10.0 — 2026-05-06
 
 **Tone categorization v1 (6 tones + `auto`).**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM node:18-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
+
+FROM node:18-alpine AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+RUN addgroup -S patina && adduser -S patina -G patina
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json package-lock.json ./
+COPY bin ./bin
+COPY src ./src
+COPY core ./core
+COPY patterns ./patterns
+COPY profiles ./profiles
+COPY lexicon ./lexicon
+COPY .patina.default.yaml README.md LICENSE ./
+RUN chmod +x bin/patina.js \
+  && ln -s /app/bin/patina.js /usr/local/bin/patina \
+  && chown -R patina:patina /app
+USER patina
+ENTRYPOINT ["patina"]
+CMD ["--help"]

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -90,7 +90,13 @@ Pick the row matching the host the user is running you in, and run **only that c
 
 ### Step 3 (optional): Install the standalone Node CLI
 
-Only if the user wants to invoke `patina` from a shell without going through an agent:
+Only if the user wants to invoke `patina` from a shell without going through an agent. After the npm package is published, the shortest path is:
+
+```bash
+npx patina-cli --lang en input.txt
+```
+
+For local development or unpublished commits:
 
 ```bash
 cd ~/.claude/skills/patina && npm install && npm link
@@ -158,6 +164,15 @@ Or via the standalone Node CLI (only if Step 3 of Path B was run):
 ```
 patina --lang ko input.txt
 ```
+
+Or through Docker after the GHCR release image exists:
+
+```bash
+printf '%s\n' 'Coffee has emerged as a pivotal cultural phenomenon.' \
+  | docker run --rm -i -e PATINA_API_KEY ghcr.io/devswha/patina:3.11.0 --lang en --provider openai
+```
+
+The Docker image intentionally does not bake in codex/claude/gemini CLI binaries or logins. Use API-backed providers inside the container, or mount your own authenticated tooling explicitly.
 
 Free tier: when [`codex`](https://github.com/openai/codex) is installed and logged in, patina works **without** an API key — it dispatches through the codex backend automatically.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,13 @@ Auto-detect and apply the best-fit tone:
 
 ### As a standalone CLI
 
-Requires Node.js ≥ 18.
+Requires Node.js ≥ 18. After the npm release is cut, use the package directly:
+
+```bash
+npx patina-cli --lang en input.txt
+```
+
+Until then, or when you want to hack on the repo:
 
 ```bash
 git clone https://github.com/devswha/patina.git
@@ -104,6 +110,29 @@ printf '%s\n' 'Coffee has emerged as a pivotal cultural phenomenon that has fund
 ```
 
 > 🆓 **No API key required** if you have any of [`codex`](https://github.com/openai/codex), [`claude`](https://docs.anthropic.com/en/docs/claude-code), or [`gemini`](https://github.com/google-gemini/gemini-cli) CLIs logged in. Pick one with `--backend codex-cli | claude-cli | gemini-cli`, or let the model heuristic route automatically (`--model claude-*` → claude-cli, etc.). See [AUTHENTICATION.md](docs/AUTHENTICATION.md) for the full backend list.
+
+### CI integrations
+
+Patina now includes no-key deterministic CI surfaces for prose review:
+
+```yaml
+# .github/workflows/patina.yml
+steps:
+  - uses: actions/checkout@v6
+  - uses: devswha/patina@main # pin to @v1 after the release tag exists
+    with:
+      gate: 30
+      comment: true
+```
+
+Docker release images are published to GHCR on version tags:
+
+```bash
+printf '%s\n' 'Coffee has emerged as a pivotal cultural phenomenon.' \
+  | docker run --rm -i -e PATINA_API_KEY ghcr.io/devswha/patina:3.11.0 --lang en --provider openai
+```
+
+Pre-commit, Husky, Lefthook, Docker, and release workflow notes live in [docs/integrations/](docs/integrations/).
 
 ## Intended Use
 
@@ -218,6 +247,10 @@ Pattern packs are auto-discovered by language prefix. `.patina.yaml` in the work
 - **[Demo](docs/DEMO.md)** — terminal transcript and multi-genre before/after snapshots
 - **[Patterns](docs/PATTERNS.md)** — full 146-pattern catalog
 - **[Authentication](docs/AUTHENTICATION.md)** — backends, providers, free-tier setup
+- **[GitHub Action](docs/integrations/github-action.md)** — PR hotspot comments without a live model key
+- **[Pre-commit](docs/integrations/pre-commit.md)** — pre-commit, Husky, and Lefthook score-only recipes
+- **[Docker](docs/integrations/docker.md)** — GHCR image usage and release tags
+- **[Release workflow](docs/integrations/release.md)** — npm provenance + GHCR publishing checklist
 - **[CLI Contract](docs/CLI.md)** — score gate, exit codes, and automation-safe surfaces
 - **[Ethics](docs/ETHICS.md)** — intended use, non-use, and disclosure stance
 - **[FAQ](docs/FAQ.md)** — detector-bypass concerns, MPS, false positives, contribution starting points

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,63 @@
+name: patina-action
+branding:
+  icon: edit-3
+  color: green
+description: Comment on pull requests with deterministic Patina prose hotspot scores.
+inputs:
+  files:
+    description: Optional newline- or comma-separated file list. Defaults to changed PR files.
+    required: false
+    default: ''
+  lang:
+    description: "Language hint: auto, ko, en, zh, or ja."
+    required: false
+    default: auto
+  gate:
+    description: Maximum allowed percentage of hot prose paragraphs.
+    required: false
+    default: '30'
+  max-files:
+    description: Maximum number of changed prose files to score.
+    required: false
+    default: '50'
+  comment:
+    description: Create or update a sticky PR comment.
+    required: false
+    default: 'true'
+  fail-on-gate:
+    description: Fail the workflow when any scored file exceeds the gate.
+    required: false
+    default: 'false'
+  token:
+    description: GitHub token used to list PR files and write comments.
+    required: false
+    default: ''
+outputs:
+  file-count:
+    description: Number of prose files scored.
+    value: ${{ steps.score.outputs.file-count }}
+  failed-count:
+    description: Number of files above the gate.
+    value: ${{ steps.score.outputs.failed-count }}
+  max-score:
+    description: Highest file score percentage.
+    value: ${{ steps.score.outputs.max-score }}
+runs:
+  using: composite
+  steps:
+    - name: Install action dependencies
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: npm ci --omit=dev --ignore-scripts
+    - name: Score prose files
+      id: score
+      shell: bash
+      env:
+        INPUT_FILES: ${{ inputs.files }}
+        INPUT_LANG: ${{ inputs.lang }}
+        INPUT_GATE: ${{ inputs.gate }}
+        INPUT_MAX_FILES: ${{ inputs.max-files }}
+        INPUT_COMMENT: ${{ inputs.comment }}
+        INPUT_FAIL_ON_GATE: ${{ inputs.fail-on-gate }}
+        INPUT_TOKEN: ${{ inputs.token || github.token }}
+      run: node "${{ github.action_path }}/scripts/github-action.mjs"

--- a/docs/integrations/docker.md
+++ b/docs/integrations/docker.md
@@ -1,0 +1,15 @@
+# Docker image
+
+The release job publishes `ghcr.io/devswha/patina` when a maintainer pushes a version tag.
+
+```bash
+printf '%s\n' 'Coffee has emerged as a pivotal cultural phenomenon.' \
+  | docker run --rm -i -e PATINA_API_KEY ghcr.io/devswha/patina:3.11.0 --lang en --provider openai
+```
+
+Tags:
+
+- `ghcr.io/devswha/patina:3.11.0` — version tag from `v3.11.0`.
+- `ghcr.io/devswha/patina:latest` — latest release tag.
+
+The image uses `node:18-alpine`. It does **not** include codex, claude, or gemini CLI binaries, and it never carries local login state. For container runs, use an API-backed provider or mount your own authenticated tools explicitly.

--- a/docs/integrations/github-action.md
+++ b/docs/integrations/github-action.md
@@ -1,0 +1,48 @@
+# GitHub Action
+
+Patina ships a composite Action for pull request prose review. No model call is required. It leaves a sticky comment with file-level hotspot scores, so docs reviewers can spot stiff or repetitive paragraphs before merge instead of finding them after publication. The check runs locally in the Action process and does not send text to a live model.
+
+> The checked-in Action can be used from this repository immediately with `@main`. After a release tag is cut, pin to `@v1` or a full version tag.
+
+```yaml
+name: Patina prose score
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '**/*.mdx'
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  patina:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: devswha/patina@main # replace with @v1 after the v1 tag exists
+        with:
+          gate: 30
+          lang: auto
+          comment: true
+          fail-on-gate: false
+```
+
+## Inputs
+
+| Input | Default | Meaning |
+|---|---:|---|
+| `files` | changed PR files | Optional newline/comma-separated file list. |
+| `lang` | `auto` | `auto`, `ko`, `en`, `zh`, or `ja`. |
+| `gate` | `30` | Maximum hot-paragraph percentage per file. |
+| `max-files` | `50` | Limit for large PRs. |
+| `comment` | `true` | Create/update a sticky PR comment. |
+| `fail-on-gate` | `false` | Fail the check when any file exceeds `gate`. |
+| `token` | `${{ github.token }}` | Token used to list PR files and write comments. |
+
+## What it measures
+
+The Action uses the same deterministic burstiness, MATTR, and AI-lexicon signals as the checked-in benchmark. Read the table as a review queue. Open the highest row, check the surrounding paragraph, and decide whether the prose actually needs editing for your audience. It reports **editing hotspots**, not proof that text was AI-written.

--- a/docs/integrations/pre-commit.md
+++ b/docs/integrations/pre-commit.md
@@ -1,0 +1,77 @@
+# Pre-commit integrations
+
+Use these recipes when you want Patina to flag AI-sounding prose before Markdown changes land in a docs or blog repository.
+
+The hook is **score-only**: it never rewrites files during commit. It uses Patina's deterministic stylometry/lexicon layer, so it does not need an API key and it does not claim authorship provenance.
+
+## pre-commit framework
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/devswha/patina
+    rev: main # replace with a release tag after v1 is cut
+    hooks:
+      - id: patina-score
+        args: [--gate, "30", --lang, auto]
+```
+
+Run it locally:
+
+```bash
+pre-commit run patina-score --all-files
+```
+
+## Husky + lint-staged
+
+```bash
+npm install --save-dev husky lint-staged patina-cli
+npx husky init
+```
+
+```jsonc
+// package.json
+{
+  "lint-staged": {
+    "*.{md,mdx}": "patina-score --gate 30 --lang auto"
+  }
+}
+```
+
+```bash
+# .husky/pre-commit
+npx lint-staged
+```
+
+## Lefthook
+
+Install the package in the repository first:
+
+```bash
+npm install --save-dev patina-cli
+```
+
+```yaml
+# lefthook.yml
+pre-commit:
+  commands:
+    patina-score:
+      glob: "*.{md,mdx}"
+      run: npx patina-score --gate 30 --lang auto {staged_files}
+```
+
+A repo-local Lefthook command if this repository is vendored or checked out:
+
+```yaml
+pre-commit:
+  commands:
+    patina-score:
+      glob: "*.{md,mdx}"
+      run: node scripts/precommit-score.mjs --gate 30 --lang auto {staged_files}
+```
+
+## Tuning
+
+- `--gate 30` means fail when more than 30% of prose paragraphs in a file trip a hot signal.
+- `--lang auto` infers language from filename and Unicode ranges; pass `ko`, `en`, `zh`, or `ja` when a repo is single-language.
+- Use this as a discussion prompt, not as an accusation. See [ETHICS.md](../ETHICS.md).

--- a/docs/integrations/release.md
+++ b/docs/integrations/release.md
@@ -1,0 +1,36 @@
+# Release
+
+`release.yml` is the maintainer path for distribution artifacts.
+
+## Dry run
+
+```bash
+gh workflow run release.yml -f publish=false
+```
+
+The dry run verifies:
+
+- version metadata across `package.json`, skill files, `.patina.default.yaml`, README, and CHANGELOG;
+- unit/e2e tests;
+- benchmark report schema;
+- dogfood docs score;
+- `npm pack --dry-run` for both `patina-cli` and the `patina-humanizer` alias package.
+
+## Publish
+
+Publishing is intended for `v*.*.*` tags:
+
+```bash
+git tag v3.11.0
+git push origin v3.11.0
+```
+
+Required secret:
+
+- `NPM_TOKEN` for npm provenance publishing.
+
+The publish job uploads:
+
+- `patina-cli` to npm;
+- `patina-humanizer` alias to npm;
+- `ghcr.io/devswha/patina:latest` and `ghcr.io/devswha/patina:<version>`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "js-yaml": "^4.1.0"
       },
       "bin": {
-        "patina": "bin/patina.js"
+        "patina": "bin/patina.js",
+        "patina-score": "scripts/precommit-score.mjs"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "src/cli.js",
   "bin": {
-    "patina": "bin/patina.js"
+    "patina": "bin/patina.js",
+    "patina-score": "scripts/precommit-score.mjs"
   },
   "scripts": {
     "test": "node --test tests/unit/*.test.js tests/e2e/*.test.js",
@@ -14,7 +15,9 @@
     "benchmark": "node tests/quality/benchmark.mjs",
     "benchmark:report": "node scripts/benchmark-report.mjs",
     "dogfood": "node tests/quality/dogfood.mjs",
-    "lint": "node scripts/lint.mjs"
+    "lint": "node scripts/lint.mjs",
+    "release:check": "node scripts/check-release-metadata.mjs",
+    "prepublishOnly": "npm run release:check && npm test && npm run benchmark:report && npm run dogfood"
   },
   "dependencies": {
     "js-yaml": "^4.1.0"
@@ -69,6 +72,12 @@
     "patina-max/SKILL.md",
     ".patina.default.yaml",
     "LICENSE",
-    "CHANGELOG.md"
-  ]
+    "CHANGELOG.md",
+    "scripts/check-release-metadata.mjs",
+    "scripts/prose-score.mjs",
+    "scripts/precommit-score.mjs"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/patina-humanizer/README.md
+++ b/packages/patina-humanizer/README.md
@@ -1,0 +1,10 @@
+# patina-humanizer
+
+`patina-humanizer` is a tiny npm alias for [`patina-cli`](https://github.com/devswha/patina).
+It exists so people searching for an AI-text humanizer can still land on Patina.
+
+```bash
+npx patina-humanizer --lang en input.md
+```
+
+All implementation lives in `patina-cli`; this package only forwards the binary.

--- a/packages/patina-humanizer/bin/patina-humanizer.js
+++ b/packages/patina-humanizer/bin/patina-humanizer.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import 'patina-cli/bin/patina.js';

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "patina-humanizer",
+  "version": "3.11.0",
+  "description": "SEO-friendly alias for patina-cli",
+  "type": "module",
+  "bin": {
+    "patina-humanizer": "bin/patina-humanizer.js"
+  },
+  "dependencies": {
+    "patina-cli": "3.11.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/devswha/patina.git"
+  },
+  "homepage": "https://github.com/devswha/patina#readme",
+  "bugs": {
+    "url": "https://github.com/devswha/patina/issues"
+  },
+  "files": [
+    "bin/",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs';
+
+const pkg = readJson('package.json');
+const version = pkg.version;
+const checks = [];
+
+expect(pkg.private === false, 'package.json private must be false');
+expect(pkg.bin?.patina === 'bin/patina.js', 'package.json bin.patina must point to bin/patina.js');
+expect(pkg.bin?.['patina-score'] === 'scripts/precommit-score.mjs', 'package.json bin.patina-score must point to scripts/precommit-score.mjs');
+expect(existsSync('bin/patina.js'), 'bin/patina.js must exist');
+expect(readVersionField('SKILL.md') === version, 'SKILL.md version must match package.json');
+expect(readVersionField('SKILL-MAX.md') === version, 'SKILL-MAX.md version must match package.json');
+expect(readVersionField('patina-max/SKILL.md') === version, 'patina-max/SKILL.md version must match package.json');
+expect(readVersionField('.patina.default.yaml') === version, '.patina.default.yaml version must match package.json');
+expect(readFileSync('README.md', 'utf8').includes(`version: "${version}"`), 'README.md config example version must match package.json');
+expect(new RegExp(`^## ${escapeRegex(version)} — \\d{4}-\\d{2}-\\d{2}`, 'm').test(readFileSync('CHANGELOG.md', 'utf8')), 'CHANGELOG.md must contain a release heading for package.json version');
+
+const aliasPkg = readJson('packages/patina-humanizer/package.json');
+expect(aliasPkg.name === 'patina-humanizer', 'alias package name must be patina-humanizer');
+expect(aliasPkg.version === version, 'patina-humanizer version must match package.json');
+expect(aliasPkg.dependencies?.['patina-cli'] === version, 'patina-humanizer must depend on exact patina-cli version');
+expect(aliasPkg.bin?.['patina-humanizer'] === 'bin/patina-humanizer.js', 'patina-humanizer bin must point to bin/patina-humanizer.js');
+expect(existsSync('packages/patina-humanizer/bin/patina-humanizer.js'), 'patina-humanizer bin file must exist');
+
+if (checks.length) {
+  console.error(checks.map((msg) => `- ${msg}`).join('\n'));
+  process.exit(1);
+}
+console.log(`Release metadata OK for ${version}`);
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function readVersionField(path) {
+  const text = readFileSync(path, 'utf8');
+  const match = text.match(/^version:\s*["']?([^"'\n]+)["']?/m);
+  return match?.[1]?.trim();
+}
+
+function expect(condition, message) {
+  if (!condition) checks.push(message);
+}
+
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/scripts/github-action.mjs
+++ b/scripts/github-action.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+
+import {
+  formatMarkdownReport,
+  parseBoolean,
+  parseFileList,
+  scoreFiles,
+  summarizeRows,
+} from './prose-score.mjs';
+
+const COMMENT_MARKER = '<!-- patina-pr-score -->';
+
+async function main() {
+  const gate = numberInput('INPUT_GATE', 30, { max: 100 });
+  const maxFiles = numberInput('INPUT_MAX_FILES', 50, { max: 1000, integer: true });
+  const lang = process.env.INPUT_LANG || 'auto';
+  const token = process.env.INPUT_TOKEN || process.env.GITHUB_TOKEN || '';
+  const comment = parseBoolean(process.env.INPUT_COMMENT, true);
+  const failOnGate = parseBoolean(process.env.INPUT_FAIL_ON_GATE, false);
+  const explicitFiles = parseFileList(process.env.INPUT_FILES || '');
+  const files = explicitFiles.length ? explicitFiles : await changedFilesFromContext({ token, maxFiles });
+
+  const rows = scoreFiles(files, { gate, lang, maxFiles });
+  const summary = summarizeRows(rows);
+  const report = formatMarkdownReport(rows, { gate, title: 'Patina PR prose hotspot report' });
+  const body = `${COMMENT_MARKER}\n${report}`;
+
+  writeOutput('file-count', String(summary.fileCount));
+  writeOutput('failed-count', String(summary.failedCount));
+  writeOutput('max-score', summary.maxScore.toFixed(1));
+  writeStepSummary(report);
+  console.log(report);
+
+  if (comment) {
+    try {
+      await upsertPullRequestComment({ token, body });
+    } catch (error) {
+      console.warn(`patina-action: could not write PR comment: ${error.message}`);
+    }
+  }
+
+  if (failOnGate && summary.failedCount > 0) {
+    console.error(`patina-action: ${summary.failedCount}/${summary.fileCount} file(s) exceeded gate ${gate}.`);
+    process.exitCode = 1;
+  }
+}
+
+function numberInput(name, defaultValue, { min = 0, max = 100, integer = false } = {}) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return defaultValue;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < min || n > max || (integer && !Number.isInteger(n))) {
+    throw new Error(`${name} must be ${integer ? 'an integer' : 'a number'} from ${min} to ${max}, got ${raw}`);
+  }
+  return n;
+}
+
+async function changedFilesFromContext({ token, maxFiles }) {
+  const event = readEvent();
+  const pull = event.pull_request;
+  if (!pull || !token) return [];
+  const fullName = event.repository?.full_name;
+  if (!fullName) return [];
+  const [owner, repo] = fullName.split('/');
+  const files = [];
+  for (let page = 1; files.length < maxFiles; page++) {
+    const batch = await githubJson({
+      token,
+      path: `/repos/${owner}/${repo}/pulls/${pull.number}/files?per_page=100&page=${page}`,
+    });
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    files.push(...batch.map((item) => item.filename).filter(Boolean));
+    if (batch.length < 100) break;
+  }
+  return files.slice(0, maxFiles);
+}
+
+function readEvent() {
+  const path = process.env.GITHUB_EVENT_PATH;
+  if (!path || !existsSync(path)) return {};
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+async function upsertPullRequestComment({ token, body }) {
+  const event = readEvent();
+  const pull = event.pull_request;
+  const fullName = event.repository?.full_name;
+  if (!token || !pull || !fullName) return;
+  const [owner, repo] = fullName.split('/');
+  const comments = await githubJson({
+    token,
+    path: `/repos/${owner}/${repo}/issues/${pull.number}/comments?per_page=100`,
+  });
+  const existing = Array.isArray(comments)
+    ? comments.find((comment) => String(comment.body || '').includes(COMMENT_MARKER))
+    : null;
+  if (existing) {
+    await githubJson({
+      token,
+      method: 'PATCH',
+      path: `/repos/${owner}/${repo}/issues/comments/${existing.id}`,
+      body: { body },
+    });
+  } else {
+    await githubJson({
+      token,
+      method: 'POST',
+      path: `/repos/${owner}/${repo}/issues/${pull.number}/comments`,
+      body: { body },
+    });
+  }
+}
+
+async function githubJson({ token, method = 'GET', path, body }) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: 'application/vnd.github+json',
+      'content-type': 'application/json',
+      'user-agent': 'patina-action',
+      'x-github-api-version': '2022-11-28',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`GitHub API ${method} ${path} failed: ${response.status} ${text.slice(0, 200)}`);
+  }
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+function writeOutput(name, value) {
+  const path = process.env.GITHUB_OUTPUT;
+  if (!path) return;
+  appendFileSync(path, `${name}=${value}\n`);
+}
+
+function writeStepSummary(report) {
+  const path = process.env.GITHUB_STEP_SUMMARY;
+  if (!path) return;
+  appendFileSync(path, `${report}\n`);
+}
+
+main().catch((error) => {
+  console.error(`patina-action: ${error.message}`);
+  process.exit(2);
+});

--- a/scripts/precommit-score.mjs
+++ b/scripts/precommit-score.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { formatMarkdownReport, scoreFiles, summarizeRows } from './prose-score.mjs';
+
+function parseArgs(argv) {
+  const out = { files: [], gate: 30, lang: 'auto', maxFiles: 200 };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--gate' || arg === '--score-threshold') out.gate = Number(argv[++i]);
+    else if (arg === '--lang') out.lang = argv[++i] || 'auto';
+    else if (arg === '--max-files') out.maxFiles = Number(argv[++i]);
+    else if (!arg.startsWith('-')) out.files.push(arg);
+  }
+  if (!Number.isFinite(out.gate) || out.gate < 0 || out.gate > 100) {
+    throw new Error(`--gate expects a number from 0 to 100, got ${out.gate}`);
+  }
+  return out;
+}
+
+try {
+  const opts = parseArgs(process.argv.slice(2));
+  const rows = scoreFiles(opts.files, opts);
+  const summary = summarizeRows(rows);
+  console.log(formatMarkdownReport(rows, { gate: opts.gate, title: 'Patina pre-commit prose score' }));
+  if (summary.failedCount > 0) {
+    console.error(`\npatina-score: ${summary.failedCount}/${summary.fileCount} file(s) exceeded gate ${opts.gate}.`);
+    process.exitCode = 1;
+  }
+} catch (error) {
+  console.error(`patina-score: ${error.message}`);
+  process.exitCode = 2;
+}

--- a/scripts/prose-score.mjs
+++ b/scripts/prose-score.mjs
@@ -1,0 +1,186 @@
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { analyzeText } from '../src/features/index.js';
+import { loadLexicon } from '../src/features/lexicon.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const DEFAULT_REPO_ROOT = resolve(__dirname, '..');
+export const DEFAULT_PROSE_EXTENSIONS = ['.md', '.mdx', '.txt', '.rst', '.adoc'];
+
+const lexiconCache = new Map();
+
+export function parseBoolean(value, defaultValue = false) {
+  if (value === undefined || value === null || value === '') return defaultValue;
+  return ['1', 'true', 'yes', 'on'].includes(String(value).trim().toLowerCase());
+}
+
+export function parseFileList(value = '') {
+  return String(value)
+    .split(/[\n,]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function isProsePath(file, extensions = DEFAULT_PROSE_EXTENSIONS) {
+  const lower = file.toLowerCase();
+  return extensions.some((ext) => lower.endsWith(ext));
+}
+
+export function stripNonProse(markdown) {
+  return String(markdown || '')
+    .replace(/^---\n[\s\S]*?\n---\s*/, '\n')
+    .replace(/```[\s\S]*?```/g, '\n')
+    .replace(/~~~[\s\S]*?~~~/g, '\n')
+    .replace(/`[^`]*`/g, ' ')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/<svg[\s\S]*?<\/svg>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/^\s*\|.*\|\s*$/gm, '\n')
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+    .replace(/^\s{0,3}>\s?/gm, '')
+    .replace(/^\s*[-*+]\s+\[[ xX]\]\s+/gm, '')
+    .replace(/^\s*[-*+]\s+/gm, '')
+    .replace(/^\s*\d+[.)]\s+/gm, '')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+}
+
+export function detectLanguage(file, text = '', requested = 'auto') {
+  const normalized = String(requested || 'auto').toLowerCase();
+  if (['ko', 'en', 'zh', 'ja'].includes(normalized)) return normalized;
+
+  const path = String(file || '').toLowerCase();
+  if (/(^|[._/-])kr([._/-]|$)|(^|[._/-])ko([._/-]|$)|korean/.test(path)) return 'ko';
+  if (/(^|[._/-])ja([._/-]|$)|japanese/.test(path)) return 'ja';
+  if (/(^|[._/-])zh([._/-]|$)|chinese/.test(path)) return 'zh';
+
+  const sample = String(text || '').slice(0, 12000);
+  const hangul = (sample.match(/[\uac00-\ud7af]/g) || []).length;
+  const kana = (sample.match(/[\u3040-\u30ff]/g) || []).length;
+  const cjk = (sample.match(/[\u4e00-\u9fff]/g) || []).length;
+  const latin = (sample.match(/[A-Za-z]/g) || []).length;
+  const cjkTotal = hangul + kana + cjk;
+  if (latin >= 80 && latin > cjkTotal * 2) return 'en';
+  if (hangul >= 8 && hangul >= kana && hangul >= cjk) return 'ko';
+  if (kana >= 8) return 'ja';
+  if (cjk >= 8) return 'zh';
+  return 'en';
+}
+
+function getLexicon(lang, repoRoot) {
+  const key = `${repoRoot}\0${lang}`;
+  if (!lexiconCache.has(key)) lexiconCache.set(key, loadLexicon(lang, repoRoot));
+  return lexiconCache.get(key);
+}
+
+export function scoreText(text, { file = '', lang = 'auto', gate = 30, repoRoot = DEFAULT_REPO_ROOT } = {}) {
+  const prose = stripNonProse(text);
+  const resolvedLang = detectLanguage(file, prose, lang);
+  const result = analyzeText(prose, {
+    lang: resolvedLang,
+    repoRoot,
+    lexicon: getLexicon(resolvedLang, repoRoot),
+  });
+  const paragraphCount = result.paragraphs.length;
+  const hotCount = result.paragraphs.filter((p) => p.hot).length;
+  const score = paragraphCount ? (hotCount / paragraphCount) * 100 : 0;
+  return {
+    file,
+    lang: resolvedLang,
+    paragraphCount,
+    hotCount,
+    score,
+    gate,
+    overGate: score > gate,
+    skipped: paragraphCount === 0,
+  };
+}
+
+function isInside(base, candidate) {
+  const rel = relative(base, candidate);
+  return rel === '' || (!rel.startsWith('..') && !rel.includes(`..${sep}`));
+}
+
+export function normalizeFiles(files, {
+  cwd = process.cwd(),
+  extensions = DEFAULT_PROSE_EXTENSIONS,
+  maxFiles = 50,
+} = {}) {
+  const base = resolve(cwd);
+  const seen = new Set();
+  const out = [];
+  for (const raw of files) {
+    if (!raw) continue;
+    const absolute = resolve(base, raw);
+    if (!isInside(base, absolute)) continue;
+    if (seen.has(absolute)) continue;
+    seen.add(absolute);
+    if (!existsSync(absolute)) continue;
+    if (!statSync(absolute).isFile()) continue;
+    const rel = relative(base, absolute);
+    if (!isProsePath(rel, extensions)) continue;
+    out.push(rel);
+    if (out.length >= maxFiles) break;
+  }
+  return out;
+}
+
+export function scoreFiles(files, {
+  cwd = process.cwd(),
+  repoRoot = DEFAULT_REPO_ROOT,
+  lang = 'auto',
+  gate = 30,
+  extensions = DEFAULT_PROSE_EXTENSIONS,
+  maxFiles = 50,
+} = {}) {
+  return normalizeFiles(files, { cwd, extensions, maxFiles }).map((file) => {
+    const body = readFileSync(resolve(cwd, file), 'utf8');
+    return scoreText(body, { file, lang, gate, repoRoot });
+  });
+}
+
+function statusIcon(row) {
+  if (row.skipped) return 'skip';
+  return row.overGate ? 'fail' : 'pass';
+}
+
+export function formatMarkdownReport(rows, { gate = 30, title = 'Patina prose hotspot report' } = {}) {
+  const lines = [
+    `# ${title}`,
+    '',
+    `Gate: **${Number(gate).toFixed(0)}%** hot prose paragraphs. This deterministic check flags editing hotspots; it is not an authorship verdict.`,
+    '',
+  ];
+
+  if (rows.length === 0) {
+    lines.push('No changed prose files were found.');
+    return lines.join('\n');
+  }
+
+  lines.push('| status | file | lang | paragraphs | hot | score |');
+  lines.push('|---|---|---:|---:|---:|---:|');
+  for (const row of rows) {
+    lines.push(
+      `| ${statusIcon(row)} | ${escapeCell(row.file)} | ${row.lang} | ${row.paragraphCount} | ${row.hotCount} | ${row.score.toFixed(1)}% |`
+    );
+  }
+  return lines.join('\n');
+}
+
+export function summarizeRows(rows) {
+  const maxScore = rows.reduce((max, row) => Math.max(max, row.score), 0);
+  const failed = rows.filter((row) => row.overGate);
+  return {
+    fileCount: rows.length,
+    failedCount: failed.length,
+    maxScore,
+    failed,
+  };
+}
+
+function escapeCell(value) {
+  return String(value).replace(/\|/g, '\\|').replace(/\s+/g, ' ').trim();
+}

--- a/tests/e2e/precommit-score.test.js
+++ b/tests/e2e/precommit-score.test.js
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+test('precommit score exits non-zero when a Markdown file exceeds the gate', () => {
+  const dir = mkdtempSync(resolve(tmpdir(), 'patina-precommit-'));
+  writeFileSync(
+    resolve(dir, 'hot.md'),
+    'This innovative solution is pivotal. This innovative solution is pivotal. This innovative solution is pivotal.'
+  );
+  const result = spawnSync(
+    process.execPath,
+    [resolve(REPO_ROOT, 'scripts/precommit-score.mjs'), '--gate', '0', 'hot.md'],
+    { cwd: dir, encoding: 'utf8' }
+  );
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stdout, /hot\.md/);
+  assert.match(result.stderr, /exceeded gate 0/);
+});

--- a/tests/unit/prose-score.test.js
+++ b/tests/unit/prose-score.test.js
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+import {
+  detectLanguage,
+  formatMarkdownReport,
+  parseFileList,
+  scoreFiles,
+  scoreText,
+  stripNonProse,
+} from '../../scripts/prose-score.mjs';
+
+test('parseFileList accepts newline and comma separated paths', () => {
+  assert.deepEqual(parseFileList('README.md, docs/a.md\nnotes.mdx'), ['README.md', 'docs/a.md', 'notes.mdx']);
+});
+
+test('stripNonProse keeps prose while removing code and tables', () => {
+  const stripped = stripNonProse('# Title\n\nReal prose stays.\n\n```js\nconst x = 1;\n```\n\n| a | b |\n|---|---|');
+  assert.match(stripped, /Real prose stays/);
+  assert.doesNotMatch(stripped, /const x/);
+  assert.doesNotMatch(stripped, /\| a \|/);
+});
+
+test('detectLanguage uses filename and Unicode signals', () => {
+  assert.equal(detectLanguage('README_KR.md', '', 'auto'), 'ko');
+  assert.equal(detectLanguage('guide.md', '이 문장은 한국어 문장입니다. 자연스러운 신호를 확인합니다.', 'auto'), 'ko');
+  assert.equal(detectLanguage('guide.md', 'これは日本語の文章です。かなを含みます。', 'auto'), 'ja');
+  assert.equal(detectLanguage('guide.md', '这是中文内容，用来确认语言推断。', 'auto'), 'zh');
+  assert.equal(detectLanguage('guide.md', 'plain English prose', 'auto'), 'en');
+});
+
+test('scoreText flags repetitive AI-lexicon prose as over gate', () => {
+  const row = scoreText(
+    'This innovative solution is pivotal. This innovative solution is pivotal. This innovative solution is pivotal.',
+    { file: 'sample.md', gate: 30 }
+  );
+  assert.equal(row.lang, 'en');
+  assert.equal(row.overGate, true);
+  assert.ok(row.score > 30);
+});
+
+test('scoreFiles filters non-prose files and formats a markdown report', () => {
+  const dir = mkdtempSync(resolve(tmpdir(), 'patina-score-'));
+  writeFileSync(resolve(dir, 'hot.md'), 'This innovative solution is pivotal. This innovative solution is pivotal.');
+  writeFileSync(resolve(dir, 'script.js'), 'const pivotal = true;');
+  const rows = scoreFiles(['hot.md', 'script.js'], { cwd: dir, gate: 0 });
+  assert.equal(rows.length, 1);
+  const report = formatMarkdownReport(rows, { gate: 0 });
+  assert.match(report, /hot\.md/);
+  assert.match(report, /fail/);
+});


### PR DESCRIPTION
## Summary

- prepare release metadata and a `release.yml` path for `patina-cli`, `patina-humanizer`, npm provenance, and GHCR images
- add a root composite `patina-action` plus deterministic PR prose scoring scripts
- add `.pre-commit-hooks.yaml`, `patina-score` bin, Husky/Lefthook/pre-commit docs, and E2E coverage
- add Dockerfile + Docker/GitHub Action/release docs without touching the core skill pipeline

Closes #205.
Refs #203, #204, #209.

## Verification

- `npm run lint`
- `npm test`
- `npm run release:check`
- `npm run benchmark`
- `npm run dogfood`
- `npm pack --dry-run`
- `cd packages/patina-humanizer && npm pack --dry-run`
- `docker build -t patina:test .`
- `docker run --rm patina:test --version`
- `docker save patina:test | gzip -c | wc -c` → ~42.3MB compressed
- `git diff --check`

## Notes / deferred

- Actual npm publish still needs `NPM_TOKEN` and a `v3.11.0` tag.
- Actual GHCR publish happens from the release workflow on tag push.
- #204 asked for a separate `devswha/patina-action` repo; this PR ships a root Action first so it can be pinned from this repo or mirrored later.
