### PR TITLE
feat: add MAX wall-clock timeout

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -162,6 +162,7 @@ export async function main(args) {
         config,
         patterns,
         maxConcurrency: parsed.maxConcurrency,
+        wallClockBudgetMs: parsed.maxTimeoutSeconds === undefined ? undefined : parsed.maxTimeoutSeconds * 1000,
       });
     } else if (parsed.ouroboros) {
       result = await runOuroboros({
@@ -423,6 +424,20 @@ function parseArgs(args) {
           );
         }
         parsed.maxConcurrency = n;
+        break;
+      }
+      case '--max-timeout': {
+        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
+        i++;
+        const n = Number(value);
+        if (!Number.isFinite(n) || n <= 0) {
+          throw inputError(
+            '--max-timeout expects a positive number of seconds',
+            `Received ${value === undefined ? 'no value' : `"${value}"`}.`,
+            'Use `--max-timeout 300`, or omit it for the default 300 seconds.'
+          );
+        }
+        parsed.maxTimeoutSeconds = n;
         break;
       }
       case '--model':
@@ -729,6 +744,7 @@ MODEL & AUTH
   --models <list>         MAX mode: comma-separated model list
   --max-concurrency <n>   Cap parallel MAX-mode requests (default: min(models, 3);
                           use 0 for unlimited, which can hit free-tier quotas)
+  --max-timeout <sec>     Wall-clock budget for standalone MAX mode (default: 300)
 
 ADVANCED
   --variants <n>          Generate N rewrite variants (1-5; rewrite mode only)

--- a/src/max-mode.js
+++ b/src/max-mode.js
@@ -1,50 +1,93 @@
 import { callLLMMultiple } from './api.js';
 import { scoreText, scoreMPS } from './scoring.js';
 
-export async function runMaxMode({ prompt, sourceText, models, apiKey, baseURL, config, patterns, maxConcurrency }) {
+const DEFAULT_WALL_CLOCK_BUDGET_MS = 300_000;
+
+export async function runMaxMode({
+  prompt,
+  sourceText,
+  models,
+  apiKey,
+  baseURL,
+  config,
+  patterns,
+  maxConcurrency,
+  wallClockBudgetMs = DEFAULT_WALL_CLOCK_BUDGET_MS,
+  callLLMMultipleImpl = callLLMMultiple,
+  scoreTextImpl = scoreText,
+  scoreMPSImpl = scoreMPS,
+}) {
   console.error(`[patina-max] Dispatching to ${models.length} models: ${models.join(', ')}`);
 
-  const results = await callLLMMultiple({
-    prompt,
-    models,
-    apiKey,
-    baseURL,
-    maxConcurrency,
-    onStart: (model) => console.error(`[patina-max] Starting ${model}...`),
-    onComplete: (model, ok) => console.error(`[patina-max] ${model} ${ok ? 'completed' : 'failed'}`),
-  });
+  const controller = new AbortController();
+  const deadline = Date.now() + wallClockBudgetMs;
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+    console.error(`[patina-max] MAX wall-clock timeout reached; returning partial results`);
+  }, wallClockBudgetMs);
 
   const candidates = [];
-  for (const r of results) {
-    if (!r.ok) {
-      candidates.push({ model: r.model, ok: false, error: r.error });
-      continue;
+  try {
+    const results = await callLLMMultipleImpl({
+      prompt,
+      models,
+      apiKey,
+      baseURL,
+      maxConcurrency,
+      deadline,
+      signal: controller.signal,
+      onStart: (model) => console.error(`[patina-max] Starting ${model}...`),
+      onComplete: (model, ok) => console.error(`[patina-max] ${model} ${ok ? 'completed' : 'failed'}`),
+    });
+
+    for (const r of results) {
+      if (!r.ok) {
+        candidates.push({ model: r.model, ok: false, error: r.error });
+        continue;
+      }
+
+      let aiScoreResult = null;
+      let mpsResult = null;
+
+      if (!timedOut) {
+        aiScoreResult = await scoreTextImpl({
+          text: r.result,
+          config,
+          patterns,
+          apiKey,
+          baseURL,
+          model: r.model,
+          deadline,
+          signal: controller.signal,
+        });
+      }
+
+      if (!timedOut) {
+        mpsResult = await scoreMPSImpl({
+          original: sourceText,
+          rewritten: r.result,
+          apiKey,
+          baseURL,
+          model: r.model,
+          deadline,
+          signal: controller.signal,
+        });
+      }
+
+      candidates.push({
+        model: r.model,
+        ok: true,
+        result: r.result,
+        aiScore: aiScoreResult?.overall ?? null,
+        mps: mpsResult?.mps ?? null,
+      });
+
+      if (timedOut) break;
     }
-
-    const aiScoreResult = await scoreText({
-      text: r.result,
-      config,
-      patterns,
-      apiKey,
-      baseURL,
-      model: r.model,
-    });
-
-    const mpsResult = await scoreMPS({
-      original: sourceText,
-      rewritten: r.result,
-      apiKey,
-      baseURL,
-      model: r.model,
-    });
-
-    candidates.push({
-      model: r.model,
-      ok: true,
-      result: r.result,
-      aiScore: aiScoreResult?.overall ?? null,
-      mps: mpsResult?.mps ?? null,
-    });
+  } finally {
+    clearTimeout(timeout);
   }
 
   const best = selectBest(candidates);
@@ -58,6 +101,7 @@ export async function runMaxMode({ prompt, sourceText, models, apiKey, baseURL, 
     best,
     allFailed,
     mpsFallback,
+    timedOut,
   };
 }
 

--- a/src/output.js
+++ b/src/output.js
@@ -390,6 +390,9 @@ function formatMaxModeOutput(result) {
   const { candidates, best } = result;
 
   let output = '## MAX Mode Results\n\n';
+  if (result.timedOut) {
+    output += '⚠ MAX wall-clock timeout reached; showing partial results.\n\n';
+  }
   output += '| Model | AI Score | MPS | Status |\n';
   output += '|-------|----------|-----|--------|\n';
 

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -30,11 +30,11 @@ function parseStrictJson(text) {
 }
 
 // Call LLM and parse strict JSON. On schema failure, retry once at temperature 0.
-async function callAndParseJson({ prompt, apiKey, baseURL, model, temperature = 0.1 }) {
+async function callAndParseJson({ prompt, apiKey, baseURL, model, temperature = 0.1, deadline, signal }) {
   let lastError;
   for (let attempt = 0; attempt < 2; attempt++) {
     const t = attempt === 0 ? temperature : 0;
-    const result = await callLLM({ prompt, apiKey, baseURL, model, temperature: t });
+    const result = await callLLM({ prompt, apiKey, baseURL, model, temperature: t, deadline, signal });
     try {
       return { parsed: parseStrictJson(result), raw: result };
     } catch (e) {
@@ -47,7 +47,7 @@ async function callAndParseJson({ prompt, apiKey, baseURL, model, temperature = 
   throw lastError;
 }
 
-export async function scoreText({ text, config, patterns, apiKey, baseURL, model }) {
+export async function scoreText({ text, config, patterns, apiKey, baseURL, model, deadline, signal }) {
   const lang = config.language || 'ko';
   const weights = config.ouroboros?.['category-weights']?.[lang] || {};
 
@@ -82,7 +82,7 @@ ${text}
 `;
 
   try {
-    const { parsed } = await callAndParseJson({ prompt, apiKey, baseURL, model });
+    const { parsed } = await callAndParseJson({ prompt, apiKey, baseURL, model, deadline, signal });
     return parsed;
   } catch (e) {
     console.error(`[patina] scoreText schema failure after retry: ${e.message}`);
@@ -90,7 +90,7 @@ ${text}
   }
 }
 
-export async function scoreMPS({ original, rewritten, apiKey, baseURL, model }) {
+export async function scoreMPS({ original, rewritten, apiKey, baseURL, model, deadline, signal }) {
   const prompt = `You are a Meaning Preservation evaluator. Compare the ORIGINAL text with the REWRITTEN text.
 
 Extract semantic anchors from the original (claims, polarity, causation, quantifiers, negations) and check if each is preserved in the rewritten text.
@@ -123,7 +123,7 @@ ${rewritten}
 `;
 
   try {
-    const { parsed } = await callAndParseJson({ prompt, apiKey, baseURL, model });
+    const { parsed } = await callAndParseJson({ prompt, apiKey, baseURL, model, deadline, signal });
     return parsed;
   } catch (e) {
     console.error(`[patina] scoreMPS schema failure after retry: ${e.message}`);

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -233,6 +233,7 @@ describe('CLI End-to-End with Mock API', () => {
     assert.ok(help.includes('EXAMPLES'), 'help should include examples');
     assert.ok(help.includes('--gate <n>'), 'help should document score gate');
     assert.ok(help.includes('--format <fmt>'), 'help should document output format');
+    assert.ok(help.includes('--max-timeout <sec>'), 'help should document MAX wall-clock timeout');
     assert.ok(
       help.includes('openai-http, codex-cli, claude-cli, gemini-cli'),
       'help should list every backend name'

--- a/tests/unit/max-mode.test.js
+++ b/tests/unit/max-mode.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 
-import { selectBest } from '../../src/max-mode.js';
+import { runMaxMode, selectBest } from '../../src/max-mode.js';
 
 test('selectBest keeps config order and logs AI-score ties among MPS-passing candidates', () => {
   const logs = [];
@@ -25,4 +25,37 @@ test('selectBest keeps config order and logs MPS ties when no candidate passes M
 
   assert.equal(best.model, 'claude');
   assert.deepEqual(logs, ['[patina-max] Tie on MPS — picked claude by config order']);
+});
+
+test('runMaxMode aborts dispatch and returns partial results on wall-clock timeout', async () => {
+  let sawAbortSignal = false;
+  let signalWasAborted = false;
+
+  const result = await runMaxMode({
+    prompt: 'rewrite this',
+    sourceText: 'source text',
+    models: ['slow-model'],
+    apiKey: 'test',
+    baseURL: 'https://example.com/v1',
+    config: {},
+    patterns: [],
+    wallClockBudgetMs: 1,
+    callLLMMultipleImpl: ({ signal }) => new Promise((resolve) => {
+      sawAbortSignal = typeof signal?.addEventListener === 'function';
+      signal.addEventListener('abort', () => {
+        signalWasAborted = signal.aborted;
+        resolve([{ model: 'slow-model', ok: false, error: 'aborted' }]);
+      }, { once: true });
+    }),
+  });
+
+  assert.equal(sawAbortSignal, true);
+  assert.equal(signalWasAborted, true);
+  assert.equal(result.timedOut, true);
+  assert.equal(result.allFailed, true);
+  assert.equal(result.mpsFallback, false);
+  assert.deepEqual(result.candidates, [
+    { model: 'slow-model', ok: false, error: 'aborted' },
+  ]);
+  assert.equal(result.best, null);
 });


### PR DESCRIPTION
## Summary
- add a 300s default wall-clock budget to standalone MAX mode
- propagate the deadline and abort signal through rewrite, AI-score, and MPS calls
- return partial MAX results with `timedOut: true` when the budget expires
- add `--max-timeout <sec>` help/parser support and a partial-results warning in MAX output
- add unit coverage for timeout-driven aborts

Closes #140

## Verification
- node --test tests/unit/max-mode.test.js
- node --test tests/e2e/cli-api.test.js
- node bin/patina.js --help | rg -n -- "--max-timeout|skill-side timeout"
- npm run lint
- npm test
- git diff --check