### PR TITLE
test: cover patina-max composite reselection

### DIFF
--- a/SKILL-MAX.md
+++ b/SKILL-MAX.md
@@ -334,6 +334,45 @@ Best: claude (AI Score: 23, MPS: 92)
 - 모든 후보의 MPS < 70인 경우, MPS가 가장 높은 후보를 선택한다 (의미 보존 우선)
 - 동점이면 설정 파일의 모델 순서에서 먼저 오는 것을 우선한다
 
+### Composite 재선택 artifact (선택)
+
+`patina-max/composite.py`로 4축(AI, MPS, RSS, EditCons) 재선택을 실행하려면 `$RUN_DIR`에 아래 레이아웃을 생성한다. 기존 `*-output.txt`는 진단용으로 유지하고, 성공한 후보의 최종 텍스트를 모델별 Markdown 파일로도 저장한다.
+
+```text
+$RUN_DIR/
+  input.md
+  claude.md
+  gemini.md
+  codex.md
+  meta.md
+```
+
+- `input.md`: 사용자가 제공한 원문 텍스트
+- `{model}.md`: 해당 모델의 humanize 결과. 실패한 모델은 파일을 생략하거나 실패 메모만 둔다
+- `meta.md`: 후보별 `model`, `status`, `ai_score`, `mps` 값을 `candidates:` 목록으로 기록한다
+
+`meta.md` 예시:
+
+```yaml
+candidates:
+  - model: claude
+    status: success
+    ai_score: 23
+    mps: 92
+  - model: gemini
+    status: failed
+    ai_score: n/a
+    mps: n/a
+```
+
+실행:
+
+```bash
+python3 patina-max/composite.py "$RUN_DIR"
+```
+
+스크립트는 `$RUN_DIR/composite.md`와 `$RUN_DIR/winner.md`를 생성한다. `--weights ai=0.4,rss=0.3`처럼 가중치를 덮어쓸 수 있으며, 지정하지 않은 축은 기본값을 사용한 뒤 합계가 1이 되도록 정규화한다.
+
 ---
 
 ## 8단계: 출력

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "SKILL.md",
     "SKILL-MAX.md",
     "patina-max/SKILL.md",
+    "patina-max/composite.py",
     ".patina.default.yaml",
     "LICENSE",
     "CHANGELOG.md",

--- a/patina-max/SKILL.md
+++ b/patina-max/SKILL.md
@@ -402,6 +402,45 @@ Best: claude (AI Score: 23, MPS: 92)
 - 모든 후보의 MPS < 70인 경우, MPS가 가장 높은 후보를 선택한다 (의미 보존 우선)
 - 동점이면 설정 파일의 모델 순서에서 먼저 오는 것을 우선한다
 
+### Composite 재선택 artifact (선택)
+
+`patina-max/composite.py`로 4축(AI, MPS, RSS, EditCons) 재선택을 실행하려면 `$RUN_DIR`에 아래 레이아웃을 생성한다. 기존 `*-output.txt`는 진단용으로 유지하고, 성공한 후보의 최종 텍스트를 모델별 Markdown 파일로도 저장한다.
+
+```text
+$RUN_DIR/
+  input.md
+  claude.md
+  gemini.md
+  codex.md
+  meta.md
+```
+
+- `input.md`: 사용자가 제공한 원문 텍스트
+- `{model}.md`: 해당 모델의 humanize 결과. 실패한 모델은 파일을 생략하거나 실패 메모만 둔다
+- `meta.md`: 후보별 `model`, `status`, `ai_score`, `mps` 값을 `candidates:` 목록으로 기록한다
+
+`meta.md` 예시:
+
+```yaml
+candidates:
+  - model: claude
+    status: success
+    ai_score: 23
+    mps: 92
+  - model: gemini
+    status: failed
+    ai_score: n/a
+    mps: n/a
+```
+
+실행:
+
+```bash
+python3 patina-max/composite.py "$RUN_DIR"
+```
+
+스크립트는 `$RUN_DIR/composite.md`와 `$RUN_DIR/winner.md`를 생성한다. `--weights ai=0.4,rss=0.3`처럼 가중치를 덮어쓸 수 있으며, 지정하지 않은 축은 기본값을 사용한 뒤 합계가 1이 되도록 정규화한다.
+
 ---
 
 ## 8단계: 출력

--- a/patina-max/composite.py
+++ b/patina-max/composite.py
@@ -9,7 +9,7 @@ Edit Conservativeness (EditCons) — and reselects the winner.
 
 Usage
 -----
-    python3 patina-max/composite.py <run_dir> [--judge] [--weights ...]
+    python3 patina-max/composite.py <run_dir> [--weights ...]
 
 Layout consumed
 ---------------
@@ -324,7 +324,6 @@ def render_composite_md(
     weights: dict[str, float],
     candidates: list[Candidate],
     winner: Optional[Candidate],
-    judge_requested: bool,
 ) -> str:
     lines: list[str] = []
     lines.append(f"# patina-composite scores for `{run_dir.name}`")
@@ -355,8 +354,6 @@ def render_composite_md(
     else:
         lines.append("**Winner:** none (no candidate scored successfully)")
     lines.append("")
-    if judge_requested:
-        lines.append("> `--judge` requested but not implemented; deterministic 4-axis result above is authoritative.")
     if any(cand.notes for cand in candidates):
         lines.append("")
         lines.append("## Notes")
@@ -374,11 +371,6 @@ def main(argv: Optional[list[str]] = None) -> int:
         type=str,
         default=None,
         help="override weights, comma-separated (e.g. ai=0.4,rss=0.3)",
-    )
-    parser.add_argument(
-        "--judge",
-        action="store_true",
-        help="opt-in LLM-as-Judge tiebreaker (currently a stub; logs and proceeds with 4-axis only)",
     )
     parser.add_argument(
         "--config",
@@ -438,7 +430,7 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     composite_path = run_dir / "composite.md"
     composite_path.write_text(
-        render_composite_md(run_dir, weights, candidates, winner, args.judge),
+        render_composite_md(run_dir, weights, candidates, winner),
         encoding="utf-8",
     )
 

--- a/tests/unit/test_composite.py
+++ b/tests/unit/test_composite.py
@@ -1,0 +1,76 @@
+import contextlib
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPOSITE_PATH = ROOT / "patina-max" / "composite.py"
+SPEC = importlib.util.spec_from_file_location("patina_max_composite", COMPOSITE_PATH)
+composite = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = composite
+SPEC.loader.exec_module(composite)
+
+
+class CompositeTest(unittest.TestCase):
+    def test_parse_metric_handles_ranges_notes_and_placeholders(self):
+        self.assertEqual(composite.parse_metric("0-2 (within noise floor)"), 1.0)
+        self.assertEqual(composite.parse_metric("92 (all anchors preserved)"), 92.0)
+        self.assertEqual(composite.parse_metric("  '73.5'  "), 73.5)
+        self.assertIsNone(composite.parse_metric("pending"))
+        self.assertIsNone(composite.parse_metric("—"))
+        self.assertIsNone(composite.parse_metric(None))
+
+    def test_normalise_weights_scales_positive_weights(self):
+        weights = composite.normalise_weights({"ai": 2.0, "mps": 1.0, "rss": 1.0})
+
+        self.assertAlmostEqual(sum(weights.values()), 1.0)
+        self.assertAlmostEqual(weights["ai"], 0.5)
+        self.assertAlmostEqual(weights["mps"], 0.25)
+        self.assertAlmostEqual(weights["rss"], 0.25)
+
+    def test_normalise_weights_rejects_zero_sum(self):
+        with self.assertRaisesRegex(ValueError, "positive"):
+            composite.normalise_weights({"ai": 0.0, "mps": 0.0})
+
+    def test_main_selects_highest_composite_winner(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp)
+            (run_dir / "input.md").write_text("제품은 안정적입니다. 팀은 빠르게 대응합니다.\n", encoding="utf-8")
+            (run_dir / "claude.md").write_text("제품은 안정적입니다. 팀은 빠르게 대응합니다.\n", encoding="utf-8")
+            (run_dir / "gemini.md").write_text("제품은 안정적이에요. 팀은 빠르게 대응해요.\n", encoding="utf-8")
+            (run_dir / "codex.md").write_text("failed\n", encoding="utf-8")
+            (run_dir / "meta.md").write_text(
+                """candidates:
+  - model: claude
+    status: success
+    ai_score: 20
+    mps: 92
+  - model: gemini
+    status: success
+    ai_score: 45
+    mps: 72
+  - model: codex
+    status: failed
+    ai_score: n/a
+    mps: n/a
+""",
+                encoding="utf-8",
+            )
+
+            with contextlib.redirect_stdout(io.StringIO()):
+                exit_code = composite.main([str(run_dir), "--config", str(run_dir / "missing.yaml")])
+
+            self.assertEqual(exit_code, 0)
+            winner = (run_dir / "winner.md").read_text(encoding="utf-8")
+            report = (run_dir / "composite.md").read_text(encoding="utf-8")
+            self.assertIn("winner_model: claude", winner)
+            self.assertIn("**Winner:** `claude`", report)
+            self.assertIn("| codex | failed |", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add stdlib Python tests for composite metric parsing, weight normalization, and winner selection
- remove the unused --judge stub from patina-max/composite.py
- document the composite run-dir layout and invocation in both MAX skill files
- include patina-max/composite.py in the npm package file list

Closes #145

## Verification
- python3 -m unittest tests/unit/test_composite.py
- python3 -m py_compile patina-max/composite.py tests/unit/test_composite.py
- npm run release:check
- npm run lint
- npm test
- npm pack --dry-run --json | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>{const data=JSON.parse(s)[0]; console.log(data.files.some(f=>f.path==='patina-max/composite.py') ? 'includes patina-max/composite.py' : 'missing patina-max/composite.py');})"
- git diff --check