### PR TITLE
feat: colorize diff output

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -329,6 +329,9 @@ function parseArgs(args) {
       case '--diff':
         parsed.diff = true;
         break;
+      case '--no-color':
+        parsed.noColor = true;
+        break;
       case '--audit':
         parsed.audit = true;
         break;
@@ -706,6 +709,7 @@ COMMANDS
 
 MODES
   --diff                  Show changes pattern by pattern
+  --no-color              Disable ANSI colors in --diff output
   --audit                 Detect patterns only (no rewrite)
   --score                 Output AI-likeness score (0-100)
   --gate <n>              With --score, exit 3 when overall score > n

--- a/src/output.js
+++ b/src/output.js
@@ -1,7 +1,7 @@
 export function formatOutput(result, mode, parsed = {}, opts = {}) {
   const tone = opts.tone || null;
   const format = parsed.format || 'markdown';
-  const body = renderFormattedBody(result, mode);
+  const body = renderFormattedBody(result, mode, parsed, opts);
 
   if (format === 'json') {
     return formatJsonOutput({ result, mode, body, tone, gate: parsed.gate });
@@ -14,7 +14,7 @@ export function formatOutput(result, mode, parsed = {}, opts = {}) {
   return appendToneFooter(body, tone);
 }
 
-function renderFormattedBody(result, mode) {
+function renderFormattedBody(result, mode, parsed = {}, opts = {}) {
   let body = renderBody(result);
   // Only rewrite and ouroboros emit [BODY]/[VARIANT n] tags; diff/audit/score
   // emit tables and don't need the extraction step.
@@ -22,7 +22,38 @@ function renderFormattedBody(result, mode) {
     const variants = extractVariants(body);
     body = variants.length > 0 ? formatVariants(variants, body) : stripSelfAudit(body);
   }
+  if (mode === 'diff') {
+    body = colorizeDiff(body, { parsed, env: opts.env, stdout: opts.stdout });
+  }
   return body;
+}
+
+const ANSI = {
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m',
+};
+
+function colorizeDiff(body, { parsed = {}, env = process.env, stdout = process.stdout } = {}) {
+  if (!shouldColorDiff({ parsed, env, stdout })) return body;
+
+  return String(body || '').split(/\r?\n/).map((line) => {
+    if (/^(\s*)(Removed:)(.*)$/u.test(line)) {
+      return line.replace(/^(\s*)(Removed:)(.*)$/u, `$1${ANSI.red}$2$3${ANSI.reset}`);
+    }
+    if (/^(\s*)(Added:)(.*)$/u.test(line)) {
+      return line.replace(/^(\s*)(Added:)(.*)$/u, `$1${ANSI.green}$2$3${ANSI.reset}`);
+    }
+    if (/^(\s*)(Pattern:)(.*)$/u.test(line)) {
+      return line.replace(/^(\s*)(Pattern:)(.*)$/u, `$1${ANSI.bold}$2$3${ANSI.reset}`);
+    }
+    return line;
+  }).join('\n');
+}
+
+function shouldColorDiff({ parsed = {}, env = process.env, stdout = process.stdout } = {}) {
+  return !parsed.noColor && env.NO_COLOR === undefined && stdout?.isTTY === true;
 }
 
 // v3.11 Phase 3.1: extract [VARIANT n]...[/VARIANT] blocks from a model

--- a/src/prompt-builder.js
+++ b/src/prompt-builder.js
@@ -194,11 +194,12 @@ function buildOutputFormatBlock({ variants = 1 } = {}) {
 }
 
 function buildDiffInstructions() {
-  return `Show what changed and why, pattern by pattern. For each change:\n` +
-    `- Show the original text\n` +
-    `- Show the corrected text\n` +
-    `- Name the pattern that triggered the change (use exact \`N. Pattern Name\` from the loaded packs)\n` +
-    `- Explain why it was changed\n`;
+  return `Show what changed and why, pattern by pattern. For each change use this exact label format:\n\n` +
+    `Pattern: N. Pattern Name\n` +
+    `Removed: original text\n` +
+    `Added: corrected text\n` +
+    `Why: one short reason\n\n` +
+    `Use the exact \`N. Pattern Name\` from the loaded packs. Do not invent pattern names.\n`;
 }
 
 function buildAuditInstructions() {

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -234,6 +234,7 @@ describe('CLI End-to-End with Mock API', () => {
     assert.ok(help.includes('--gate <n>'), 'help should document score gate');
     assert.ok(help.includes('--format <fmt>'), 'help should document output format');
     assert.ok(help.includes('--max-timeout <sec>'), 'help should document MAX wall-clock timeout');
+    assert.ok(help.includes('--no-color'), 'help should document diff color opt-out');
     assert.ok(
       help.includes('openai-http, codex-cli, claude-cli, gemini-cli'),
       'help should list every backend name'

--- a/tests/unit/tone.test.js
+++ b/tests/unit/tone.test.js
@@ -105,6 +105,33 @@ test('formatOutput: no tone → no footer', () => {
   assert.equal(out, 'Hello world');
 });
 
+test('formatOutput: colorizes labeled diff output on TTY', () => {
+  const out = formatOutput(
+    'Pattern: 1. Generic polish\nRemoved: old phrasing\nAdded: sharper phrasing',
+    'diff',
+    {},
+    { env: {}, stdout: { isTTY: true } }
+  );
+
+  assert.ok(out.includes('\x1b[1mPattern: 1. Generic polish\x1b[0m'));
+  assert.ok(out.includes('\x1b[31mRemoved: old phrasing\x1b[0m'));
+  assert.ok(out.includes('\x1b[32mAdded: sharper phrasing\x1b[0m'));
+});
+
+test('formatOutput: disables diff colors for NO_COLOR, --no-color, and non-TTY', () => {
+  const raw = 'Pattern: 1. Generic polish\nRemoved: old phrasing\nAdded: sharper phrasing';
+
+  assert.equal(formatOutput(raw, 'diff', {}, { env: { NO_COLOR: '1' }, stdout: { isTTY: true } }), raw);
+  assert.equal(formatOutput(raw, 'diff', { noColor: true }, { env: {}, stdout: { isTTY: true } }), raw);
+  assert.equal(formatOutput(raw, 'diff', {}, { env: {}, stdout: { isTTY: false } }), raw);
+});
+
+test('formatOutput: does not colorize non-diff modes', () => {
+  const raw = 'Pattern: 1. Generic polish\nRemoved: old phrasing\nAdded: sharper phrasing';
+  const out = formatOutput(raw, 'audit', {}, { env: {}, stdout: { isTTY: true } });
+  assert.equal(out, raw);
+});
+
 test('formatOutput: does not duplicate complete footer', () => {
   const existing = 'Body text\n---\ntone: casual\ntone_source: user\ntone_evidence: []\ntone_confidence: high\n---';
   const tone = { tone: 'casual', tone_source: 'user', tone_evidence: [], tone_confidence: 'high' };


### PR DESCRIPTION
## Summary
- make diff-mode prompts emit stable Pattern/Removed/Added labels
- color Pattern labels bold, Removed lines red, and Added lines green when stdout is a TTY
- add --no-color plus NO_COLOR and non-TTY opt-outs
- keep non-diff modes uncolored

Closes #182

## Verification
- node --test tests/unit/tone.test.js
- node --test tests/e2e/cli-api.test.js
- node bin/patina.js --help | rg -n -- "--no-color|--diff"
- npm run lint
- npm test
- git diff --check