### PR TITLE
docs: add per-language pattern references

### DIFF
--- a/docs/PATTERNS-EN.md
+++ b/docs/PATTERNS-EN.md
@@ -1,0 +1,656 @@
+# English Pattern Reference
+
+This page expands the English pattern packs into a browsable reference. It is generated from `patterns/en-*.md`, so the numbers, names, watch words, fire conditions, and examples mirror the source pattern files.
+
+- Rewrite-capable patterns: 31
+- Score/audit-only viral-hook patterns: 5
+- Main selector: [PATTERNS.md](PATTERNS.md)
+
+## Pattern Index
+
+| # | Type | Pattern | Source |
+|---|------|---------|--------|
+| 1 | rewrite | Undue Emphasis on Significance | [en-content.md](../patterns/en-content.md) |
+| 2 | rewrite | Undue Emphasis on Notability/Media | [en-content.md](../patterns/en-content.md) |
+| 3 | rewrite | Superficial -ing Analyses | [en-content.md](../patterns/en-content.md) |
+| 4 | rewrite | Promotional Language | [en-content.md](../patterns/en-content.md) |
+| 5 | rewrite | Vague Attributions | [en-content.md](../patterns/en-content.md) |
+| 6 | rewrite | Formulaic "Challenges and Prospects" | [en-content.md](../patterns/en-content.md) |
+| 7 | rewrite | AI Vocabulary Words | [en-language.md](../patterns/en-language.md) |
+| 8 | rewrite | Copula Avoidance ("serves as") | [en-language.md](../patterns/en-language.md) |
+| 9 | rewrite | Negative Parallelisms | [en-language.md](../patterns/en-language.md) |
+| 10 | rewrite | Rule of Three Overuse | [en-language.md](../patterns/en-language.md) |
+| 11 | rewrite | Elegant Variation (Synonym Cycling) | [en-language.md](../patterns/en-language.md) |
+| 12 | rewrite | False Ranges | [en-language.md](../patterns/en-language.md) |
+| 13 | rewrite | Em Dash Overuse | [en-style.md](../patterns/en-style.md) |
+| 14 | rewrite | Boldface Overuse | [en-style.md](../patterns/en-style.md) |
+| 15 | rewrite | Inline-Header Vertical Lists | [en-style.md](../patterns/en-style.md) |
+| 16 | rewrite | Title Case in Headings | [en-style.md](../patterns/en-style.md) |
+| 17 | rewrite | Emojis | [en-style.md](../patterns/en-style.md) |
+| 18 | rewrite | Curly Quotation Marks | [en-style.md](../patterns/en-style.md) |
+| 19 | rewrite | Collaborative Communication Artifacts | [en-communication.md](../patterns/en-communication.md) |
+| 20 | rewrite | Knowledge-Cutoff Disclaimers | [en-communication.md](../patterns/en-communication.md) |
+| 21 | rewrite | Sycophantic/Servile Tone | [en-communication.md](../patterns/en-communication.md) |
+| 29 | rewrite | False Nuance (Retroactive Reframing) | [en-communication.md](../patterns/en-communication.md) |
+| 22 | rewrite | Filler Phrases | [en-filler.md](../patterns/en-filler.md) |
+| 23 | rewrite | Excessive Hedging | [en-filler.md](../patterns/en-filler.md) |
+| 24 | rewrite | Generic Positive Conclusions | [en-filler.md](../patterns/en-filler.md) |
+| 31 | rewrite | Conclusion Signal Words | [en-filler.md](../patterns/en-filler.md) |
+| 25 | rewrite | Metronomic Paragraph Structure | [en-structure.md](../patterns/en-structure.md) |
+| 26 | rewrite | Passive Nominalization Chains | [en-structure.md](../patterns/en-structure.md) |
+| 27 | rewrite | Zombie Nouns (Excessive Nominalization) | [en-structure.md](../patterns/en-structure.md) |
+| 28 | rewrite | Stacked Subordinate Clauses | [en-structure.md](../patterns/en-structure.md) |
+| 30 | rewrite | Rhetorical Question Openers | [en-structure.md](../patterns/en-structure.md) |
+| VH-1 | score/audit only | Shock Numbers as Hook | [en-viral-hook.md](../patterns/en-viral-hook.md) |
+| VH-2 | score/audit only | Clickbait Mystery Close | [en-viral-hook.md](../patterns/en-viral-hook.md) |
+| VH-3 | score/audit only | Source-Skipping Authority | [en-viral-hook.md](../patterns/en-viral-hook.md) |
+| VH-4 | score/audit only | Breath-Optimized Short-Sentence Stacking | [en-viral-hook.md](../patterns/en-viral-hook.md) |
+| VH-5 | score/audit only | Hyperbolic Engagement Lexicon | [en-viral-hook.md](../patterns/en-viral-hook.md) |
+
+## Content Patterns
+
+### 1. Undue Emphasis on Significance
+
+- Source: [en-content.md](../patterns/en-content.md)
+- Type: rewrite-capable pattern
+- Watch words: significant milestone, pivotal moment, groundbreaking, transformative, paradigm shift, revolutionary, game-changing, unprecedented, landmark achievement, watershed moment, trailblazing, monumental
+- Fire condition: 2+ emphasis words appear in the same paragraph, or a single word like "revolutionary" or "groundbreaking" applied to an ordinary product or event.
+- Example files: [failure](../examples/en-01-failure-01.md) · [success](../examples/en-01-success-01.md)
+
+Example before:
+
+> The company's new mobile app represents a groundbreaking paradigm shift in how users interact with grocery delivery services. This transformative, game-changing platform marks an unprecedented milestone in the retail industry.
+
+Example after:
+
+> The company launched a grocery delivery app. It lets users schedule same-day deliveries and track orders in real time. Downloads hit 2 million in the first month.
+
+### 2. Undue Emphasis on Notability/Media
+
+- Source: [en-content.md](../patterns/en-content.md)
+- Type: rewrite-capable pattern
+- Watch words: garnered significant attention, widely recognized, has been featured in, attracted widespread interest, gained international acclaim, made headlines, captured the imagination of, has been praised by critics and audiences alike
+- Fire condition: A claim of broad attention, coverage, or acclaim appears without a named publication, outlet, or specific figure.
+- Example files: [failure](../examples/en-02-failure-01.md) · [success](../examples/en-02-success-01.md)
+
+Example before:
+
+> Her artwork has garnered significant attention from critics and audiences alike, and has been widely recognized as a defining voice of her generation. Her exhibitions have attracted widespread interest across the globe.
+
+Example after:
+
+> The New York Times reviewed her 2023 exhibition, calling her use of recycled materials "quietly radical." The show sold out its three-week run at the Whitechapel Gallery.
+
+### 3. Superficial -ing Analyses
+
+- Source: [en-content.md](../patterns/en-content.md)
+- Type: rewrite-capable pattern
+- Watch words: showcasing, highlighting, underscoring, demonstrating, illustrating, reflecting, signaling, exemplifying, reinforcing, embodying, encapsulating
+- Fire condition: 3+ present-participle phrases chained in a single sentence or consecutive clauses with no concrete causal explanation.
+- Example files: [failure](../examples/en-03-failure-01.md) · [success](../examples/en-03-success-01.md)
+
+Example before:
+
+> The festival brings together artists from 30 countries, showcasing the diversity of contemporary dance, highlighting the importance of cross-cultural dialogue, and underscoring the role of the arts in fostering global understanding.
+
+Example after:
+
+> The festival brings together artists from 30 countries. This year, a butoh troupe from Tokyo collaborated with a hip-hop crew from Lagos — a pairing that would not have happened without the festival's residency program.
+
+### 4. Promotional Language
+
+- Source: [en-content.md](../patterns/en-content.md)
+- Type: rewrite-capable pattern
+- Watch words: stunning, breathtaking, world-class, gem of, hidden treasure, crown jewel, vibrant, nestled in, boasts, a must-visit, unparalleled, exquisite, awe-inspiring, picturesque
+- Fire condition: 2+ promotional adjectives modifying the same subject, or a single strong superlative ("world-class", "breathtaking", "must-visit") used as descriptive prose rather than quoted marketing copy.
+- Example files: [failure](../examples/en-04-failure-01.md) · [success](../examples/en-04-success-01.md)
+
+Example before:
+
+> Nestled in the rolling hills of Tuscany, this stunning village boasts breathtaking views, world-class cuisine, and an exquisite charm that makes it a must-visit hidden gem for any discerning traveler.
+
+Example after:
+
+> The village sits on a hill about 40 minutes south of Florence. It has one restaurant, a weekly market on Thursdays, and a 14th-century church with frescoes that are slowly being restored.
+
+### 5. Vague Attributions
+
+- Source: [en-content.md](../patterns/en-content.md)
+- Type: rewrite-capable pattern
+- Watch words: experts say, many believe, it is widely accepted, studies show, research indicates, critics argue, according to sources, observers note, analysts predict, some suggest, it is generally agreed
+- Fire condition: Any claim of authority appears with an unspecified source rather than a named one (person, institution, publication, or study with date).
+- Example files: [failure](../examples/en-05-failure-01.md) · [success](../examples/en-05-success-01.md)
+
+Example before:
+
+> Experts say that remote work is here to stay. Studies show that productivity increases when employees work from home, and many believe this trend will reshape the commercial real estate market.
+
+Example after:
+
+> A 2023 Stanford study by Nicholas Bloom found that hybrid workers were 3% more productive than full-time office workers. Kastle Systems data shows U.S. office occupancy has stabilized at about 50% of pre-pandemic levels.
+
+### 6. Formulaic "Challenges and Prospects"
+
+- Source: [en-content.md](../patterns/en-content.md)
+- Type: rewrite-capable pattern
+- Watch words: despite these challenges, remains to be seen, poised for growth, at a crossroads, on the cusp of, only time will tell, the road ahead, faces significant hurdles but, with continued effort, looking forward
+- Fire condition: A paragraph or conclusion contains both a generic challenge phrase AND a generic optimism phrase — the classic two-step pattern of acknowledging problems then pivoting to vague hope.
+- Example files: [failure](../examples/en-06-failure-01.md) · [success](../examples/en-06-success-01.md)
+
+Example before:
+
+> Despite these challenges, the industry remains poised for significant growth. While it remains to be seen how regulations will evolve, the sector stands at a crossroads, and with continued innovation and collaboration, a bright future lies ahead.
+
+Example after:
+
+> The biggest obstacle is the FDA approval timeline — the average wait is 14 months. Two of the five pending applications were filed before 2022 and still have no decision date. The company says it will shift trials to the EU if U.S. approval is not granted by Q3.
+
+## Language Patterns
+
+### 7. AI Vocabulary Words
+
+- Source: [en-language.md](../patterns/en-language.md)
+- Type: rewrite-capable pattern
+- Watch words: delve, tapestry, landscape, multifaceted, comprehensive, pivotal, testament, intricate, nuanced, leverage, foster, crucial, moreover, furthermore, realm, robust, facilitate, endeavor, resonate, underscore, embark, myriad, paramount, encompass, holistic, synergy, elucidate, culminate, juxtapose, burgeoning
+- Fire condition: 3+ watch words appear in one paragraph.
+- Example files: [failure](../examples/en-07-failure-01.md) · [success](../examples/en-07-success-01.md)
+
+Example before:
+
+> This comprehensive report delves into the multifaceted landscape of renewable energy, leveraging nuanced insights to foster a robust understanding. Moreover, the intricate tapestry of stakeholder interests underscores the pivotal role of policy in this crucial endeavor.
+
+Example after:
+
+> This report covers renewable energy policy from three angles: cost, grid reliability, and public opinion. Each section uses data from the EIA and interviews with six state utility commissioners.
+
+### 8. Copula Avoidance ("serves as")
+
+- Source: [en-language.md](../patterns/en-language.md)
+- Type: rewrite-capable pattern
+- Watch words: serves as, acts as, functions as, stands as, operates as, works as, remains as, exists as
+- Fire condition: 2+ copula-avoidance constructions in the same paragraph, or a single instance where "is" would be shorter and clearer.
+- Example files: [failure](../examples/en-08-failure-01.md) · [success](../examples/en-08-success-01.md)
+
+Example before:
+
+> The library serves as a vital community hub, functioning as both an educational resource and a social gathering space. It also acts as a testament to the city's commitment to public access.
+
+Example after:
+
+> The library is the neighborhood's main public space. People use it for study groups, ESL classes, and the Saturday morning story hour, which draws about 40 kids a week.
+
+### 9. Negative Parallelisms
+
+- Source: [en-language.md](../patterns/en-language.md)
+- Type: rewrite-capable pattern
+- Watch words: not just...but, not merely...but also, not only...but, goes beyond...to, more than just...it is, transcends...to become
+- Fire condition: 2+ "not X but Y" structures in the same document, or a single instance where the positive statement alone would be simpler and equally clear.
+- Example files: [failure](../examples/en-09-failure-01.md) · [success](../examples/en-09-success-01.md)
+
+Example before:
+
+> This initiative is not just a policy change but a fundamental reimagining of urban planning. It goes beyond mere infrastructure investment to become a statement about the kind of city residents want to live in.
+
+Example after:
+
+> The initiative rezones 12 blocks for mixed-use development and adds a bike lane network connecting the east and west sides of the river.
+
+### 10. Rule of Three Overuse
+
+- Source: [en-language.md](../patterns/en-language.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 3-item lists appear 2+ times in the same document, or a triple-part sentence where the count is arbitrary and another count would be equally valid.
+- Example files: [failure](../examples/en-10-failure-01.md) · [success](../examples/en-10-success-01.md)
+
+Example before:
+
+> The program fosters creativity, innovation, and collaboration. Participants gain inspiration, practical skills, and lasting connections. The result is a more dynamic, inclusive, and forward-thinking community.
+
+Example after:
+
+> The program pairs early-career designers with experienced mentors for a 10-week project. Last year's cohort produced two apps that are still in active use.
+
+### 11. Elegant Variation (Synonym Cycling)
+
+- Source: [en-language.md](../patterns/en-language.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: The same entity referred to by 3+ different names or synonyms within a single paragraph.
+- Example files: [failure](../examples/en-11-failure-01.md) · [success](../examples/en-11-success-01.md)
+
+Example before:
+
+> Tokyo is the most populous city in Japan. The metropolis is known for its blend of tradition and modernity. The urban center attracts millions of tourists each year. The Japanese capital continues to grow.
+
+Example after:
+
+> Tokyo is the most populous city in Japan, with about 14 million residents. It draws roughly 20 million foreign tourists a year, a number that has doubled since 2015.
+
+### 12. False Ranges
+
+- Source: [en-language.md](../patterns/en-language.md)
+- Type: rewrite-capable pattern
+- Watch words: from X to Y, ranging from...to, spanning...to, everything from...to, whether...or
+- Fire condition: A "from X to Y" construction appears where the two poles do not meaningfully bound a spectrum — the range is decorative rather than informative.
+- Example files: [failure](../examples/en-12-failure-01.md) · [success](../examples/en-12-success-01.md)
+
+Example before:
+
+> The festival offers something for everyone, from young children to seasoned professionals, spanning everything from traditional folk music to cutting-edge electronic performances.
+
+Example after:
+
+> The festival has three stages. The main stage books established acts (this year: Yo-Yo Ma, Thundercat). The tent stage is for local bands. There is also a children's area with instrument demos.
+
+## Style Patterns
+
+### 13. Em Dash Overuse
+
+- Source: [en-style.md](../patterns/en-style.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 3+ em dashes appear in a single text.
+- Example files: [failure](../examples/en-13-failure-01.md) · [success](../examples/en-13-success-01.md)
+
+Example before:
+
+> The new policy — which was announced last Tuesday — aims to address a long-standing issue — affordable housing. Critics — including several council members — argue that the plan lacks specifics — a concern that the mayor dismissed as premature.
+
+Example after:
+
+> The new policy, announced last Tuesday, aims to address affordable housing. Several council members say the plan lacks specifics. The mayor called the criticism premature.
+
+### 14. Boldface Overuse
+
+- Source: [en-style.md](../patterns/en-style.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 5+ bolded terms in a single document, or 3+ in a single paragraph.
+- Example files: [failure](../examples/en-14-failure-01.md) · [success](../examples/en-14-success-01.md)
+
+Example before:
+
+> **Machine learning** is a subset of **artificial intelligence** that uses **statistical methods** to enable computers to **learn from data**. The most common approaches include **supervised learning**, **unsupervised learning**, and **reinforcement learning**.
+
+Example after:
+
+> Machine learning is a subset of artificial intelligence that uses statistical methods to let computers learn from data. The three main approaches are supervised learning, unsupervised learning, and reinforcement learning.
+
+### 15. Inline-Header Vertical Lists
+
+- Source: [en-style.md](../patterns/en-style.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 2+ "**Label:** explanation" bullets in the same list.
+- Example files: [failure](../examples/en-15-failure-01.md) · [success](../examples/en-15-success-01.md)
+
+Example before:
+
+> - **Accessibility:** The platform supports screen readers and keyboard navigation.
+> - **Performance:** Load times have been reduced by 40%.
+> - **Security:** All data is encrypted end-to-end.
+
+Example after:
+
+> The platform now supports screen readers and keyboard navigation, load times are down 40%, and all data is encrypted end-to-end.
+
+### 16. Title Case in Headings
+
+- Source: [en-style.md](../patterns/en-style.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 3+ content words (non-articles, non-prepositions) capitalized in the same heading when sentence case would be correct.
+- Example files: [failure](../examples/en-16-failure-01.md) · [success](../examples/en-16-success-01.md)
+
+Example before:
+
+> ## The Impact Of Remote Work On Urban Development And Housing Markets
+
+Example after:
+
+> ## The impact of remote work on urban development and housing markets
+
+### 17. Emojis
+
+- Source: [en-style.md](../patterns/en-style.md)
+- Type: rewrite-capable pattern
+- Watch words: emojis used as section markers or emphasis
+- Fire condition: Any emoji in professional, academic, or editorial text.
+- Example files: [failure](../examples/en-17-failure-01.md) · [success](../examples/en-17-success-01.md)
+
+Example before:
+
+> Here are five tips for better sleep:
+> 1. Set a consistent bedtime
+> 2. Avoid screens before bed
+> 3. Keep your room cool
+> 4. Limit caffeine after noon
+> 5. Try reading instead of scrolling
+
+Example after:
+
+> Five tips for better sleep:
+> 1. Set a consistent bedtime.
+> 2. Avoid screens before bed.
+> 3. Keep your room cool.
+> 4. Limit caffeine after noon.
+> 5. Read instead of scrolling.
+
+### 18. Curly Quotation Marks
+
+- Source: [en-style.md](../patterns/en-style.md)
+- Type: rewrite-capable pattern
+- Watch words: curly/smart quotes used in contexts where straight quotes are standard
+- Fire condition: Curly quotes appear inside code blocks, inline code spans, configuration file examples, or plain-text technical documents where straight quotes are required.
+- Example files: [failure](../examples/en-18-failure-01.md) · [success](../examples/en-18-success-01.md)
+
+Example before:
+
+> Set the variable: `name = "hello"`
+>
+> In your config file, add: `timeout = '30'`
+
+Example after:
+
+> Set the variable: `name = "hello"`
+>
+> In your config file, add: `timeout = '30'`
+
+## Communication Patterns
+
+### 19. Collaborative Communication Artifacts
+
+- Source: [en-communication.md](../patterns/en-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: I hope this helps!, Let me know if you need, Feel free to ask, Happy to help, Don't hesitate to reach out, I'd be glad to, Is there anything else, Hope that clarifies things, Let me know if you'd like me to
+- Fire condition: Any chatbot-style conversational phrase appears in content that is not a live interactive conversation.
+- Example files: [failure](../examples/en-19-failure-01.md) · [success](../examples/en-19-success-01.md)
+
+Example before:
+
+> The French Revolution began in 1789, driven by fiscal crisis and food shortages. I hope this helps! Let me know if you need more details on any specific aspect of the revolution. Feel free to ask about the key figures involved.
+
+Example after:
+
+> The French Revolution began in 1789, driven by fiscal crisis and food shortages. The immediate trigger was the near-bankruptcy of the French state and a bread price spike that hit Paris hardest.
+
+### 20. Knowledge-Cutoff Disclaimers
+
+- Source: [en-communication.md](../patterns/en-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: as of my last update, I don't have access to real-time, my training data, I cannot verify current, as of my knowledge cutoff, I'm not able to browse, please verify this information, this may have changed since
+- Fire condition: Any AI self-reference or training-data caveat appears in editorial, journalistic, or analytical content.
+- Example files: [failure](../examples/en-20-failure-01.md) · [success](../examples/en-20-success-01.md)
+
+Example before:
+
+> As of my last update in April 2024, the company had around 5,000 employees. I don't have access to real-time data, so please verify this information with current sources.
+
+Example after:
+
+> The company had about 5,000 employees as of its 2024 annual report.
+
+### 21. Sycophantic/Servile Tone
+
+- Source: [en-communication.md](../patterns/en-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: Great question!, That's an excellent point, You've raised a fascinating, What a thoughtful, That's a really interesting, Absolutely!, You're absolutely right, What a great observation
+- Fire condition: Any flattering or servile opener appears before substantive content.
+- Example files: [failure](../examples/en-21-failure-01.md) · [success](../examples/en-21-success-01.md)
+
+Example before:
+
+> Great question! That's a really fascinating topic. You've raised an excellent point about the economic factors at play. Let me break this down for you.
+
+Example after:
+
+> The main economic factor is the gap between housing supply and demand. Building permits in the metro area dropped 18% last year while population grew 2.1%.
+
+### 29. False Nuance (Retroactive Reframing)
+
+- Source: [en-communication.md](../patterns/en-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: Actually, it's more nuanced than that, To be more precise, Well, it's not quite that simple, That said, the reality is more complex, More accurately, In fairness, it's more that, If we're being precise, Though to be fair
+- Fire condition: The text restates or lightly reframes the preceding claim under the guise of adding nuance, without introducing new information, evidence, or a genuinely different perspective.
+
+Example before:
+
+> Remote work increases productivity. Actually, it's more nuanced than that — remote work can enhance productivity in certain contexts while presenting challenges in others, and the net effect depends on organizational culture and individual work styles.
+
+Example after:
+
+> Remote work increases productivity for focused solo tasks — a Stanford study found a 13% gain for call center workers. It hurts spontaneous collaboration, though: Microsoft's 2021 internal data showed cross-team communication dropped 25% after going fully remote.
+
+## Filler & Hedging Patterns
+
+### 22. Filler Phrases
+
+- Source: [en-filler.md](../patterns/en-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: it's important to note that, it's worth mentioning that, it should be noted that, in order to, due to the fact that, at the end of the day, when it comes to, in terms of, the fact of the matter is, it goes without saying, needless to say, as a matter of fact, for all intents and purposes, in light of the fact that
+- Fire condition: 2+ filler phrases appear in the same paragraph, or a single phrase that can be deleted without any loss of meaning.
+- Example files: [failure](../examples/en-22-failure-01.md) · [success](../examples/en-22-success-01.md)
+
+Example before:
+
+> It's important to note that, in order to achieve sustainable growth, companies need to invest in R&D. Due to the fact that competition is increasing, it's worth mentioning that firms must also focus on talent retention. At the end of the day, when it comes to long-term success, innovation is key.
+
+Example after:
+
+> Companies that want to grow need to invest in R&D. Competition for talent is rising just as fast — Gartner reports that tech attrition hit 20% last year.
+
+### 23. Excessive Hedging
+
+- Source: [en-filler.md](../patterns/en-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: it could potentially be argued that perhaps, may or may not, it is possible that, to some extent, in certain cases, it could be said that, there is a chance that, one might argue, it seems likely that, arguably, it is conceivable that, tends to suggest
+- Fire condition: 3+ qualifiers stacked on a single claim, or a statement so hedged it makes no falsifiable assertion.
+- Example files: [failure](../examples/en-23-failure-01.md) · [success](../examples/en-23-success-01.md)
+
+Example before:
+
+> It could potentially be argued that this approach may, to some extent, offer certain advantages in some cases, though it is possible that the results might vary depending on a number of factors that arguably remain to be fully understood.
+
+Example after:
+
+> This approach has advantages, but results vary. The biggest variable is team size: teams under five people saw a 30% improvement, while larger teams saw little change.
+
+### 24. Generic Positive Conclusions
+
+- Source: [en-filler.md](../patterns/en-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: a bright future lies ahead, exciting journey, the possibilities are endless, stands as a testament, the sky is the limit, promising outlook, exciting times ahead, the best is yet to come, transformative potential, a new chapter
+- Fire condition: 2+ vague optimism phrases appear in the same paragraph or conclusion, or a standalone final sentence that is entirely optimism filler with no specific claim.
+- Example files: [failure](../examples/en-24-failure-01.md) · [success](../examples/en-24-success-01.md)
+
+Example before:
+
+> As the company enters this exciting new chapter, the possibilities are truly endless. With its talented team and innovative vision, a bright future undoubtedly lies ahead. The best is yet to come.
+
+Example after:
+
+> The company plans to open two more locations by June and is hiring 15 engineers for its new climate-tech division.
+
+### 31. Conclusion Signal Words
+
+- Source: [en-filler.md](../patterns/en-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: In conclusion, Ultimately, In summary, To conclude, To sum up, Finally, All in all, In the end, Overall, On the whole
+- Fire condition: The document's final paragraph (or second-to-last) opens with one of the watch words. Or 2+ such conclusion signals appear across paragraphs.
+- Example files: [failure](../examples/en-31-failure-01.md) · [success](../examples/en-31-success-01.md)
+
+Example before:
+
+> In conclusion, work-life balance is not a luxury but a necessity. It is a critical foundation upon which sustainable success — both personal and professional — must be built.
+
+Example after:
+
+> Work-life balance isn't optional. Without it, the rest of the structure cracks.
+
+## Structure Patterns
+
+### 25. Metronomic Paragraph Structure
+
+- Source: [en-structure.md](../patterns/en-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 3+ consecutive paragraphs follow the identical internal template — e.g., claim → evidence → significance, or problem → solution → benefit, or intro → development → conclusion.
+- Example files: [failure](../examples/en-25-failure-01.md) · [success](../examples/en-25-success-01.md)
+
+Example before:
+
+> The electric vehicle market has experienced unprecedented growth in recent years. Sales doubled between 2021 and 2023, driven by falling battery costs and expanded charging infrastructure. This trend signals a fundamental shift in how consumers relate to personal transportation.
+>
+> Battery technology has improved considerably over the same period. Energy density has increased by 40% since 2018, while costs have fallen from $140 to $90 per kWh. These advances have made electric vehicles competitive with internal combustion alternatives on a total cost of ownership basis.
+>
+> Government policy has played a significant supporting role. Tax credits of up to $7,500 are available in the United States, and the EU has mandated a ban on new petrol vehicle sales by 2035. Such regulatory tailwinds are expected to sustain the sector's momentum into the next decade.
+
+Example after:
+
+> Electric vehicle sales doubled between 2021 and 2023. The main driver isn't policy — it's battery prices, which fell from $140 to $90 per kWh.
+>
+> The US $7,500 tax credit helps, but it phases out once a manufacturer hits 200,000 vehicles sold. Tesla already passed that cap years ago.
+>
+> Whether the EU's 2035 petrol ban survives is genuinely unclear. Germany's coalition nearly collapsed over it in 2023, and three major automakers are lobbying for a 2040 date instead.
+
+### 26. Passive Nominalization Chains
+
+- Source: [en-structure.md](../patterns/en-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: was conducted, was performed, was developed, was established, were identified, is required, has been shown, is provided, are considered, is achieved, is determined, is utilized, is noted
+- Fire condition: 2+ passive nominalization phrases in the same paragraph — e.g., "an analysis was conducted", "consideration was given to", "a decision was made".
+- Example files: [failure](../examples/en-26-failure-01.md) · [success](../examples/en-26-success-01.md)
+
+Example before:
+
+> An extensive review of the literature was conducted in order to identify key patterns. Consideration was given to a range of methodological approaches, and a decision was made to adopt a mixed-methods design. Data collection was performed over a six-month period, after which an analysis was undertaken to identify recurring themes.
+
+Example after:
+
+> We reviewed 47 papers published between 2018 and 2024. Most used surveys; we chose interviews instead, since the population was small enough to go deep. Six months of interviews, then we coded the transcripts.
+
+### 27. Zombie Nouns (Excessive Nominalization)
+
+- Source: [en-structure.md](../patterns/en-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: make an improvement to, provide a description of, conduct an analysis of, give consideration to, offer an explanation of, achieve a reduction in, have an impact on, make a decision about, reach a conclusion regarding, perform an evaluation of, carry out an investigation into, give an indication of
+- Fire condition: 3+ nominalized verb phrases in the same paragraph — e.g., "make improvements" instead of "improve", "conduct an analysis" instead of "analyze".
+- Example files: [failure](../examples/en-27-failure-01.md) · [success](../examples/en-27-success-01.md)
+
+Example before:
+
+> The committee made a decision to conduct an analysis of the current situation and to provide a recommendation regarding future strategy. An evaluation of the available options was performed, and after careful consideration was given to each alternative, an agreement was reached on the most viable approach.
+
+Example after:
+
+> The committee analyzed the situation and agreed on a strategy. They evaluated three options and chose the one with the lowest implementation risk.
+
+### 28. Stacked Subordinate Clauses
+
+- Source: [en-structure.md](../patterns/en-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: A single sentence contains 3+ embedded relative clauses, appositives, or participial phrases before the main verb reaches its object — or the reader must parse 4+ commas before understanding the sentence's main claim.
+- Example files: [failure](../examples/en-28-failure-01.md) · [success](../examples/en-28-success-01.md)
+
+Example before:
+
+> The initiative, which was developed in response to increasing concerns about, and growing awareness of, the urgent need to address the challenges facing both urban and rural communities in the context of rapid technological transformation, aims to bridge the gap between innovation and equitable access.
+
+Example after:
+
+> Rural and urban communities are getting left behind as technology changes fast. The initiative targets that gap directly — access to tools, not just the tools themselves.
+
+### 30. Rhetorical Question Openers
+
+- Source: [en-structure.md](../patterns/en-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: A paragraph opens with an interrogative sentence ("Why...?", "How...?", "What...?", "But what if...?") AND the answer follows in the same or next sentence within the same paragraph. Or: the document contains 2+ rhetorical questions used as paragraph openers across paragraphs.
+- Example files: [failure](../examples/en-30-failure-01.md) · [success](../examples/en-30-success-01.md)
+
+Example before:
+
+> So why did Korean coffee culture grow so fast? The answer is surprisingly simple. Cafés moved beyond being places to buy drinks and became social hubs.
+>
+> But what about the future? Experts believe the trend will continue.
+
+Example after:
+
+> Korean coffee culture grew fast for a surprisingly simple reason: cafés moved beyond being places to buy drinks and became social hubs.
+>
+> The trend is likely to continue. Experts agree.
+
+## Viral Hook Patterns (score-only)
+
+### Viral 1. Shock Numbers as Hook
+
+- Source: [en-viral-hook.md](../patterns/en-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: in just N days, only N hours, jumped from 0 to N, hit N million in N weeks, N% growth in N months, broke the N-million mark, N-figure result
+- Fire condition: A bold claim relies on a striking number (time-to-X, scale, percentage) and the same piece offers no source or verification path.
+
+Detection example:
+
+> 250K stars in just 60 days.
+> $100M revenue with zero ad spend.
+
+### Viral 2. Clickbait Mystery Close
+
+- Source: [en-viral-hook.md](../patterns/en-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: what makes them tick, why is everyone, you'll never guess, can you believe, the reason might surprise you, here's why
+- Fire condition: The **last sentence** of the piece is a rhetorical question that the body has not answered, or a teaser that explicitly redirects the reader to engagement (subscribe, follow, save).
+
+Detection example:
+
+> So why are devs flocking to it without any marketing?
+> The reason might surprise you.
+
+### Viral 3. Source-Skipping Authority
+
+- Source: [en-viral-hook.md](../patterns/en-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: for the first time in history, a global first, never before seen, the only X that, reportedly (with no named source), industry insiders say (with no source)
+- Fire condition: Absolute scope or rank claims ("first ever", "no one has", "industry-wide change") appear without an accompanying source, link, screenshot, or named expert.
+
+Detection example:
+
+> The fastest growth GitHub has ever seen.
+> Developers worldwide are losing their minds over this.
+
+### Viral 4. Breath-Optimized Short-Sentence Stacking
+
+- Source: [en-viral-hook.md](../patterns/en-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: (structural pattern — judged by form, not vocabulary)
+- Fire condition: The whole piece is composed almost entirely of one-sentence paragraphs, four or more in a row, with average sentence length under ~12 words. A handful of short sentences mixed with longer ones does not fire this.
+
+Detection example:
+
+> No one has ever shipped this fast.
+>
+> 250K stars in 60 days.
+>
+> A tool called OpenClaw did it.
+>
+> Why are devs flocking to it without any marketing?
+> 
+> (Four one-line paragraphs, average ~10 words, line-break separated → fires.)
+
+### Viral 5. Hyperbolic Engagement Lexicon
+
+- Source: [en-viral-hook.md](../patterns/en-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: absolutely insane, totally wild, mind-blowing, game-changing, you can't sleep on this, don't miss out, hands down the best, literally everyone is, this changes everything, a no-brainer
+- Fire condition:
+
+> - One occurrence in the piece: Low
+> - Two occurrences: Medium
+> - Three or more: High
+
+Detection example:
+
+> This is absolutely insane and developers are losing their minds.
+> Hands down the best dev tool of the year — don't sleep on it.

--- a/docs/PATTERNS-JA.md
+++ b/docs/PATTERNS-JA.md
@@ -1,0 +1,633 @@
+# Japanese Pattern Reference
+
+This page expands the Japanese pattern packs into a browsable reference. It is generated from `patterns/ja-*.md`, so the numbers, names, watch words, fire conditions, and examples mirror the source pattern files.
+
+- Rewrite-capable patterns: 32
+- Score/audit-only viral-hook patterns: 5
+- Main selector: [PATTERNS.md](PATTERNS.md)
+
+## Pattern Index
+
+| # | Type | Pattern | Source |
+|---|------|---------|--------|
+| 1 | rewrite | 過度な重要性の強調 | [ja-content.md](../patterns/ja-content.md) |
+| 2 | rewrite | 過度な注目度・メディア言及 | [ja-content.md](../patterns/ja-content.md) |
+| 3 | rewrite | ～しながら/～することで 表層的分析 | [ja-content.md](../patterns/ja-content.md) |
+| 4 | rewrite | 広告的・宣伝的言語 | [ja-content.md](../patterns/ja-content.md) |
+| 5 | rewrite | 曖昧な出典引用 | [ja-content.md](../patterns/ja-content.md) |
+| 6 | rewrite | 定型的な課題と展望 | [ja-content.md](../patterns/ja-content.md) |
+| 7 | rewrite | AI特有の語彙の多用 | [ja-language.md](../patterns/ja-language.md) |
+| 8 | rewrite | 〜的（てき）接尾辞の多用 | [ja-language.md](../patterns/ja-language.md) |
+| 9 | rewrite | 否定並列構造 | [ja-language.md](../patterns/ja-language.md) |
+| 10 | rewrite | 三の法則の多用 | [ja-language.md](../patterns/ja-language.md) |
+| 11 | rewrite | 類義語の循環 | [ja-language.md](../patterns/ja-language.md) |
+| 12 | rewrite | カタカナ外来語の多用 | [ja-language.md](../patterns/ja-language.md) |
+| 32 | rewrite | 「より」比較副詞の濫用 | [ja-language.md](../patterns/ja-language.md) |
+| 13 | rewrite | 接続表現の過剰使用 | [ja-style.md](../patterns/ja-style.md) |
+| 14 | rewrite | 太字の多用 | [ja-style.md](../patterns/ja-style.md) |
+| 15 | rewrite | インラインヘッダーリスト | [ja-style.md](../patterns/ja-style.md) |
+| 16 | rewrite | ございます／でございます敬語の過剰使用 | [ja-style.md](../patterns/ja-style.md) |
+| 17 | rewrite | 絵文字 | [ja-style.md](../patterns/ja-style.md) |
+| 18 | rewrite | 過剰なである調／硬質文体 | [ja-style.md](../patterns/ja-style.md) |
+| 19 | rewrite | チャットボットの痕跡 | [ja-communication.md](../patterns/ja-communication.md) |
+| 20 | rewrite | 学習データ切断日の免責 | [ja-communication.md](../patterns/ja-communication.md) |
+| 21 | rewrite | お世辞・追従的な語調 | [ja-communication.md](../patterns/ja-communication.md) |
+| 29 | rewrite | 偽りのニュアンス（事後的な言い換え） | [ja-communication.md](../patterns/ja-communication.md) |
+| 22 | rewrite | フィラー表現 | [ja-filler.md](../patterns/ja-filler.md) |
+| 23 | rewrite | 過剰なヘッジング | [ja-filler.md](../patterns/ja-filler.md) |
+| 24 | rewrite | 空虚な楽観的結論 | [ja-filler.md](../patterns/ja-filler.md) |
+| 31 | rewrite | 結論シグナルワードの濫用 | [ja-filler.md](../patterns/ja-filler.md) |
+| 25 | rewrite | 構造的繰り返し | [ja-structure.md](../patterns/ja-structure.md) |
+| 26 | rewrite | 翻訳調 | [ja-structure.md](../patterns/ja-structure.md) |
+| 27 | rewrite | ている進行形の多用 | [ja-structure.md](../patterns/ja-structure.md) |
+| 28 | rewrite | 起承転結の過剰使用 | [ja-structure.md](../patterns/ja-structure.md) |
+| 30 | rewrite | 修辞的疑問の段落冒頭 | [ja-structure.md](../patterns/ja-structure.md) |
+| VH-1 | score/audit only | 数字ショックフック | [ja-viral-hook.md](../patterns/ja-viral-hook.md) |
+| VH-2 | score/audit only | クリックベイト末尾 | [ja-viral-hook.md](../patterns/ja-viral-hook.md) |
+| VH-3 | score/audit only | 出典回避の権威主張 | [ja-viral-hook.md](../patterns/ja-viral-hook.md) |
+| VH-4 | score/audit only | 息継ぎ最適化の短文羅列 | [ja-viral-hook.md](../patterns/ja-viral-hook.md) |
+| VH-5 | score/audit only | 誇張エンゲージメント語彙 | [ja-viral-hook.md](../patterns/ja-viral-hook.md) |
+
+## コンテンツパターン
+
+### 1. 過度な重要性の強調
+
+- Source: [ja-content.md](../patterns/ja-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 画期的な、革新的な、パラダイムシフト、歴史的な転換点、新たな地平を切り開く、礎を築く、金字塔、～の先駆けとなる、～において極めて重要な意義を持つ、～の幕開け、時代を画する
+- Fire condition: 同一段落に注意語彙が2つ以上出現するか、「画期的」「パラダイムシフト」などの強い表現が日常的な事象・製品に使われている場合。
+
+Example before:
+
+> 日本の半導体産業の発展は、国家経済において画期的な役割を果たし、グローバル技術競争における革新的なパラダイムシフトを意味する。この成果は新たな地平を切り開く礎を築いた。
+
+Example after:
+
+> 日本の半導体産業は1980年代にDRAM世界シェアの80%を占めた。現在はロジック半導体の製造拠点誘致に2兆円規模の補助金を投じている。
+
+### 2. 過度な注目度・メディア言及
+
+- Source: [ja-content.md](../patterns/ja-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 大きな注目を集めている、世界的に認められた、国内外のメディアから高い評価を受け、各方面から称賛の声が上がっている、話題を呼んでいる
+- Fire condition: 具体的な媒体名・記事タイトル・日付なしに、広範な注目・報道・評価を主張している場合。媒体名があっても文脈なく羅列しただけの場合。
+
+Example before:
+
+> この作品は国内外のメディアから高い評価を受け、世界的に認められた芸術家として大きな注目を集めている。各方面から称賛の声が上がっている。
+
+Example after:
+
+> ニューヨーク・タイムズは2024年の記事で、この作品を「日本の現代美術における新たな潮流」と紹介した。
+
+### 3. ～しながら/～することで 表層的分析
+
+- Source: [ja-content.md](../patterns/ja-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 示しながら、強調しつつ、反映しており、象徴するとともに、促進しながら、体現しつつ、見せながら、物語っており
+- Fire condition: 一文または連続する節に「～しながら/～しつつ/～しており」の連結形が3つ以上並び、具体的な因果説明なく羅列のみの場合。
+
+Example before:
+
+> この祭りは地域文化の多様性を示しながら、伝統と現代の調和を象徴するとともに、地域経済の活性化を促進しつつ、世代間交流の場を提供している。
+
+Example after:
+
+> 祭りには毎年約30万人が訪れる。期間中、周辺商店街の売上は通常の40%増になる。
+
+### 4. 広告的・宣伝的言語
+
+- Source: [ja-content.md](../patterns/ja-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 素晴らしい、世界クラスの、必見の、息をのむような、魅力あふれる、唯一無二の、圧巻の、感動的な、類まれなる、他に類を見ない、～の宝庫、至高の
+- Fire condition: 同一対象に宣伝的な形容詞が2つ以上つくか、「息をのむような」「～の宝庫」などの強い修飾語が叙述文（広告引用ではない本文）に使われている場合。
+
+Example before:
+
+> 京都は素晴らしい歴史的建造物と魅力あふれる文化遺産が調和する世界クラスの観光都市であり、日本文化の宝庫と言える。息をのむような景観は訪れる人々に感動的な体験を与える。
+
+Example after:
+
+> 京都市内には世界遺産が17件ある。2023年の観光客数は約5,300万人で、コロナ前の水準に戻った。オーバーツーリズム対策として、一部の寺社は拝観料を値上げしている。
+
+### 5. 曖昧な出典引用
+
+- Source: [ja-content.md](../patterns/ja-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 専門家によると、研究によれば、関係者は、業界では、一部の見方では、調査結果が示すように（具体的調査名なし）
+- Fire condition: 出典が人名・機関・発表日なく「専門家」「関係者」「研究によれば」などの匿名権威のみで提示されている場合。
+
+Example before:
+
+> 専門家によると、この技術は今後の産業全般に革新的な変化をもたらすと見られている。関係者は、市場規模は継続的に成長すると予測している。
+
+Example after:
+
+> 経済産業省の2024年版「ものづくり白書」によると、国内製造業のAI導入率は前年比12ポイント増の34%に達した。
+
+### 6. 定型的な課題と展望
+
+- Source: [ja-content.md](../patterns/ja-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 課題はあるものの、今後の発展が期待される、～にもかかわらず前途は明るい、さまざまな課題を乗り越え、急速に変化する現代社会において、～の時代を迎え、100年に一度の変革期、Society 5.0の実現に向けて
+- Fire condition: 同一段落または結論部で曖昧な課題表現（「さまざまな課題が残されている」）と曖昧な楽観表現（「今後の発展が期待される」）が同時に出現する場合。または導入部が「急速に変化する～」「100年に一度の変革期」などの時代公式で始まる場合。
+
+Example before:
+
+> これらの成果にもかかわらず、依然としてさまざまな課題が残されている。しかし、持続的な努力と革新により、今後の発展が期待される。
+
+Example after:
+
+> 2024年の会計検査院報告書は、人員不足と予算執行率の低さを主要な問題として指摘した。省庁は2025年度予算を18%増額し、専門人材40名を採用する方針だ。
+
+## 言語・文法パターン
+
+### 7. AI特有の語彙の多用
+
+- Source: [ja-language.md](../patterns/ja-language.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 同一段落に高頻度語彙が3つ以上出現する場合。
+
+Example before:
+
+> さらに、多様な革新的技術が活発に開発されており、これにより体系的かつ効果的なソリューションを提供している。加えて、こうした持続的な取り組みは主導的な役割を果たしている。
+
+Example after:
+
+> 今年出た技術の中では、バッテリー寿命を20%延ばした電力管理チップと、処理速度が従来の2倍になったNPUがある。
+
+### 8. 〜的（てき）接尾辞の多用
+
+- Source: [ja-language.md](../patterns/ja-language.md)
+- Type: rewrite-capable pattern
+- Watch words: 革新的、体系的、効果的、効率的、先進的、積極的、総合的、核心的、戦略的、実質的、根本的、画期的、抜本的
+- Fire condition: 一文に「〜的」形容詞が3つ以上、または連続2文にわたって4つ以上使用された場合。
+
+Example before:
+
+> 革新的かつ体系的なアプローチにより、効果的かつ効率的な成果を導き、先進的かつ積極的な姿勢で総合的な発展を推進している。
+
+Example after:
+
+> チームは既存のプロセスを単純化し、不要な承認ステップを省いて、デプロイ時間を半分に短縮した。
+
+### 9. 否定並列構造
+
+- Source: [ja-language.md](../patterns/ja-language.md)
+- Type: rewrite-capable pattern
+- Watch words: 〜にとどまらず、〜のみならず〜も、単に〜だけでなく、〜を超えて
+- Fire condition: 同一文書に否定並列構造が2回以上出現、または肯定文だけでより簡潔に表現できる箇所に使用された場合。
+
+Example before:
+
+> これは単なる技術革新にとどまらず、社会全体にわたる根本的な変革を意味する。これは経済的側面のみならず、社会的・文化的側面においても重大な意味を持つ。
+
+Example after:
+
+> この技術は最初に製造工程に導入され、その後物流と顧客サービスにも使われ始めた。
+
+### 10. 三の法則の多用
+
+- Source: [ja-language.md](../patterns/ja-language.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 同一文書に3項目の列挙が2回以上出現、または3つにまとめた根拠が恣意的で他の数でも同等に成り立つ場合。
+
+Example before:
+
+> このプログラムは創造性、革新性、そして持続可能性を追求します。参加者はインスピレーション、実践的スキル、そして持続的なつながりを得ることができます。
+
+Example after:
+
+> このプログラムは実務プロジェクト中心で、参加者は8週間かけて実際の製品開発に取り組む。昨年のコホートが作った2つのアプリは今も使われている。
+
+### 11. 類義語の循環
+
+- Source: [ja-language.md](../patterns/ja-language.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 同一段落で同一対象が3つ以上の異なる名称・同義語で指称された場合。
+
+Example before:
+
+> 東京は日本最大の都市である。この大都市は伝統と現代の融合で知られる。同都市圏には多くの観光客が訪れる。日本の首都は今も成長を続けている。
+
+Example after:
+
+> 東京の人口は約1,400万人で、日本最大の都市だ。外国人観光客は年間約2,000万人で、2015年から倍増した。
+
+### 12. カタカナ外来語の多用
+
+- Source: [ja-language.md](../patterns/ja-language.md)
+- Type: rewrite-capable pattern
+- Watch words: イノベーション、ソリューション、パフォーマンス、ガバナンス、コンセンサス、シナジー、モメンタム、マイルストーン、トリガー、スケールアップ、オンボーディング、フィードバックループ、ペインポイント、ディシジョンメイキング、エコシステム、レジリエンス、サステナビリティ
+- Fire condition: 同一段落に日本語の代替がある外来語が3つ以上出現する場合。業界で定着した専門用語（マーケティング、ブランディング等）は除外。
+
+Example before:
+
+> 今回のプロジェクトのインサイトをレバレッジし、シナジーを最大化して、サステナブルなモメンタムを確保することがキーマイルストーンだ。チームのパフォーマンスを向上させるため、オンボーディングプロセスを改善し、ペインポイントを解決するソリューションを導入する必要がある。
+
+Example after:
+
+> 今回のプロジェクトから得た教訓を活かして相乗効果を高め、推進力を維持するのが主な目標だ。チームの成果を上げるには、新入社員の受け入れ体制を改善し、現場の課題を解決する仕組みを作る必要がある。
+
+### 32. 「より」比較副詞の濫用
+
+- Source: [ja-language.md](../patterns/ja-language.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 1つの文書に「より + 形容詞/副詞」の形が 2 回以上登場。または、1つの段落に「より + 形容詞」が 1 回出現し、同じ段落に他のフォーマルマーカー（「かと思われます」「であると考えます」「いたします」「ございます」など）が共起する場合。
+- Example files: [failure](../examples/ja-32-failure-01.md) · [success](../examples/ja-32-success-01.md)
+
+Example before:
+
+> プロジェクトのスケジュールに関しては、より具体的なマイルストーンの設定が必要かと思われます。予算配分についても、より効率的な運用方法の検討が必要であると考えます。可能であれば、来週中により深い議論を進められれば幸いです。
+
+Example after:
+
+> プロジェクトの日程は、もっと具体的なマイルストーンが必要そうです。予算の使い方についても、一度見直したほうがよさそうです。来週、もう少しじっくり話せる時間を取れたら助かります。
+
+## スタイルパターン
+
+### 13. 接続表現の過剰使用
+
+- Source: [ja-style.md](../patterns/ja-style.md)
+- Type: rewrite-capable pattern
+- Watch words: これにより、こうした点で、こうした中、一方で、また、さらに、加えて、これに伴い、これに関連して、これを踏まえて、それゆえ、したがって
+- Fire condition: 連続3文以上で毎文の冒頭に接続表現が付く場合、または同一段落に注意語彙が3つ以上出現する場合。
+
+Example before:
+
+> これにより、企業の競争力が強化された。こうした点で、今回の施策は大きな意味を持つ。一方で、一部では懸念の声も上がっている。こうした中、今後の方向性について議論が必要である。
+
+Example after:
+
+> 施策後、輸出企業10社のうち7社が営業利益を伸ばした。ただし中小企業団体は原材料コストの上昇負担が依然大きいと表明している。
+
+### 14. 太字の多用
+
+- Source: [ja-style.md](../patterns/ja-style.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 同一段落に太字処理された語句が3つ以上、または文書全体で5つ以上。
+
+Example before:
+
+> **機械学習**は**人工知能**の一分野であり、**統計的手法**を用いてコンピュータに**データからの学習**を可能にする。主なアプローチには**教師あり学習**、**教師なし学習**、**強化学習**がある。
+
+Example after:
+
+> 機械学習は人工知能の一分野で、統計的手法によりデータから学習する。主なアプローチは教師あり学習、教師なし学習、強化学習の3つ。
+
+### 15. インラインヘッダーリスト
+
+- Source: [ja-style.md](../patterns/ja-style.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 同一リストに「**ラベル：** 説明」形式の項目が2つ以上。
+
+Example before:
+
+> - **ユーザー体験：** 新しいインターフェースにより体験が大幅に改善された。
+> - **パフォーマンス：** アルゴリズム最適化で処理速度が50%向上した。
+> - **セキュリティ：** エンドツーエンド暗号化でセキュリティが強化された。
+
+Example after:
+
+> 今回のアップデートではUIを刷新し、アルゴリズム最適化で処理速度を50%向上させ、エンドツーエンド暗号化を追加した。
+
+### 16. ございます／でございます敬語の過剰使用
+
+- Source: [ja-style.md](../patterns/ja-style.md)
+- Type: rewrite-capable pattern
+- Watch words: 〜でございます、〜ございます、〜いただけますと幸いです、〜させていただきます、〜いただければと存じます、〜いただけますでしょうか
+- Fire condition: 同一段落で「ございます」「させていただきます」が3回以上使われた場合、またはカジュアルな文脈（ブログ記事、解説文等）で過剰な敬語が使われた場合。
+
+Example before:
+
+> こちらの機能についてご説明させていただきます。この技術は非常に優れたものでございまして、多くの場面でご活用いただけるものとなっております。ご不明な点がございましたら、お気軽にお問い合わせいただければと存じます。
+
+Example after:
+
+> この機能は画像認識の精度を従来比15%向上させたもので、製造ラインの検品に使える。詳しくはドキュメントの第3章を参照。
+
+### 17. 絵文字
+
+- Source: [ja-style.md](../patterns/ja-style.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 専門的・学術的・編集テキストに絵文字が1つでも出現する場合。
+
+Example before:
+
+> 🚀 **リリース：** 製品は第3四半期にリリースされます
+> 💡 **インサイト：** ユーザーはシンプルさを好みます
+> ✅ **次のステップ：** フォローアップミーティングを設定してください
+
+Example after:
+
+> 製品は第3四半期にリリース予定。ユーザー調査の結果、シンプルなUIへの好みが最も高かった。次のステップはフォローアップ会議の日程調整。
+
+### 18. 過剰なである調／硬質文体
+
+- Source: [ja-style.md](../patterns/ja-style.md)
+- Type: rewrite-capable pattern
+- Watch words: 〜と言えよう、〜であると言わざるを得ない、〜の感が否めない、〜と言っても過言ではない、〜の一助となれば幸いである、鑑みるに、畢竟、蓋し
+- Fire condition: 同一段落に硬質文体表現が3つ以上出現する場合、または日常的な内容（ブログ、ガイド等）に学術的な結びの表現が使われた場合。
+
+Example before:
+
+> この事態を鑑みるに、早急な対策が必要であると言わざるを得ない。現状の問題点を指摘することが今後の改善の一助となれば幸いである。
+
+Example after:
+
+> 対策は急いだ方がいい。現状の問題は2つ：人手不足と、既存システムとの互換性だ。
+
+## コミュニケーションパターン
+
+### 19. チャットボットの痕跡
+
+- Source: [ja-communication.md](../patterns/ja-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: お役に立てれば幸いです、ご不明な点がございましたら、以下にまとめました、ご紹介させていただきます、さらに詳しい情報が必要な場合は、お答えします
+- Fire condition: リアルタイム対話ではないコンテンツ（記事、報告書、文書）にチャットボット的表現が1つでも出現する場合。
+
+Example before:
+
+> フランス革命についてまとめさせていただきます。お役に立てれば幸いです！さらに詳しい情報が必要な場合は、お気軽にお尋ねください。
+
+Example after:
+
+> フランス革命は1789年に始まった。直接のきっかけは国家の財政破綻寸前の状態と、パリでのパン価格の高騰だった。
+
+### 20. 学習データ切断日の免責
+
+- Source: [ja-communication.md](../patterns/ja-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: 私の知識のカットオフ時点では、リアルタイム情報にはアクセスできません、最新の情報と異なる場合があります、具体的なデータは変動している可能性があります、最新の情報をご確認ください
+- Fire condition: 編集・報道・分析コンテンツにAI学習データの限界を示唆する自己参照または免責表現が1つでも出現する場合。
+
+Example before:
+
+> 私の知識のカットオフ時点では、同社の従業員数は約5,000人です。具体的なデータは変動している可能性がありますので、最新の情報をご確認ください。
+
+Example after:
+
+> 同社の2024年度有価証券報告書によると、従業員数は約5,000人。
+
+### 21. お世辞・追従的な語調
+
+- Source: [ja-communication.md](../patterns/ja-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: 素晴らしいご質問ですね、おっしゃる通りです、非常に鋭いご指摘です、とても興味深いテーマですね、大変価値のあるお考えですね
+- Fire condition: 実質的な内容の前にお世辞・追従表現が1つでも出現する場合。
+
+Example before:
+
+> 素晴らしいご質問ですね！おっしゃる通り、これは非常に重要なテーマです。経済的要因に関するご指摘は鋭いですね。詳しくご説明させていただきます。
+
+Example after:
+
+> 経済的要因が核心だ。昨年、住宅供給は18%減少したが、人口は2.1%増えており、需給ギャップが拡大している。
+
+### 29. 偽りのニュアンス（事後的な言い換え）
+
+- Source: [ja-communication.md](../patterns/ja-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: 実はもう少し微妙な問題で, 正確に言えば, 単純にはそう言えませんが, もちろん現実はもっと複雑で, より正確には, 公平に見れば, もう少し掘り下げると
+- Fire condition: 先行する主張を新たな証拠・視点なしに「微妙だ」というフレーミングで言い換える場合。
+
+Example before:
+
+> リモートワークは生産性を向上させます。実はもう少し微妙な問題でして、リモートワークは特定の状況では生産性を高める可能性がありますが、他の状況では課題をもたらすこともあり、純効果は組織文化と個人の働き方によって異なります。
+
+Example after:
+
+> リモートワークは集中作業の生産性を高める——スタンフォードの研究でコールセンター従業員基準13%の向上が確認された。ただし自発的な協業には不利で、マイクロソフトの2021年社内データによると、完全リモート移行後にチーム間コミュニケーションが25%減少した。
+
+## フィラー・ヘッジングパターン
+
+### 22. フィラー表現
+
+- Source: [ja-filler.md](../patterns/ja-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: 周知の通り、言うまでもなく、疑いなく、指摘すべきは、強調すべきは、注目すべきは、事実として、〜という点は注目に値する、〜に留意する必要がある
+- Fire condition: 同一段落にフィラー表現が2つ以上出現、または削除しても意味が変わらないフィラーが単独使用された場合。
+
+Example before:
+
+> 周知の通り、AIは世界を変えつつある。言うまでもなく、この技術の発展速度は多くの人の予想を上回っている。指摘すべきは、ある程度AIの倫理的問題も顕在化しているという点である。
+
+Example after:
+
+> OpenAIの昨年の売上は16億ドルから36億ドルに伸びた。同時期にEUのAI規制法が施行され、ハイリスクAIシステムにコンプライアンス審査が義務付けられた。
+
+### 23. 過剰なヘッジング
+
+- Source: [ja-filler.md](../patterns/ja-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: おそらく〜かもしれない、ある程度〜の可能性がある、〜とも考えられなくはない、ある意味では〜とも言える、〜と言えるかもしれない、一概には〜とは言い切れない
+- Fire condition: 同一主張にヘッジ・限定表現が3つ以上重なる場合、またはヘッジが多すぎて反証不可能になっている場合。
+
+Example before:
+
+> おそらく、ある程度この政策は何らかの効果をもたらす可能性があるかもしれないと考えられなくはないが、これはさまざまな要因に依存すると言えるかもしれない。
+
+Example after:
+
+> この政策は効果がある可能性があるが、最大の変数は実行力だ。大阪のパイロットでは、減税後に中小企業の生存率が62%から71%に上がった。
+
+### 24. 空虚な楽観的結論
+
+- Source: [ja-filler.md](../patterns/ja-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: 今後が期待される、今後の展開に注目したい、大きな可能性を秘めている、輝かしい未来が待っている、ワクワクする未来、無限の可能性、新たな章の幕開け
+- Fire condition: 同一段落または結論部に空虚な楽観表現が2つ以上出現、または最終文が楽観フィラーだけで構成されている場合。
+
+Example before:
+
+> 今後が大いに期待される！AIの発展は輝かしい未来をもたらすだろう。ワクワクする展開を楽しみにしたい。
+
+Example after:
+
+> 来四半期に大阪と福岡にデータセンターを新設する計画で、年末の稼働開始を目指している。
+
+### 31. 結論シグナルワードの濫用
+
+- Source: [ja-filler.md](../patterns/ja-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 文書の最終段落（または最後から2番目）の先頭文が上記シグナルワードのいずれかで始まる。または、同じ文書に結論シグナルワードが 2 回以上登場。
+- Example files: [failure](../examples/ja-31-failure-01.md) · [success](../examples/ja-31-success-01.md)
+
+Example before:
+
+> 結論として、デジタルノマドのライフスタイルは一時的な流行ではなく、社会全体に持続的に根付く新しい標準として定着しつつある。
+
+Example after:
+
+> デジタルノマドはもう流行の話ではない。働き方そのものが変わり、人々はその上に新しい日常を築いている。
+
+## 構造パターン
+
+### 25. 構造的繰り返し
+
+- Source: [ja-structure.md](../patterns/ja-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 連続3つ以上の段落が同一の内部構造テンプレートに従う場合。
+
+Example before:
+
+> 医療分野では、AIが重要な役割を果たしている。例えば、AI診断支援システムが多くの病院で導入されている。この技術の応用は医療サービスの質の向上に貢献している。
+>
+> 教育分野でも、AIは大きな可能性を示している。例えば、個別最適化学習システムが生徒に合わせた学習プランを提供している。この革新は教育の公平化に新たな道を開いている。
+>
+> 交通分野においても、AIの活用が進んでいる。例えば、自動運転技術が商業化に向けて加速している。この発展は都市交通に新たなアプローチを提供している。
+
+Example after:
+
+> AIが病院で一番役に立っているのは、派手なものではなく、画像診断の補助だ。東大病院のデータでは、AI肺結節スクリーニングの見落とし率が医師単独より12ポイント低い。
+>
+> 教育は別の話だ。
+>
+> アダプティブラーニングはもう5〜6年やっているが、効果の定量化が難しい。交通には硬いデータがある——Waymoは東京での実証実験で累計200万kmを走行した。
+
+### 26. 翻訳調
+
+- Source: [ja-structure.md](../patterns/ja-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: 〜という事実、〜することが可能である、〜によって〜される、〜に関して、〜に基づいて、〜の観点から、〜する傾向がある
+- Fire condition: 同一段落に翻訳調の表現が2つ以上出現する場合。単独1回は許容。
+
+Example before:
+
+> この技術が有望であるという事実は否定できない。この技術によって多くの問題が解決されることが可能であり、この技術に関して関心を持つことが必要である。
+
+Example after:
+
+> この技術は有望だ。実際にA社はこれで不良率を30%減らした。関心を持つ価値はある。
+
+### 27. ている進行形の多用
+
+- Source: [ja-structure.md](../patterns/ja-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: 〜している、〜を推進している、〜を展開している、〜に取り組んでいる、〜を進めている、〜に拍車をかけている
+- Fire condition: 同一段落で「〜ている」系の進行形が3回以上使用された場合、または連続2文がともに「〜ている」で終わる場合。
+
+Example before:
+
+> 企業は新たな市場を開拓しており、技術革新を推進しており、グローバルなパートナーシップを拡大している。これにより持続的な成長を遂げている。
+
+Example after:
+
+> 企業は今年東南アジア市場に進出し、来年はヨーロッパ展開を計画している。
+
+### 28. 起承転結の過剰使用
+
+- Source: [ja-structure.md](../patterns/ja-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 文章全体が「導入（テーマ提示）→展開（具体例）→転換（別の視点）→結論（まとめ）」の四段構成に明確に従い、結論が導入の繰り返しになっている場合。
+
+Example before:
+
+> DXは現代企業にとって不可避の課題である。技術面では、クラウドとAIの導入が進んでいる。しかし、人材不足という壁もある。今後も継続的な取り組みが必要だ。
+
+Example after:
+
+> 従業員200人のメーカーが、去年すべての受注管理をkintoneに移行した。理由は単純で、コロナ後に海外顧客とのやりとりが全部オンラインになり、FAXとメールでは追いつかなくなったからだ。IT部門は3人で、2ヶ月で完了した。
+
+### 30. 修辞的疑問の段落冒頭
+
+- Source: [ja-structure.md](../patterns/ja-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 段落の冒頭が疑問形（"なぜ…か"、"どうすれば…"、"何が…"、"…とは何か"）で、答えが同じ段落内で即座に提示される。または、文書全体で段落冒頭の修辞的疑問が 2 回以上登場。
+- Example files: [failure](../examples/ja-30-failure-01.md) · [success](../examples/ja-30-success-01.md)
+
+Example before:
+
+> では、韓国のコーヒー文化はなぜこれほど急速に成長したのか？答えは意外にも単純だ。カフェは単なる飲料の販売空間を超えて、社交の拠点になったからだ。
+>
+> では、今後の展望はどうだろうか？専門家たちはこのトレンドが当面続くと見ている。
+
+Example after:
+
+> 韓国のコーヒー文化が急速に育った理由は意外にも単純だ。カフェが飲み物を売る場所を超えて、人々が集まる拠点になった。
+>
+> この流れは当面続きそうだ。専門家たちの意見も一致している。
+
+## バイラルフックパターン（スコア専用） (score/audit only)
+
+### Viral 1. 数字ショックフック
+
+- Source: [ja-viral-hook.md](../patterns/ja-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: たった N 日で / わずか N 時間、N 万人 / N 億再生 / フォロワー N 万、ゼロ予算で / 0 円で、N 倍成長、N% 急増
+- Fire condition: 主張がインパクト数字（時間・規模・割合）に依存し、同じ投稿内に検証経路がない場合。
+
+Detection example:
+
+> たった 60 日でスター 25 万。
+> 広告ゼロで全世界バズった。
+
+### Viral 2. クリックベイト末尾
+
+- Source: [ja-viral-hook.md](../patterns/ja-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: 〜とは？、〜の理由、知らないと損する、〜って実は…、見ないと後悔する
+- Fire condition: 投稿の**最後の文**が本文で答えていない修辞疑問、もしくはフォロー・保存などのアクションを明示的に誘導する締め。
+
+Detection example:
+
+> その理由、知ってる？
+> なぜ世界中の開発者が殺到するのか？
+
+### Viral 3. 出典回避の権威主張
+
+- Source: [ja-viral-hook.md](../patterns/ja-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: 史上初 / 過去最高 / 過去最速、業界初 / 唯一無二、〜らしい（出典なし）、〜と言われている（主体なし）、業界関係者によると（出典なし）
+- Fire condition: 「史上初」「業界唯一」「過去最速」など絶対範囲・順位の主張が出典なしで登場。同じ投稿に他の検証手がかり（リンク・引用・スクリーンショット）も無い。
+
+Detection example:
+
+> GitHub 史上、こんなスピードは見たことがない。
+> 世界中のエンジニアが殺到している。
+
+### Viral 4. 息継ぎ最適化の短文羅列
+
+- Source: [ja-viral-hook.md](../patterns/ja-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: （構造的パターン——形で判断、語彙ではない）
+- Fire condition: 投稿全体がほぼ「1文＝1行＝1段落」形式で、4文以上連続、平均文長が15字未満の場合。短文が一つ二つ混じる程度では発火しない。
+
+Detection example:
+
+> こんなスピード、見たことない。
+>
+> 60 日でスター 25 万。
+>
+> OpenClaw というツールが達成。
+>
+> 広告ゼロでなぜここまで広がったのか？
+> 
+> （4段落の短文、平均約12字、改行分離 → 発火。）
+
+### Viral 5. 誇張エンゲージメント語彙
+
+- Source: [ja-viral-hook.md](../patterns/ja-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: ヤバい / マジヤバい、神アプデ / 神回 / 神ツール、革命 / ゲームチェンジャー、見ないと損、知らないと損、絶対に試すべき、圧倒的、爆速、神コスパ
+- Fire condition:
+
+> - 1投稿に1回出現：Low
+> - 2回出現：Medium
+> - 3回以上：High
+
+Detection example:
+
+> このツール、マジでヤバい。神アプデ過ぎる。
+> 知らないと損する圧倒的なツール。

--- a/docs/PATTERNS-KO.md
+++ b/docs/PATTERNS-KO.md
@@ -1,0 +1,662 @@
+# Korean Pattern Reference
+
+This page expands the Korean pattern packs into a browsable reference. It is generated from `patterns/ko-*.md`, so the numbers, names, watch words, fire conditions, and examples mirror the source pattern files.
+
+- Rewrite-capable patterns: 32
+- Score/audit-only viral-hook patterns: 5
+- Main selector: [PATTERNS.md](PATTERNS.md)
+
+## Pattern Index
+
+| # | Type | Pattern | Source |
+|---|------|---------|--------|
+| 1 | rewrite | 과도한 중요성 부여 | [ko-content.md](../patterns/ko-content.md) |
+| 2 | rewrite | 과도한 주목도/미디어 언급 | [ko-content.md](../patterns/ko-content.md) |
+| 3 | rewrite | ~하며/~하고 피상적 분석 | [ko-content.md](../patterns/ko-content.md) |
+| 4 | rewrite | 홍보성/광고성 언어 | [ko-content.md](../patterns/ko-content.md) |
+| 5 | rewrite | 모호한 출처 인용 | [ko-content.md](../patterns/ko-content.md) |
+| 6 | rewrite | 틀에 박힌 "과제와 전망" 섹션 | [ko-content.md](../patterns/ko-content.md) |
+| 7 | rewrite | AI 특유 어휘 남발 | [ko-language.md](../patterns/ko-language.md) |
+| 8 | rewrite | ~적(的) 접미사 남발 | [ko-language.md](../patterns/ko-language.md) |
+| 9 | rewrite | 부정 병렬구조 | [ko-language.md](../patterns/ko-language.md) |
+| 10 | rewrite | 3의 법칙 남발 | [ko-language.md](../patterns/ko-language.md) |
+| 11 | rewrite | 유의어 순환 | [ko-language.md](../patterns/ko-language.md) |
+| 12 | rewrite | ~에 있어서/~함에 있어 장황한 조사 사용 | [ko-language.md](../patterns/ko-language.md) |
+| 32 | rewrite | "보다" 비교부사 남용 | [ko-language.md](../patterns/ko-language.md) |
+| 13 | rewrite | 과도한 연결 표현 | [ko-style.md](../patterns/ko-style.md) |
+| 14 | rewrite | 볼드체 남발 | [ko-style.md](../patterns/ko-style.md) |
+| 15 | rewrite | 인라인 헤더 목록 | [ko-style.md](../patterns/ko-style.md) |
+| 16 | rewrite | ~고 있다 진행형 남발 | [ko-style.md](../patterns/ko-style.md) |
+| 17 | rewrite | 이모지 | [ko-style.md](../patterns/ko-style.md) |
+| 18 | rewrite | 과도한 한자어/공식어 사용 | [ko-style.md](../patterns/ko-style.md) |
+| 19 | rewrite | 챗봇 표현 | [ko-communication.md](../patterns/ko-communication.md) |
+| 20 | rewrite | 학습 데이터 기한 면책 | [ko-communication.md](../patterns/ko-communication.md) |
+| 21 | rewrite | 아첨하는 말투 | [ko-communication.md](../patterns/ko-communication.md) |
+| 29 | rewrite | 거짓 뉘앙스 (소급적 재해석) | [ko-communication.md](../patterns/ko-communication.md) |
+| 22 | rewrite | 채움 표현 | [ko-filler.md](../patterns/ko-filler.md) |
+| 23 | rewrite | 과도한 헤징 | [ko-filler.md](../patterns/ko-filler.md) |
+| 24 | rewrite | 막연한 긍정적 결론 | [ko-filler.md](../patterns/ko-filler.md) |
+| 31 | rewrite | 결론 신호어 남용 | [ko-filler.md](../patterns/ko-filler.md) |
+| 25 | rewrite | 구조적 반복 | [ko-structure.md](../patterns/ko-structure.md) |
+| 26 | rewrite | 번역체 | [ko-structure.md](../patterns/ko-structure.md) |
+| 27 | rewrite | 수동태 남용 | [ko-structure.md](../patterns/ko-structure.md) |
+| 28 | rewrite | 불필요한 외래어 남발 | [ko-structure.md](../patterns/ko-structure.md) |
+| 30 | rewrite | 수사적 질문 단락 시작 | [ko-structure.md](../patterns/ko-structure.md) |
+| VH-1 | score/audit only | 숫자 충격 훅 | [ko-viral-hook.md](../patterns/ko-viral-hook.md) |
+| VH-2 | score/audit only | 클릭베이트 미스터리 종결 | [ko-viral-hook.md](../patterns/ko-viral-hook.md) |
+| VH-3 | score/audit only | 검증 회피 단언 | [ko-viral-hook.md](../patterns/ko-viral-hook.md) |
+| VH-4 | score/audit only | 호흡 최적화 단문 배열 | [ko-viral-hook.md](../patterns/ko-viral-hook.md) |
+| VH-5 | score/audit only | AI 인플루언서 어휘 | [ko-viral-hook.md](../patterns/ko-viral-hook.md) |
+
+## 콘텐츠 패턴
+
+### 1. 과도한 중요성 부여
+
+- Source: [ko-content.md](../patterns/ko-content.md)
+- Type: rewrite-capable pattern
+- Watch words: ~의 핵심적/중추적/획기적인 역할, ~에 있어 중대한 의의, ~의 위상을 드높이다, ~의 토대를 마련하다, 패러다임의 전환, ~라는 점에서 의의가 크다, ~의 이정표, 전환점을 맞이하다, 새로운 지평을 열다, ~의 발자취
+- Fire condition: 같은 문단에 주의 어휘가 2개 이상 등장하거나, "획기적", "전환점" 같은 강한 표현이 일상적 사건·제품에 적용된 경우.
+- Example files: [failure](../examples/01-failure-01.md) · [success](../examples/01-success-01.md)
+
+Example before:
+
+> 한국 반도체 산업의 발전은 대한민국 경제 성장에 있어 핵심적인 역할을 했으며, 이는 국가 산업의 획기적인 전환점을 의미한다. 이러한 성과는 글로벌 기술 경쟁에서 대한민국의 위상을 드높이는 데 크게 기여하였다.
+
+Example after:
+
+> 삼성전자가 64K DRAM을 만든 게 1983년이다. 40년 지난 지금 한국이 메모리 반도체 시장의 60%를 갖고 있다.
+
+### 2. 과도한 주목도/미디어 언급
+
+- Source: [ko-content.md](../patterns/ko-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 국내외 언론의 주목을 받다, ~에서 크게 보도되다, 세계적인 미디어의 관심, 활발한 활동을 이어가다
+- Fire condition: 구체적 매체명·기사 제목·날짜 없이 광범위한 주목·보도를 주장하는 경우. 매체명이 있더라도 맥락 없이 나열만 한 경우.
+- Example files: [failure](../examples/02-failure-01.md) · [success](../examples/02-success-01.md)
+
+Example before:
+
+> 그의 작품은 뉴욕타임스, BBC, 르몽드 등 세계적인 언론 매체에서 주목을 받았으며, 국내외에서 활발한 활동을 이어가고 있다.
+
+Example after:
+
+> 뉴욕타임스는 2023년 기사에서 그의 작품을 "한국 현대미술의 새로운 흐름"으로 소개했다.
+
+### 3. ~하며/~하고 피상적 분석
+
+- Source: [ko-content.md](../patterns/ko-content.md)
+- Type: rewrite-capable pattern
+- Watch words: ~을 보여주며, ~을 상징하고, ~에 기여하며, ~을 촉진하고, ~을 도모하며, ~의 장을 마련하고
+- Fire condition: 한 문장 또는 연속 절에 "~하며/~하고" 연결형이 3개 이상 나열되면서, 구체적 인과 설명 없이 나열만 한 경우.
+- Example files: [failure](../examples/03-failure-01.md) · [success](../examples/03-success-01.md)
+
+Example before:
+
+> 이 축제는 지역 문화의 다양성을 보여주며, 전통과 현대의 조화를 상징하고, 지역 경제 활성화에 기여하며, 세대 간 소통의 장을 마련하고 있다.
+
+Example after:
+
+> 축제에는 매년 약 50만 명이 방문하며, 기간 중 지역 상권 매출이 평소보다 30% 늘어난다.
+
+### 4. 홍보성/광고성 언어
+
+- Source: [ko-content.md](../patterns/ko-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 수려한, 빼어난, 풍부한, 활기찬, 역동적인, ~의 보석, ~의 자랑, ~의 메카, 감동적인, 매혹적인, 아름다운, 잊을 수 없는, 가슴 뛰는, 숨막히는, 경이로운
+- Fire condition: 같은 대상에 홍보성 형용사가 2개 이상 붙거나, "~의 보석", "숨막히는" 같은 강한 수식어가 서술문(광고 인용이 아닌 본문)에 사용된 경우.
+- Example files: [failure](../examples/04-failure-01.md) · [success](../examples/04-success-01.md)
+
+Example before:
+
+> 제주도는 수려한 자연경관과 풍부한 문화유산이 조화를 이루는 아름다운 섬으로, 대한민국 관광의 보석이라 할 수 있다. 이곳의 매혹적인 풍경은 방문객들에게 잊을 수 없는 감동을 선사한다.
+
+Example after:
+
+> 제주도에는 한라산이랑 오름이 360개 정도 있다. 연간 1,500만 명이 온다. 사람이 너무 많아서 입장 제한을 거는 곳도 늘고 있다.
+
+### 5. 모호한 출처 인용
+
+- Source: [ko-content.md](../patterns/ko-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 전문가들은, 업계 관계자에 따르면, 학계에서는, 일각에서는, 관련 연구에 따르면 (구체적 연구 없이)
+- Fire condition: 출처가 인명·기관·발표 날짜 없이 "전문가들", "업계 관계자", "관련 연구" 같은 익명 권위로만 제시된 경우.
+- Example files: [failure](../examples/05-failure-01.md) · [success](../examples/05-success-01.md)
+
+Example before:
+
+> 전문가들은 이 기술이 향후 산업 전반에 걸쳐 혁신적인 변화를 가져올 것으로 전망하고 있다. 업계 관계자에 따르면, 시장 규모는 지속적으로 성장할 것으로 예상된다.
+
+Example after:
+
+> 한국전자통신연구원(ETRI)의 2024년 보고서에 따르면, 국내 AI 반도체 시장은 2027년까지 연평균 25% 성장이 예상된다.
+
+### 6. 틀에 박힌 "과제와 전망" 섹션
+
+- Source: [ko-content.md](../patterns/ko-content.md)
+- Type: rewrite-capable pattern
+- Watch words: ~에도 불구하고 여전히 많은 과제가, 이러한 과제에도 불구하고, ~을 통해 극복해 나갈 것으로, 밝은 전망이 기대된다, 오늘날 급변하는 시대에, 최근 들어 ~이/가 급격히 변화하고 있다, ~의 시대가 도래하면서, 21세기 들어, 4차 산업혁명 시대를 맞이하여
+- Fire condition: 같은 문단이나 결론부에 모호한 과제 표현("여전히 많은 과제가")과 모호한 낙관 표현("밝은 전망이 기대된다")이 함께 등장하는 경우. 또는 도입부가 "오늘날 급변하는 ~", "4차 산업혁명 시대를 맞이하여" 같은 시대 공식으로 시작하는 경우.
+- Example files: [failure](../examples/06-failure-01.md) · [success](../examples/06-success-01.md)
+
+Example before:
+
+> 이러한 성과에도 불구하고 여전히 많은 과제가 남아 있다. 하지만 이러한 과제에도 불구하고, 지속적인 노력과 혁신을 통해 밝은 미래를 기대할 수 있다.
+
+Example after:
+
+> 2023년 감사원 보고서는 인력 부족과 예산 집행률 저조를 주요 문제로 지적했다. 시는 2024년 예산을 15% 늘리고 전문 인력 30명을 채용할 계획이다.
+
+## 언어/문법 패턴
+
+### 7. AI 특유 어휘 남발
+
+- Source: [ko-language.md](../patterns/ko-language.md)
+- Type: rewrite-capable pattern
+- Watch words: 다양한, 활발한, 주목할 만한, 혁신적인, 체계적인, 지속적인, 효과적인, 적극적인, 심층적인, 유기적인, 종합적인, 선도적인, 아울러, 나아가, 이를 통해, 이러한 맥락에서, 도모하다, 촉진하다, 극대화하다
+- Fire condition: 한 문단에 고빈도 AI 어휘가 3개 이상 등장하는 경우.
+- Example files: [failure](../examples/07-failure-01.md) · [success](../examples/07-success-01.md)
+
+Example before:
+
+> 아울러, 다양한 혁신적인 기술들이 활발하게 개발되고 있으며, 이를 통해 체계적이고 효과적인 솔루션을 제공하고 있다. 나아가, 이러한 지속적인 노력은 주목할 만한 성과를 거두고 있다.
+
+Example after:
+
+> 올해 나온 기술 중에는 배터리 수명을 20% 늘린 전력 관리 칩과, 처리 속도가 기존보다 두 배 빠른 NPU가 있다.
+
+### 8. ~적(的) 접미사 남발
+
+- Source: [ko-language.md](../patterns/ko-language.md)
+- Type: rewrite-capable pattern
+- Watch words: 혁신적, 체계적, 효과적, 효율적, 선도적, 진취적, 종합적, 핵심적, 전략적, 실질적, 근본적, 획기적
+- Fire condition: 한 문장에 "~적" 형용사가 3개 이상 등장하거나, 연속 2문장에 걸쳐 4개 이상 사용된 경우.
+- Example files: [failure](../examples/08-failure-01.md) · [success](../examples/08-success-01.md)
+
+Example before:
+
+> 혁신적이고 체계적인 접근 방식을 통해, 효과적이고 효율적인 결과를 도출하며, 선도적이고 진취적인 자세로 종합적인 발전을 추구하고 있다.
+
+Example after:
+
+> 팀은 기존 프로세스를 단순화하고, 불필요한 승인 단계를 빼서 배포 시간을 절반으로 줄였다.
+
+### 9. 부정 병렬구조
+
+- Source: [ko-language.md](../patterns/ko-language.md)
+- Type: rewrite-capable pattern
+- Watch words: ~에 그치지 않고, ~뿐만 아니라 ~도, 비단 ~뿐 아니라, ~을 넘어
+- Fire condition: 같은 문서에 "~뿐만 아니라", "~에 그치지 않고" 등의 부정 병렬 구조가 2회 이상 등장하거나, 긍정 서술만으로 더 간결하게 표현할 수 있는 곳에 단일 사용된 경우.
+- Example files: [failure](../examples/09-failure-01.md) · [success](../examples/09-success-01.md)
+
+Example before:
+
+> 이것은 단순한 기술 발전에 그치지 않고, 우리 사회 전반에 걸친 근본적인 변화를 의미한다. 이는 비단 경제적 측면뿐만 아니라, 사회적·문화적 측면에서도 중대한 함의를 지닌다.
+
+Example after:
+
+> 이 기술은 처음에 제조 공정에 적용됐고, 이후 물류와 고객 서비스에도 쓰이기 시작했다.
+
+### 10. 3의 법칙 남발
+
+- Source: [ko-language.md](../patterns/ko-language.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 같은 문서에 3개 항목 나열이 2회 이상 등장하거나, 셋으로 묶은 근거가 자의적이어서 다른 개수도 동등하게 성립하는 경우.
+- Example files: [failure](../examples/10-failure-01.md) · [success](../examples/10-success-01.md)
+
+Example before:
+
+> 이 프로그램은 창의성, 혁신성, 그리고 지속가능성을 추구합니다. 참가자들은 영감, 통찰, 그리고 실질적인 경험을 얻을 수 있습니다.
+
+Example after:
+
+> 이 프로그램은 실무 프로젝트 중심으로 운영되며, 참가자들은 8주간 실제 제품 개발에 참여한다.
+
+### 11. 유의어 순환
+
+- Source: [ko-language.md](../patterns/ko-language.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 같은 문단에서 동일 대상이 3개 이상의 다른 명칭·동의어로 지칭되는 경우.
+- Example files: [failure](../examples/11-failure-01.md) · [success](../examples/11-success-01.md)
+
+Example before:
+
+> 이 도시는 많은 관광객을 끌어모으고 있다. 이 지역은 다양한 문화 행사로 유명하다. 해당 지자체는 관광 인프라를 확충 중이다. 이곳은 연간 방문객이 100만 명에 달한다.
+
+Example after:
+
+> 이 도시에는 연간 100만 명이 방문한다. 문화 행사가 많고, 시는 관광 인프라에 500억 원을 투자하고 있다.
+
+### 12. ~에 있어서/~함에 있어 장황한 조사 사용
+
+- Source: [ko-language.md](../patterns/ko-language.md)
+- Type: rewrite-capable pattern
+- Watch words: ~에 있어서, ~함에 있어, ~(으)로서, ~(이)라는 점에서, ~의 관점에서 볼 때
+- Fire condition: 같은 문단에 장황한 조사 표현이 2개 이상 등장하거나, "~에서"로 충분한 곳에 "~에 있어서"가 사용된 경우.
+- Example files: [failure](../examples/12-failure-01.md) · [success](../examples/12-success-01.md)
+
+Example before:
+
+> 교육에 있어서 가장 중요한 것은 학생들의 참여를 이끌어 내는 것이며, 이를 달성함에 있어 교사의 역할이 핵심적이다. 학습 효과를 극대화함에 있어서는 개별화된 접근이 필요하다.
+
+Example after:
+
+> 교육에서 가장 중요한 것은 학생 참여다. 교사들은 학생별로 다른 과제를 내는 방식을 시도하고 있다.
+
+### 32. "보다" 비교부사 남용
+
+- Source: [ko-language.md](../patterns/ko-language.md)
+- Type: rewrite-capable pattern
+- Watch words: 보다 + 형용사/부사 형태 — "보다 구체적인", "보다 효율적인", "보다 심도 있는", "보다 다양한", "보다 명확한", "보다 적극적인", "보다 체계적인", "보다 효과적인", "보다 신중한", "보다 폭넓은"
+- Fire condition: 한 문서 안에 "보다 [형용사/부사 + 한]" 형태가 2회 이상 등장. 또는 한 단락 안에 "보다 X" 표현이 1회 등장하면서 같은 단락에 다른 격식체 마커("~을 위한", "~에 있어서", "~사료됩니다", "~할 것으로 보입니다")가 함께 있는 경우.
+- Example files: [failure](../examples/32-failure-01.md) · [success](../examples/32-success-01.md)
+
+Example before:
+
+> 프로젝트 일정과 관련하여 보다 구체적인 마일스톤 설정이 필요할 것으로 보입니다. 예산 배분에 있어서도 보다 효율적인 운영 방안에 대한 검토가 이루어져야 할 것으로 사료됩니다. 가능하시다면 다음 주 중 보다 심도 있는 논의를 진행하는 것이 어떨까 싶습니다.
+
+Example after:
+
+> 프로젝트 일정에 더 구체적인 마일스톤이 있어야 할 것 같습니다. 예산 운영 방안도 한 번 점검이 필요해 보입니다. 다음 주에 자세히 이야기 나누면 좋겠습니다.
+
+## 스타일 패턴
+
+### 13. 과도한 연결 표현
+
+- Source: [ko-style.md](../patterns/ko-style.md)
+- Type: rewrite-capable pattern
+- Watch words: 이를 통해, 이러한 점에서, 이러한 맥락에서, 한편, 또한, 더불어, 아울러, 이에 따라, 이와 관련하여, 이를 바탕으로
+- Fire condition: 연속 3문장 이상에서 매 문장 앞에 연결 표현이 붙는 경우, 또는 같은 문단에 주의 어휘가 3개 이상 등장하는 경우.
+- Example files: [failure](../examples/13-failure-01.md) · [success](../examples/13-success-01.md)
+
+Example before:
+
+> 이를 통해 기업의 경쟁력이 강화되었다. 이러한 점에서 이번 정책은 큰 의미를 지닌다. 한편, 일부에서는 우려의 목소리도 나오고 있다. 이러한 맥락에서 향후 정책 방향에 대한 논의가 필요하다.
+
+Example after:
+
+> 이번 정책 이후 수출 기업 10곳 중 7곳이 영업이익이 늘었다. 다만 중소기업연합회는 원자재 가격 상승 부담이 여전하다고 밝혔다.
+
+### 14. 볼드체 남발
+
+- Source: [ko-style.md](../patterns/ko-style.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 한 문단에 볼드 처리된 단어/구가 3개 이상이거나, 문서 전체에 5개 이상인 경우.
+- Example files: [failure](../examples/14-failure-01.md) · [success](../examples/14-success-01.md)
+
+Example before:
+
+> **OKR(목표 및 핵심 결과)**, **KPI(핵심 성과 지표)**, 그리고 **BSC(균형 성과표)** 등 **다양한 성과 관리 프레임워크**를 통합적으로 활용합니다.
+
+Example after:
+
+> OKR, KPI, BSC 등 성과 관리 도구를 함께 활용한다.
+
+### 15. 인라인 헤더 목록
+
+- Source: [ko-style.md](../patterns/ko-style.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 같은 목록에 "**레이블:** 설명" 형식의 항목이 2개 이상인 경우.
+- Example files: [failure](../examples/15-failure-01.md) · [success](../examples/15-success-01.md)
+
+Example before:
+
+> - **사용자 경험:** 새로운 인터페이스로 사용자 경험이 크게 개선되었습니다.
+> - **성능:** 알고리즘 최적화를 통해 성능이 향상되었습니다.
+> - **보안:** 종단간 암호화로 보안이 강화되었습니다.
+
+Example after:
+
+> 이번 업데이트는 인터페이스를 개선하고, 알고리즘 최적화로 속도를 높였으며, 종단간 암호화를 추가했다.
+
+### 16. ~고 있다 진행형 남발
+
+- Source: [ko-style.md](../patterns/ko-style.md)
+- Type: rewrite-capable pattern
+- Watch words: ~하고 있다, ~해 나가고 있다, ~을 추진하고 있다, ~을 이어가고 있다, ~에 박차를 가하고 있다
+- Fire condition: 같은 문단에서 "~고 있다" 계열 진행형이 3회 이상 사용된 경우, 또는 연속 2문장이 모두 "~고 있다"로 끝나는 경우.
+- Example files: [failure](../examples/16-failure-01.md) · [success](../examples/16-success-01.md)
+
+Example before:
+
+> 기업들은 새로운 시장을 개척하고 있으며, 기술 혁신을 추진하고 있고, 글로벌 파트너십을 확대하고 있다. 이를 통해 지속적인 성장을 이루어 나가고 있다.
+
+Example after:
+
+> 기업들은 올해 동남아 시장에 진출했고, 내년에는 유럽 진출을 계획 중이다.
+
+### 17. 이모지
+
+- Source: [ko-style.md](../patterns/ko-style.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 전문적·학술적·편집 텍스트에 이모지가 1개라도 등장하는 경우.
+- Example files: [failure](../examples/17-failure-01.md) · [success](../examples/17-success-01.md)
+
+Example before:
+
+> 🚀 **출시 단계:** 제품은 3분기에 출시됩니다
+> 💡 **핵심 인사이트:** 사용자는 단순함을 선호합니다
+> ✅ **다음 단계:** 후속 미팅을 잡으세요
+
+Example after:
+
+> 제품은 3분기에 출시된다. 사용자 조사 결과 단순한 인터페이스를 선호했다. 다음 단계는 후속 미팅이다.
+
+### 18. 과도한 한자어/공식어 사용
+
+- Source: [ko-style.md](../patterns/ko-style.md)
+- Type: rewrite-capable pattern
+- Watch words: 도모하다, 기하다, 수립하다, 강구하다, 추진하다, 이행하다, 상기, 전술한, 본 사업, 관계 기관, 유기적, 복리 증진
+- Fire condition: 같은 문단에 공식어·관료적 한자어가 3개 이상 등장하거나, "본 사업", "전술한", "상기" 같은 공문서 전용 표현이 일반 산문에 사용된 경우.
+- Example files: [failure](../examples/18-failure-01.md) · [success](../examples/18-success-01.md)
+
+Example before:
+
+> 본 사업은 지역 경제 활성화 및 주민 복리 증진을 도모하기 위한 것으로, 관계 기관 간 유기적 협력 체계를 구축하여 효율적인 사업 추진을 기하고자 한다.
+
+Example after:
+
+> 이 사업은 지역 경제를 살리고 주민 생활을 개선하려는 것이다. 시청과 구청이 함께 진행한다.
+
+## 소통 패턴
+
+### 19. 챗봇 표현
+
+- Source: [ko-communication.md](../patterns/ko-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: 도움이 되셨으면 좋겠습니다, 궁금한 점이 있으시면 말씀해 주세요, ~에 대해 알아보겠습니다, ~를 정리해 드리겠습니다, 더 자세한 내용이 필요하시면
+- Fire condition: 실시간 대화가 아닌 콘텐츠(기사, 보고서, 문서)에 챗봇 대화체 표현이 1개라도 등장하는 경우.
+- Example files: [failure](../examples/19-failure-01.md) · [success](../examples/19-success-01.md)
+
+Example before:
+
+> 프랑스 혁명에 대해 정리해 드리겠습니다. 도움이 되셨으면 좋겠습니다! 더 자세한 내용이 필요하시면 말씀해 주세요.
+
+Example after:
+
+> 프랑스 혁명은 1789년 재정 위기와 식량 부족으로 시작되었다.
+
+### 20. 학습 데이터 기한 면책
+
+- Source: [ko-communication.md](../patterns/ko-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: ~년 기준으로, 최신 정보와 다를 수 있습니다, 구체적인 정보는 제한적이나, 확인 가능한 자료에 따르면
+- Fire condition: 편집·보도·분석 콘텐츠에 AI 학습 데이터 한계를 암시하는 자기 참조 또는 면책 표현이 1개라도 등장하는 경우.
+- Example files: [failure](../examples/20-failure-01.md) · [success](../examples/20-success-01.md)
+
+Example before:
+
+> 이 회사의 설립 배경에 대한 구체적인 정보는 제한적이나, 확인 가능한 자료에 따르면 1990년대에 설립된 것으로 보입니다.
+
+Example after:
+
+> 이 회사는 1994년에 설립되었다(사업자등록 기준).
+
+### 21. 아첨하는 말투
+
+- Source: [ko-communication.md](../patterns/ko-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 본론 앞에 아첨·비위 맞추기 표현이 1개라도 등장하는 경우.
+- Example files: [failure](../examples/21-failure-01.md) · [success](../examples/21-success-01.md)
+
+Example before:
+
+> 좋은 질문이십니다! 정확하게 짚어주셨는데요, 이 주제는 정말 중요합니다. 경제적 요인에 대한 지적이 정말 탁월하십니다.
+
+Example after:
+
+> 말씀하신 경제적 요인이 여기서 중요하다.
+
+### 29. 거짓 뉘앙스 (소급적 재해석)
+
+- Source: [ko-communication.md](../patterns/ko-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: 사실 좀 더 미묘한 문제인데, 정확하게 말하자면, 단순하게 말하긴 어렵지만, 물론 현실은 더 복잡한데, 보다 정확히 말하면, 공정하게 보자면, 좀 더 깊이 들어가면
+- Fire condition: 앞선 주장을 새로운 증거·관점 없이 '미묘하다'는 프레이밍으로 바꿔 말하는 경우.
+
+Example before:
+
+> 재택근무는 생산성을 높입니다. 물론 이건 좀 더 미묘한 문제인데요, 재택근무가 특정 상황에서는 생산성을 높일 수 있지만 다른 상황에서는 어려움을 줄 수도 있고, 순효과는 조직 문화와 개인 업무 스타일에 따라 달라집니다.
+
+Example after:
+
+> 재택근무는 집중 작업에서 생산성을 높인다 — 스탠퍼드 연구에서 콜센터 직원 기준 13% 향상을 확인했다. 다만 즉흥적 협업에는 불리한데, 마이크로소프트 2021년 내부 데이터에 따르면 전면 재택 이후 팀 간 소통이 25% 줄었다.
+
+## 채움/완화 패턴
+
+### 22. 채움 표현
+
+- Source: [ko-filler.md](../patterns/ko-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 같은 문단에 채움 표현이 2개 이상 등장하거나, 삭제해도 의미가 전혀 변하지 않는 채움 표현이 단독으로 사용된 경우.
+- Example files: [failure](../examples/22-failure-01.md) · [success](../examples/22-success-01.md)
+
+Example transformations:
+
+> - "이 목표를 달성하기 위해서는" → "이 목표를 이루려면"
+> - "~라는 사실에 기인하여" → "~때문에"
+> - "현 시점에서 볼 때" → "지금"
+> - "~하는 경우에 한하여" → "~하면"
+> - "~할 수 있는 능력을 보유하고 있다" → "~할 수 있다"
+> - "주목할 만한 점은 ~라는 것이다" → 직접 서술
+
+### 23. 과도한 헤징
+
+- Source: [ko-filler.md](../patterns/ko-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 하나의 주장에 한정·완화 표현("~수도 있다", "~것으로 보인다", "어느 정도", "일정 부분")이 3개 이상 중첩되거나, 반박 가능한 주장이 전혀 없을 정도로 헤징된 경우.
+- Example files: [failure](../examples/23-failure-01.md) · [success](../examples/23-success-01.md)
+
+Example before:
+
+> 이 정책이 어느 정도의 효과를 가져올 수 있을 것으로 판단될 수도 있다는 점에서 일정 부분 긍정적인 측면이 있는 것으로 보입니다.
+
+Example after:
+
+> 이 정책은 효과가 있을 수 있다.
+
+### 24. 막연한 긍정적 결론
+
+- Source: [ko-filler.md](../patterns/ko-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 같은 문단이나 결론부에 막연한 낙관 표현("밝은 미래가 기대된다", "새로운 도약", "흥미진진한 여정")이 2개 이상 등장하거나, 구체적 주장 없이 낙관 표현만으로 구성된 마무리 문장이 있는 경우.
+- Example files: [failure](../examples/24-failure-01.md) · [success](../examples/24-success-01.md)
+
+Example before:
+
+> 앞으로 더욱 밝은 미래가 기대된다. 지속적인 발전과 혁신을 통해 새로운 도약을 이룰 것으로 전망된다. 흥미진진한 여정이 우리 앞에 펼쳐져 있다.
+
+Example after:
+
+> 회사는 내년에 매장 두 곳을 추가로 열 계획이다.
+
+### 31. 결론 신호어 남용
+
+- Source: [ko-filler.md](../patterns/ko-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: 결론적으로, 결국, 궁극적으로, 요컨대, 종합하면, 종합해보면, 정리하면, 마지막으로
+- Fire condition: 글의 마지막 문단(또는 마지막에서 두 번째 문단) 첫 문장이 위 신호어 중 하나로 시작. 또는 같은 문서에 결론 신호어가 2회 이상 등장.
+- Example files: [failure](../examples/31-failure-01.md) · [success](../examples/31-success-01.md)
+
+Example before:
+
+> 결론적으로, 디지털 노마드 라이프스타일은 일시적인 유행이 아닌, 우리 사회 전반에 걸쳐 지속적으로 자리잡아갈 새로운 표준으로 자리매김하고 있다.
+
+Example after:
+
+> 디지털 노마드는 더 이상 유행이 아니다. 일하는 방식 하나가 바뀌었고, 사람들은 그 위에 새 일상을 짓고 있다.
+
+## 구조 패턴
+
+### 25. 구조적 반복
+
+- Source: [ko-structure.md](../patterns/ko-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 연속 3개 이상의 단락이 동일한 구조적 틀을 반복할 때. 예: 모든 단락이 "일반 진술 → 구체 사례/수치 → 의의/전망"으로 끝나는 경우. 또는 모든 단락이 "주제문 → 부연 → 요약" 동일 패턴.
+- Example files: [failure](../examples/25-failure-01.md) · [success](../examples/25-success-01.md)
+
+Example before:
+
+> 한국의 반도체 산업은 1980년대부터 본격적으로 성장했다. 삼성전자는 1983년 64K DRAM 개발에 성공했으며, 이후 세계 시장에서 두각을 나타냈다. 이러한 성과는 한국 경제 발전의 중요한 토대가 되었다.
+>
+> 한국의 자동차 산업도 비약적인 발전을 이루었다. 현대자동차는 1976년 포니를 출시하며 국산 자동차 시대를 열었고, 현재 글로벌 5위권의 자동차 제조사로 성장했다. 이는 한국 제조업의 경쟁력을 보여주는 대표적인 사례이다.
+>
+> 한국의 조선 산업 역시 세계적인 수준에 도달했다. 현대중공업은 1972년 설립 이후 꾸준히 기술력을 축적했으며, 세계 최대 조선소로 자리매김했다. 이러한 발전은 한국의 산업 다각화에 크게 기여하였다.
+
+Example after:
+
+> 한국 반도체의 시작은 의외로 단순하다. 1983년, 삼성전자가 64K DRAM을 만들었다. 40년 뒤인 지금, 메모리 반도체 세계 시장의 60%가 한국 것이다.
+>
+> 자동차는 좀 다른 길을 걸었다. 현대차 포니가 1976년에 나왔을 때 아무도 진지하게 안 봤다. 솔직히 품질이 안 좋았으니까. 근데 지금은 글로벌 5위다.
+>
+> 조선은? 이건 거의 기적에 가깝다. 바다도 안 보이는 울산 벌판에 1972년 조선소를 세웠는데, 배 한 척 안 만들어 본 사람들이 시작했다.
+
+### 26. 번역체
+
+- Source: [ko-structure.md](../patterns/ko-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: ~것은 사실이다, ~라고 할 수 있다, ~하는 것이 가능하다, ~에 의해 ~되다, ~에 대해 ~하다 (영어 "about"의 직역), ~하는 경향이 있다 (tend to), ~에 기반하여 (based on), ~를 통해서 (through), 그것은 ~이다 (It is ~)
+- Fire condition: 한 문단 내에 번역체 표현이 2개 이상 등장할 때. 단독 1회 사용은 허용 — 정상적인 한국어에서도 간혹 나타나는 표현이므로.
+- Example files: [failure](../examples/26-failure-01.md) · [success](../examples/26-success-01.md)
+
+Example before:
+
+> 이 기술이 유망하다는 것은 사실이다. 이 기술에 의해 많은 문제가 해결될 수 있다고 할 수 있다. 이 기술에 대해 관심을 갖는 것이 필요하며, 이 기술을 활용하는 것이 가능하다면 큰 성과를 거두는 것이 가능할 것이다.
+
+Example after:
+
+> 이 기술은 유망하다. 실제로 A사는 이걸로 불량률을 30% 줄였다. 관심 가질 만하고, 쓸 수 있으면 써보는 게 좋다.
+
+### 27. 수동태 남용
+
+- Source: [ko-structure.md](../patterns/ko-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: ~되어지다, ~되어질 수 있다, ~되어져야 한다, ~되어지고 있다, ~되어진, ~에 의해 ~되다 (행위자가 분명한 경우)
+- Fire condition: 이중 피동("~되어지다" 계열) 1회 이상 사용, 또는 "~에 의해 ~되다" 수동 구문이 2회 이상 반복될 때.
+- Example files: [failure](../examples/27-failure-01.md) · [success](../examples/27-success-01.md)
+
+Example before:
+
+> 이 정책은 정부에 의해 시행되어지고 있다. 많은 변화가 이루어져야 한다고 판단되어진다. 국민의 의견이 반영되어져야 하며, 새로운 방안이 마련되어져야 할 것이다.
+
+Example after:
+
+> 정부가 이 정책을 시행하고 있다. 바꿀 게 많다. 국민 의견을 반영해야 하고, 새 방안도 필요하다.
+
+### 28. 불필요한 외래어 남발
+
+- Source: [ko-structure.md](../patterns/ko-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: 인사이트, 임팩트, 레버리지, 이노베이션, 솔루션, 퍼포먼스, 거버넌스, 컨센서스, 시너지, 모멘텀, 마일스톤, 트리거, 매니징, 스케일업, 온보딩, 피드백 루프, 페인 포인트, 디시전 메이킹
+- Fire condition: 한 문단 내에 한국어 대안이 있는 외래어가 3개 이상 등장할 때. 업계에서 정착된 전문 용어(예: 마케팅, 브랜딩)는 제외.
+- Example files: [failure](../examples/28-failure-01.md) · [success](../examples/28-success-01.md)
+
+Example before:
+
+> 이번 프로젝트의 인사이트를 레버리지하여 시너지를 극대화하고, 지속 가능한 모멘텀을 확보하는 것이 핵심 마일스톤이다. 팀의 퍼포먼스를 높이기 위해 온보딩 프로세스를 개선하고, 페인 포인트를 해결하는 솔루션을 도입해야 한다.
+
+Example after:
+
+> 이번 프로젝트에서 얻은 교훈을 활용해서 협력 효과를 높이고, 추진력을 유지하는 것이 핵심 목표다. 팀 성과를 높이려면 신규 합류자 적응 과정을 개선하고, 현장의 문제를 해결할 방법을 찾아야 한다.
+
+### 30. 수사적 질문 단락 시작
+
+- Source: [ko-structure.md](../patterns/ko-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 단락의 첫 문장이 의문형(`-까?`, `-는가?`, `-일까?`, `-는지?`)이고, 그 질문에 대한 답이 같은 단락 안에서 즉시 제시되는 경우. 또는 문서 전체에 단락 첫 문장으로 등장하는 수사적 질문이 2회 이상.
+- Example files: [failure](../examples/30-failure-01.md) · [success](../examples/30-success-01.md)
+
+Example before:
+
+> 그렇다면 한국 커피 문화는 왜 이렇게 빠르게 성장했을까? 답은 의외로 단순하다. 카페가 단순한 음료 판매 공간을 넘어 사회적 거점으로 자리잡았기 때문이다.
+>
+> 그렇다면 앞으로의 전망은 어떨까? 전문가들은 이 트렌드가 당분간 지속될 것으로 보고 있다.
+
+Example after:
+
+> 한국 커피 문화가 이렇게 빨리 자란 이유는 의외로 단순하다. 카페가 음료를 파는 곳을 넘어 사람들이 모이는 거점이 됐다.
+>
+> 이 흐름은 당분간 이어질 것 같다. 전문가들도 같은 의견이다.
+
+## 바이럴 훅 패턴 (score-only)
+
+### Viral 1. 숫자 충격 훅
+
+- Source: [ko-viral-hook.md](../patterns/ko-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: 단 N일/시간/주 만에, 단 N개월 만에, N억/N만 명/N만 개/N만 회, 0원으로 N원, 단돈 N원에, N% 폭증, N배 성장
+- Fire condition: 단언에 충격적인 숫자(시간·규모·비율)가 등장하지만 같은 글 안에 출처·검증 경로가 없는 경우.
+
+Detection example:
+
+> 단 60일 만에 별 25만 개.
+> 0원으로 100억 매출.
+
+### Viral 2. 클릭베이트 미스터리 종결
+
+- Source: [ko-viral-hook.md](../patterns/ko-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: ~이유가 뭘까, ~이유는 뭐였을까, ~이게 가능할까요, ~궁금하지 않나요, ~정말 충격이지 않나요, ~왜일까
+- Fire condition: 글의 **마지막 문장**이 답을 주지 않는 수사적 질문이고, 본문이 그 질문에 충분한 답을 제공하지 않는 경우.
+
+Detection example:
+
+> 광고 한 번 안 하고 전 세계 개발자들이 미친 듯이 달려든 이유가 뭘까.
+> 이게 정말 가능한 일일까요?
+
+### Viral 3. 검증 회피 단언
+
+- Source: [ko-viral-hook.md](../patterns/ko-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: 역사상 처음, 역사상 이런 X은 없었다, 전 세계가 주목, 역대 최고, 유일무이한, ~에 따르면 (출처 명시 없이), ~로 알려졌다 (주체 없음)
+- Fire condition: "역사상 X", "전 세계 Y", "역대 최고 Z" 같은 절대 범위/순위 단언이 출처·근거 없이 등장. 같은 글에 검증 가능한 다른 단서(링크·인용·스크린샷)도 부재.
+
+Detection example:
+
+> GitHub 역사상 이런 속도는 없었다.
+> 전 세계 개발자들이 미친 듯이 달려든
+
+### Viral 4. 호흡 최적화 단문 배열
+
+- Source: [ko-viral-hook.md](../patterns/ko-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: (구조적 패턴 — 어휘가 아니라 형태로 판단)
+- Fire condition: 글 전체가 거의 모두 한 문장 = 한 줄 = 한 단락 형식이고, 4문장 이상 연속이며, 평균 문장 길이가 30자 미만인 경우. 단문이 한두 개만 섞인 경우는 발화하지 않는다.
+
+Detection example:
+
+> GitHub 역사상 이런 속도는 없었다.
+>
+> 단 60일 만에 별 25만 개.
+>
+> OpenClaw라는 도구가 세운 기록임.
+>
+> 광고 한 번 안 하고 전 세계 개발자들이 미친 듯이 달려든 이유가 뭘까.
+> 
+> (4문장 모두 1줄 단문, 줄바꿈으로 분리, 평균 25자 내외 → 발화)
+
+### Viral 5. AI 인플루언서 어휘
+
+- Source: [ko-viral-hook.md](../patterns/ko-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: 미친 듯이, 미쳤다, 역대급, 다 뒤집어졌다, 판이 바뀌었다, 이거 모르면 손해, 안 보면 후회, 충격적이지 않나요, 게임 체인저, 다들 난리난, 진짜 미쳤네, 이거 진심임
+- Fire condition:
+
+> - 한 글에 1개 등장: Low
+> - 2개 등장: Medium
+> - 3개 이상: High
+
+Detection example:
+
+> 전 세계 개발자들이 미친 듯이 달려든
+> 역대급 도구가 등장했다

--- a/docs/PATTERNS-ZH.md
+++ b/docs/PATTERNS-ZH.md
@@ -1,0 +1,616 @@
+# Chinese Pattern Reference
+
+This page expands the Chinese pattern packs into a browsable reference. It is generated from `patterns/zh-*.md`, so the numbers, names, watch words, fire conditions, and examples mirror the source pattern files.
+
+- Rewrite-capable patterns: 31
+- Score/audit-only viral-hook patterns: 5
+- Main selector: [PATTERNS.md](PATTERNS.md)
+
+## Pattern Index
+
+| # | Type | Pattern | Source |
+|---|------|---------|--------|
+| 1 | rewrite | 过度强调重要性 | [zh-content.md](../patterns/zh-content.md) |
+| 2 | rewrite | 过度强调关注度/媒体报道 | [zh-content.md](../patterns/zh-content.md) |
+| 3 | rewrite | 表面化的"～着"/"～了"连缀分析 | [zh-content.md](../patterns/zh-content.md) |
+| 4 | rewrite | 宣传性/广告性语言 | [zh-content.md](../patterns/zh-content.md) |
+| 5 | rewrite | 模糊出处引用 | [zh-content.md](../patterns/zh-content.md) |
+| 6 | rewrite | 套路化的"挑战与展望" | [zh-content.md](../patterns/zh-content.md) |
+| 7 | rewrite | AI高频词汇堆砌 | [zh-language.md](../patterns/zh-language.md) |
+| 8 | rewrite | 四字成语/四字格过度使用 | [zh-language.md](../patterns/zh-language.md) |
+| 9 | rewrite | "的地得"和书面语语法过度规范化 | [zh-language.md](../patterns/zh-language.md) |
+| 10 | rewrite | 排比句过度使用 | [zh-language.md](../patterns/zh-language.md) |
+| 11 | rewrite | 同义词循环替换 | [zh-language.md](../patterns/zh-language.md) |
+| 12 | rewrite | 冗长的介词结构 | [zh-language.md](../patterns/zh-language.md) |
+| 13 | rewrite | 过度使用连接词/过渡词 | [zh-style.md](../patterns/zh-style.md) |
+| 14 | rewrite | 加粗滥用 | [zh-style.md](../patterns/zh-style.md) |
+| 15 | rewrite | 内联标题列表 | [zh-style.md](../patterns/zh-style.md) |
+| 16 | rewrite | "～地"副词修饰过度 | [zh-style.md](../patterns/zh-style.md) |
+| 17 | rewrite | 表情符号 | [zh-style.md](../patterns/zh-style.md) |
+| 18 | rewrite | 过度使用书面/公文体 | [zh-style.md](../patterns/zh-style.md) |
+| 19 | rewrite | 聊天机器人痕迹 | [zh-communication.md](../patterns/zh-communication.md) |
+| 20 | rewrite | 训练数据截止声明 | [zh-communication.md](../patterns/zh-communication.md) |
+| 21 | rewrite | 谄媚/讨好语气 | [zh-communication.md](../patterns/zh-communication.md) |
+| 29 | rewrite | 虚假细化（事后重新表述） | [zh-communication.md](../patterns/zh-communication.md) |
+| 22 | rewrite | 填充表达 | [zh-filler.md](../patterns/zh-filler.md) |
+| 23 | rewrite | 过度弱化/套层对冲 | [zh-filler.md](../patterns/zh-filler.md) |
+| 24 | rewrite | 空洞的积极结尾 | [zh-filler.md](../patterns/zh-filler.md) |
+| 31 | rewrite | 结论信号词滥用 | [zh-filler.md](../patterns/zh-filler.md) |
+| 25 | rewrite | 结构性重复 | [zh-structure.md](../patterns/zh-structure.md) |
+| 26 | rewrite | 翻译腔/欧化语法 | [zh-structure.md](../patterns/zh-structure.md) |
+| 27 | rewrite | 被字句/被动语态过度使用 | [zh-structure.md](../patterns/zh-structure.md) |
+| 28 | rewrite | 总分总结构过度使用 | [zh-structure.md](../patterns/zh-structure.md) |
+| 30 | rewrite | 修辞性疑问句段首 | [zh-structure.md](../patterns/zh-structure.md) |
+| VH-1 | score/audit only | 数字震撼钩子 | [zh-viral-hook.md](../patterns/zh-viral-hook.md) |
+| VH-2 | score/audit only | 标题党悬念结尾 | [zh-viral-hook.md](../patterns/zh-viral-hook.md) |
+| VH-3 | score/audit only | 回避验证的权威断言 | [zh-viral-hook.md](../patterns/zh-viral-hook.md) |
+| VH-4 | score/audit only | 呼吸优化短句堆叠 | [zh-viral-hook.md](../patterns/zh-viral-hook.md) |
+| VH-5 | score/audit only | 夸张互动词汇 | [zh-viral-hook.md](../patterns/zh-viral-hook.md) |
+
+## 内容模式
+
+### 1. 过度强调重要性
+
+- Source: [zh-content.md](../patterns/zh-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 具有里程碑式的意义、划时代的、开创性的、革命性的、历史性的突破、标志着～的到来、具有深远意义、奠定了坚实基础、开辟了新纪元、谱写了新篇章、掀开了新的一页、具有划时代的意义
+- Fire condition: 同一段落中出现2个以上高频词汇，或"划时代"、"里程碑"等强调词被用于普通事件/产品。
+
+Example before:
+
+> 我国人工智能产业的发展具有里程碑式的意义，标志着新一代科技革命的到来。这一划时代的成就为我国在全球科技竞争中奠定了坚实基础，谱写了科技强国建设的新篇章。
+
+Example after:
+
+> 2024年国内AI企业拿到的融资总额超过800亿元，比上一年翻了一番。其中大模型赛道占了六成。
+
+### 2. 过度强调关注度/媒体报道
+
+- Source: [zh-content.md](../patterns/zh-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 引起了社会各界的广泛关注、受到了国内外媒体的高度关注、获得了业界的一致好评、在国际上产生了深远影响、赢得了广泛赞誉
+- Fire condition: 声称获得广泛关注/报道/好评，但未提供具体媒体名称、文章标题或日期。
+
+Example before:
+
+> 该项目引起了社会各界的广泛关注，受到了国内外媒体的高度关注和一致好评，在国际上产生了深远影响。
+
+Example after:
+
+> 《人民日报》2024年3月的报道称该项目"首次实现了量子纠错的工程化应用"。Nature同月刊发了评论文章。
+
+### 3. 表面化的"～着"/"～了"连缀分析
+
+- Source: [zh-content.md](../patterns/zh-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 展现了、彰显了、体现了、反映了、推动了、促进了、凸显了、见证了、标志着、意味着、象征着
+- Fire condition: 同一句或连续分句中出现3个以上此类动词，且没有具体因果解释。
+
+Example before:
+
+> 这项活动展现了中华文化的深厚底蕴，彰显了文化自信的力量，体现了传统与现代的完美融合，推动了文化产业的蓬勃发展。
+
+Example after:
+
+> 活动期间周边商户营业额增长了40%。最受欢迎的是非遗手工体验摊位，三天接待了两万多人。
+
+### 4. 宣传性/广告性语言
+
+- Source: [zh-content.md](../patterns/zh-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 美丽的、壮丽的、丰富多彩的、独具特色的、底蕴深厚的、享有盛誉的、闻名遐迩的、令人叹为观止的、令人流连忘返的、如诗如画的、人间仙境、～的瑰宝、～的明珠
+- Fire condition: 同一对象出现2个以上宣传性形容词，或在叙述性本文（非广告引文）中使用"人间仙境"、"令人叹为观止"等强修饰词。
+
+Example before:
+
+> 张家界以其壮丽的自然风光和独具特色的地貌闻名遐迩，是一处令人叹为观止的人间仙境，被誉为大自然的瑰宝。这里如诗如画的景色让人流连忘返。
+
+Example after:
+
+> 张家界的砂岩柱地貌在全球范围内罕见，核心景区有3000多根石柱。2023年接待游客超过3500万人次，门票收入约28亿元。
+
+### 5. 模糊出处引用
+
+- Source: [zh-content.md](../patterns/zh-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 专家表示、业内人士指出、有关研究表明、据了解、相关数据显示、有学者认为、有分析人士认为
+- Fire condition: 引用权威但未提供姓名、机构、发表日期，仅以"专家"、"业内人士"、"有关研究"等匿名表述呈现。
+
+Example before:
+
+> 专家表示，这项技术将在未来五年内彻底改变行业格局。业内人士指出，市场规模有望持续快速增长。
+
+Example after:
+
+> 中国信息通信研究院2024年白皮书预测，国内大模型市场规模2027年将达到600亿元，年复合增长率约45%。
+
+### 6. 套路化的"挑战与展望"
+
+- Source: [zh-content.md](../patterns/zh-content.md)
+- Type: rewrite-capable pattern
+- Watch words: 尽管如此～仍面临诸多挑战、但我们有理由相信、前景十分广阔、机遇与挑战并存、在～的浪潮下、站在～的历史节点上、百年未有之大变局、新时代新征程
+- Fire condition: 同一段落或结尾部分同时出现模糊的挑战表述（"仍面临诸多挑战"）和模糊的乐观表述（"前景十分广阔"）。或开头使用"百年未有之大变局"、"新时代新征程"等时代套话。
+
+Example before:
+
+> 尽管取得了显著成绩，我国AI产业仍面临诸多挑战。但我们有理由相信，通过持续创新和不懈努力，前景十分广阔。
+
+Example after:
+
+> 目前的主要瓶颈是高端GPU的供应——受出口管制影响，国内企业获取H100的渠道收窄。华为昇腾910B已开始替代，但生态兼容性仍需半年以上的适配周期。
+
+## 语言/语法模式
+
+### 7. AI高频词汇堆砌
+
+- Source: [zh-language.md](../patterns/zh-language.md)
+- Type: rewrite-capable pattern
+- Watch words: 赋能、助力、深耕、布局、打造、构建、引领、聚焦、链接、生态、维度、颗粒度、底层逻辑、顶层设计、全方位、多层次、宽领域、高质量发展、新质生产力
+- Fire condition: 同一段落中出现3个以上高频AI词汇。
+
+Example before:
+
+> 我们致力于深耕AI赛道，聚焦底层逻辑创新，全方位赋能千行百业，打造多层次的智能生态体系，助力高质量发展。
+
+Example after:
+
+> 公司主要做两件事：训练行业专用模型，给制造业和物流企业做部署。去年签了47个客户，比前年多了一倍。
+
+### 8. 四字成语/四字格过度使用
+
+- Source: [zh-language.md](../patterns/zh-language.md)
+- Type: rewrite-capable pattern
+- Watch words: 蓬勃发展、与日俱增、日新月异、任重道远、砥砺前行、不遗余力、齐心协力、众志成城、凝心聚力、守正创新、踔厉奋发、勇毅前行
+- Fire condition: 同一段落中出现3个以上四字成语/四字格词组，或连续2句都以四字格结尾。
+
+Example before:
+
+> 在全体员工齐心协力、砥砺前行的共同努力下，公司业务蓬勃发展、蒸蒸日上，各项指标与日俱增，展现出日新月异的发展态势。
+
+Example after:
+
+> 公司去年营收增长了23%，员工数从120人扩到了190人。增长最快的是海外业务，占比从15%涨到了28%。
+
+### 9. "的地得"和书面语语法过度规范化
+
+- Source: [zh-language.md](../patterns/zh-language.md)
+- Type: rewrite-capable pattern
+- Watch words: 积极地、有效地、充分地、深入地、全面地、切实地、进一步地、使得、以至于、鉴于此、有鉴于此
+- Fire condition: 同一段落中出现3个以上"X地+动词"结构（特别是"积极地"、"有效地"、"充分地"这类程度副词），或使用明显文言语法的书面化表达在日常文体中出现。
+
+Example before:
+
+> 团队积极地探索新方向，有效地整合了各方资源，充分地发挥了技术优势，切实地推动了项目进展。
+
+Example after:
+
+> 团队换了个方向——把原来做通用模型的算力转去做垂直场景。三个月搞定了医疗影像的原型，现在已经进了两家三甲医院试用。
+
+### 10. 排比句过度使用
+
+- Source: [zh-language.md](../patterns/zh-language.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 同一段落中出现2组以上排比结构，或单组排比中并列3个以上结构高度相似的分句且可以用更简练的方式表达。
+
+Example before:
+
+> 我们要坚持创新驱动发展，坚持人才优先战略，坚持开放合作共赢，坚持绿色可持续理念，努力开创各项事业发展新局面。
+
+Example after:
+
+> 明年的重点是招30个算法工程师，把研发投入从营收的12%提到18%。
+
+### 11. 同义词循环替换
+
+- Source: [zh-language.md](../patterns/zh-language.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 同一段落中同一实体被3个以上不同的名称/同义词指代。
+
+Example before:
+
+> 华为在芯片领域取得了重大突破。该企业近年来持续加大研发投入。这家科技巨头的自研芯片已应用于多款产品。该公司表示将继续推进技术自主化进程。
+
+Example after:
+
+> 华为的麒麟9000S是用中芯国际的7纳米工艺造的。去年装在Mate 60上之后，这款手机国内销量超过了3500万台。
+
+### 12. 冗长的介词结构
+
+- Source: [zh-language.md](../patterns/zh-language.md)
+- Type: rewrite-capable pattern
+- Watch words: 在～的过程中、在～的背景下、在～的基础上、在～的推动下、在～的带领下、以～为目标、以～为契机、以～为抓手、对于～而言、从～的角度来看
+- Fire condition: 同一段落中出现2个以上冗长介词结构，或删除后完全不影响意思的介词结构被单独使用。
+
+Example before:
+
+> 在数字化转型的大背景下，在政策大力推动的基础上，以提升核心竞争力为目标，我们以此次改革为契机，全面推进业务升级。
+
+Example after:
+
+> 公司今年把ERP系统换成了自研的，砍掉了三层审批流程。结果订单处理时间从4天缩到了1天半。
+
+## 风格模式
+
+### 13. 过度使用连接词/过渡词
+
+- Source: [zh-style.md](../patterns/zh-style.md)
+- Type: rewrite-capable pattern
+- Watch words: 与此同时、此外、另外、不仅如此、更为重要的是、值得一提的是、值得注意的是、在此基础上、总而言之、综上所述、由此可见、毋庸置疑
+- Fire condition: 连续3句以上每句都以连接词/过渡词开头，或同一段落中出现3个以上高频连接词。
+
+Example before:
+
+> 与此同时，公司加大了研发投入。此外，人才战略也进行了调整。不仅如此，组织架构也进行了优化。更为重要的是，企业文化也在悄然转变。
+
+Example after:
+
+> 公司去年研发投入增加了30%，同时把技术团队从3个拆成了5个小组，每组独立负责一条产品线。
+
+### 14. 加粗滥用
+
+- Source: [zh-style.md](../patterns/zh-style.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 同一段落中加粗处理的词/短语达3个以上，或全文达5个以上。
+
+Example before:
+
+> **人工智能**是**计算机科学**的一个分支，它使用**机器学习**和**深度学习**等**核心技术**来实现**智能决策**。
+
+Example after:
+
+> 人工智能是计算机科学的一个分支，主要通过机器学习和深度学习来实现自动决策。
+
+### 15. 内联标题列表
+
+- Source: [zh-style.md](../patterns/zh-style.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 同一列表中出现2个以上"**标签：** 说明"格式的条目。
+
+Example before:
+
+> - **用户体验：** 新界面大幅提升了用户体验。
+> - **性能优化：** 通过算法改进，性能提升了50%。
+> - **安全升级：** 采用端到端加密，安全性显著增强。
+
+Example after:
+
+> 这次更新改了界面、优化了算法（速度快了一半），还加上了端到端加密。
+
+### 16. "～地"副词修饰过度
+
+- Source: [zh-style.md](../patterns/zh-style.md)
+- Type: rewrite-capable pattern
+- Watch words: 大力地、不断地、持续地、积极地、深入地、全面地、有效地、切实地、扎实地、稳步地
+- Fire condition: 同一段落中出现3个以上"～地+动词"结构，或连续2句都包含"～地+动词"修饰。
+
+Example before:
+
+> 公司积极地拓展海外市场，不断地完善产品体系，持续地加大技术投入，深入地推进数字化转型。
+
+Example after:
+
+> 公司去年在东南亚开了3个办公室，产品线从5个扩到了8个。技术投入增加了40%，主要花在了云原生改造上。
+
+### 17. 表情符号
+
+- Source: [zh-style.md](../patterns/zh-style.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 专业、学术或编辑类文本中出现1个以上表情符号。
+
+Example before:
+
+> 🚀 **产品发布：** 新版将于第三季度上线
+> 💡 **核心洞察：** 用户偏好简洁的界面
+> ✅ **下一步：** 安排后续会议
+
+Example after:
+
+> 新版定在第三季度上线。用户调研显示简洁界面的偏好度最高。下一步是安排后续会议确定细节。
+
+### 18. 过度使用书面/公文体
+
+- Source: [zh-style.md](../patterns/zh-style.md)
+- Type: rewrite-capable pattern
+- Watch words: 切实、务必、着力、扎实推进、统筹协调、部署落实、深入贯彻、狠抓落实、严格把关、高度重视、强化担当、压实责任
+- Fire condition: 同一段落中出现3个以上公文体表达，或"深入贯彻"、"狠抓落实"、"统筹协调"等政府文件专用表达出现在一般文章中。
+
+Example before:
+
+> 各部门要切实增强责任意识，深入贯彻落实公司战略部署，着力推进各项工作任务，狠抓落实确保取得实效。
+
+Example after:
+
+> 各部门这个月要完成两件事：把客户投诉响应时间从48小时压到24小时，把上线前的测试覆盖率提到80%。
+
+## 沟通模式
+
+### 19. 聊天机器人痕迹
+
+- Source: [zh-communication.md](../patterns/zh-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: 希望对您有所帮助、如有疑问请随时提问、以下为您整理了、让我为您详细介绍、如需了解更多信息、很高兴为您解答
+- Fire condition: 非实时对话的内容（文章、报告、文档）中出现1个以上聊天机器人式表达。
+
+Example before:
+
+> 以下为您整理了法国大革命的主要事件。希望对您有所帮助！如有其他疑问，请随时提问。
+
+Example after:
+
+> 法国大革命始于1789年，直接导火索是政府接近破产和巴黎的面包价格暴涨。
+
+### 20. 训练数据截止声明
+
+- Source: [zh-communication.md](../patterns/zh-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: 截至我的知识截止日期、我无法获取实时信息、请以最新信息为准、具体数据可能有变化、建议您查阅最新资料
+- Fire condition: 编辑/报道/分析类内容中出现1个以上AI训练数据限制的自我引用或免责表达。
+
+Example before:
+
+> 截至我的知识截止日期，该公司约有5000名员工。具体数据可能有变化，建议您查阅最新资料。
+
+Example after:
+
+> 该公司2024年年报显示员工约5000人。
+
+### 21. 谄媚/讨好语气
+
+- Source: [zh-communication.md](../patterns/zh-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: 非常好的问题、您说得非常对、这个问题问得很好、您的观点非常有深度、这是一个非常有价值的思考、感谢您的分享
+- Fire condition: 正文之前出现1个以上讨好/恭维表达。
+
+Example before:
+
+> 非常好的问题！您说得非常对，这确实是一个值得深入探讨的话题。关于经济因素的分析非常有深度。让我来为您详细解答。
+
+Example after:
+
+> 经济因素是核心问题。去年住房供给量下降了18%，但人口增长了2.1%，供需缺口在扩大。
+
+### 29. 虚假细化（事后重新表述）
+
+- Source: [zh-communication.md](../patterns/zh-communication.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 在没有新证据或新视角的情况下，以"更细微"的包装重新表述前面的主张。
+
+Example before:
+
+> 远程办公提高了生产力。其实更准确地说，远程办公在某些情况下可以提高生产力，但在其他情况下也会带来挑战，其净效果取决于组织文化和个人工作方式。
+
+Example after:
+
+> 远程办公提高了专注型工作的生产力——斯坦福研究发现呼叫中心员工效率提升了13%。但自发协作受到影响：微软2021年内部数据显示，全面远程后跨团队沟通减少了25%。
+
+## 填充/弱化模式
+
+### 22. 填充表达
+
+- Source: [zh-filler.md](../patterns/zh-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: 众所周知、不言而喻、毫无疑问、毋庸置疑、不可否认的是、必须指出的是、需要强调的是、有必要指出、应当注意到、事实上
+- Fire condition: 同一段落中出现2个以上填充表达，或删除后完全不影响意思的填充表达被单独使用。
+
+Example before:
+
+> 众所周知，人工智能正在改变世界。不可否认的是，这一技术的发展速度超出了许多人的预期。必须指出的是，在一定程度上，AI的伦理问题也日益凸显。
+
+Example after:
+
+> OpenAI去年的营收从16亿美元涨到了36亿。与此同时，欧盟AI法案正式生效，要求高风险AI系统必须通过合规审查。
+
+### 23. 过度弱化/套层对冲
+
+- Source: [zh-filler.md](../patterns/zh-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: 或许可以认为、在某种程度上可能、不排除～的可能性、从一定意义上来说、就某种角度而言、也许在一定条件下
+- Fire condition: 同一个论断叠加了3个以上弱化/限定表达，或陈述被弱化到完全无法证伪的程度。
+
+Example before:
+
+> 或许可以认为，在某种程度上，这一政策可能会在一定条件下对经济产生某些方面的积极影响，当然这还取决于多种因素。
+
+Example after:
+
+> 这一政策可能有正面效果，但关键变量是执行力度。上海试点的数据是：减税后小微企业存活率从62%升到了71%。
+
+### 24. 空洞的积极结尾
+
+- Source: [zh-filler.md](../patterns/zh-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: 未来可期、前景可期、未来已来、我们拭目以待、让我们共同期待、大有可为、令人振奋、前途光明、充满希望、值得期待
+- Fire condition: 同一段落或结尾部分出现2个以上空洞乐观表达，或最后一句完全由乐观套话组成。
+
+Example before:
+
+> 未来可期！人工智能的发展前景令人振奋，前途光明。让我们共同期待这一领域带来更多惊喜和突破。
+
+Example after:
+
+> 公司下个季度计划在深圳和成都各开一个数据中心，预计年底前完工。
+
+### 31. 结论信号词滥用
+
+- Source: [zh-filler.md](../patterns/zh-filler.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 文章最后一段（或倒数第二段）首句以上述信号词之一开头。或同一文档中此类信号词出现 2 次以上。
+- Example files: [failure](../examples/zh-31-failure-01.md) · [success](../examples/zh-31-success-01.md)
+
+Example before:
+
+> 综上所述，数字游民生活方式不是一时的潮流，而是已在我们社会广泛扎根、将持续发展的新标准。
+
+Example after:
+
+> 数字游民已经不只是潮流问题。工作方式整个变了，人们正在这上面建起新的日常。
+
+## 结构模式
+
+### 25. 结构性重复
+
+- Source: [zh-structure.md](../patterns/zh-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 连续3个以上段落遵循相同的内部结构模板。例如：每段都以总述开头、以"意义/展望"收尾。
+
+Example before:
+
+> 在医疗领域，人工智能正在发挥越来越重要的作用。例如，AI辅助诊断系统已在多家医院投入使用。这一技术的应用为提升医疗服务质量奠定了基础。
+>
+> 在教育领域，人工智能同样展现出巨大潜力。例如，智能辅导系统能够为学生提供个性化学习方案。这一创新为教育公平化开辟了新的途径。
+>
+> 在交通领域，人工智能的应用也在不断深入。例如，自动驾驶技术正在加速商业化落地。这一发展为城市交通治理提供了全新思路。
+
+Example after:
+
+> AI在医院里最实用的不是什么高大上的东西，是帮放射科医生看片子。北京协和的数据是：AI筛查肺结节的漏诊率比人工低了12个百分点。
+>
+> 教育是另一回事。
+>
+> 自适应学习系统已经做了五六年了，但实际效果很难量化。松鼠AI号称覆盖了200万学生，但独立的第三方评估几乎找不到。交通倒是有硬数据——百度Apollo在武汉的无人出租车已经跑了400多万公里。
+
+### 26. 翻译腔/欧化语法
+
+- Source: [zh-structure.md](../patterns/zh-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: 这是一个～的事实、可以被认为是、作为一种～的方式、被～所～、对于～来说、基于～的原因、关于～的问题、通过～来实现
+- Fire condition: 同一段落中出现2个以上翻译腔表达。单次使用可容忍——正常中文偶尔也会出现。
+
+Example before:
+
+> 这是一个不争的事实——该技术可以被认为是行业的一个重大突破。通过使用这一技术来实现效率提升，对于企业来说是一个值得考虑的选择。
+
+Example after:
+
+> 这技术确实有用。A公司用了之后，生产效率提高了25%，次品率降了一半。
+
+### 27. 被字句/被动语态过度使用
+
+- Source: [zh-structure.md](../patterns/zh-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: 被广泛应用于、被认为是、被视为、被誉为、被用于、被证明是、被期望
+- Fire condition: 同一段落中出现3个以上"被"字句，或"被"字句出现在主语明确的场合。
+
+Example before:
+
+> 这项技术被广泛应用于医疗领域，被认为是近年来最重要的创新之一。它被期望在未来五年内被推广到更多场景，被更多企业和机构所采用。
+
+Example after:
+
+> 这项技术目前在150多家医院使用，主要用在影像诊断和病理分析上。预计三年内覆盖县级医院。
+
+### 28. 总分总结构过度使用
+
+- Source: [zh-structure.md](../patterns/zh-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 文章整体或单个段落呈现"开头总述→中间分点展开→结尾再次总结"的三段式结构，且结尾总结基本重复开头内容。
+
+Example before:
+
+> 数字化转型是当前企业发展的核心战略。在技术层面，企业纷纷引入云计算和大数据技术。在管理层面，组织架构正在向扁平化方向调整。在文化层面，创新意识日益深入人心。综上所述，数字化转型已成为企业不可逆转的发展趋势。
+
+Example after:
+
+> 一家做了20年的外贸公司，去年把所有订单流程搬到了飞书上。老板说原因很简单：疫情后海外客户全在线上谈，传真和邮件跟不上了。IT部门就3个人，花了两个月搞定。
+
+### 30. 修辞性疑问句段首
+
+- Source: [zh-structure.md](../patterns/zh-structure.md)
+- Type: rewrite-capable pattern
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 段落首句是疑问形（"为什么...？"、"如何...？"、"什么...？"、"怎样才能..."），且答案在同段或下段立即给出。或者全文中作为段首的修辞性疑问出现 2 次以上。
+- Example files: [failure](../examples/zh-30-failure-01.md) · [success](../examples/zh-30-success-01.md)
+
+Example before:
+
+> 那么韩国咖啡文化为什么发展得如此迅速呢？答案出乎意料地简单。咖啡馆已经从单纯的饮品店变成了社交据点。
+>
+> 那么未来又会怎样？专家们认为这一趋势在短期内不会停止。
+
+Example after:
+
+> 韩国咖啡文化发展得快，原因很简单：咖啡馆早已不只是卖咖啡的地方，而是人们的社交据点。
+>
+> 这股势头看上去会延续下去。专家们意见也基本一致。
+
+## 病毒钩子模式（仅评分） (score/audit only)
+
+### Viral 1. 数字震撼钩子
+
+- Source: [zh-viral-hook.md](../patterns/zh-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 强主张依赖一个抢眼数字（时间、规模、百分比），同一篇没有给出来源或核验路径。
+
+Detection example:
+
+> 60 天破 25 万 star。
+> 0 预算做出 1 亿曝光。
+
+### Viral 2. 标题党悬念结尾
+
+- Source: [zh-viral-hook.md](../patterns/zh-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 文章**最后一句**是一个未被正文回答的反问，或显式引导读者做出参与行为（关注、收藏）。
+
+Detection example:
+
+> 0 预算做到这个，你猜他怎么操作的？
+> 你品，你细品。
+
+### Viral 3. 回避验证的权威断言
+
+- Source: [zh-viral-hook.md](../patterns/zh-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 出现"史上首次 X"、"全球唯一 Y"等绝对范围或排名断言，同时全文没有来源、链接、截图、具名专家。
+
+Detection example:
+
+> GitHub 史上从未见过这种增长速度。
+> 全球开发者都在疯狂使用。
+
+### Viral 4. 呼吸优化短句堆叠
+
+- Source: [zh-viral-hook.md](../patterns/zh-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition: 整篇几乎都是 1 句 = 1 段的形式，连续 4 个以上单句段落，平均句长在 15 字以下。零星出现一两个短句不触发。
+
+Detection example:
+
+> 史上从未有过这种增速。
+>
+> 仅 60 天，25 万 star。
+>
+> 一个叫 OpenClaw 的工具做到了。
+>
+> 0 广告，全球开发者却疯狂涌入，凭什么？
+> 
+> （4 段单句，平均约 12 字，换行分隔 → 触发。）
+
+### Viral 5. 夸张互动词汇
+
+- Source: [zh-viral-hook.md](../patterns/zh-viral-hook.md)
+- Type: score/audit only; rewrite modes skip this pack
+- Watch words: Structural pattern; inspect the fire condition rather than a fixed vocabulary list.
+- Fire condition:
+
+> - 一篇出现 1 次：Low
+> - 出现 2 次：Medium
+> - 出现 3 次或以上：High
+
+Detection example:
+
+> 这工具真的绝了，开发者都疯了。
+> 不试试就亏大了的神级工具。

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -1,147 +1,22 @@
 # Pattern Catalog
 
-146 pattern entries across 4 languages (37 KO + 36 EN + 36 ZH + 37 JA). The main catalog has 126 rewrite-capable patterns; the extra 20 are score/audit-only viral-hook patterns (5 per language). Most patterns are universal; a few slots have language-specific variants. Each pattern has a fire condition, an exclude condition (so legitimate uses don't get flagged), and example before/after pairs in `examples/`.
+Patina ships 146 pattern entries across four languages. The language-specific references below expand each pack with pattern numbers, names, watch words, fire conditions, source links, and examples.
 
-| Category | # of patterns | Range |
-|----------|---------------|-------|
-| Content | 6 | #1–#6 |
-| Language | 6 | #7–#12 *(language-specific)* |
-| Style | 6 | #13–#18 *(some language-specific)* |
-| Communication | 4 | #19–#21, #29 |
-| Filler & Hedging | 3 | #22–#24 |
-| Structure | 4 | #25–#28 *(some language-specific)* |
-| Universal extensions | 3 | #30–#32 *(KO/JA only for #32)* |
-| Viral hook | 5 per language | score/audit-only SNS-marketing signals |
+| Language | Reference | Rewrite-capable patterns | Score/audit-only viral-hook patterns |
+|----------|-----------|--------------------------|--------------------------------------|
+| Korean | [PATTERNS-KO.md](PATTERNS-KO.md) | 32 | 5 |
+| English | [PATTERNS-EN.md](PATTERNS-EN.md) | 31 | 5 |
+| Chinese | [PATTERNS-ZH.md](PATTERNS-ZH.md) | 31 | 5 |
+| Japanese | [PATTERNS-JA.md](PATTERNS-JA.md) | 32 | 5 |
 
-## Universal patterns
+## Notes
 
-These categories are identical across all four languages.
+- Rewrite-capable patterns are applied by `--rewrite`, `--diff`, and `--ouroboros` according to their pack metadata and runtime mode.
+- Viral-hook patterns are score/audit-only SNS-marketing signals. They affect `--score` and `--audit`, but rewrite modes skip them because the rhetoric may be intentional.
+- Pattern packs are auto-discovered from `patterns/{lang}-*.md`. To add a language or custom pack, follow [CONTRIBUTING.md](../CONTRIBUTING.md) and the frontmatter format used in the existing packs.
 
-### Content (#1–#6)
+## Supporting References
 
-| # | Pattern | What AI does | Fix |
-|---|---------|-------------|-----|
-| 1 | Importance Inflation | "groundbreaking milestone", "pivotal turning point" | Specific facts, dates, numbers |
-| 2 | Media/Notability Inflation | "garnered significant attention" | Cite one specific source |
-| 3 | Superficial Analysis | Chains of "-ing" / "-하며" verbs with no real explanation | Real explanation or sources |
-| 4 | Promotional Language | "stunning, world-class, hidden gem" | Neutral description |
-| 5 | Vague Attributions | "experts say... studies show" | Name the actual source |
-| 6 | Formulaic Challenges/Prospects | "despite challenges... bright future" | Specific problems and concrete plans |
-
-### Communication (#19–#21, #29)
-
-| # | Pattern | What AI does | Fix |
-|---|---------|-------------|-----|
-| 19 | Chatbot Phrases | "Hope this helps! Let me know" | Remove |
-| 20 | Training Cutoff Disclaimers | "as of my last update" | Find sources or remove |
-| 21 | Sycophantic Tone | "Great question! Exactly right" | Respond directly |
-| 29 | False Nuance | "Actually, it's more nuanced..." | Add real evidence or cut |
-
-### Filler & Hedging (#22–#24)
-
-| # | Pattern | What AI does | Fix |
-|---|---------|-------------|-----|
-| 22 | Filler Phrases | Padding words | Cut |
-| 23 | Excessive Hedging | Over-qualified statements | Direct statement |
-| 24 | Vague Positive Conclusions | "bright future ahead" | Specific plans or facts |
-
-## Language-specific patterns
-
-### Language (#7–#12) — grammar and vocabulary
-
-| # | KO | EN | ZH | JA |
-|---|----|----|----|----|
-| 7 | AI filler vocabulary | AI vocabulary (delve, tapestry) | AI buzzwords (赋能/助力/深耕) | AI buzzword overuse |
-| 8 | -jeok (적) suffix overuse | Copula avoidance ("serves as") | Four-character idioms (成语) | -teki (的) suffix overuse |
-| 9 | Negative parallelisms | Negative parallelisms | 的/地/得 over-normalization | Negative parallelisms |
-| 10 | Rule of three | Rule of three | Parallelism overuse (排比句) | Rule of three |
-| 11 | Synonym cycling | Synonym cycling | Synonym cycling | Synonym cycling |
-| 12 | Verbose particles | False ranges ("from X to Y") | Verbose prepositional frames | Katakana loanword overuse |
-
-### Style (#13–#18) — formatting and register
-
-| # | KO | EN | ZH | JA |
-|---|----|----|----|----|
-| 13 | Excessive connectors | Em dash overuse | Excessive connectors | Excessive connectors |
-| 14 | Boldface overuse | Boldface overuse | Boldface overuse | Boldface overuse |
-| 15 | Inline-header lists | Inline-header lists | Inline-header lists | Inline-header lists |
-| 16 | Progressive tense (-고 있다) | Title Case in headings | 地-adverb overuse | Excessive keigo (ございます) |
-| 17 | Emojis | Emojis | Emojis | Emojis |
-| 18 | Excessive formal language | Curly quotation marks | Bureaucratic register (公文体) | Stiff である-style |
-
-### Structure (#25–#28) — document-level
-
-| # | KO | EN | ZH | JA |
-|---|----|----|----|----|
-| 25 | Structural repetition | Metronomic paragraph structure | Structural repetition | Structural repetition |
-| 26 | Translationese | Passive nominalization chains | Translationese / Europeanized | Translationese |
-| 27 | Passive voice overuse | Zombie nouns | 被-overuse | ている progressive overuse |
-| 28 | Unnecessary loanwords | Stacked subordinate clauses | 总分总 structure overuse | 起承転結 formula overuse |
-
-## Universal extensions (v3.4.0+)
-
-| # | All languages |
-|---|---------------|
-| 30 | Rhetorical question openers ("Have you ever wondered…?", "혹시 ~인가요?", "那么…呢？", "~でしょうか？") |
-| 31 | Conclusion signal words ("In conclusion", "결론적으로", "总而言之", "結論として") |
-| 32 | Comparative adverb overuse — KO `보다` / JA `より` only |
-
-## Score-only viral hooks (v3.11.0+)
-
-Each language has a `patterns/{lang}-viral-hook.md` pack with 5 score/audit-only patterns:
-
-1. Shock numbers as hook
-2. Clickbait mystery close
-3. Source-skipping authority
-4. Breath-optimized short-sentence stacking
-5. Hyperbolic engagement lexicon
-
-These signals affect `--score` and `--audit` only. `--rewrite`, `--diff`, and `--ouroboros` skip them because the rhetoric may be intentional.
-
-## AI-lexicon overlap (step 4.7)
-
-Separate from the pattern catalog, two flat dictionaries flag AI-favored phrases:
-
-- `lexicon/ai-en.md` — 108 entries (50 strict + 58 phrases)
-- `lexicon/ai-ko.md` — 102 entries (49 strict + 54 phrases)
-
-Densities are computed per 1000 tokens; threshold default is 2.0. See `core/stylometry.md` §16 for the algorithm and the post-evaluation drop list.
-
-## Adding a new language
-
-1. Create `patterns/{lang}-content.md`, `{lang}-language.md`, `{lang}-style.md`, `{lang}-communication.md`, `{lang}-filler.md`, `{lang}-structure.md`, and optionally `{lang}-viral-hook.md` for score-only SNS signals.
-2. Set `language: {lang}` in each file's frontmatter.
-3. Use `/patina --lang {lang}` — auto-discovered, no config changes needed.
-
-Pattern frontmatter format:
-
-```yaml
----
-pack: my-patterns
-language: ko
-name: My Custom Patterns
-version: 1.0.0
-patterns: 1
----
-```
-
-## Custom patterns
-
-Drop a `.md` file into `custom/patterns/` — auto-loaded:
-
-```markdown
----
-pack: my-patterns
-language: ko
-name: My Custom Patterns
-version: 1.0.0
-patterns: 1
----
-
-### 1. Pattern Name
-**Problem:** What AI does wrong
-**Before:** > AI-sounding example
-**After:** > Natural-sounding fix
-```
-
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for submission guidelines and staleness reports.
+- [Scoring](../core/scoring.md) — category weights, AI-likeness score, fidelity, and MPS
+- [Stylometry](../core/stylometry.md) — burstiness, MATTR, and AI-lexicon overlap
+- [Examples](../examples/README.md) — standalone failure/success fixtures used by the pattern docs

--- a/tests/unit/pattern-docs.test.js
+++ b/tests/unit/pattern-docs.test.js
@@ -1,13 +1,14 @@
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { readFileSync, readdirSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { basename, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../..');
 const PATTERN_DIR = resolve(REPO_ROOT, 'patterns');
+const DOCS_DIR = resolve(REPO_ROOT, 'docs');
 const SCORING_PATH = resolve(REPO_ROOT, 'core/scoring.md');
 const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
 const LANGS = ['ko', 'en', 'zh', 'ja'];
@@ -63,6 +64,14 @@ function scoringTables() {
   return out;
 }
 
+function patternHeadings(path) {
+  const raw = readFileSync(path, 'utf8');
+  return [...raw.matchAll(/^###\s+(\d+)\.\s+(.+)$/gm)].map((m) => ({
+    number: Number(m[1]),
+    name: m[2].trim(),
+  }));
+}
+
 test('pattern pack frontmatter counts match numbered pattern headings', () => {
   for (const file of patternFiles()) {
     const parsed = parsePatternFile(file);
@@ -88,5 +97,32 @@ test('core/scoring.md category counts match pattern pack frontmatter', () => {
     }
     const expectedTotal = Object.values(packs[lang]).reduce((sum, n) => sum + n, 0);
     assert.equal(tables[lang].Total, expectedTotal, `${lang} scoring total drifted`);
+  }
+});
+
+test('per-language pattern references cover source pattern packs', () => {
+  const selector = readFileSync(resolve(DOCS_DIR, 'PATTERNS.md'), 'utf8');
+  for (const lang of LANGS) {
+    const pageName = `PATTERNS-${lang.toUpperCase()}.md`;
+    assert.match(selector, new RegExp(`\\[${pageName}\\]\\(${pageName}\\)`));
+
+    const doc = readFileSync(resolve(DOCS_DIR, pageName), 'utf8');
+    const sourceFiles = patternFiles().filter((file) => parsePatternFile(file).meta.language === lang);
+    const expectedHeadings = sourceFiles.flatMap((file) => patternHeadings(file));
+    const actualHeadingCount = (doc.match(/^###\s+/gm) || []).length;
+
+    assert.equal(
+      actualHeadingCount,
+      expectedHeadings.length,
+      `${pageName} must list every ${lang} pattern heading`
+    );
+
+    for (const file of sourceFiles) {
+      assert.match(doc, new RegExp(`\\[${basename(file)}\\]\\(\\.\\./patterns/`));
+    }
+
+    for (const { name } of expectedHeadings) {
+      assert.match(doc, new RegExp(name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    }
   }
 });


### PR DESCRIPTION
Closes #193.

## Summary
- turn `docs/PATTERNS.md` into a language selector
- add `PATTERNS-KO/EN/ZH/JA.md` references generated from the source pattern packs
- include pattern numbers, source links, watch words, fire conditions, example links, and inline examples/detection examples
- add a unit test that verifies the per-language docs cover every source pattern heading

## Notes
- The source packs currently contain 31-32 rewrite-capable patterns per language plus 5 score/audit-only viral-hook patterns, matching the existing 146 total pattern entries.

## Verification
- npm run lint
- npm test
- git diff --check