### PR TITLE
docs: sync localized v3.11 READMEs

### DIFF
--- a/README_JA.md
+++ b/README_JA.md
@@ -44,7 +44,7 @@
 curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
 ```
 
-インストーラが Claude Code、[Codex CLI](https://github.com/openai/codex)、Cursor、OpenCode に一括で配線します。続いて：
+インストーラが Claude Code、[Codex CLI](https://github.com/openai/codex)、Cursor、OpenCode に一括で配線します。checkout 前に repository HEAD を具体的な commit に解決します。完全に固定したインストールが必要な場合は `PATINA_REF=<tag-or-full-sha>` を設定してください。続いて：
 
 ```
 /patina --lang ja
@@ -80,7 +80,18 @@ cd patina && npm install && npm link
 patina --lang ja input.txt
 ```
 
+link 後に stdin でも試せます:
+
+```bash
+printf '%s\n' 'コーヒーは、世界中の社会的交流を根本的に変えた重要な文化現象として浮上しました。' \
+  | patina --lang ja --backend codex-cli
+```
+
 > 🆓 **API キー不要** — [`codex`](https://github.com/openai/codex)、[`claude`](https://docs.anthropic.com/en/docs/claude-code)、[`gemini`](https://github.com/google-gemini/gemini-cli) のいずれか CLI にログイン済みであれば OK。`--backend codex-cli | claude-cli | gemini-cli` で直接選択するか、`--model claude-*` / `--model gemini-*` のようにモデル名でルーティングできます。全バックエンドは [AUTHENTICATION.md](docs/AUTHENTICATION.md) を参照。
+
+## 想定用途
+
+Patina は、著者が AI 支援を使うことを許されている場合の AI 後編集、audit trail、voice cleanup のためのツールです。テキストが「もともと人間によって書かれた」ことを約束するものではなく、学業上の honor-code 回避、出版社 disclosure の迂回、盗用の洗浄、detector-bypass 主張に使うべきではありません。[ETHICS.md](docs/ETHICS.md) を参照してください。
 
 ## モード
 
@@ -93,6 +104,7 @@ patina --lang <ko|en|zh|ja> [モード] [--profile <名前>] input.txt
 | *(デフォルト)* | 書き換え |
 | `--audit` | AI パターン検出のみ |
 | `--score` | 0–100 AI 類似度スコア + カテゴリ別内訳 |
+| `--score --gate <n>` | CI を厳格に保つ: `overall > n` の場合は終了コード `3` |
 | `--diff` | 変更箇所をパターンごとに表示 |
 | `--ouroboros` | スコア収束まで反復（MPS ロールバック付き） |
 | `--lang <ko\|en\|zh\|ja>` | 言語選択（デフォルト：`ko`） |
@@ -104,7 +116,27 @@ patina --lang <ko|en|zh|ja> [モード] [--profile <名前>] input.txt
 
 ### スコア専用パターン
 
-`--score`と`--audit`は`--rewrite`より少し広い範囲のシグナルを測定します。韓国語パック `ko-viral-hook`(数字ショックフック、クリックベイト末尾、出典回避の権威主張、息継ぎ最適化の短文羅列、誇張エンゲージメント語彙の5パターン)は**検出専用**です — スコアと監査に現れることでSNSマーケティングコピーに対するユーザーの直感とベンチマークを一致させますが、これらのシグナルは意図的な修辞であることが多いため `--rewrite`/`--diff`/`--ouroboros` は対象外です。実例: [`examples/viral-hook/`](examples/viral-hook/).
+`--score`と`--audit`は`--rewrite`より少し広い範囲のシグナルを測定します。viral-hook パック（`ko/en/zh/ja-viral-hook`、各5パターン: 数字ショックフック、クリックベイト末尾、出典を飛ばした権威主張、息継ぎに最適化された短文の積み重ね、誇張されたエンゲージメント語彙）は**検出専用**です — スコアと監査に現れることで、4言語のSNSマーケティングコピーに対するユーザーの直感とベンチマークを一致させますが、これらのシグナルは意図的な修辞であることが多いため `--rewrite`/`--diff`/`--ouroboros` は対象外です。実例: [`examples/viral-hook/`](examples/viral-hook/).
+
+### プロンプトモード調整 (v3.11)
+
+`--prompt-mode strict|minimal|auto` では、完全なパターンパック（約34KBの構造化プロンプト）と圧縮されたカジュアル指示（約3KB）のどちらを使うかを調整できます。`auto` はバックエンドごとに選択します — Gemini は minimal の方が良く（長い構造化プロンプトで過度に制約されるため）、Claude は完全なパックを活用し、Codex はおおむね影響を受けません。case-05 が A/B を記録しています。
+
+### 複数の文体バリアント (v3.11)
+
+`--variants <1-5>` は、1回の呼び出しで N 個のリライト音声バリアントを求めます（例: V1 casual、V2 direct、V3 measured）。事実、数値、因果関係はすべてのバリアントで同一に保たれます。各結果は `## Variant N` として返るため、必要な声色を選べます。
+
+### 短文スコアリング補正 (v3.11)
+
+入力が200文字以下、または3段落以下の場合、register に敏感なカテゴリ（`language`、`style`、`viral-hook`）へ 1.5 倍の severity multiplier を適用し、単一段落の声色変化もスコアに反映されるようにします。case-04 では、長文向けの式がこれらを過小評価していたことが確認されました。
+
+### セルフ監査の分離 (v3.11)
+
+rewrite モードでは、モデルは `[BODY]`/`[/BODY]` ブロック（`--variants > 1` の場合は `[VARIANT n]` ブロック）を囲む `[SELF_AUDIT]`/`[/SELF_AUDIT]` タグの中にセルフ監査メモを出力します。patina はユーザーに表示する前に監査部分を取り除くため、出力はクリーンです — 以前のバージョンでは "남아 있는 AI 티" や "Phase 3" のような前置きがユーザー向けテキストに漏れることがありました。
+
+### スコア重みドリフト検出 (v3.11)
+
+`--score` 実行時は、モデルが出力した Weight 列を設定の `category-weights` と照合します。モデルが存在しないカテゴリ（例: `discord`）を作ったり、別の数値に置き換えたりした場合、stderr に `[patina]` 警告が出ます — これは観測用であり、スコア自体は変更しません。
 
 ## トーン
 
@@ -162,16 +194,28 @@ tone:                     # casual | professional | academic | narrative | marke
 max-models: [claude, gemini]
 ```
 
-パターンパックは言語プレフィックスで自動検出されます。作業ディレクトリの `.patina.yaml` がデフォルトを上書きします。
+パターンパックは言語プレフィックスで自動検出されます。作業ディレクトリの `.patina.yaml` がデフォルトを上書きします。検出を拡張するリストキー（`blocklist`、`allowlist`、`skip-patterns`）は default/global/project 設定の間で追加的にマージされ、`max-models` などの provider リストはユーザーが正確なバックエンド集合を選べるように置き換えられます。
 
 ## ドキュメント
 
+- **[Glossary](docs/GLOSSARY.md)** — MPS、fidelity、burstiness、MATTR、モードなどの反復用語の短い定義
+- **[Demo](docs/DEMO.md)** — ターミナル transcript と複数ジャンルの before/after スナップショット
 - **[Patterns](docs/PATTERNS.md)** — 146 パターンカタログ
 - **[Authentication](docs/AUTHENTICATION.md)** — バックエンド、プロバイダ、無料ティア設定
+- **[CLI Contract](docs/CLI.md)** — score gate、終了コード、自動化に安全なインターフェイス
+- **[Ethics](docs/ETHICS.md)** — 想定用途、禁止用途、disclosure 方針
+- **[FAQ](docs/FAQ.md)** — detector-bypass の懸念、MPS、誤検出、貢献の始め方
+- **[Comparison](docs/COMPARISON.md)** — 一般的な paraphraser/humanizer ツールとの事実ベース比較
+- **[Branding](docs/BRANDING.md)** — canonical logo/social assets と OG 設定メモ
+- **[Roadmap](docs/ROADMAP.md)** — 品質、ベンチマーク、プロダクト、コミュニティ、ローンチ優先事項
+- **[Benchmark Report](docs/benchmarks/latest.md)** — 最新の再現可能な suspect-zone ベンチマーク要約
+- **[AI/Human Metrics Research](docs/research/ai-human-metrics.md)** — AI-like writing signals 測定用ベンチマーク設計メモ
+- **[Launch Copy](docs/social/patina-launch-copy.md)** — Show HN、Reddit、X、韓国コミュニティ向け下書き
 - **[Stylometry](core/stylometry.md)** — burstiness + MATTR + AI 語彙アルゴリズム
 - **[Scoring](core/scoring.md)** — AI 類似度 + 忠実度 + MPS
 - **[Changelog](CHANGELOG.md)** — リリースノートと方法論
-- **[Contributing](CONTRIBUTING.md)** — パターン提出、陳腐化レポート
+- **[Contributing](CONTRIBUTING.md)** — パターン提出、誤検出 triage、ベンチマーク fixture、バージョン管理
+- **[Governance](GOVERNANCE.md)** / **[Maintainers](MAINTAINERS.md)** — 軽量なプロジェクト意思決定ルール
 
 ## 着想元
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -44,7 +44,7 @@
 curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
 ```
 
-설치 스크립트가 Claude Code, [Codex CLI](https://github.com/openai/codex), Cursor, OpenCode 에 한 번에 연결합니다. 그런 다음:
+설치 스크립트가 Claude Code, [Codex CLI](https://github.com/openai/codex), Cursor, OpenCode 에 한 번에 연결합니다. 체크아웃 전에 repository HEAD를 구체적인 commit으로 해석합니다. 완전히 고정된 설치가 필요하면 `PATINA_REF=<tag-or-full-sha>`를 설정하세요. 그런 다음:
 
 ```
 /patina --lang ko
@@ -78,7 +78,18 @@ cd patina && npm install && npm link
 patina --lang ko input.txt
 ```
 
+link 후 stdin으로도 시험할 수 있습니다:
+
+```bash
+printf '%s\n' '커피는 전 세계의 사회적 상호작용을 근본적으로 바꾼 중요한 문화 현상으로 부상했다.' \
+  | patina --lang ko --backend codex-cli
+```
+
 > 🆓 **API 키 없이 무료 사용 가능** — [`codex`](https://github.com/openai/codex), [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`gemini`](https://github.com/google-gemini/gemini-cli) CLI 중 하나만 로그인되어 있으면 됩니다. `--backend codex-cli | claude-cli | gemini-cli` 로 직접 선택하거나 `--model claude-*` / `--model gemini-*` 처럼 모델명으로 라우팅됩니다. 전체 백엔드는 [AUTHENTICATION.md](docs/AUTHENTICATION.md) 참조.
+
+## 의도한 사용
+
+Patina는 작성자가 AI 지원을 사용할 수 있는 상황에서 AI 이후 편집, audit trail, voice cleanup을 돕는 도구입니다. 텍스트가 "원래 사람이 쓴 것"이라는 약속이 아니며, 학업 honor-code 회피, 출판사 disclosure 우회, 표절 세탁, detector-bypass 주장에 사용해서는 안 됩니다. [ETHICS.md](docs/ETHICS.md)를 참고하세요.
 
 ## 모드
 
@@ -91,6 +102,7 @@ patina --lang <ko|en|zh|ja> [모드] [--profile <이름>] input.txt
 | *(기본)* | 재작성 |
 | `--audit` | AI 패턴 탐지만 수행 |
 | `--score` | 0–100 AI 유사도 점수 + 카테고리별 분석 |
+| `--score --gate <n>` | CI를 엄격하게 유지: `overall > n`이면 종료 코드 `3` |
 | `--diff` | 변경 사항을 패턴별로 표시 |
 | `--ouroboros` | 점수가 수렴할 때까지 반복 (MPS 롤백 포함) |
 | `--lang <ko\|en\|zh\|ja>` | 언어 선택 (기본값: `ko`) |
@@ -102,7 +114,27 @@ patina --lang <ko|en|zh|ja> [모드] [--profile <이름>] input.txt
 
 ### 스코어 전용 패턴
 
-`--score`와 `--audit`는 `--rewrite`보다 약간 더 넓은 신호를 측정합니다. 한국어 팩 `ko-viral-hook` (숫자 충격 훅, 클릭베이트 미스터리 종결, 검증 회피 단언, 호흡 최적화 단문 배열, AI 인플루언서 어휘 5개 패턴)은 **탐지 전용**입니다 — score와 audit에는 나타나서 SNS 마케팅 카피에 대한 사용자 직관과 점수가 일치하도록 하지만, `--rewrite`/`--diff`/`--ouroboros`는 이 신호들이 의도된 수사일 수 있어 건너뜁니다. 실제 데모: [`examples/viral-hook/`](examples/viral-hook/).
+`--score`와 `--audit`는 `--rewrite`보다 약간 더 넓은 신호를 측정합니다. viral-hook 팩(`ko/en/zh/ja-viral-hook`, 각 5개 패턴: 숫자 충격 훅, 클릭베이트 종결, 출처 회피 권위 주장, 호흡 최적화 단문 배열, 과장된 참여 유도 어휘)은 **탐지 전용**입니다 — score와 audit에는 나타나서 네 언어의 SNS 마케팅 카피에 대한 사용자 직관과 벤치마크가 일치하도록 하지만, `--rewrite`/`--diff`/`--ouroboros`는 이 신호들이 의도된 수사일 수 있어 건너뜁니다. 실제 데모: [`examples/viral-hook/`](examples/viral-hook/).
+
+### 프롬프트 모드 튜닝 (v3.11)
+
+`--prompt-mode strict|minimal|auto` 는 전체 패턴 팩(약 34KB 구조화 프롬프트)과 압축된 캐주얼 지시문(약 3KB) 사이의 균형을 선택합니다. `auto` 는 백엔드별로 선택합니다 — Gemini는 minimal에서 더 잘 동작하고(긴 구조화 프롬프트에 과도하게 제약됨), Claude는 전체 팩을 활용하며, Codex는 대체로 차이가 작습니다. case-05가 A/B 결과를 문서화합니다.
+
+### 여러 스타일 변형 (v3.11)
+
+`--variants <1-5>` 는 한 번의 호출에서 N개의 보이스 변형을 요청합니다(예: V1 캐주얼, V2 직설적, V3 절제됨). 사실, 수치, 인과관계는 모든 변형에서 동일하게 유지됩니다. 각 결과는 `## Variant N` 형식으로 돌아오므로 원하는 보이스를 고를 수 있습니다.
+
+### 짧은 텍스트 점수 보정 (v3.11)
+
+입력이 200자 이하이거나 3문단 이하이면 레지스터에 민감한 카테고리(`language`, `style`, `viral-hook`)에 1.5배 severity multiplier를 적용해 단일 문단의 보이스 변화도 점수에 드러나게 합니다. case-04에서 긴 글 기준 공식이 이런 신호를 과소계산한다는 점을 확인했습니다.
+
+### 자기검수 분리 (v3.11)
+
+rewrite 모드에서 모델은 `[BODY]`/`[/BODY]` 블록(또는 `--variants > 1`일 때 `[VARIANT n]` 블록)을 감싸는 `[SELF_AUDIT]`/`[/SELF_AUDIT]` 태그 안에 자기검수 메모를 냅니다. patina는 사용자에게 보여주기 전에 audit을 제거하므로 원시 출력이 깔끔합니다 — 이전 버전에서는 "남아 있는 AI 티"나 "Phase 3" 같은 프리앰블이 사용자-facing 텍스트에 새어 나오는 경우가 있었습니다.
+
+### 점수 가중치 드리프트 감지 (v3.11)
+
+`--score` 실행은 모델이 출력한 Weight 열을 설정의 `category-weights`와 교차 확인합니다. 모델이 존재하지 않는 카테고리(예: `discord`)를 만들거나 다른 숫자로 바꾸면 `[patina]` 경고가 stderr에 출력됩니다 — 관측용일 뿐 점수 자체는 바꾸지 않습니다.
 
 ## 톤
 
@@ -160,16 +192,28 @@ tone:                     # casual | professional | academic | narrative | marke
 max-models: [claude, gemini]
 ```
 
-패턴 팩은 언어 접두사로 자동 탐색됩니다. 작업 디렉토리의 `.patina.yaml` 이 기본값을 오버라이드합니다.
+패턴 팩은 언어 접두사로 자동 탐색됩니다. 작업 디렉토리의 `.patina.yaml` 이 기본값을 오버라이드합니다. 탐지를 확장하는 목록 키(`blocklist`, `allowlist`, `skip-patterns`)는 default/global/project 설정 사이에서 추가 병합되고, `max-models` 같은 provider 목록은 사용자가 정확한 백엔드 세트를 선택할 수 있도록 대체됩니다.
 
 ## 문서
 
+- **[Glossary](docs/GLOSSARY.md)** — MPS, fidelity, burstiness, MATTR, 모드 등 반복 용어의 짧은 정의
+- **[Demo](docs/DEMO.md)** — 터미널 transcript와 여러 장르의 before/after 스냅샷
 - **[Patterns](docs/PATTERNS.md)** — 146개 패턴 카탈로그
 - **[Authentication](docs/AUTHENTICATION.md)** — 백엔드, 프로바이더, 무료 티어 설정
+- **[CLI Contract](docs/CLI.md)** — score gate, exit code, 자동화에 안전한 표면
+- **[Ethics](docs/ETHICS.md)** — 의도한 사용, 금지 사용, disclosure 입장
+- **[FAQ](docs/FAQ.md)** — detector-bypass 우려, MPS, 오탐, 기여 시작점
+- **[Comparison](docs/COMPARISON.md)** — 일반 paraphraser/humanizer 도구와의 사실 기반 비교
+- **[Branding](docs/BRANDING.md)** — canonical 로고/소셜 asset과 OG 설정 메모
+- **[Roadmap](docs/ROADMAP.md)** — 품질, 벤치마크, 제품, 커뮤니티, 런칭 우선순위
+- **[Benchmark Report](docs/benchmarks/latest.md)** — 최신 재현 가능 suspect-zone 벤치마크 요약
+- **[AI/Human Metrics Research](docs/research/ai-human-metrics.md)** — AI-like writing signal 측정용 벤치마크 설계 메모
+- **[Launch Copy](docs/social/patina-launch-copy.md)** — Show HN, Reddit, X, 한국 커뮤니티 초안
 - **[Stylometry](core/stylometry.md)** — burstiness + MATTR + AI 어휘 알고리즘
 - **[Scoring](core/scoring.md)** — AI 유사도 + 충실도 + MPS
 - **[Changelog](CHANGELOG.md)** — 릴리스 노트와 방법론
-- **[Contributing](CONTRIBUTING.md)** — 패턴 추가, 노화 신고
+- **[Contributing](CONTRIBUTING.md)** — 패턴 제출, 오탐 triage, 벤치마크 fixture, 버전 관리
+- **[Governance](GOVERNANCE.md)** / **[Maintainers](MAINTAINERS.md)** — 가벼운 프로젝트 의사결정 규칙
 
 ## 영감
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -44,7 +44,7 @@
 curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
 ```
 
-安装脚本会一次性将 patina 接入 Claude Code、[Codex CLI](https://github.com/openai/codex)、Cursor、OpenCode。然后：
+安装脚本会一次性将 patina 接入 Claude Code、[Codex CLI](https://github.com/openai/codex)、Cursor、OpenCode。它会在 checkout 前把 repository HEAD 解析到具体 commit；如果需要完全固定安装，请设置 `PATINA_REF=<tag-or-full-sha>`。然后：
 
 ```
 /patina --lang zh
@@ -80,7 +80,18 @@ cd patina && npm install && npm link
 patina --lang zh input.txt
 ```
 
+也可以 link 后通过 stdin 试用：
+
+```bash
+printf '%s\n' '咖啡已成为一种关键文化现象，从根本上改变了全球各地的社会互动。' \
+  | patina --lang zh --backend codex-cli
+```
+
 > 🆓 **无需 API 密钥** — 只要 [`codex`](https://github.com/openai/codex)、[`claude`](https://docs.anthropic.com/en/docs/claude-code)、[`gemini`](https://github.com/google-gemini/gemini-cli) 任一 CLI 已登录即可。可通过 `--backend codex-cli | claude-cli | gemini-cli` 直接选择，或用 `--model claude-*` / `--model gemini-*` 按模型名路由。完整后端列表见 [AUTHENTICATION.md](docs/AUTHENTICATION.md)。
+
+## 预期用途
+
+Patina 用于作者被允许使用 AI 辅助时的 AI 后编辑、审计轨迹和 voice cleanup。它不承诺文本“原本由人类写成”，也不应被用于规避学术 honor-code、绕过出版方 disclosure、洗白抄袭，或声称 detector-bypass。见 [ETHICS.md](docs/ETHICS.md)。
 
 ## 模式
 
@@ -93,6 +104,7 @@ patina --lang <ko|en|zh|ja> [模式] [--profile <名称>] input.txt
 | *(默认)* | 改写 |
 | `--audit` | 仅检测 AI 模式 |
 | `--score` | 0–100 AI 相似度评分 + 类别细分 |
+| `--score --gate <n>` | 保持 CI 严格：当 `overall > n` 时以退出码 `3` 结束 |
 | `--diff` | 按模式逐项展示改动 |
 | `--ouroboros` | 反复改写直到分数收敛（含 MPS 回滚） |
 | `--lang <ko\|en\|zh\|ja>` | 选择语言（默认：`ko`） |
@@ -104,7 +116,27 @@ patina --lang <ko|en|zh|ja> [模式] [--profile <名称>] input.txt
 
 ### 仅评分模式
 
-`--score` 和 `--audit` 测量的信号范围比 `--rewrite` 略广。韩文模式包 `ko-viral-hook`（数字震撼钩子、标题党悬念结尾、回避验证的权威断言、呼吸优化短句堆叠、夸张互动词汇 共5个模式）为**仅检测**模式 — 它会出现在评分和审计中，使基准与用户对 SNS 营销文案的直觉一致，但 `--rewrite`/`--diff`/`--ouroboros` 会跳过它们，因为这些信号往往是有意的修辞。实例: [`examples/viral-hook/`](examples/viral-hook/).
+`--score` 和 `--audit` 测量的信号范围比 `--rewrite` 略广。viral-hook 包（`ko/en/zh/ja-viral-hook`，每种语言 5 个模式：数字震撼钩子、标题党收尾、跳过来源的权威断言、适合呼吸节奏的短句堆叠、夸张互动词汇）为**仅检测**模式 — 它会出现在评分和审计中，使基准与用户对四种语言 SNS 营销文案的直觉一致，但 `--rewrite`/`--diff`/`--ouroboros` 会跳过它们，因为这些信号往往是有意的修辞。实例: [`examples/viral-hook/`](examples/viral-hook/).
+
+### 提示模式调优 (v3.11)
+
+`--prompt-mode strict|minimal|auto` 可在完整模式包（约 34KB 结构化提示）和压缩的轻量指令（约 3KB）之间取舍。`auto` 会按后端选择 — Gemini 在 minimal 下表现更好（长结构化提示会让它过度受限），Claude 能利用完整模式包，Codex 大致不敏感。case-05 记录了 A/B 结果。
+
+### 多个风格变体 (v3.11)
+
+`--variants <1-5>` 会在一次调用中请求 N 个改写声音变体（例如 V1 casual、V2 direct、V3 measured）— 事实、数字和因果关系在所有变体中保持一致。每个结果会以 `## Variant N` 返回，方便你选择需要的语气。
+
+### 短文本评分增强 (v3.11)
+
+当输入不超过 200 个字符或不超过 3 个段落时，对 register 敏感的类别（`language`、`style`、`viral-hook`）会获得 1.5 倍 severity multiplier，让单段文本里的声音变化也能体现在分数中。case-04 发现这些信号会被长文本公式低估。
+
+### 自审隔离 (v3.11)
+
+在 rewrite 模式中，模型会把自审笔记放在 `[SELF_AUDIT]`/`[/SELF_AUDIT]` 标签内，并包裹一个 `[BODY]`/`[/BODY]` 块（当 `--variants > 1` 时则是 `[VARIANT n]` 块）。patina 会在展示给用户前移除审计内容，因此原始输出保持干净 — 早期版本有时会把 “남아 있는 AI 티” 或 “Phase 3” 之类的前言泄漏到用户可见文本中。
+
+### 分数权重漂移检测 (v3.11)
+
+`--score` 运行会把模型输出的 Weight 列与配置中的 `category-weights` 交叉检查。如果模型凭空创造类别（例如 `discord`）或替换成不同数字，stderr 会出现 `[patina]` 警告 — 这只用于可观测性，不会改变分数本身。
 
 ## 语调
 
@@ -162,20 +194,32 @@ tone:                     # casual | professional | academic | narrative | marke
 max-models: [claude, gemini]
 ```
 
-模式包按语言前缀自动发现。工作目录中的 `.patina.yaml` 会覆盖默认值。
+模式包按语言前缀自动发现。工作目录中的 `.patina.yaml` 会覆盖默认值。扩展检测的列表键（`blocklist`、`allowlist`、`skip-patterns`）会在 default/global/project 配置之间追加合并；`max-models` 等 provider 列表会替换原值，便于用户选择精确的后端集合。
 
 ## 文档
 
+- **[Glossary](docs/GLOSSARY.md)** — MPS、fidelity、burstiness、MATTR、模式等常见术语的简短定义
+- **[Demo](docs/DEMO.md)** — 终端 transcript 与多种体裁的 before/after 快照
 - **[Patterns](docs/PATTERNS.md)** — 146 个模式目录
 - **[Authentication](docs/AUTHENTICATION.md)** — 后端、服务商、免费层设置
+- **[CLI Contract](docs/CLI.md)** — score gate、退出码，以及适合自动化的接口边界
+- **[Ethics](docs/ETHICS.md)** — 预期用途、禁止用途和披露立场
+- **[FAQ](docs/FAQ.md)** — detector-bypass 疑虑、MPS、误报、贡献起点
+- **[Comparison](docs/COMPARISON.md)** — 与常见 paraphraser/humanizer 工具的事实比较
+- **[Branding](docs/BRANDING.md)** — canonical logo/social assets 和 OG 设置说明
+- **[Roadmap](docs/ROADMAP.md)** — 质量、基准、产品、社区和发布优先级
+- **[Benchmark Report](docs/benchmarks/latest.md)** — 最新可复现 suspect-zone 基准摘要
+- **[AI/Human Metrics Research](docs/research/ai-human-metrics.md)** — 用于测量 AI-like writing signals 的基准设计说明
+- **[Launch Copy](docs/social/patina-launch-copy.md)** — Show HN、Reddit、X、韩国社区草稿
 - **[Stylometry](core/stylometry.md)** — burstiness + MATTR + AI 词汇算法
 - **[Scoring](core/scoring.md)** — AI 相似度 + 忠实度 + MPS
 - **[Changelog](CHANGELOG.md)** — 发布说明和方法论
-- **[Contributing](CONTRIBUTING.md)** — 模式提交、陈旧报告
+- **[Contributing](CONTRIBUTING.md)** — 模式提交、误报 triage、基准 fixture、版本管理
+- **[Governance](GOVERNANCE.md)** / **[Maintainers](MAINTAINERS.md)** — 轻量级项目决策规则
 
 ## 致谢
 
-灵感来自 [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh) 的插件架构（模式即插件，配置文件即主题）、[Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing)、[blader/humanizer](https://github.com/blader/humanizer)。
+灵感来自 [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh) 的插件架构（模式即插件，profile 即主题）、[Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing)、[blader/humanizer](https://github.com/blader/humanizer)。
 
 ## 许可证
 


### PR DESCRIPTION
Closes #189.

## Summary
- add the missing localized Intended Use section and stdin/pinned-install quick-start notes
- translate the v3.11 mode additions across Korean, Chinese, and Japanese READMEs
- sync the config merge note and documentation footer links with README.md

## Verification
- npm run lint
- npm test
- git diff --check
- custom README heading/doc-link structure check