### PR TITLE
Make CLI auth checks match runtime behavior

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,105 @@
+import { readFileSync } from 'node:fs';
+import { inputError } from './errors.js';
+
+export const HTTP_KEY_ENV_VARS = [
+  'PATINA_API_KEY',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'GROQ_API_KEY',
+  'TOGETHER_API_KEY',
+];
+
+// Default openai-http runs against the OpenAI-compatible default endpoint, so
+// only generic/OpenAI keys make it authenticated without an explicit provider.
+export const DEFAULT_HTTP_KEY_ENV_VARS = [
+  'PATINA_API_KEY',
+  'OPENAI_API_KEY',
+];
+
+export function providerHttpKeyEnvVars(providerApiKeyEnv) {
+  if (!providerApiKeyEnv) return DEFAULT_HTTP_KEY_ENV_VARS;
+  return uniqueEnvVars([providerApiKeyEnv, 'PATINA_API_KEY']);
+}
+
+export function inspectHttpApiKeySource({
+  env = process.env,
+  readFile = readFileSync,
+  envVars = DEFAULT_HTTP_KEY_ENV_VARS,
+} = {}) {
+  const filePath = env.PATINA_API_KEY_FILE;
+  if (filePath) {
+    const file = readApiKeyFile(filePath, readFile);
+    return file.ok
+      ? { ok: true, source: 'PATINA_API_KEY_FILE', envVars: [], filePath, detail: `Authenticated via PATINA_API_KEY_FILE (${filePath}).` }
+      : { ok: false, source: 'PATINA_API_KEY_FILE', envVars: [], filePath, detail: file.detail };
+  }
+
+  const present = uniqueEnvVars(envVars).filter((key) => env[key]);
+  if (present.length > 0) {
+    return { ok: true, source: present[0], envVars: present, filePath: null, detail: `Authenticated via ${present.join(', ')}.` };
+  }
+
+  return {
+    ok: false,
+    source: null,
+    envVars: [],
+    filePath: null,
+    detail: 'Set PATINA_API_KEY, PATINA_API_KEY_FILE, OPENAI_API_KEY, or select a provider with its key.',
+  };
+}
+
+export function resolveHttpApiKey({
+  explicitApiKey,
+  apiKeyFile,
+  env = process.env,
+  readFile = readFileSync,
+  envVars = DEFAULT_HTTP_KEY_ENV_VARS,
+} = {}) {
+  const filePath = apiKeyFile || env.PATINA_API_KEY_FILE;
+  if (filePath) {
+    const file = readApiKeyFile(filePath, readFile);
+    if (!file.ok) {
+      throw inputError(
+        file.what,
+        file.detail,
+        'Check the path, write the key into the file, or unset PATINA_API_KEY_FILE.'
+      );
+    }
+    return file.key;
+  }
+
+  if (explicitApiKey) return explicitApiKey;
+
+  const source = inspectHttpApiKeySource({ env, readFile, envVars });
+  return source.ok && source.source !== 'PATINA_API_KEY_FILE'
+    ? env[source.source]
+    : undefined;
+}
+
+function uniqueEnvVars(envVars) {
+  return [...new Set(envVars.filter(Boolean))];
+}
+
+function readApiKeyFile(filePath, readFile) {
+  let contents;
+  try {
+    contents = readFile(filePath, 'utf8');
+  } catch (err) {
+    return {
+      ok: false,
+      what: 'cannot read API key file',
+      detail: `${filePath}: ${err.message}`,
+    };
+  }
+
+  const key = contents.replace(/[\r\n]+$/, '').trim();
+  if (!key) {
+    return {
+      ok: false,
+      what: 'API key file is empty',
+      detail: filePath,
+    };
+  }
+
+  return { ok: true, key };
+}

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -2,28 +2,14 @@ import { callLLM } from '../api.js';
 import * as codexCli from './codex-cli.js';
 import * as claudeCli from './claude-cli.js';
 import * as geminiCli from './gemini-cli.js';
-
-// Provider env vars patina recognizes via --provider <name>.
-// Keep in sync with PROVIDERS in src/providers.js.
-const HTTP_KEY_ENV_VARS = [
-  'PATINA_API_KEY',
-  'OPENAI_API_KEY',
-  'GEMINI_API_KEY',
-  'GROQ_API_KEY',
-  'TOGETHER_API_KEY',
-];
+import { inspectHttpApiKeySource } from '../auth.js';
+import { inputError } from '../errors.js';
 
 const openaiHttp = {
   name: 'openai-http',
   isAvailable: () => true,
-  isAuthenticated: () => HTTP_KEY_ENV_VARS.some((k) => process.env[k]),
-  authHint: () => {
-    const present = HTTP_KEY_ENV_VARS.filter((k) => process.env[k]);
-    if (present.length > 0) {
-      return `Authenticated via ${present.join(', ')}.`;
-    }
-    return 'Set PATINA_API_KEY (or use --provider gemini|groq|together with the matching <PROVIDER>_API_KEY).';
-  },
+  isAuthenticated: () => inspectHttpApiKeySource().ok,
+  authHint: () => inspectHttpApiKeySource().detail,
   invoke: ({ prompt, apiKey, baseURL, model, timeout }) =>
     callLLM({ prompt, apiKey, baseURL, model, timeout }),
 };
@@ -55,7 +41,11 @@ export function selectBackend({ name, model } = {}) {
   if (name) {
     const backend = REGISTRY[name];
     if (!backend) {
-      throw new Error(`Unknown backend: ${name}. Available: ${Object.keys(REGISTRY).join(', ')}`);
+      throw inputError(
+        `Unknown backend: ${name}`,
+        `Available backends are: ${Object.keys(REGISTRY).join(', ')}.`,
+        'Run `patina --list-backends` to inspect local availability.'
+      );
     }
     return { backend, autoSelected: false, reason: 'explicit' };
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,6 +11,7 @@ import { buildManifest, appendResult, writeManifest } from './manifest.js';
 import { runDoctor } from './commands/doctor.js';
 import { runInit } from './commands/init.js';
 import { inputError, runtimeError, renderCliError, getExitCode } from './errors.js';
+import { inspectHttpApiKeySource, providerHttpKeyEnvVars, resolveHttpApiKey } from './auth.js';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, basename, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -47,12 +48,16 @@ export async function main(args) {
   }
 
   if (parsed.models && parsed.variants && parsed.variants > 1) {
-    throw new Error('--variants is not supported with --models/MAX mode yet. Omit --variants or run one model at a time.');
+    throw inputError(
+      '--variants is not supported with --models/MAX mode yet',
+      'MAX mode already fans out across models, so variant fan-out is ambiguous.',
+      'Omit --variants or run one model at a time.'
+    );
   }
 
   if (parsed.gate !== undefined && !parsed.score) {
     throw inputError(
-      '--gate can only be used with --score',
+      `${parsed.gateOption || '--gate'} can only be used with --score`,
       'Score gates need a parsed overall score.',
       'Run `patina --score --exit-on 30 <file>`.'
     );
@@ -68,7 +73,6 @@ export async function main(args) {
     return;
   }
 
-  const apiKey = resolveApiKey(parsed);
   const configPath = parsed.config ? resolve(process.cwd(), parsed.config) : undefined;
   const config = loadConfig(configPath);
 
@@ -76,6 +80,7 @@ export async function main(args) {
   if (parsed.profile) config.profile = parsed.profile;
 
   const provider = selectProvider(parsed.provider ?? config.provider);
+  const apiKey = resolveApiKey(parsed, provider);
   const resolved = resolveProviderConfig({
     provider,
     apiKey,
@@ -181,7 +186,7 @@ export async function main(args) {
       }
 
       if (backend.name === 'openai-http' && !resolved.apiKey) {
-        const msg = ['No API key found. Set PATINA_API_KEY or pass --api-key.'];
+        const msg = ['No API key found. Set PATINA_API_KEY, PATINA_API_KEY_FILE, OPENAI_API_KEY, or pass --api-key.'];
         if (provider) {
           msg.push(`(--provider ${provider.name} expects ${provider.apiKeyEnv} or PATINA_API_KEY.)`);
         }
@@ -209,18 +214,23 @@ export async function main(args) {
     }
 
     let output;
+    let scoreValidationOutput = null;
     if (parsed.ouroboros) {
       const ouroborosBody = formatOuroborosOutput(result);
       output = formatOutput(ouroborosBody, mode, parsed, { tone: toneResolution });
+      scoreValidationOutput = ouroborosBody;
     } else {
       output = formatOutput(result, mode, parsed, { tone: toneResolution });
+      if (mode === 'score') {
+        scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' });
+      }
     }
 
     // v3.11 Phase 1.3: surface weight drift between config and the score
     // table the model emitted. Warnings only — does not alter the output.
     if (mode === 'score') {
       const configWeights = config.ouroboros?.['category-weights']?.[lang] || {};
-      const warnings = validateScoreWeights(output, configWeights);
+      const warnings = validateScoreWeights(scoreValidationOutput || output, configWeights);
       for (const w of warnings) {
         console.error(`[patina] ${w}`);
       }
@@ -294,19 +304,23 @@ function parseArgs(args) {
         parsed.version = true;
         break;
       case '--lang':
-        parsed.lang = args[++i];
+        parsed.lang = readOptionValue(args, i, arg);
+        i++;
         break;
       case '--profile':
-        parsed.profile = args[++i];
+        parsed.profile = readOptionValue(args, i, arg);
+        i++;
         break;
       case '--tone': {
-        const t = args[++i];
-        if (t === undefined) {
-          throw new Error(`--tone requires a value. Valid tones: casual, professional, academic, narrative, marketing, instructional, auto`);
-        }
+        const t = readOptionValue(args, i, arg);
+        i++;
         const valid = ['casual', 'professional', 'academic', 'narrative', 'marketing', 'instructional', 'auto'];
         if (!valid.includes(t)) {
-          throw new Error(`Unknown tone '${t}'. Valid tones: ${valid.join(', ')}`);
+          throw inputError(
+            `unknown tone ${t}`,
+            `Valid tones are: ${valid.join(', ')}.`,
+            'Use `--tone auto` to let patina infer tone from the text.'
+          );
         }
         parsed.tone = t;
         break;
@@ -321,7 +335,8 @@ function parseArgs(args) {
         parsed.score = true;
         break;
       case '--format': {
-        const value = args[++i];
+        const value = readOptionValue(args, i, arg);
+        i++;
         if (!['json', 'text', 'markdown'].includes(value)) {
           throw inputError(
             '--format expects json, text, or markdown',
@@ -336,23 +351,33 @@ function parseArgs(args) {
         parsed.format = 'json';
         break;
       case '--gate': {
-        const n = Number(args[++i]);
+        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
+        i++;
+        const n = Number(value);
         if (!Number.isFinite(n) || n < 0 || n > 100) {
-          throw new Error(`--gate expects a number from 0 to 100, got ${args[i]}`);
+          throw inputError(
+            '--gate expects a number from 0 to 100',
+            `Received ${value === undefined ? 'no value' : `"${value}"`}.`,
+            'Use `patina --score --gate 30 <file>` for CI gates.'
+          );
         }
         parsed.gate = n;
+        parsed.gateOption = '--gate';
         break;
       }
       case '--exit-on': {
-        const n = Number(args[++i]);
+        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
+        i++;
+        const n = Number(value);
         if (!Number.isFinite(n) || n < 0 || n > 100) {
           throw inputError(
             '--exit-on expects a number from 0 to 100',
-            `Received ${args[i] === undefined ? 'no value' : `"${args[i]}"`}.`,
+            `Received ${value === undefined ? 'no value' : `"${value}"`}.`,
             'Use `patina --score --exit-on 30 <file>` for CI gates.'
           );
         }
         parsed.gate = n;
+        parsed.gateOption = '--exit-on';
         break;
       }
       case '--ouroboros':
@@ -365,45 +390,70 @@ function parseArgs(args) {
         parsed.inPlace = true;
         break;
       case '--suffix':
-        parsed.suffix = args[++i];
+        parsed.suffix = readOptionValue(args, i, arg, { allowFlagLike: true });
+        i++;
         break;
       case '--outdir':
-        parsed.outdir = args[++i];
+        parsed.outdir = readOptionValue(args, i, arg);
+        i++;
         break;
       case '--models':
-        parsed.models = args[++i].split(',').map((m) => m.trim());
+        parsed.models = readOptionValue(args, i, arg)
+          .split(',')
+          .map((m) => m.trim())
+          .filter(Boolean);
+        i++;
+        if (parsed.models.length === 0) {
+          throw inputError(
+            '--models expects at least one model id',
+            'The comma-separated model list was empty.',
+            'Use `--models gpt-4o,claude-3-5-sonnet`.'
+          );
+        }
         break;
       case '--max-concurrency': {
-        const n = Number(args[++i]);
-        if (!Number.isFinite(n) || n < 0) {
-          throw new Error(`--max-concurrency expects a non-negative integer, got ${args[i]}`);
+        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
+        i++;
+        const n = Number(value);
+        if (!Number.isInteger(n) || n < 0) {
+          throw inputError(
+            '--max-concurrency expects a non-negative integer',
+            `Received ${value === undefined ? 'no value' : `"${value}"`}.`,
+            'Use `--max-concurrency 2` or omit it for unlimited concurrency.'
+          );
         }
         parsed.maxConcurrency = n;
         break;
       }
       case '--model':
-        parsed.model = args[++i];
+        parsed.model = readOptionValue(args, i, arg);
+        i++;
         break;
       case '--api-key':
-        parsed.apiKey = args[++i];
+        parsed.apiKey = readOptionValue(args, i, arg);
+        i++;
         break;
       case '--api-key-file':
-        parsed.apiKeyFile = args[++i];
+        parsed.apiKeyFile = readOptionValue(args, i, arg);
+        i++;
         break;
       case '--allow-private-base-url':
         parsed.allowPrivateBaseURL = true;
         break;
       case '--base-url':
-        parsed.baseURL = args[++i];
+        parsed.baseURL = readOptionValue(args, i, arg);
+        i++;
         break;
       case '--backend':
-        parsed.backend = args[++i];
+        parsed.backend = readOptionValue(args, i, arg);
+        i++;
         break;
       case '--list-backends':
         parsed.listBackends = true;
         break;
       case '--provider':
-        parsed.provider = args[++i];
+        parsed.provider = readOptionValue(args, i, arg);
+        i++;
         break;
       case '--list-providers':
         parsed.listProviders = true;
@@ -412,23 +462,36 @@ function parseArgs(args) {
         parsed.allowInsecureBaseURL = true;
         break;
       case '--config':
-        parsed.config = args[++i];
+        parsed.config = readOptionValue(args, i, arg);
+        i++;
         break;
       case '--save-run':
-        parsed.saveRun = args[++i];
+        parsed.saveRun = readOptionValue(args, i, arg);
+        i++;
         break;
       case '--prompt-mode': {
-        const m = args[++i];
+        const m = readOptionValue(args, i, arg);
+        i++;
         if (!m || !['strict', 'minimal', 'auto'].includes(m)) {
-          throw new Error(`--prompt-mode expects 'strict' | 'minimal' | 'auto', got ${m}`);
+          throw inputError(
+            '--prompt-mode expects strict, minimal, or auto',
+            `Received ${m === undefined ? 'no value' : `"${m}"`}.`,
+            'Use `--prompt-mode auto` unless you need a specific prompt style.'
+          );
         }
         parsed.promptMode = m;
         break;
       }
       case '--variants': {
-        const n = Number(args[++i]);
+        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
+        i++;
+        const n = Number(value);
         if (!Number.isInteger(n) || n < 1 || n > 5) {
-          throw new Error(`--variants expects an integer 1-5, got ${args[i]}`);
+          throw inputError(
+            '--variants expects an integer from 1 to 5',
+            `Received ${value === undefined ? 'no value' : `"${value}"`}.`,
+            'Use `--variants 2` for alternate rewrite drafts.'
+          );
         }
         parsed.variants = n;
         break;
@@ -453,10 +516,18 @@ function parseArgs(args) {
   return parsed;
 }
 
-// Resolve the API key, preferring file-based sources to keep the secret out
-// of argv and shell history (CWE-214). Precedence: --api-key-file >
-// PATINA_API_KEY_FILE > --api-key (with deprecation warning) > parsed.apiKey
-// passed through to provider config (env var path stays in providers.js).
+function readOptionValue(args, index, option, { allowFlagLike = false } = {}) {
+  const value = args[index + 1];
+  if (value === undefined || (!allowFlagLike && value.startsWith('-'))) {
+    throw inputError(
+      `${option} requires a value`,
+      'The option was provided without the value it needs.',
+      `Run \`patina --help\` to see the expected ${option} syntax.`
+    );
+  }
+  return value;
+}
+
 // v3.11: case-05 found that prompt-mode preference is per-backend.
 // auto resolves to strict for codex-cli/claude (instruction-rich) and
 // minimal for gemini (voice-rich, over-constrained by long prompts).
@@ -472,32 +543,27 @@ export function resolvePromptMode(mode, { backend, model }) {
   return 'strict';
 }
 
-function resolveApiKey(parsed) {
-  const filePath = parsed.apiKeyFile || process.env.PATINA_API_KEY_FILE;
-  if (filePath) {
-    let contents;
-    try {
-      contents = readFileSync(filePath, 'utf8');
-    } catch (err) {
-      throw new Error(`Cannot read --api-key-file ${filePath}: ${err.message}`);
-    }
-    const key = contents.replace(/[\r\n]+$/, '').trim();
-    if (!key) {
-      throw new Error(`API key file ${filePath} is empty`);
-    }
-    if (parsed.apiKey) {
-      console.error('[patina] both --api-key-file and --api-key were provided; using --api-key-file');
-    }
-    return key;
+// Resolve the API key, preferring file-based sources to keep the secret out
+// of argv and shell history (CWE-214). Precedence: --api-key-file >
+// PATINA_API_KEY_FILE > --api-key (with deprecation warning) > provider/default
+// env vars.
+function resolveApiKey(parsed, provider) {
+  const hasApiKeyFile = Boolean(parsed.apiKeyFile || process.env.PATINA_API_KEY_FILE);
+  const apiKey = resolveHttpApiKey({
+    explicitApiKey: parsed.apiKey,
+    apiKeyFile: parsed.apiKeyFile,
+    envVars: providerHttpKeyEnvVars(provider?.apiKeyEnv),
+  });
+  if (hasApiKeyFile && parsed.apiKey) {
+    console.error('[patina] both --api-key-file and --api-key were provided; using --api-key-file');
   }
-  if (parsed.apiKey) {
+  if (parsed.apiKey && !hasApiKeyFile) {
     console.error(
       '[patina] warning: --api-key exposes the secret in shell history and `ps` output.\n' +
       '         Prefer PATINA_API_KEY env var, --api-key-file <path>, or PATINA_API_KEY_FILE.'
     );
-    return parsed.apiKey;
   }
-  return undefined;
+  return apiKey;
 }
 
 async function loadInputs(parsed) {
@@ -768,26 +834,35 @@ function printProviderStatus() {
   const rows = Object.values(PROVIDERS).map((p) => ({
     name: p.name,
     free: p.freeTier ? 'yes' : 'no',
-    keySet: process.env[p.apiKeyEnv] ? 'yes' : 'no',
+    keySource: providerKeySource(p),
+    providerEnv: process.env[p.apiKeyEnv] ? 'set' : 'missing',
     note: `${p.apiKeyEnv} → ${p.baseURL}`,
   }));
   const widths = {
     name: Math.max('Provider'.length, ...rows.map((r) => r.name.length)),
     free: Math.max('Free tier'.length, ...rows.map((r) => r.free.length)),
-    keySet: Math.max('Key set'.length, ...rows.map((r) => r.keySet.length)),
+    keySource: Math.max('Key source'.length, ...rows.map((r) => r.keySource.length)),
+    providerEnv: Math.max('Provider env'.length, ...rows.map((r) => r.providerEnv.length)),
   };
   const pad = (s, w) => s + ' '.repeat(Math.max(0, w - s.length));
   console.log(
-    `${pad('Provider', widths.name)}  ${pad('Free tier', widths.free)}  ${pad('Key set', widths.keySet)}  Notes`
+    `${pad('Provider', widths.name)}  ${pad('Free tier', widths.free)}  ${pad('Key source', widths.keySource)}  ${pad('Provider env', widths.providerEnv)}  Notes`
   );
   console.log(
-    `${'-'.repeat(widths.name)}  ${'-'.repeat(widths.free)}  ${'-'.repeat(widths.keySet)}  -----`
+    `${'-'.repeat(widths.name)}  ${'-'.repeat(widths.free)}  ${'-'.repeat(widths.keySource)}  ${'-'.repeat(widths.providerEnv)}  -----`
   );
   for (const r of rows) {
     console.log(
-      `${pad(r.name, widths.name)}  ${pad(r.free, widths.free)}  ${pad(r.keySet, widths.keySet)}  ${r.note}`
+      `${pad(r.name, widths.name)}  ${pad(r.free, widths.free)}  ${pad(r.keySource, widths.keySource)}  ${pad(r.providerEnv, widths.providerEnv)}  ${r.note}`
     );
   }
+}
+
+function providerKeySource(provider) {
+  const source = inspectHttpApiKeySource({
+    envVars: providerHttpKeyEnvVars(provider.apiKeyEnv),
+  });
+  return source.ok ? source.source : 'missing';
 }
 
 function handleAuth(subArgs) {

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,17 +1,10 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { HTTP_KEY_ENV_VARS, inspectHttpApiKeySource, providerHttpKeyEnvVars } from '../auth.js';
 import { listBackends } from '../backends/index.js';
 import { PROVIDERS } from '../providers.js';
 import { inputError } from '../errors.js';
 
 const MIN_NODE_MAJOR = 18;
-const API_KEY_ENVS = [
-  'PATINA_API_KEY',
-  'OPENAI_API_KEY',
-  'GEMINI_API_KEY',
-  'GROQ_API_KEY',
-  'TOGETHER_API_KEY',
-];
 
 export function runDoctor(args = [], { version } = {}) {
   const parsed = parseDoctorArgs(args);
@@ -65,26 +58,27 @@ export function buildDoctorReport({ version } = {}) {
       : 'only needed for tmux-based MAX dispatch; direct/API modes still work',
   });
 
-  const apiKeys = API_KEY_ENVS.map((name) => ({
+  const apiKeySource = inspectHttpApiKeySource();
+  const apiKeys = HTTP_KEY_ENV_VARS.map((name) => ({
     name,
     set: Boolean(process.env[name]),
   }));
-  const apiKeyFile = checkApiKeyFile(process.env.PATINA_API_KEY_FILE);
   checks.push({
     name: 'api-key-env',
-    status: apiKeyFile.status === 'blocker'
+    status: apiKeySource.source === 'PATINA_API_KEY_FILE' && !apiKeySource.ok
       ? 'blocker'
-      : (apiKeys.some((k) => k.set) || apiKeyFile.status === 'ok' ? 'ok' : 'warning'),
-    summary: apiKeys.some((k) => k.set) || apiKeyFile.status === 'ok'
-      ? 'API key source detected'
-      : 'no API key env var detected',
-    detail: apiKeyFile.detail || 'HTTP provider use requires PATINA_API_KEY or a provider-specific key',
+      : (apiKeySource.ok ? 'ok' : 'warning'),
+    summary: apiKeySource.ok
+      ? 'default HTTP API key source detected'
+      : 'no default HTTP API key source detected',
+    detail: apiKeySource.detail,
   });
 
   const providerKeys = Object.values(PROVIDERS).map((provider) => ({
     name: provider.name,
     apiKeyEnv: provider.apiKeyEnv,
-    keySet: Boolean(process.env[provider.apiKeyEnv] || process.env.PATINA_API_KEY),
+    providerEnvSet: Boolean(process.env[provider.apiKeyEnv]),
+    keySource: getProviderKeySource(provider),
     baseURL: provider.baseURL,
     defaultModel: provider.defaultModel,
   }));
@@ -173,20 +167,11 @@ function checkCommand(cmd, args) {
   }
 }
 
-function checkApiKeyFile(path) {
-  if (!path) return { status: 'missing', detail: '' };
-  if (!existsSync(path)) {
-    return { status: 'blocker', detail: `PATINA_API_KEY_FILE points to a missing file: ${path}` };
-  }
-  try {
-    const contents = readFileSync(path, 'utf8').trim();
-    if (!contents) {
-      return { status: 'blocker', detail: `PATINA_API_KEY_FILE is empty: ${path}` };
-    }
-    return { status: 'ok', detail: `PATINA_API_KEY_FILE is readable: ${path}` };
-  } catch (err) {
-    return { status: 'blocker', detail: `Cannot read PATINA_API_KEY_FILE ${path}: ${err.message}` };
-  }
+function getProviderKeySource(provider) {
+  const source = inspectHttpApiKeySource({
+    envVars: providerHttpKeyEnvVars(provider.apiKeyEnv),
+  });
+  return source.ok ? source.source : null;
 }
 
 function formatDoctorText(report) {
@@ -212,7 +197,10 @@ function formatDoctorText(report) {
 
   lines.push('', 'Provider keys:');
   for (const provider of report.providers) {
-    lines.push(`  ${provider.keySet ? '✓' : '!'} ${provider.name}: ${provider.apiKeyEnv}=${provider.keySet ? 'set' : 'missing'}`);
+    lines.push(
+      `  ${provider.keySource ? '✓' : '!'} ${provider.name}: key=${provider.keySource || 'missing'} ` +
+      `(provider env ${provider.apiKeyEnv}=${provider.providerEnvSet ? 'set' : 'missing'})`
+    );
   }
 
   if (report.blockers.length > 0) {

--- a/src/providers.js
+++ b/src/providers.js
@@ -2,6 +2,7 @@
 // Each provider maps to a base URL + a recommended default model + the env
 // variable users typically set to authenticate. Selecting a provider is
 // equivalent to manually setting --base-url, --model, and the right key.
+import { inputError } from './errors.js';
 
 export const PROVIDERS = {
   openai: {
@@ -42,8 +43,10 @@ export function selectProvider(name) {
   if (!name) return null;
   const provider = PROVIDERS[name];
   if (!provider) {
-    throw new Error(
-      `Unknown provider: ${name}. Available: ${Object.keys(PROVIDERS).join(', ')}`
+    throw inputError(
+      `Unknown provider: ${name}`,
+      `Available providers are: ${Object.keys(PROVIDERS).join(', ')}.`,
+      'Run `patina --list-providers` to inspect provider presets.'
     );
   }
   return provider;

--- a/src/security.js
+++ b/src/security.js
@@ -4,15 +4,16 @@
 // --base-url, PATINA_API_BASE, and provider presets. Both are sent into either
 // fs.readFileSync or fetch() with the API key attached, so they need to be
 // validated before use.
+import { inputError } from './errors.js';
 
 const PROFILE_NAME_RE = /^[A-Za-z0-9_][A-Za-z0-9_-]*$/;
 
 export function validateProfileName(name) {
   if (typeof name !== 'string' || !PROFILE_NAME_RE.test(name)) {
-    throw new Error(
-      `Invalid profile name: ${JSON.stringify(name)}. ` +
-      `Profile names must match /^[A-Za-z0-9_][A-Za-z0-9_-]*$/ ` +
-      `(no slashes, no "..", no path separators).`
+    throw inputError(
+      `Invalid profile name: ${JSON.stringify(name)}`,
+      'Profile names may only contain letters, numbers, underscore, and hyphen, and cannot contain slashes or "..".',
+      'Run `patina --help` to see profile examples.'
     );
   }
 }
@@ -67,11 +68,17 @@ export function validateBaseURL(baseURL, { allowInsecure = false, allowPrivate =
   try {
     url = new URL(baseURL);
   } catch {
-    throw new Error(`Invalid base URL: ${JSON.stringify(baseURL)}`);
+    throw inputError(
+      `Invalid base URL: ${JSON.stringify(baseURL)}`,
+      'The value is not a parseable URL.',
+      'Use an https:// URL, or http://127.0.0.1 for local test servers.'
+    );
   }
   if (url.protocol !== 'https:' && url.protocol !== 'http:') {
-    throw new Error(
-      `Base URL must use http or https (got ${url.protocol}): ${baseURL}`
+    throw inputError(
+      'base URL must use http or https',
+      `Received ${url.protocol}: ${baseURL}`,
+      'Use an https:// URL, or http://127.0.0.1 for local test servers.'
     );
   }
   // Either an explicit caller opt-in or the env var override is enough to
@@ -79,10 +86,10 @@ export function validateBaseURL(baseURL, { allowInsecure = false, allowPrivate =
   // is passed so downstream callLLM calls don't have to plumb the flag.
   const allowInsec = allowInsecure || shouldAllowInsecureBaseURL();
   if (url.protocol === 'http:' && !isLoopbackHost(url.hostname) && !allowInsec) {
-    throw new Error(
-      `Refusing to send prompts and API key over plaintext HTTP to ${url.hostname}.\n` +
-      `Use an https:// URL, or pass --allow-insecure-base-url ` +
-      `(or set PATINA_ALLOW_INSECURE_BASE_URL=1) to override for trusted private endpoints.`
+    throw inputError(
+      `refusing plaintext HTTP to ${url.hostname}`,
+      'patina will not send prompts and API keys over non-loopback HTTP by default.',
+      'Use an https:// URL, or pass --allow-insecure-base-url for a trusted endpoint.'
     );
   }
   // SSRF guard: refuse non-loopback private/IMDS literal IPs unless explicitly
@@ -93,11 +100,10 @@ export function validateBaseURL(baseURL, { allowInsecure = false, allowPrivate =
     isPrivateOrSpecialIP(url.hostname) &&
     !allowPriv
   ) {
-    throw new Error(
-      `Refusing to send the API key to private/reserved IP ${url.hostname}.\n` +
-      `This blocks SSRF to cloud metadata endpoints (169.254.169.254) and RFC 1918 hosts.\n` +
-      `Pass --allow-private-base-url (or set PATINA_ALLOW_PRIVATE_BASE_URL=1) ` +
-      `if you intentionally target an internal endpoint.`
+    throw inputError(
+      `refusing private/reserved base URL ${url.hostname}`,
+      'This blocks sending API keys to cloud metadata or RFC 1918/private endpoints by accident.',
+      'Pass --allow-private-base-url only if you intentionally target an internal endpoint.'
     );
   }
 }

--- a/tests/e2e/cli-adoption.test.js
+++ b/tests/e2e/cli-adoption.test.js
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -64,6 +64,63 @@ describe('CLI adoption commands', () => {
     }
   });
 
+  it('patina doctor treats PATINA_API_KEY_FILE as an authenticated HTTP backend source', async () => {
+    const oldExitCode = process.exitCode;
+    const dir = mkdtempSync(join(tmpdir(), 'patina-doctor-key-file-'));
+    const keyFile = join(dir, 'key.txt');
+    writeFileSync(keyFile, 'test-key\n');
+    process.exitCode = undefined;
+    try {
+      await withEnv({
+        PATINA_API_KEY: undefined,
+        OPENAI_API_KEY: 'env-key',
+        GEMINI_API_KEY: undefined,
+        GROQ_API_KEY: undefined,
+        TOGETHER_API_KEY: undefined,
+        PATINA_API_KEY_FILE: keyFile,
+      }, async () => {
+        const { logs } = await captureConsole(() => main(['doctor', '--json']));
+        const report = JSON.parse(logs.join('\n'));
+        const http = report.backends.find((backend) => backend.name === 'openai-http');
+        const usable = report.checks.find((check) => check.name === 'usable-backend');
+        const openai = report.providers.find((provider) => provider.name === 'openai');
+        assert.strictEqual(report.ok, true);
+        assert.strictEqual(http.authenticated, true);
+        assert.strictEqual(usable.status, 'ok');
+        assert.match(usable.detail, /openai-http/);
+        assert.strictEqual(openai.keySource, 'PATINA_API_KEY_FILE');
+      });
+    } finally {
+      process.exitCode = oldExitCode;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('patina --list-providers shows the effective shared key source', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'patina-provider-key-file-'));
+    const keyFile = join(dir, 'key.txt');
+    writeFileSync(keyFile, 'file-key\n');
+    try {
+      await withEnv({
+        PATINA_API_KEY: undefined,
+        OPENAI_API_KEY: 'env-key',
+        GEMINI_API_KEY: undefined,
+        GROQ_API_KEY: undefined,
+        TOGETHER_API_KEY: undefined,
+        PATINA_API_KEY_FILE: keyFile,
+      }, async () => {
+        const { logs } = await captureConsole(() => main(['--list-providers']));
+        const output = logs.join('\n');
+        assert.match(output, /Key source/);
+        assert.match(output, /Provider env/);
+        assert.match(output, /PATINA_API_KEY_FILE/);
+        assert.match(output, /OPENAI_API_KEY/);
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('patina init --defaults writes a parseable project config', async () => {
     const cwd = process.cwd();
     const dir = mkdtempSync(join(tmpdir(), 'patina-init-test-'));
@@ -102,5 +159,46 @@ describe('CLI adoption exit/error behavior', () => {
     assert.strictEqual(result.status, 2);
     assert.match(result.stderr, /\[patina\] Error: empty input on stdin/);
     assert.ok(result.stderr.includes('echo "This is a draft." | patina --lang en'));
+  });
+
+  it('value-taking usage errors use the standardized input exit code', () => {
+    const cases = [
+      { args: ['--tone'], message: /--tone requires a value/ },
+      { args: ['--models'], message: /--models requires a value/ },
+      { args: ['--gate', 'nope'], message: /--gate expects a number/ },
+      { args: ['--prompt-mode', 'wrong'], message: /--prompt-mode expects/ },
+      { args: ['--api-key', '--base-url'], message: /--api-key requires a value/ },
+    ];
+
+    for (const { args, message } of cases) {
+      const result = spawnSync(process.execPath, [BIN, ...args], {
+        cwd: REPO_ROOT,
+        input: '',
+        encoding: 'utf8',
+      });
+      assert.strictEqual(result.status, 2, `${args.join(' ')} should exit 2`);
+      assert.match(result.stderr, message);
+    }
+  });
+
+  it('--exit-on outside score mode names the alias and exits 2', () => {
+    const result = spawnSync(process.execPath, [BIN, '--exit-on', '30'], {
+      cwd: REPO_ROOT,
+      input: '',
+      encoding: 'utf8',
+    });
+    assert.strictEqual(result.status, 2);
+    assert.match(result.stderr, /--exit-on can only be used with --score/);
+  });
+
+  it('keeps hyphen-prefixed batch suffix values parseable', () => {
+    const result = spawnSync(process.execPath, [BIN, '--batch', '--suffix', '-humanized'], {
+      cwd: REPO_ROOT,
+      input: '   \n',
+      encoding: 'utf8',
+    });
+    assert.strictEqual(result.status, 2);
+    assert.match(result.stderr, /empty input on stdin/);
+    assert.doesNotMatch(result.stderr, /--suffix requires a value/);
   });
 });

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -13,11 +13,13 @@ let mockServer;
 let mockPort;
 let callCount = 0;
 let lastRequestBody = null;
+let lastAuthorization = null;
 
 function startMockServer(responseText, statusCode = 200) {
   return new Promise((resolve) => {
     mockServer = createServer((req, res) => {
       callCount++;
+      lastAuthorization = req.headers.authorization || null;
       let body = '';
       req.on('data', (chunk) => { body += chunk; });
       req.on('end', () => {
@@ -55,6 +57,23 @@ async function captureConsole(fn) {
     console.error = originalError;
   }
   return { logs, errors };
+}
+
+async function withEnv(envOverrides, fn) {
+  const original = {};
+  for (const key of Object.keys(envOverrides)) {
+    original[key] = process.env[key];
+    if (envOverrides[key] === undefined) delete process.env[key];
+    else process.env[key] = envOverrides[key];
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const key of Object.keys(original)) {
+      if (original[key] === undefined) delete process.env[key];
+      else process.env[key] = original[key];
+    }
+  }
 }
 
 describe('CLI End-to-End with Mock API', () => {
@@ -103,6 +122,62 @@ describe('CLI End-to-End with Mock API', () => {
     ]);
 
     assert.strictEqual(lastRequestBody.temperature, 0.7);
+  });
+
+  it('uses OPENAI_API_KEY for the default HTTP backend when no --api-key is passed', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+    lastAuthorization = null;
+
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+
+    await withEnv({
+      PATINA_API_KEY: undefined,
+      PATINA_API_KEY_FILE: undefined,
+      OPENAI_API_KEY: 'openai-env-key',
+      GEMINI_API_KEY: undefined,
+      GROQ_API_KEY: undefined,
+      TOGETHER_API_KEY: undefined,
+    }, async () => {
+      await main([
+        '--lang', 'en',
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        '--model', 'gpt-5',
+        testFile,
+      ]);
+    });
+
+    assert.strictEqual(callCount, 1, 'Should make exactly one API call');
+    assert.strictEqual(lastAuthorization, 'Bearer openai-env-key');
+  });
+
+  it('keeps selected provider env keys ahead of generic PATINA_API_KEY', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+    lastAuthorization = null;
+
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+
+    await withEnv({
+      PATINA_API_KEY: 'patina-env-key',
+      PATINA_API_KEY_FILE: undefined,
+      OPENAI_API_KEY: 'openai-env-key',
+      GEMINI_API_KEY: 'gemini-env-key',
+      GROQ_API_KEY: undefined,
+      TOGETHER_API_KEY: undefined,
+    }, async () => {
+      await main([
+        '--lang', 'en',
+        '--provider', 'gemini',
+        '--backend', 'openai-http',
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        '--model', 'provider-test',
+        testFile,
+      ]);
+    });
+
+    assert.strictEqual(callCount, 1, 'Should make exactly one API call');
+    assert.strictEqual(lastAuthorization, 'Bearer gemini-env-key');
   });
 
   it('should handle --audit mode', async () => {
@@ -194,6 +269,39 @@ describe('CLI End-to-End with Mock API', () => {
     });
     assert.strictEqual(parsed.categories[0].name, 'style');
     assert.ok(parsed.tone);
+    await stopMockServer();
+    await startMockServer('This is the humanized result.');
+  });
+
+  it('should validate score weights before wrapping --format json output', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+    await stopMockServer();
+    await startMockServer([
+      '| Category | Weight | Detected | Raw Score | Weighted |',
+      '|---|---:|---:|---:|---:|',
+      '| content | 0.20 | 0 | 0 | 0 |',
+      '| language | 0.20 | 0 | 0 | 0 |',
+      '| style | 0.20 | 0 | 0 | 0 |',
+      '| communication | 0.12 | 0 | 0 | 0 |',
+      '| filler | 0.08 | 0 | 0 | 0 |',
+      '| structure | 0.10 | 0 | 0 | 0 |',
+      '| viral-hook | 0.10 | 0 | 0 | 0 |',
+      '| Overall | - | - | - | 23 |',
+    ].join('\n'));
+
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+    const { errors, logs } = await captureConsole(() => main([
+      '--lang', 'en',
+      '--score',
+      '--format', 'json',
+      '--api-key', 'test-key',
+      '--base-url', `http://127.0.0.1:${mockPort}`,
+      testFile,
+    ]));
+
+    assert.strictEqual(JSON.parse(logs.join('\n')).overall, 23);
+    assert.ok(!errors.some((line) => line.includes('weight check')), errors.join('\n'));
     await stopMockServer();
     await startMockServer('This is the humanized result.');
   });


### PR DESCRIPTION
## Summary
- resolve final review blockers from the CLI adoption wave follow-up
- centralize HTTP API-key inspection/resolution for doctor, backend listing, provider listing, and runtime
- keep `--suffix -humanized` parseable and add regressions for auth/source precedence

## Review evidence
- Final code review: APPROVE
- Final architecture review: CLEAR
- No new npm dependencies
- No core skill pipeline changes

## Verification
- `npm test` — PASS (185 tests)
- `npm run lint` — PASS (Syntax OK, 51 files)
- `npm run benchmark` — PASS (34 fixtures, 100.0% accuracy)
- `npm run dogfood` — PASS (README 19.7, docs/FAQ 21.2, SKILL 20.7; all < 30)

Follow-up to #239.
