### PR TITLE
ux: log max-mode tie selection

### DIFF
--- a/src/max-mode.js
+++ b/src/max-mode.js
@@ -56,7 +56,7 @@ export async function runMaxMode({ prompt, sourceText, models, apiKey, baseURL, 
   };
 }
 
-function selectBest(candidates) {
+export function selectBest(candidates, { log = console.error } = {}) {
   const valid = candidates.filter((c) => c.ok && c.aiScore !== null);
 
   if (valid.length === 0) {
@@ -66,14 +66,29 @@ function selectBest(candidates) {
   const passingMps = valid.filter((c) => (c.mps ?? 0) >= 70);
 
   if (passingMps.length > 0) {
-    return passingMps.reduce((best, current) =>
+    const best = passingMps.reduce((best, current) =>
+      // Strict comparison preserves --models config order when AI scores tie.
       (current.aiScore < best.aiScore) ? current : best
     );
+
+    if (passingMps.some((c) => c !== best && c.aiScore === best.aiScore)) {
+      log(`[patina-max] Tie on AI score — picked ${best.model} by config order`);
+    }
+
+    return best;
   }
 
-  return valid.reduce((best, current) => {
+  const best = valid.reduce((best, current) => {
     const bestMps = best.mps ?? -1;
     const currentMps = current.mps ?? -1;
+    // Strict comparison preserves --models config order when MPS scores tie.
     return currentMps > bestMps ? current : best;
   });
+
+  const bestMps = best.mps ?? -1;
+  if (valid.some((c) => c !== best && (c.mps ?? -1) === bestMps)) {
+    log(`[patina-max] Tie on MPS — picked ${best.model} by config order`);
+  }
+
+  return best;
 }

--- a/tests/unit/max-mode.test.js
+++ b/tests/unit/max-mode.test.js
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { selectBest } from '../../src/max-mode.js';
+
+test('selectBest keeps config order and logs AI-score ties among MPS-passing candidates', () => {
+  const logs = [];
+  const best = selectBest([
+    { model: 'claude', ok: true, aiScore: 12, mps: 74 },
+    { model: 'gemini', ok: true, aiScore: 12, mps: 91 },
+    { model: 'codex', ok: true, aiScore: 18, mps: 88 },
+  ], { log: (message) => logs.push(message) });
+
+  assert.equal(best.model, 'claude');
+  assert.deepEqual(logs, ['[patina-max] Tie on AI score — picked claude by config order']);
+});
+
+test('selectBest keeps config order and logs MPS ties when no candidate passes MPS floor', () => {
+  const logs = [];
+  const best = selectBest([
+    { model: 'claude', ok: true, aiScore: 42, mps: 62 },
+    { model: 'gemini', ok: true, aiScore: 18, mps: 62 },
+    { model: 'codex', ok: true, aiScore: 11, mps: 57 },
+  ], { log: (message) => logs.push(message) });
+
+  assert.equal(best.model, 'claude');
+  assert.deepEqual(logs, ['[patina-max] Tie on MPS — picked claude by config order']);
+});


### PR DESCRIPTION
## Summary
- export max-mode selectBest for focused coverage
- document first-in-config tie behavior at both reduce sites
- log selected model when AI-score or MPS fallback ties preserve config order

Closes #138

## Verification
- node --test tests/unit/max-mode.test.js
- npm run lint
- npm test
- git diff --check