### PR TITLE
CLI adoption wave

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Auto-detect and apply the best-fit tone:
 Requires Node.js ≥ 18. After the npm release is cut, use the package directly:
 
 ```bash
+npx patina-cli init --defaults
+npx patina-cli doctor
 npx patina-cli --lang en input.txt
 ```
 
@@ -149,15 +151,16 @@ patina --lang <ko|en|zh|ja> [mode] [--profile <name>] input.txt
 | *(default)* | Rewrite |
 | `--audit` | Detect AI patterns only |
 | `--score` | 0–100 AI-likeness score with category breakdown |
-| `--score --gate <n>` | Keep CI strict: exit code `3` when `overall > n` |
+| `--score --exit-on <n>` | Keep CI strict: exit code `3` when `overall > n` (`--gate` is kept as an alias) |
 | `--diff` | Show changes pattern by pattern |
 | `--ouroboros` | Iterate the rewrite until score converges (with MPS rollback) |
 | `--lang <ko\|en\|zh\|ja>` | Select language (default: `ko`) |
 | `--profile <name>` | Tone preset: `blog`, `academic`, `technical`, `formal`, `social`, `email`, `legal`, `medical`, `marketing`, `narrative`, `instructional`, `casual-conversation` |
 | `--tone <name>` | Tone category: `casual`, `professional`, `academic`, `narrative`, `marketing`, `instructional`, `auto` |
 | `--batch` | Treat positional args as a list of files (e.g. `--batch docs/*.md`) |
+| `--format json\|text\|markdown` | Select machine-readable JSON, plain text, or default Markdown output |
 
-`patina --help` for the full flag list.
+`patina --help` for the full flag list. `patina doctor --json` checks Node/backend/tmux/API-key readiness without making an LLM call, and `patina init` writes a project `.patina.yaml`.
 
 ### Score-only patterns
 
@@ -178,6 +181,10 @@ For inputs ≤200 chars or ≤3 paragraphs, register-sensitive categories (`lang
 ### Self-audit isolation (v3.11)
 
 In rewrite mode, the model emits its self-audit notes inside `[SELF_AUDIT]`/`[/SELF_AUDIT]` tags wrapped around a `[BODY]`/`[/BODY]` block (or `[VARIANT n]` blocks when `--variants > 1`). patina strips the audit before showing the user, so raw output is clean — earlier versions sometimes leaked phrases like "남아 있는 AI 티" or "Phase 3" preambles into the user-facing text.
+
+### Machine-readable output and exit codes
+
+`--format json` wraps every mode in a stable envelope with `overall`, `categories[]`, `tone`, `mps`, `gateResult`, and the cleaned `output` body. `--format markdown` is the default; `--format text` keeps the user-facing body without the YAML tone footer. Exit codes are standardized in [EXIT-CODES.md](docs/EXIT-CODES.md): `0` success, `1` runtime/backend, `2` input/usage, `3` score gate exceeded, `4` MAX MPS fallback/all-candidates-failed.
 
 ### Score weight drift detection (v3.11)
 
@@ -251,7 +258,8 @@ Pattern packs are auto-discovered by language prefix. `.patina.yaml` in the work
 - **[Pre-commit](docs/integrations/pre-commit.md)** — pre-commit, Husky, and Lefthook score-only recipes
 - **[Docker](docs/integrations/docker.md)** — GHCR image usage and release tags
 - **[Release workflow](docs/integrations/release.md)** — npm provenance + GHCR publishing checklist
-- **[CLI Contract](docs/CLI.md)** — score gate, exit codes, and automation-safe surfaces
+- **[CLI Contract](docs/CLI.md)** — score gate, JSON/text/Markdown output, and automation-safe surfaces
+- **[Exit Codes](docs/EXIT-CODES.md)** — process code contract for CI and editor integrations
 - **[Ethics](docs/ETHICS.md)** — intended use, non-use, and disclosure stance
 - **[FAQ](docs/FAQ.md)** — detector-bypass concerns, MPS, false positives, contribution starting points
 - **[Comparison](docs/COMPARISON.md)** — factual comparison with common paraphraser/humanizer tools

--- a/bin/patina.js
+++ b/bin/patina.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
 import { main } from '../src/cli.js';
+import { renderCliError, getExitCode } from '../src/errors.js';
 
 main(process.argv.slice(2)).catch((err) => {
-  console.error(err);
-  process.exit(1);
+  console.error(renderCliError(err));
+  process.exit(getExitCode(err));
 });

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -4,10 +4,10 @@ patina's CLI is optimized for interactive editing, but a few surfaces are stable
 
 ## Score gate
 
-Use `--score --gate <n>` when CI should fail if a text still reads too AI-like.
+Use `--score --exit-on <n>` (or the older `--gate <n>` alias) when CI should fail if a text still reads too AI-like.
 
 ```bash
-patina --lang en --score --gate 30 draft.md
+patina --lang en --score --exit-on 30 draft.md
 ```
 
 - `--score` still prints the model's score output.
@@ -18,15 +18,33 @@ patina --lang en --score --gate 30 draft.md
 
 | Code | Meaning |
 |---:|---|
-| `0` | Command completed; for `--score --gate`, the score was at or below the gate. |
+| `0` | Command completed; for `--score --exit-on`, the score was at or below the gate. |
 | `1` | Runtime or backend error, including API/auth/backend failures. |
 | `2` | Input/usage error from no interactive input or empty stdin. |
-| `3` | `--score --gate` completed, but the score exceeded the configured gate. |
+| `3` | `--score --exit-on` / `--score --gate` completed, but the score exceeded the configured gate. |
+| `4` | MAX mode all candidates failed, or patina fell back because no candidate met the MPS floor. |
 
-## Current machine-readable surfaces
+## Output formats
 
-- `--score` asks the backend to emit a JSON-like score with an `overall` field; `--gate` parses that field for exit-code decisions.
+`--format markdown` is the default and preserves the existing human-readable output. `--format text` emits the same user-facing content without the YAML tone footer. `--format json` wraps every mode in a stable envelope:
+
+```json
+{
+  "mode": "score",
+  "format": "json",
+  "overall": 23,
+  "categories": [],
+  "tone": { "tone": null, "tone_source": "profile_only" },
+  "mps": null,
+  "gateResult": { "threshold": 30, "overall": 23, "passed": true, "exitCode": 0 },
+  "output": "raw model output after patina cleanup"
+}
+```
+
+- `overall` and `categories[]` are populated when patina can parse them from score JSON or score tables.
+- `mps` is populated for MAX-mode results when available.
+- `gateResult` is `null` unless `--exit-on` / `--gate` is used.
 - `--save-run <dir>` writes `manifest.json` plus `output-N.txt` files for reproducible audit trails.
-- `--list-backends` and `--list-providers` print tabular status for auth/debugging.
+- `patina doctor --json` emits setup diagnostics for CI without making an LLM call.
 
-Future output-format work should keep these contracts backward-compatible instead of changing existing stdout by surprise.
+See [EXIT-CODES.md](EXIT-CODES.md) for the full process contract.

--- a/docs/EXIT-CODES.md
+++ b/docs/EXIT-CODES.md
@@ -1,0 +1,25 @@
+# Exit Codes
+
+patina uses stable exit codes so CI and editor integrations can distinguish content gates from setup failures.
+
+| Code | Meaning |
+|---:|---|
+| `0` | Success. For `--score --exit-on <n>`, the parsed `overall` score was at or below the threshold. |
+| `1` | Runtime/backend failure: API/auth/backend errors, failed doctor blockers, invalid runtime setup, or unexpected exceptions. |
+| `2` | Input/usage failure: unknown flags, missing required option values, empty stdin, or `--no-interactive` with no input. |
+| `3` | Score gate exceeded. `--score --exit-on <n>` or `--score --gate <n>` completed, but `overall > n`. |
+| `4` | MAX mode could not produce a fully acceptable candidate: all candidates failed, or no candidate reached the MPS floor and patina selected the highest-MPS fallback. |
+
+## Score gates
+
+```bash
+patina --lang en --score --exit-on 30 draft.md
+```
+
+`--gate <n>` remains as a backward-compatible alias for the same behavior. The command still prints the score output; only the process exit code changes to `3` when the gate fails.
+
+## Empty input
+
+- Piped empty or whitespace-only stdin exits `2` and prints a three-line `[patina] Error:` message.
+- In an interactive TTY, patina prompts for one-shot stdin and waits until Ctrl-D.
+- `--no-interactive` restores script-safe no-input behavior: no prompt, exit `2`.

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,6 +8,9 @@ import { formatOutput, validateScoreWeights } from './output.js';
 import { runMaxMode } from './max-mode.js';
 import { runOuroboros } from './ouroboros.js';
 import { buildManifest, appendResult, writeManifest } from './manifest.js';
+import { runDoctor } from './commands/doctor.js';
+import { runInit } from './commands/init.js';
+import { inputError, runtimeError, renderCliError, getExitCode } from './errors.js';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, basename, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -19,6 +22,16 @@ const PACKAGE_VERSION = JSON.parse(
 export async function main(args) {
   if (args[0] === 'auth') {
     return handleAuth(args.slice(1));
+  }
+  if (args[0] === 'doctor') {
+    return runDoctor(args.slice(1), { version: PACKAGE_VERSION });
+  }
+  if (args[0] === 'init') {
+    return runInit(args.slice(1));
+  }
+  if (args[0] === 'help') {
+    printHelp();
+    return;
   }
 
   const parsed = parseArgs(args);
@@ -38,7 +51,11 @@ export async function main(args) {
   }
 
   if (parsed.gate !== undefined && !parsed.score) {
-    throw new Error('--gate can only be used with --score.');
+    throw inputError(
+      '--gate can only be used with --score',
+      'Score gates need a parsed overall score.',
+      'Run `patina --score --exit-on 30 <file>`.'
+    );
   }
 
   if (parsed.listBackends) {
@@ -51,26 +68,27 @@ export async function main(args) {
     return;
   }
 
-  const provider = selectProvider(parsed.provider);
   const apiKey = resolveApiKey(parsed);
+  const configPath = parsed.config ? resolve(process.cwd(), parsed.config) : undefined;
+  const config = loadConfig(configPath);
+
+  if (parsed.lang) config.language = parsed.lang;
+  if (parsed.profile) config.profile = parsed.profile;
+
+  const provider = selectProvider(parsed.provider ?? config.provider);
   const resolved = resolveProviderConfig({
     provider,
     apiKey,
-    baseURL: parsed.baseURL,
-    model: parsed.model,
+    baseURL: parsed.baseURL ?? config.baseURL ?? config['base-url'],
+    model: parsed.model ?? config.model,
   });
   applyInsecureBaseURLOptIn(parsed);
   applyPrivateBaseURLOptIn(parsed);
   validateBaseURL(resolved.baseURL);
 
-  const configPath = parsed.config ? resolve(process.cwd(), parsed.config) : undefined;
-  const config = loadConfig(configPath);
   const startedAt = new Date().toISOString();
   const manifestResults = [];
   const manifestOutputs = [];
-
-  if (parsed.lang) config.language = parsed.lang;
-  if (parsed.profile) config.profile = parsed.profile;
 
   const repoRoot = getRepoRoot();
   const lang = config.language || 'ko';
@@ -122,7 +140,7 @@ export async function main(args) {
       tone: toneResolution,
       promptMode: resolvePromptMode(
         parsed.promptMode || config['prompt-mode'] || 'strict',
-        { backend: parsed.backend, model: resolved.model }
+        { backend: parsed.backend ?? config.backend, model: resolved.model }
       ),
       variants: parsed.variants || 1,
     });
@@ -154,7 +172,7 @@ export async function main(args) {
       });
     } else {
       const { backend, autoSelected, reason } = selectBackend({
-        name: parsed.backend,
+        name: parsed.backend ?? config.backend,
         model: resolved.model,
       });
 
@@ -175,7 +193,11 @@ export async function main(args) {
         } else if (codex && !codex.available) {
           msg.push('Or install `codex` from https://github.com/openai/codex and pass `--backend codex-cli`.');
         }
-        throw new Error(msg.join('\n'));
+        throw runtimeError(
+          'no API key found',
+          msg[0],
+          msg.slice(1).join(' ') || 'Set PATINA_API_KEY or pass --backend codex-cli after logging in.'
+        );
       }
 
       result = await backend.invoke({
@@ -208,6 +230,10 @@ export async function main(args) {
       }
     }
 
+    if (result?.type === 'max-mode' && (result.allFailed || result.mpsFallback)) {
+      process.exitCode = Math.max(Number(process.exitCode) || 0, 4);
+    }
+
     if (parsed.saveRun) {
       const idx = manifestResults.length + 1;
       const outputName = `output-${idx}.txt`;
@@ -233,7 +259,7 @@ export async function main(args) {
       lang,
       profile: profileName,
       provider: provider?.name,
-      backend: parsed.backend ?? 'openai-http',
+      backend: parsed.backend ?? config.backend ?? 'openai-http',
       model: resolved.model,
       configPath: configPath ?? null,
       config,
@@ -253,6 +279,7 @@ export async function main(args) {
 function parseArgs(args) {
   const parsed = {
     files: [],
+    format: 'markdown',
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -293,10 +320,37 @@ function parseArgs(args) {
       case '--score':
         parsed.score = true;
         break;
+      case '--format': {
+        const value = args[++i];
+        if (!['json', 'text', 'markdown'].includes(value)) {
+          throw inputError(
+            '--format expects json, text, or markdown',
+            `Received ${value === undefined ? 'no value' : `"${value}"`}.`,
+            'Use `--format json`, `--format text`, or `--format markdown`.'
+          );
+        }
+        parsed.format = value;
+        break;
+      }
+      case '--json':
+        parsed.format = 'json';
+        break;
       case '--gate': {
         const n = Number(args[++i]);
         if (!Number.isFinite(n) || n < 0 || n > 100) {
           throw new Error(`--gate expects a number from 0 to 100, got ${args[i]}`);
+        }
+        parsed.gate = n;
+        break;
+      }
+      case '--exit-on': {
+        const n = Number(args[++i]);
+        if (!Number.isFinite(n) || n < 0 || n > 100) {
+          throw inputError(
+            '--exit-on expects a number from 0 to 100',
+            `Received ${args[i] === undefined ? 'no value' : `"${args[i]}"`}.`,
+            'Use `patina --score --exit-on 30 <file>` for CI gates.'
+          );
         }
         parsed.gate = n;
         break;
@@ -379,9 +433,18 @@ function parseArgs(args) {
         parsed.variants = n;
         break;
       }
+      case '--no-interactive':
+        parsed.noInteractive = true;
+        break;
       default:
         if (!arg.startsWith('-')) {
           parsed.files.push(arg);
+        } else {
+          throw inputError(
+            `unknown option ${arg}`,
+            'patina does not recognize this CLI flag.',
+            'Run `patina --help` to see supported options.'
+          );
         }
         break;
     }
@@ -439,17 +502,23 @@ function resolveApiKey(parsed) {
 
 async function loadInputs(parsed) {
   if (parsed.files.length === 0) {
-    // No file args. If stdin is a TTY (interactive terminal), there is no input
-    // to read — print help instead of hanging or sending empty text to the LLM.
     if (process.stdin.isTTY) {
-      printHelp();
-      console.error('\nNo input provided. Pass a file path, pipe text via stdin, or run `patina --help`.');
-      process.exit(2);
+      if (parsed.noInteractive) {
+        throw inputError(
+          'no input provided',
+          'No file path or piped stdin was available.',
+          'Pass a file path, pipe text via stdin, or omit --no-interactive to paste text and press Ctrl-D.'
+        );
+      }
+      console.error('[patina] Paste text, then press Ctrl-D to run (Ctrl-C to cancel).');
     }
-    const stdin = await readStdin();
+    const stdin = await readStdin({ interactive: Boolean(process.stdin.isTTY) });
     if (!stdin.trim()) {
-      console.error('Error: empty input on stdin. Pipe text via stdin or pass a file path.');
-      process.exit(2);
+      throw inputError(
+        'empty input on stdin',
+        'patina received stdin, but it contained no non-whitespace text.',
+        'Try `echo "This is a draft." | patina --lang en` or pass a file path.'
+      );
     }
     return [{ path: '-', text: stdin }];
   }
@@ -462,17 +531,38 @@ async function loadInputs(parsed) {
   return inputs;
 }
 
-function readStdin() {
+function readStdin({ interactive = false } = {}) {
   return new Promise((resolve, reject) => {
     let data = '';
+    let cleanupSigint = () => {};
+    if (interactive) {
+      const onSigint = () => {
+        cleanupSigint();
+        const err = inputError(
+          'interrupted',
+          'Ctrl-C canceled interactive stdin before patina could process text.',
+          'Run the command again, or pass --no-interactive in scripts.'
+        );
+        err.exitCode = 130;
+        reject(err);
+        process.exitCode = 130;
+      };
+      process.once('SIGINT', onSigint);
+      cleanupSigint = () => process.removeListener('SIGINT', onSigint);
+    }
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', (chunk) => {
       data += chunk;
     });
     process.stdin.on('end', () => {
+      cleanupSigint();
       resolve(data);
     });
-    process.stdin.on('error', reject);
+    process.stdin.on('error', (err) => {
+      cleanupSigint();
+      reject(err);
+    });
+    if (interactive) process.stdin.resume();
   });
 }
 
@@ -525,86 +615,75 @@ function printHelp() {
   const backendChoices = listBackendNames().join(', ');
   console.log(`patina — AI text humanizer CLI
 
-Usage: patina [options] [file...]
+Usage: patina [command] [options] [file...]
 
-Core options:
-  -h, --help           Show this help message
-  -v, --version        Show version
-  --lang <code>        Language: ko, en, zh, ja (default: ko)
-  --profile <name>     Profile: default, blog, academic, technical, formal,
-                       social, email, legal, medical, marketing,
-                       narrative, instructional
-  --tone <name>        Tone category: casual, professional, academic,
-                       narrative, marketing, instructional, auto.
-                       Resolution: --tone > config tone > config profile.
-                       zh/ja with explicit tone → warns + profile-only fallback.
+COMMANDS
+  patina init             Create a project .patina.yaml
+  patina doctor [--json]  Check Node, backends, tmux, and auth setup
+  patina auth status      Show backend availability and authentication status
+  patina auth login       Print per-backend authentication instructions
 
-Modes:
-  --diff               Show changes pattern by pattern
-  --audit              Detect patterns only (no rewrite)
-  --score              Output AI-likeness score (0-100)
-  --gate <n>           With --score, set exit code 3 when overall score > n
-  --ouroboros          Iterative self-improvement loop
+MODES
+  --diff                  Show changes pattern by pattern
+  --audit                 Detect patterns only (no rewrite)
+  --score                 Output AI-likeness score (0-100)
+  --gate <n>              With --score, exit 3 when overall score > n
+  --exit-on <n>           Alias for --gate, intended for CI scripts
+  --ouroboros             Iterative self-improvement loop
 
-Batch / output:
-  --batch              Process multiple files
-  --in-place           Overwrite original files (with --batch)
-  --suffix <ext>       Save as {name}{ext}{extname}
-  --outdir <dir>       Save results to directory
-  --save-run <dir>     Write manifest.json + output-N.txt under <dir> after the
-                       run (records version, prompt/config hashes, patterns,
-                       provider/model — useful for reproducibility / audit)
+OUTPUT & BATCH
+  --format <fmt>          Output format: markdown (default), text, json
+  --json                  Alias for --format json
+  --batch                 Process multiple files
+  --in-place              Overwrite original files (with --batch)
+  --suffix <ext>          Save as {name}{ext}{extname}
+  --outdir <dir>          Save results to directory
+  --save-run <dir>        Write manifest.json + output-N.txt for reproducibility
+  --no-interactive        Do not wait for TTY stdin; exit 2 when no input is given
 
-MAX / variants:
-  --models <list>      MAX mode: comma-separated model list
-  --max-concurrency <n>  Cap parallel MAX-mode requests (default: unlimited)
-  --variants <n>       Generate N stylistic variants of the rewrite (1-5,
-                       default 1). Each variant preserves facts/numbers but
-                       differs in voice (V1 casual, V2 direct, V3 measured…).
-                       Output prints each as ## Variant N. Only --rewrite mode.
+LANGUAGE & PROFILE
+  --lang <code>           Language: ko, en, zh, ja (default: ko)
+  --profile <name>        Profile: default, blog, academic, technical, formal,
+                          social, email, legal, medical, marketing,
+                          narrative, instructional
+  --tone <name>           Tone: casual, professional, academic, narrative,
+                          marketing, instructional, auto. Resolution:
+                          --tone > config tone > config profile.
 
-Model / auth / backend:
-  --model <id>         Single model ID (default: gpt-4o)
-  --api-key <key>      API key (DEPRECATED: leaks via ps/shell history; prefer
-                       PATINA_API_KEY env or --api-key-file)
-  --api-key-file <path>  Read API key from file (recommended for shared hosts)
-  --base-url <url>     API base URL (or PATINA_API_BASE env)
-  --backend <name>     Backend: ${backendChoices} (default: openai-http)
-  --list-backends      List available backends and their availability
-  --provider <name>    Provider preset: openai, gemini, groq, together
-                       (sets base-url + default model + reads <PROVIDER>_API_KEY)
-  --list-providers     List provider presets and which keys are set
+MODEL & AUTH
+  --model <id>            Single model ID (default: gpt-4o)
+  --api-key <key>         API key (DEPRECATED: leaks via ps/shell history; prefer
+                          PATINA_API_KEY env or --api-key-file)
+  --api-key-file <path>   Read API key from file (recommended)
+  --base-url <url>        API base URL (or PATINA_API_BASE env)
+  --backend <name>        Backend: ${backendChoices} (default: openai-http)
+  --list-backends         List available backends and their availability
+  --provider <name>       Provider preset: openai, gemini, groq, together
+  --list-providers        List provider presets and which keys are set
+  --models <list>         MAX mode: comma-separated model list
+  --max-concurrency <n>   Cap parallel MAX-mode requests (default: unlimited)
+
+ADVANCED
+  --variants <n>          Generate N rewrite variants (1-5; rewrite mode only)
+  --config <path>         Load config from <path> instead of .patina.default.yaml
+  --prompt-mode <m>       strict | minimal | auto. auto picks per backend.
   --allow-insecure-base-url  Permit plaintext http:// to non-localhost endpoints
-                       (also enabled by PATINA_ALLOW_INSECURE_BASE_URL=1)
-  --allow-private-base-url   Permit base URL pointing at private/IMDS IPs
-                       (also enabled by PATINA_ALLOW_PRIVATE_BASE_URL=1).
-                       Default: refuse to send the API key to RFC 1918 / link-local
-                       hosts to block SSRF to cloud metadata endpoints.
+  --allow-private-base-url   Permit private/IMDS base URLs
+  -h, --help              Show this help message
+  -v, --version           Show version
 
-Prompt / config:
-  --config <path>      Load config from <path> instead of .patina.default.yaml
-  --prompt-mode <m>    Rewrite prompt mode: strict | minimal | auto.
-                       strict (default): full pattern packs (~34KB).
-                       minimal: compressed watch-words + casual instruction (~3KB).
-                       auto: pick by backend — gemini → minimal, others → strict.
-                       case-05 finding: minimal helps Gemini, hurts Claude,
-                       neutral for Codex. Only affects --rewrite mode.
+EXAMPLES
+  echo "This is a draft." | patina --lang en --backend codex-cli
+  patina --score --exit-on 30 --format json draft.md
+  patina init --defaults
+  patina doctor --json
 
-Environment Variables:
-  PATINA_API_KEY       API authentication key (any provider)
-  PATINA_API_KEY_FILE  Path to file containing the API key (alt to PATINA_API_KEY)
-  PATINA_API_BASE      API base URL (default: https://api.openai.com/v1)
-  PATINA_MODEL         Default model ID
-  PATINA_ALLOW_INSECURE_BASE_URL  Set to 1 to permit plain HTTP to non-loopback
-  PATINA_ALLOW_PRIVATE_BASE_URL   Set to 1 to permit private/IMDS base URLs
-  GEMINI_API_KEY       Used when --provider gemini
-  GROQ_API_KEY         Used when --provider groq
-  TOGETHER_API_KEY     Used when --provider together
-  OPENAI_API_KEY       Used when --provider openai (alternative to PATINA_API_KEY)
+ENVIRONMENT
+  PATINA_API_KEY, PATINA_API_KEY_FILE, PATINA_API_BASE, PATINA_MODEL
+  OPENAI_API_KEY, GEMINI_API_KEY, GROQ_API_KEY, TOGETHER_API_KEY
 
-Subcommands:
-  patina auth status   Show backend availability and authentication status
-  patina auth login    Print per-backend instructions for authenticating
+EXIT CODES
+  0 success · 1 runtime/backend · 2 input/usage · 3 score gate exceeded · 4 MAX MPS fallback/all candidates failed
 
 If no API key is set, pass --backend codex-cli to use a logged-in codex CLI
 (no key required). Auto-fallback was removed in v3.9 to keep agent-mode
@@ -726,8 +805,11 @@ function handleAuth(subArgs) {
     }
     return;
   }
-  console.error(`Unknown auth subcommand: ${sub}. Try \`patina auth status\` or \`patina auth login\`.`);
-  process.exit(1);
+  throw inputError(
+    `unknown auth subcommand ${sub}`,
+    'Supported auth subcommands are status and login.',
+    'Try `patina auth status` or `patina auth login`.'
+  );
 }
 
 // Self-invocation guard (#113): when run directly via `node src/cli.js ...`,
@@ -735,7 +817,7 @@ function handleAuth(subArgs) {
 // the exports.
 if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
   main(process.argv.slice(2)).catch((err) => {
-    console.error(err);
-    process.exit(1);
+    console.error(renderCliError(err));
+    process.exit(getExitCode(err));
   });
 }

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,0 +1,241 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { listBackends } from '../backends/index.js';
+import { PROVIDERS } from '../providers.js';
+import { inputError } from '../errors.js';
+
+const MIN_NODE_MAJOR = 18;
+const API_KEY_ENVS = [
+  'PATINA_API_KEY',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'GROQ_API_KEY',
+  'TOGETHER_API_KEY',
+];
+
+export function runDoctor(args = [], { version } = {}) {
+  const parsed = parseDoctorArgs(args);
+  if (parsed.help) {
+    printDoctorHelp();
+    return;
+  }
+
+  const report = buildDoctorReport({ version });
+  if (parsed.format === 'json') {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatDoctorText(report));
+  }
+
+  if (!report.ok) {
+    process.exitCode = Math.max(Number(process.exitCode) || 0, 1);
+  }
+}
+
+export function buildDoctorReport({ version } = {}) {
+  const checks = [];
+  const backends = listBackends();
+  const nodeVersion = process.versions.node;
+  const nodeMajor = Number(nodeVersion.split('.')[0]);
+  const nodeOk = Number.isFinite(nodeMajor) && nodeMajor >= MIN_NODE_MAJOR;
+
+  checks.push({
+    name: 'node',
+    status: nodeOk ? 'ok' : 'blocker',
+    summary: `Node ${nodeVersion}`,
+    detail: nodeOk
+      ? `meets package engine >=${MIN_NODE_MAJOR}`
+      : `requires Node >=${MIN_NODE_MAJOR}`,
+  });
+
+  checks.push({
+    name: 'cli-version',
+    status: version ? 'ok' : 'warning',
+    summary: `patina ${version || 'unknown'}`,
+    detail: 'read from package metadata',
+  });
+
+  const tmux = checkCommand('tmux', ['-V']);
+  checks.push({
+    name: 'tmux',
+    status: tmux.ok ? 'ok' : 'warning',
+    summary: tmux.ok ? tmux.stdout.trim() : 'tmux not found',
+    detail: tmux.ok
+      ? 'available for MAX omc dispatch workflows'
+      : 'only needed for tmux-based MAX dispatch; direct/API modes still work',
+  });
+
+  const apiKeys = API_KEY_ENVS.map((name) => ({
+    name,
+    set: Boolean(process.env[name]),
+  }));
+  const apiKeyFile = checkApiKeyFile(process.env.PATINA_API_KEY_FILE);
+  checks.push({
+    name: 'api-key-env',
+    status: apiKeyFile.status === 'blocker'
+      ? 'blocker'
+      : (apiKeys.some((k) => k.set) || apiKeyFile.status === 'ok' ? 'ok' : 'warning'),
+    summary: apiKeys.some((k) => k.set) || apiKeyFile.status === 'ok'
+      ? 'API key source detected'
+      : 'no API key env var detected',
+    detail: apiKeyFile.detail || 'HTTP provider use requires PATINA_API_KEY or a provider-specific key',
+  });
+
+  const providerKeys = Object.values(PROVIDERS).map((provider) => ({
+    name: provider.name,
+    apiKeyEnv: provider.apiKeyEnv,
+    keySet: Boolean(process.env[provider.apiKeyEnv] || process.env.PATINA_API_KEY),
+    baseURL: provider.baseURL,
+    defaultModel: provider.defaultModel,
+  }));
+
+  const usableBackends = backends.filter((b) => b.available && b.authenticated);
+  checks.push({
+    name: 'usable-backend',
+    status: usableBackends.length > 0 ? 'ok' : 'blocker',
+    summary: usableBackends.length > 0
+      ? `${usableBackends.length} authenticated backend(s)`
+      : 'no authenticated backend',
+    detail: usableBackends.length > 0
+      ? usableBackends.map((b) => b.name).join(', ')
+      : 'Set an API key or authenticate one local backend (`codex login`, `claude`, or `gemini`).',
+  });
+
+  const blockers = checks.filter((check) => check.status === 'blocker');
+  return {
+    ok: blockers.length === 0,
+    version: version || null,
+    node: {
+      version: nodeVersion,
+      required: `>=${MIN_NODE_MAJOR}.0.0`,
+      ok: nodeOk,
+    },
+    checks,
+    backends,
+    providers: providerKeys,
+    env: {
+      apiKeys,
+      PATINA_API_KEY_FILE: process.env.PATINA_API_KEY_FILE || null,
+    },
+    blockers: blockers.map((check) => ({
+      name: check.name,
+      summary: check.summary,
+      detail: check.detail,
+    })),
+  };
+}
+
+function parseDoctorArgs(args) {
+  const parsed = { format: 'text' };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case '--help':
+      case '-h':
+        parsed.help = true;
+        break;
+      case '--json':
+        parsed.format = 'json';
+        break;
+      case '--format': {
+        const value = args[++i];
+        if (!['json', 'text'].includes(value)) {
+          throw inputError(
+            'patina doctor --format expects json or text',
+            `Received ${value === undefined ? 'no value' : `"${value}"`}.`,
+            'Use `patina doctor --json` for CI-readable output.'
+          );
+        }
+        parsed.format = value;
+        break;
+      }
+      default:
+        throw inputError(
+          `unknown doctor option ${arg}`,
+          'The doctor command only accepts --json, --format, and --help.',
+          'Run `patina doctor --help` for usage.'
+        );
+    }
+  }
+  return parsed;
+}
+
+function checkCommand(cmd, args) {
+  try {
+    const result = spawnSync(cmd, args, { encoding: 'utf8' });
+    return {
+      ok: result.status === 0,
+      stdout: result.stdout || '',
+      stderr: result.stderr || '',
+    };
+  } catch (err) {
+    return { ok: false, stdout: '', stderr: err.message };
+  }
+}
+
+function checkApiKeyFile(path) {
+  if (!path) return { status: 'missing', detail: '' };
+  if (!existsSync(path)) {
+    return { status: 'blocker', detail: `PATINA_API_KEY_FILE points to a missing file: ${path}` };
+  }
+  try {
+    const contents = readFileSync(path, 'utf8').trim();
+    if (!contents) {
+      return { status: 'blocker', detail: `PATINA_API_KEY_FILE is empty: ${path}` };
+    }
+    return { status: 'ok', detail: `PATINA_API_KEY_FILE is readable: ${path}` };
+  } catch (err) {
+    return { status: 'blocker', detail: `Cannot read PATINA_API_KEY_FILE ${path}: ${err.message}` };
+  }
+}
+
+function formatDoctorText(report) {
+  const icon = (status) => status === 'ok' ? '✓' : (status === 'warning' ? '!' : '✗');
+  const lines = [
+    `patina doctor — ${report.ok ? 'ok' : 'blockers found'}`,
+    '',
+    'Checks:',
+  ];
+  for (const check of report.checks) {
+    lines.push(`  ${icon(check.status)} ${check.summary}`);
+    if (check.detail) lines.push(`    ${check.detail}`);
+  }
+
+  lines.push('', 'Backends:');
+  for (const backend of report.backends) {
+    const ok = backend.available && backend.authenticated;
+    lines.push(
+      `  ${ok ? '✓' : '!'} ${backend.name}: available=${yesNo(backend.available)}, authenticated=${yesNo(backend.authenticated)}`
+    );
+    if (!ok && backend.authHint) lines.push(`    → ${backend.authHint}`);
+  }
+
+  lines.push('', 'Provider keys:');
+  for (const provider of report.providers) {
+    lines.push(`  ${provider.keySet ? '✓' : '!'} ${provider.name}: ${provider.apiKeyEnv}=${provider.keySet ? 'set' : 'missing'}`);
+  }
+
+  if (report.blockers.length > 0) {
+    lines.push('', 'Blockers:');
+    for (const blocker of report.blockers) {
+      lines.push(`  - ${blocker.summary}: ${blocker.detail}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function yesNo(value) {
+  return value ? 'yes' : 'no';
+}
+
+function printDoctorHelp() {
+  console.log(`patina doctor — check local CLI readiness
+
+Usage: patina doctor [--json]
+
+Checks Node version, patina CLI version, backend availability/authentication,
+tmux, and PATINA/provider API key environment variables. Exits 0 when no
+blockers are found, or 1 when a blocking setup issue is detected.
+`);
+}

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,0 +1,203 @@
+import { existsSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createInterface } from 'node:readline/promises';
+import { spawnSync } from 'node:child_process';
+import { stdin as input, stdout as output } from 'node:process';
+import yaml from 'js-yaml';
+import { listBackends } from '../backends/index.js';
+import { inputError } from '../errors.js';
+
+const LANGUAGES = ['ko', 'en', 'zh', 'ja'];
+const PROFILES = [
+  'default',
+  'blog',
+  'academic',
+  'technical',
+  'formal',
+  'social',
+  'email',
+  'legal',
+  'medical',
+  'marketing',
+  'narrative',
+  'instructional',
+];
+const TONES = ['profile-only', 'casual', 'professional', 'academic', 'narrative', 'marketing', 'instructional', 'auto'];
+const DISPATCH_MODES = ['omc', 'direct', 'api'];
+
+export async function runInit(args = []) {
+  const parsed = parseInitArgs(args);
+  if (parsed.help) {
+    printInitHelp();
+    return;
+  }
+
+  const target = resolve(process.cwd(), '.patina.yaml');
+  if (existsSync(target) && !parsed.force) {
+    if (parsed.defaults || !process.stdin.isTTY) {
+      throw inputError(
+        '.patina.yaml already exists',
+        'init will not overwrite an existing project config without confirmation.',
+        'Run `patina init --force` to replace it, or edit .patina.yaml manually.'
+      );
+    }
+  }
+
+  const detected = detectInitDefaults();
+  const answers = parsed.defaults
+    ? detected
+    : await promptForConfig(detected, { target, force: parsed.force });
+
+  if (!answers) {
+    console.error('[patina] kept existing .patina.yaml');
+    return;
+  }
+
+  const config = buildInitConfig(answers);
+  writeFileSync(target, `${yaml.dump(config, { lineWidth: 100 }).trimEnd()}\n`, 'utf8');
+  console.log(`[patina] wrote ${target}`);
+}
+
+export function detectInitDefaults() {
+  const backends = listBackends();
+  const authenticated = backends.filter((b) => b.available && b.authenticated);
+  const preferredBackend = (
+    authenticated.find((b) => b.name !== 'openai-http') ||
+    authenticated[0] ||
+    backends.find((b) => b.name === 'openai-http')
+  )?.name || 'openai-http';
+
+  const maxModels = authenticated
+    .map((b) => MODEL_BY_BACKEND[b.name])
+    .filter(Boolean);
+
+  return {
+    language: 'ko',
+    profile: 'default',
+    tone: 'profile-only',
+    backend: preferredBackend,
+    maxModels: maxModels.length > 0 ? maxModels : ['claude', 'gemini'],
+    dispatch: commandAvailable('tmux') ? 'omc' : 'direct',
+  };
+}
+
+function parseInitArgs(args) {
+  const parsed = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case '--help':
+      case '-h':
+        parsed.help = true;
+        break;
+      case '--defaults':
+        parsed.defaults = true;
+        break;
+      case '--force':
+      case '--yes':
+      case '-y':
+        parsed.force = true;
+        break;
+      default:
+        throw inputError(
+          `unknown init option ${arg}`,
+          'The init command only accepts --defaults, --force, and --help.',
+          'Run `patina init --help` for usage.'
+        );
+    }
+  }
+  return parsed;
+}
+
+async function promptForConfig(defaults, { target, force }) {
+  if (!process.stdin.isTTY) {
+    throw inputError(
+      'init needs an interactive terminal',
+      'guided setup asks questions before writing .patina.yaml.',
+      'Run `patina init --defaults` for a non-interactive config.'
+    );
+  }
+
+  const rl = createInterface({ input, output });
+  try {
+    if (existsSync(target) && !force) {
+      const overwrite = await ask(rl, `Overwrite existing .patina.yaml?`, 'no', ['yes', 'no']);
+      if (overwrite !== 'yes') return null;
+    }
+
+    const language = await ask(rl, 'Language', defaults.language, LANGUAGES);
+    const profile = await ask(rl, 'Profile', defaults.profile, PROFILES);
+    const tone = await ask(rl, 'Tone', defaults.tone, TONES);
+    const backendChoices = listBackends().map((b) => b.name);
+    const backend = await ask(rl, 'Backend', defaults.backend, backendChoices);
+    const maxModels = await askMulti(rl, 'MAX models', defaults.maxModels, ['claude', 'codex', 'gemini']);
+    const dispatch = await ask(rl, 'Dispatch mode', defaults.dispatch, DISPATCH_MODES);
+    return { language, profile, tone, backend, maxModels, dispatch };
+  } finally {
+    rl.close();
+  }
+}
+
+async function ask(rl, label, defaultValue, choices) {
+  const choiceHint = choices ? ` (${choices.join('/')})` : '';
+  const raw = (await rl.question(`${label}${choiceHint} [${defaultValue}]: `)).trim();
+  const value = raw || defaultValue;
+  if (choices && !choices.includes(value)) {
+    console.error(`[patina] ${label}: unknown value "${value}", keeping ${defaultValue}`);
+    return defaultValue;
+  }
+  return value;
+}
+
+async function askMulti(rl, label, defaultValues, choices) {
+  const raw = (await rl.question(`${label} (${choices.join(',')}) [${defaultValues.join(',')}]: `)).trim();
+  const values = (raw ? raw.split(',') : defaultValues)
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const valid = values.filter((value) => choices.includes(value));
+  if (valid.length === 0) {
+    console.error(`[patina] ${label}: no valid values, keeping ${defaultValues.join(',')}`);
+    return defaultValues;
+  }
+  return [...new Set(valid)];
+}
+
+function buildInitConfig(answers) {
+  return {
+    language: answers.language,
+    profile: answers.profile,
+    tone: answers.tone === 'profile-only' ? null : answers.tone,
+    backend: answers.backend,
+    'max-models': answers.maxModels,
+    dispatch: answers.dispatch,
+  };
+}
+
+function commandAvailable(name) {
+  try {
+    const result = spawnSync(name, ['-V'], { stdio: 'ignore' });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+const MODEL_BY_BACKEND = {
+  'codex-cli': 'codex',
+  'claude-cli': 'claude',
+  'gemini-cli': 'gemini',
+};
+
+function printInitHelp() {
+  console.log(`patina init — create a project .patina.yaml
+
+Usage: patina init [--defaults] [--force]
+
+Guided mode asks for language, profile, tone, backend, MAX models, and dispatch
+mode. It preselects authenticated local backends when available.
+
+Options:
+  --defaults   Write detected defaults without prompts
+  --force      Overwrite an existing .patina.yaml
+`);
+}

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,53 @@
+export class PatinaCliError extends Error {
+  constructor({ what, why, action, exitCode = 1 }) {
+    super([what, why, action].filter(Boolean).join('\n'));
+    this.name = 'PatinaCliError';
+    this.what = what;
+    this.why = why;
+    this.action = action;
+    this.exitCode = exitCode;
+  }
+}
+
+export function inputError(what, why, action) {
+  return new PatinaCliError({ what, why, action, exitCode: 2 });
+}
+
+export function runtimeError(what, why, action) {
+  return new PatinaCliError({ what, why, action, exitCode: 1 });
+}
+
+export function renderCliError(err) {
+  const normalized = normalizeError(err);
+  return [
+    `[patina] Error: ${normalized.what}`,
+    `         ${normalized.why}`,
+    `         → ${normalized.action}`,
+  ].join('\n');
+}
+
+export function getExitCode(err, fallback = 1) {
+  const n = Number(err?.exitCode);
+  return Number.isInteger(n) && n >= 0 ? n : fallback;
+}
+
+function normalizeError(err) {
+  if (err instanceof PatinaCliError) {
+    return {
+      what: err.what || 'command failed',
+      why: err.why || 'patina could not complete the request.',
+      action: err.action || 'Run `patina --help` or `patina doctor` for next steps.',
+    };
+  }
+
+  const lines = String(err?.message || err || 'unknown error')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  return {
+    what: lines[0] || 'command failed',
+    why: lines.slice(1).join(' ') || 'The command hit a runtime failure before it could finish.',
+    action: 'Run `patina doctor` to inspect your environment, or rerun with `--help` for usage.',
+  };
+}

--- a/src/max-mode.js
+++ b/src/max-mode.js
@@ -48,11 +48,16 @@ export async function runMaxMode({ prompt, sourceText, models, apiKey, baseURL, 
   }
 
   const best = selectBest(candidates);
+  const valid = candidates.filter((c) => c.ok && c.aiScore !== null);
+  const allFailed = best === null;
+  const mpsFallback = valid.length > 0 && !valid.some((c) => (c.mps ?? 0) >= 70);
 
   return {
     type: 'max-mode',
     candidates,
     best,
+    allFailed,
+    mpsFallback,
   };
 }
 

--- a/src/output.js
+++ b/src/output.js
@@ -1,5 +1,20 @@
-export function formatOutput(result, mode, _parsed, opts = {}) {
+export function formatOutput(result, mode, parsed = {}, opts = {}) {
   const tone = opts.tone || null;
+  const format = parsed.format || 'markdown';
+  const body = renderFormattedBody(result, mode);
+
+  if (format === 'json') {
+    return formatJsonOutput({ result, mode, body, tone, gate: parsed.gate });
+  }
+
+  if (format === 'text') {
+    return formatTextOutput(body, tone);
+  }
+
+  return appendToneFooter(body, tone);
+}
+
+function renderFormattedBody(result, mode) {
   let body = renderBody(result);
   // Only rewrite and ouroboros emit [BODY]/[VARIANT n] tags; diff/audit/score
   // emit tables and don't need the extraction step.
@@ -7,7 +22,7 @@ export function formatOutput(result, mode, _parsed, opts = {}) {
     const variants = extractVariants(body);
     body = variants.length > 0 ? formatVariants(variants, body) : stripSelfAudit(body);
   }
-  return appendToneFooter(body, tone);
+  return body;
 }
 
 // v3.11 Phase 3.1: extract [VARIANT n]...[/VARIANT] blocks from a model
@@ -188,6 +203,149 @@ function renderBody(result) {
   return String(result).trim();
 }
 
+function formatTextOutput(body, tone) {
+  const lines = [body.trim()];
+  if (tone?.tone_source) {
+    lines.push(
+      '',
+      `Tone: ${tone.tone === null || tone.tone === undefined ? 'profile-only' : tone.tone} (${tone.tone_source})`
+    );
+  }
+  return lines.join('\n').trimEnd();
+}
+
+function formatJsonOutput({ result, mode, body, tone, gate }) {
+  const overall = extractOverall(result, body);
+  const payload = {
+    mode,
+    format: 'json',
+    overall,
+    categories: extractCategories(result, body),
+    tone: tone ? {
+      tone: tone.tone ?? null,
+      tone_source: tone.tone_source ?? null,
+      tone_evidence: Array.isArray(tone.tone_evidence) ? tone.tone_evidence : [],
+      tone_confidence: tone.tone_confidence ?? null,
+    } : null,
+    mps: extractMps(result, body),
+    gateResult: buildGateResult(overall, gate),
+    output: body,
+  };
+
+  if (result?.type === 'max-mode') {
+    payload.max = {
+      allFailed: Boolean(result.allFailed),
+      mpsFallback: Boolean(result.mpsFallback),
+      best: result.best ? {
+        model: result.best.model,
+        aiScore: result.best.aiScore ?? null,
+        mps: result.best.mps ?? null,
+      } : null,
+      candidates: result.candidates.map((candidate) => ({
+        model: candidate.model,
+        ok: Boolean(candidate.ok),
+        aiScore: candidate.aiScore ?? null,
+        mps: candidate.mps ?? null,
+        error: candidate.error ?? null,
+      })),
+    };
+  }
+
+  return JSON.stringify(payload, null, 2);
+}
+
+function buildGateResult(overall, gate) {
+  if (gate === undefined) return null;
+  if (overall === null) {
+    return { threshold: gate, overall: null, passed: null, exitCode: null };
+  }
+  const passed = overall <= gate;
+  return { threshold: gate, overall, passed, exitCode: passed ? 0 : 3 };
+}
+
+function extractOverall(result, body) {
+  const direct = toFiniteNumber(result?.overall);
+  if (direct !== null) return direct;
+  const parsed = parseFirstJson(body) || (typeof result === 'string' ? parseFirstJson(result) : null);
+  const parsedOverall = toFiniteNumber(parsed?.overall);
+  if (parsedOverall !== null) return parsedOverall;
+  const overallFromTable = String(body || '').match(/(?:^|\n)\|\s*(?:\*\*)?Overall(?:\*\*)?\s*\|[^|]*\|[^|]*\|[^|]*\|\s*(?:\*\*)?([0-9]+(?:\.[0-9]+)?)/i);
+  if (overallFromTable) return Number(overallFromTable[1]);
+  const overallFromText = String(body || '').match(/(?:^|[\s{,"])overall(?:["\s]*[:|]|\s+score\s*[:|]?)\s*(\d+(?:\.\d+)?)/i);
+  return overallFromText ? Number(overallFromText[1]) : null;
+}
+
+function extractMps(result, body) {
+  const direct = toFiniteNumber(result?.mps ?? result?.best?.mps);
+  if (direct !== null) return direct;
+  const parsed = parseFirstJson(body);
+  return toFiniteNumber(parsed?.mps);
+}
+
+function extractCategories(result, body) {
+  const direct = normalizeCategories(result?.categories);
+  if (direct.length > 0) return direct;
+
+  const parsed = parseFirstJson(body) || (typeof result === 'string' ? parseFirstJson(result) : null);
+  const parsedCategories = normalizeCategories(parsed?.categories);
+  if (parsedCategories.length > 0) return parsedCategories;
+
+  return parseMarkdownCategories(body);
+}
+
+function normalizeCategories(categories) {
+  if (Array.isArray(categories)) {
+    return categories.map((category) => ({ ...category }));
+  }
+  if (!categories || typeof categories !== 'object') {
+    return [];
+  }
+  return Object.entries(categories).map(([name, value]) => ({
+    name,
+    ...(value && typeof value === 'object' ? value : { value }),
+  }));
+}
+
+function parseMarkdownCategories(body) {
+  const rows = [];
+  for (const line of String(body || '').split(/\r?\n/)) {
+    if (!line.trim().startsWith('|')) continue;
+    const cells = line.split('|').slice(1, -1).map((cell) => cell.trim().replace(/^\*\*|\*\*$/g, ''));
+    if (cells.length < 5) continue;
+    const [name, weight, detected, rawScore, weighted] = cells;
+    if (!name || /^-+$/.test(name) || /^category$/i.test(name) || /^overall$/i.test(name)) continue;
+    rows.push({
+      name: normalizeCategoryName(name) || name,
+      weight: toFiniteNumber(weight),
+      detected: toFiniteNumber(detected),
+      rawScore: toFiniteNumber(rawScore),
+      weighted: toFiniteNumber(weighted),
+    });
+  }
+  return rows;
+}
+
+function toFiniteNumber(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const n = Number(String(value).replace(/[^\d.-]/g, ''));
+  return Number.isFinite(n) ? n : null;
+}
+
+function parseFirstJson(text) {
+  if (!text || typeof text !== 'string') return null;
+  const candidates = [
+    text.trim(),
+    text.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1],
+    text.match(/\{[\s\S]*\}/)?.[0],
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate);
+    } catch {}
+  }
+  return null;
+}
+
 // Append the v3.10 YAML footer to every output mode (rewrite/diff/audit/score).
 // SKILL.md Phase 6 spec: footer is the *only* sanctioned tone-info surface.
 // If the LLM already emitted a footer (it should, per SKILL.md), do not duplicate.
@@ -243,6 +401,12 @@ function formatMaxModeOutput(result) {
   }
 
   output += `\n**Best: ${best?.model || 'none'}**\n\n`;
+
+  if (result.allFailed) {
+    output += '> No MAX candidate produced a scoreable result. Exit code: 4.\n\n';
+  } else if (result.mpsFallback) {
+    output += '> No candidate reached MPS ≥ 70; selected the highest-MPS fallback. Exit code: 4.\n\n';
+  }
 
   if (best?.result) {
     output += '### Final Text\n\n';

--- a/tests/e2e/cli-adoption.test.js
+++ b/tests/e2e/cli-adoption.test.js
@@ -1,0 +1,106 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import yaml from 'js-yaml';
+import { main } from '../../src/cli.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../..');
+const BIN = resolve(REPO_ROOT, 'bin/patina.js');
+
+async function captureConsole(fn) {
+  const logs = [];
+  const errors = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (...args) => logs.push(args.join(' '));
+  console.error = (...args) => errors.push(args.join(' '));
+  try {
+    await fn();
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+  return { logs, errors };
+}
+
+async function withEnv(envOverrides, fn) {
+  const original = {};
+  for (const key of Object.keys(envOverrides)) {
+    original[key] = process.env[key];
+    if (envOverrides[key] === undefined) delete process.env[key];
+    else process.env[key] = envOverrides[key];
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const key of Object.keys(original)) {
+      if (original[key] === undefined) delete process.env[key];
+      else process.env[key] = original[key];
+    }
+  }
+}
+
+describe('CLI adoption commands', () => {
+  it('patina doctor --json reports setup checks without an LLM call', async () => {
+    const oldExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await withEnv({ PATINA_API_KEY: 'test-key', PATINA_API_KEY_FILE: undefined }, async () => {
+        const { logs } = await captureConsole(() => main(['doctor', '--json']));
+        const report = JSON.parse(logs.join('\n'));
+        assert.strictEqual(report.ok, true);
+        assert.ok(report.node.ok);
+        assert.ok(report.backends.some((backend) => backend.name === 'openai-http'));
+        assert.ok(report.providers.some((provider) => provider.name === 'openai'));
+      });
+    } finally {
+      process.exitCode = oldExitCode;
+    }
+  });
+
+  it('patina init --defaults writes a parseable project config', async () => {
+    const cwd = process.cwd();
+    const dir = mkdtempSync(join(tmpdir(), 'patina-init-test-'));
+    try {
+      process.chdir(dir);
+      await captureConsole(() => main(['init', '--defaults']));
+      const config = yaml.load(readFileSync(join(dir, '.patina.yaml'), 'utf8'));
+      assert.strictEqual(config.language, 'ko');
+      assert.strictEqual(config.profile, 'default');
+      assert.ok(config.backend);
+      assert.ok(Array.isArray(config['max-models']));
+    } finally {
+      process.chdir(cwd);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('CLI adoption exit/error behavior', () => {
+  it('unknown flags fail before stdin handling with a usage exit', () => {
+    const result = spawnSync(process.execPath, [BIN, '--bogus'], {
+      cwd: REPO_ROOT,
+      input: '',
+      encoding: 'utf8',
+    });
+    assert.strictEqual(result.status, 2);
+    assert.match(result.stderr, /\[patina\] Error: unknown option --bogus/);
+  });
+
+  it('empty stdin uses the three-line patina error format and exits 2', () => {
+    const result = spawnSync(process.execPath, [BIN], {
+      cwd: REPO_ROOT,
+      input: '   \n',
+      encoding: 'utf8',
+    });
+    assert.strictEqual(result.status, 2);
+    assert.match(result.stderr, /\[patina\] Error: empty input on stdin/);
+    assert.ok(result.stderr.includes('echo "This is a draft." | patina --lang en'));
+  });
+});

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -151,14 +151,51 @@ describe('CLI End-to-End with Mock API', () => {
     const { logs } = await captureConsole(() => main(['--help']));
     const help = logs.join('\n');
 
-    assert.ok(help.includes('Core options:'), 'help should group core options');
-    assert.ok(help.includes('Modes:'), 'help should group modes');
-    assert.ok(help.includes('Model / auth / backend:'), 'help should group backend options');
+    assert.ok(help.includes('MODES'), 'help should group modes');
+    assert.ok(help.includes('OUTPUT & BATCH'), 'help should group output options');
+    assert.ok(help.includes('LANGUAGE & PROFILE'), 'help should group language options');
+    assert.ok(help.includes('MODEL & AUTH'), 'help should group backend options');
+    assert.ok(help.includes('ADVANCED'), 'help should group advanced options');
+    assert.ok(help.includes('EXAMPLES'), 'help should include examples');
     assert.ok(help.includes('--gate <n>'), 'help should document score gate');
+    assert.ok(help.includes('--format <fmt>'), 'help should document output format');
     assert.ok(
       help.includes('openai-http, codex-cli, claude-cli, gemini-cli'),
       'help should list every backend name'
     );
+  });
+
+  it('should wrap score output in documented JSON when --format json is used', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+    await stopMockServer();
+    await startMockServer('{ "overall": 23, "categories": { "style": { "score": 10 } }, "interpretation": "mostly human" }');
+
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+    const { logs } = await captureConsole(() => main([
+      '--lang', 'en',
+      '--score',
+      '--exit-on', '30',
+      '--format', 'json',
+      '--api-key', 'test-key',
+      '--base-url', `http://127.0.0.1:${mockPort}`,
+      testFile,
+    ]));
+
+    const parsed = JSON.parse(logs.join('\n'));
+    assert.strictEqual(parsed.mode, 'score');
+    assert.strictEqual(parsed.format, 'json');
+    assert.strictEqual(parsed.overall, 23);
+    assert.deepStrictEqual(parsed.gateResult, {
+      threshold: 30,
+      overall: 23,
+      passed: true,
+      exitCode: 0,
+    });
+    assert.strictEqual(parsed.categories[0].name, 'style');
+    assert.ok(parsed.tone);
+    await stopMockServer();
+    await startMockServer('This is the humanized result.');
   });
 
   it('should set exit code 3 when --score gate fails', async () => {
@@ -182,6 +219,33 @@ describe('CLI End-to-End with Mock API', () => {
 
       assert.strictEqual(process.exitCode, 3);
       assert.ok(errors.some((line) => line.includes('score gate failed')));
+    } finally {
+      process.exitCode = oldExitCode;
+    }
+    await stopMockServer();
+    await startMockServer('This is the humanized result.');
+  });
+
+  it('should accept --exit-on as the CI score gate alias', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+    await stopMockServer();
+    await startMockServer('{ "overall": 42, "interpretation": "mixed" }');
+
+    const oldExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+    try {
+      await captureConsole(() => main([
+        '--lang', 'en',
+        '--score',
+        '--exit-on', '30',
+        '--api-key', 'test-key',
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        testFile,
+      ]));
+
+      assert.strictEqual(process.exitCode, 3);
     } finally {
       process.exitCode = oldExitCode;
     }
@@ -289,6 +353,33 @@ describe('CLI End-to-End with Mock API', () => {
       ]),
       /--variants is not supported with --models\/MAX mode yet/
     );
+  });
+
+  it('should set exit code 4 when every MAX candidate fails', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+    await stopMockServer();
+    await startMockServer('Unauthorized', 401);
+
+    const oldExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+    try {
+      const { logs } = await captureConsole(() => main([
+        '--lang', 'en',
+        '--models', 'model-a',
+        '--api-key', 'test-key',
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        testFile,
+      ]));
+
+      assert.strictEqual(process.exitCode, 4);
+      assert.match(logs.join('\n'), /Best: none/);
+    } finally {
+      process.exitCode = oldExitCode;
+    }
+    await stopMockServer();
+    await startMockServer('This is the humanized result.');
   });
 
   it('should handle API errors gracefully', async () => {

--- a/tests/unit/tone.test.js
+++ b/tests/unit/tone.test.js
@@ -144,6 +144,25 @@ test('formatOutput: null tone emits null values', () => {
   assert.ok(out.includes('tone_confidence: null'));
 });
 
+test('formatOutput: text format omits YAML footer', () => {
+  const tone = { tone: null, tone_source: 'profile_only', tone_evidence: [], tone_confidence: null };
+  const out = formatOutput('Text', 'rewrite', { format: 'text' }, { tone });
+  assert.equal(out, 'Text\n\nTone: profile-only (profile_only)');
+});
+
+test('formatOutput: json format exposes score contract fields', () => {
+  const tone = { tone: null, tone_source: 'profile_only', tone_evidence: [], tone_confidence: null };
+  const out = formatOutput('{ "overall": 18, "categories": { "style": { "score": 9 } } }', 'score', {
+    format: 'json',
+    gate: 30,
+  }, { tone });
+  const parsed = JSON.parse(out);
+  assert.equal(parsed.overall, 18);
+  assert.equal(parsed.categories[0].name, 'style');
+  assert.deepEqual(parsed.gateResult, { threshold: 30, overall: 18, passed: true, exitCode: 0 });
+  assert.equal(parsed.tone.tone_source, 'profile_only');
+});
+
 // --- stripSelfAudit (v3.11) ---
 
 test('stripSelfAudit: extracts [BODY] block and drops [SELF_AUDIT]', () => {


### PR DESCRIPTION
## Summary

- add `patina doctor` with text/JSON diagnostics for Node, CLI version, backends, tmux, and API-key env setup
- add `patina init` for guided/default `.patina.yaml` creation with overwrite protection
- add `--format json|text|markdown`, `--exit-on`, standardized CLI error rendering, and documented exit codes
- reorganize `patina --help` into user-facing sections with examples
- improve empty stdin / TTY UX with one-shot interactive stdin, `--no-interactive`, and consistent next-action errors

## Verification

- `npm test`
- `npm run lint`
- `npm run benchmark`
- `npm run dogfood`
- CI parity locally: `npm run release:check`, `npm run benchmark:report`, `npm run benchmark:compare` (generated timestamp artifacts reverted)

## Constraints checked

- no new npm dependencies
- core skill pipeline unchanged

Closes #176
Closes #177
Closes #178
Closes #179
Closes #181
Closes #184
Closes #185
