### PR TITLE
fix: cap default MAX concurrency

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -100,9 +100,8 @@ export function computeBackoffMs(attempt, retryAfter, opts = {}) {
   return Math.min(exp + jitter, max);
 }
 
-// Bounded-concurrency semaphore. `max <= 0` (or undefined) yields a
-// no-op gate so the existing parallel-fanout behavior is unchanged when
-// the caller doesn't ask for a limit.
+// Bounded-concurrency semaphore. `max <= 0` yields a no-op gate for callers
+// that explicitly opt into unlimited parallelism.
 export function createSemaphore(max) {
   if (!max || max <= 0) {
     return { acquire: () => Promise.resolve(() => {}) };
@@ -243,12 +242,13 @@ export async function callLLMMultiple({
   allowInsecureBaseURL = false,
   deadline,
   signal,
-  maxConcurrency = 0, // 0 = unlimited (preserves prior behavior)
+  maxConcurrency,
   onStart,
   onComplete,
 }) {
   validateBaseURL(baseURL, { allowInsecure: allowInsecureBaseURL });
-  const sem = createSemaphore(maxConcurrency);
+  const effectiveMaxConcurrency = maxConcurrency ?? Math.min(models.length, 3);
+  const sem = createSemaphore(effectiveMaxConcurrency);
   const promises = models.map(async (model) => {
     const release = await sem.acquire();
     if (onStart) onStart(model);

--- a/src/cli.js
+++ b/src/cli.js
@@ -557,7 +557,8 @@ Batch / output:
 
 MAX / variants:
   --models <list>      MAX mode: comma-separated model list
-  --max-concurrency <n>  Cap parallel MAX-mode requests (default: unlimited)
+  --max-concurrency <n>  Cap parallel MAX-mode requests (default: min(models, 3);
+                       0 = unlimited, risky on free-tier providers)
   --variants <n>       Generate N stylistic variants of the rewrite (1-5,
                        default 1). Each variant preserves facts/numbers but
                        differs in voice (V1 casual, V2 direct, V3 measured…).

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -7,6 +7,7 @@ import {
   computeBackoffMs,
   createSemaphore,
   callLLM,
+  callLLMMultiple,
 } from '../../src/api.js';
 
 test('HttpError captures status, body, and Retry-After', () => {
@@ -105,6 +106,38 @@ test('createSemaphore enforces concurrency cap and drains the queue', async () =
   await Promise.all([work(), work(), work(), work(), work()]);
   assert.equal(peak, 2, 'never exceeds cap');
   assert.equal(active, 0, 'all releases run');
+});
+
+test('callLLMMultiple defaults to a safe concurrency cap', async () => {
+  const originalFetch = globalThis.fetch;
+  let active = 0;
+  let peak = 0;
+  globalThis.fetch = async () => {
+    active++;
+    peak = Math.max(peak, active);
+    await new Promise((r) => setTimeout(r, 5));
+    active--;
+    return {
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'ok' } }],
+      }),
+    };
+  };
+
+  try {
+    const results = await callLLMMultiple({
+      prompt: 'x',
+      apiKey: 'test',
+      baseURL: 'https://example.com/v1',
+      models: ['a', 'b', 'c', 'd', 'e'],
+    });
+
+    assert.equal(peak, 3, 'default should queue beyond min(models.length, 3)');
+    assert.deepEqual(results.map((r) => r.ok), [true, true, true, true, true]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test('callLLM clamps Retry-After sleep to the remaining deadline budget', async () => {


### PR DESCRIPTION
## Summary
- default MAX fan-out to min(models.length, 3) when --max-concurrency is unset
- keep explicit 0 as the unlimited escape hatch
- update help text with the new default and free-tier warning
- add unit coverage that default callLLMMultiple queues beyond three active requests

Closes #142

## Verification
- node --test tests/unit/api.test.js
- node bin/patina.js --help | rg -n "max-concurrency|free-tier|min\(models"
- npm run lint
- npm test
- git diff --check