### PR TITLE
docs: audit skill flag parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ patina --lang <ko|en|zh|ja> [mode] [--profile <name>] input.txt
 | `--score --gate <n>` | Keep CI strict: exit code `3` when `overall > n` |
 | `--diff` | Show changes pattern by pattern |
 | `--ouroboros` | Iterate the rewrite until score converges (with MPS rollback) |
+| `--variants <1-5>` | Generate multiple stylistic rewrite variants in one call |
 | `--lang <ko\|en\|zh\|ja>` | Select language (default: `ko`) |
 | `--profile <name>` | Tone preset: `blog`, `academic`, `technical`, `formal`, `social`, `email`, `legal`, `medical`, `marketing`, `narrative`, `instructional`, `casual-conversation` |
 | `--tone <name>` | Tone category: `casual`, `professional`, `academic`, `narrative`, `marketing`, `instructional`, `auto` |
@@ -219,6 +220,7 @@ Pattern packs are auto-discovered by language prefix. `.patina.yaml` in the work
 - **[Patterns](docs/PATTERNS.md)** — full 146-pattern catalog
 - **[Authentication](docs/AUTHENTICATION.md)** — backends, providers, free-tier setup
 - **[CLI Contract](docs/CLI.md)** — score gate, exit codes, and automation-safe surfaces
+- **[Flag Parity](docs/FLAG-PARITY.md)** — CLI vs skill flag coverage audit
 - **[Ethics](docs/ETHICS.md)** — intended use, non-use, and disclosure stance
 - **[FAQ](docs/FAQ.md)** — detector-bypass concerns, MPS, false positives, contribution starting points
 - **[Comparison](docs/COMPARISON.md)** — factual comparison with common paraphraser/humanizer tools

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,6 +41,8 @@ Glob .patina.default.yaml → Read
 - `--ouroboros`: ouroboros 모드 (반복 교정 + 점수 수렴)
 - `--lang <code>`: 처리 언어 변경 (ko, en, zh, ja). 설정 파일의 `language` 값을 오버라이드한다.
 - `--tone <name>`: 톤 카테고리 지정. 유효값: `casual | professional | academic | narrative | marketing | instructional | auto`. 알 수 없는 값이면 즉시 오류: "Unknown tone '<name>'. Valid tones: casual, professional, academic, narrative, marketing, instructional, auto"
+- `--prompt-mode <strict|minimal|auto>`: rewrite 프롬프트 크기와 구조를 선택한다. `strict`는 전체 패턴 팩을 사용하고, `minimal`은 압축 지시문을 사용하며, `auto`는 백엔드별 기본값을 고른다(Gemini는 minimal, 그 외는 strict).
+- `--variants <n>`: rewrite 모드에서 1-5개의 스타일 변형을 한 번에 생성한다. 각 변형은 사실, 수치, 인과관계를 동일하게 유지하고 최종 출력에서는 `## Variant N` 형식으로 표시한다. MAX 모드(`--models`)와는 함께 쓰지 않는다.
 - `--batch <files>`: 여러 파일을 한꺼번에 처리 (glob 또는 명시적 경로 목록).
   - `--in-place`: 원본 파일을 교정된 텍스트로 덮어쓴다.
   - `--suffix <ext>`: 결과를 `{원본명}{ext}` 파일로 저장한다 (예: `--suffix .humanized`).
@@ -81,6 +83,8 @@ if --lang in {zh, ja} and resolved_tone in 6-tone set:
 파일이 없으면 에러: "core/scoring.md not found. Please update patina."
 
 `--ouroboros`는 rewrite 출력 모드를 사용한다. `--audit`, `--diff`, `--score`와 함께 사용할 수 없다.
+
+`--prompt-mode`와 `--variants`는 rewrite 출력에만 적용된다. `--audit`, `--diff`, `--score`는 패턴 탐지와 스코어링 표면이므로 변형 출력을 만들지 않는다.
 
 ---
 

--- a/docs/FLAG-PARITY.md
+++ b/docs/FLAG-PARITY.md
@@ -1,0 +1,47 @@
+# Flag Parity
+
+This audit compares the standalone CLI help in `src/cli.js`, the main Claude/Codex skill in `SKILL.md`, and the MAX skill in `patina-max/SKILL.md`.
+
+Legend: `✓` means the surface documents the flag or subcommand as an explicit user-facing option. `✗` means it is absent from that surface.
+
+| Flag / command | CLI | `SKILL.md` | `patina-max/SKILL.md` | Notes |
+|---|---:|---:|---:|---|
+| `-h`, `--help` | ✓ | ✗ | ✗ | CLI help only. |
+| `-v`, `--version` | ✓ | ✗ | ✗ | CLI help only. |
+| `--lang <code>` | ✓ | ✓ | ✓ | Shared language selector. |
+| `--profile <name>` | ✓ | ✓ | ✓ | Shared profile selector. |
+| `--tone <name>` | ✓ | ✓ | ✗ | Main rewrite skill only. |
+| `--diff` | ✓ | ✓ | ✗ | Main rewrite skill only. |
+| `--audit` | ✓ | ✓ | ✗ | Main rewrite skill only. |
+| `--score` | ✓ | ✓ | ✗ | MAX skill scores internally, but does not expose `--score` as an argument. |
+| `--gate <n>` | ✓ | ✗ | ✗ | CLI-only score gate. |
+| `--ouroboros` | ✓ | ✓ | ✗ | MAX skill mentions re-running strong results, but does not list this as a setup option. |
+| `--batch` | ✓ | ✓ | ✗ | Main rewrite skill only. |
+| `--in-place` | ✓ | ✓ | ✗ | Batch output option. |
+| `--suffix <ext>` | ✓ | ✓ | ✗ | Batch output option. |
+| `--outdir <dir>` | ✓ | ✓ | ✗ | Batch output option. |
+| `--save-run <dir>` | ✓ | ✗ | ✗ | CLI reproducibility output. |
+| `--models <list>` | ✓ | ✗ | ✓ | CLI MAX mode and MAX skill. |
+| `--max-concurrency <n>` | ✓ | ✗ | ✗ | CLI MAX-mode concurrency cap. |
+| `--variants <n>` | ✓ | ✓ | ✗ | CLI rewrite mode and main skill. Not supported with `--models` / MAX mode. |
+| `--model <id>` | ✓ | ✗ | ✗ | Single backend model ID. |
+| `--api-key <key>` | ✓ | ✗ | ✗ | Deprecated CLI auth flag; prefer env/file. |
+| `--api-key-file <path>` | ✓ | ✗ | ✗ | CLI auth flag. |
+| `--base-url <url>` | ✓ | ✗ | ✗ | CLI HTTP backend configuration. |
+| `--backend <name>` | ✓ | ✗ | ✗ | CLI backend selector. |
+| `--list-backends` | ✓ | ✗ | ✗ | CLI auth/debug output. |
+| `--provider <name>` | ✓ | ✗ | ✗ | CLI provider preset selector. |
+| `--list-providers` | ✓ | ✗ | ✗ | CLI provider debug output. |
+| `--allow-insecure-base-url` | ✓ | ✗ | ✗ | CLI security opt-in for plaintext non-localhost HTTP. |
+| `--allow-private-base-url` | ✓ | ✗ | ✗ | CLI security opt-in for private / IMDS base URLs. |
+| `--config <path>` | ✓ | ✗ | ✗ | CLI config override. |
+| `--prompt-mode <m>` | ✓ | ✓ | ✗ | CLI rewrite mode and main skill. |
+| `--dispatch <mode>` | ✗ | ✗ | ✓ | MAX skill dispatch mode (`omc`, `direct`, `api` documented in the skill). |
+| `patina auth status` | ✓ | ✗ | ✗ | CLI subcommand. |
+| `patina auth login` | ✓ | ✗ | ✗ | CLI subcommand. |
+
+## User-visible gaps
+
+- `SKILL.md` now documents `--variants <n>` and `--prompt-mode <strict|minimal|auto>` because those change normal rewrite behavior.
+- `SKILL.md` still intentionally omits lower-level CLI-only operational flags such as `--api-key-file`, `--base-url`, `--provider`, and private URL opt-ins. Those are better covered by `patina --help` and the CLI/auth docs.
+- `patina-max/SKILL.md` is a separate orchestration skill. It should not advertise `--variants` unless MAX mode grows support for variants; the CLI currently rejects `--models` with `--variants > 1`.


### PR DESCRIPTION
Closes #188.

## Summary
- add `docs/FLAG-PARITY.md` comparing CLI, `SKILL.md`, and `patina-max/SKILL.md` flag coverage
- document `--variants` and `--prompt-mode` in `SKILL.md`
- add `--variants` to the README modes table and link the flag parity audit

## Verification
- npm run lint
- npm test
- git diff --check
- rg for `--variants`, `--prompt-mode`, and `FLAG-PARITY` in updated docs