### PR TITLE
ux(max): warn on MPS fallback

### DIFF
--- a/src/max-mode.js
+++ b/src/max-mode.js
@@ -90,17 +90,15 @@ export async function runMaxMode({
     clearTimeout(timeout);
   }
 
-  const best = selectBest(candidates);
-  const valid = candidates.filter((c) => c.ok && c.aiScore !== null);
+  const { candidate: best, fallback } = selectBest(candidates);
   const allFailed = best === null;
-  const mpsFallback = valid.length > 0 && !valid.some((c) => (c.mps ?? 0) >= 70);
 
   return {
     type: 'max-mode',
     candidates,
     best,
     allFailed,
-    mpsFallback,
+    mpsFallback: fallback,
     timedOut,
   };
 }
@@ -109,7 +107,7 @@ export function selectBest(candidates, { log = console.error } = {}) {
   const valid = candidates.filter((c) => c.ok && c.aiScore !== null);
 
   if (valid.length === 0) {
-    return null;
+    return { candidate: null, fallback: false };
   }
 
   const passingMps = valid.filter((c) => (c.mps ?? 0) >= 70);
@@ -124,7 +122,7 @@ export function selectBest(candidates, { log = console.error } = {}) {
       log(`[patina-max] Tie on AI score — picked ${best.model} by config order`);
     }
 
-    return best;
+    return { candidate: best, fallback: false };
   }
 
   const best = valid.reduce((best, current) => {
@@ -139,5 +137,5 @@ export function selectBest(candidates, { log = console.error } = {}) {
     log(`[patina-max] Tie on MPS — picked ${best.model} by config order`);
   }
 
-  return best;
+  return { candidate: best, fallback: true };
 }

--- a/src/output.js
+++ b/src/output.js
@@ -439,7 +439,8 @@ function formatMaxModeOutput(result) {
   if (result.allFailed) {
     output += '> No MAX candidate produced a scoreable result. Exit code: 4.\n\n';
   } else if (result.mpsFallback) {
-    output += '> No candidate reached MPS ≥ 70; selected the highest-MPS fallback. Exit code: 4.\n\n';
+    output += '⚠ No candidate passed MPS ≥ 70 — selecting by highest MPS (fallback)\n\n';
+    output += '> Exit code: 4.\n\n';
   }
 
   if (best?.result) {

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -491,6 +491,67 @@ describe('CLI End-to-End with Mock API', () => {
     await startMockServer('This is the humanized result.');
   });
 
+  it('should warn and set exit code 4 when MAX falls back to highest MPS', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+    await stopMockServer();
+
+    mockServer = createServer((req, res) => {
+      callCount++;
+      let body = '';
+      req.on('data', (chunk) => { body += chunk; });
+      req.on('end', () => {
+        lastRequestBody = JSON.parse(body);
+        const prompt = lastRequestBody.messages[0].content;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+
+        if (prompt.includes('AI-likeness scoring engine')) {
+          res.end(JSON.stringify({
+            choices: [{ message: { content: '{ "overall": 85, "interpretation": "still AI-like" }' } }],
+          }));
+        } else if (prompt.includes('Meaning Preservation evaluator')) {
+          res.end(JSON.stringify({
+            choices: [{ message: { content: '{ "anchors": [], "pass_count": 1, "total_count": 1, "polarity_pass_count": 0, "polarity_total_count": 0, "mps": 65 }' } }],
+          }));
+        } else {
+          res.end(JSON.stringify({
+            choices: [{ message: { content: 'Still sounds packaged.' } }],
+          }));
+        }
+      });
+    });
+
+    await new Promise((resolve) => {
+      mockServer.listen(0, '127.0.0.1', () => {
+        mockPort = mockServer.address().port;
+        resolve();
+      });
+    });
+
+    const oldExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+    try {
+      const { logs } = await captureConsole(() => main([
+        '--lang', 'en',
+        '--models', 'model-a',
+        '--api-key', 'test-key',
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        testFile,
+      ]));
+
+      assert.strictEqual(process.exitCode, 4);
+      assert.match(
+        logs.join('\n'),
+        /⚠ No candidate passed MPS ≥ 70 — selecting by highest MPS \(fallback\)/
+      );
+    } finally {
+      process.exitCode = oldExitCode;
+    }
+    await stopMockServer();
+    await startMockServer('This is the humanized result.');
+  });
+
   it('should handle API errors gracefully', async () => {
     callCount = 0;
     lastRequestBody = null;

--- a/tests/unit/max-mode.test.js
+++ b/tests/unit/max-mode.test.js
@@ -2,29 +2,41 @@ import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 
 import { runMaxMode, selectBest } from '../../src/max-mode.js';
+import { formatOutput } from '../../src/output.js';
 
 test('selectBest keeps config order and logs AI-score ties among MPS-passing candidates', () => {
   const logs = [];
-  const best = selectBest([
+  const selection = selectBest([
     { model: 'claude', ok: true, aiScore: 12, mps: 74 },
     { model: 'gemini', ok: true, aiScore: 12, mps: 91 },
     { model: 'codex', ok: true, aiScore: 18, mps: 88 },
   ], { log: (message) => logs.push(message) });
 
-  assert.equal(best.model, 'claude');
+  assert.equal(selection.candidate.model, 'claude');
+  assert.equal(selection.fallback, false);
   assert.deepEqual(logs, ['[patina-max] Tie on AI score — picked claude by config order']);
 });
 
 test('selectBest keeps config order and logs MPS ties when no candidate passes MPS floor', () => {
   const logs = [];
-  const best = selectBest([
+  const selection = selectBest([
     { model: 'claude', ok: true, aiScore: 42, mps: 62 },
     { model: 'gemini', ok: true, aiScore: 18, mps: 62 },
     { model: 'codex', ok: true, aiScore: 11, mps: 57 },
   ], { log: (message) => logs.push(message) });
 
-  assert.equal(best.model, 'claude');
+  assert.equal(selection.candidate.model, 'claude');
+  assert.equal(selection.fallback, true);
   assert.deepEqual(logs, ['[patina-max] Tie on MPS — picked claude by config order']);
+});
+
+test('selectBest returns an explicit empty non-fallback selection when no candidate is scoreable', () => {
+  const selection = selectBest([
+    { model: 'claude', ok: false, error: 'backend failed' },
+    { model: 'gemini', ok: true, aiScore: null, mps: 90 },
+  ]);
+
+  assert.deepEqual(selection, { candidate: null, fallback: false });
 });
 
 test('runMaxMode aborts dispatch and returns partial results on wall-clock timeout', async () => {
@@ -58,4 +70,22 @@ test('runMaxMode aborts dispatch and returns partial results on wall-clock timeo
     { model: 'slow-model', ok: false, error: 'aborted' },
   ]);
   assert.equal(result.best, null);
+});
+
+test('formatOutput surfaces the MAX MPS fallback warning', () => {
+  const out = formatOutput({
+    type: 'max-mode',
+    candidates: [
+      { model: 'claude', ok: true, aiScore: 85, mps: 65, result: 'Still sounds packaged.' },
+      { model: 'gemini', ok: true, aiScore: 25, mps: 61, result: 'Meaning drifted.' },
+    ],
+    best: { model: 'claude', ok: true, aiScore: 85, mps: 65, result: 'Still sounds packaged.' },
+    allFailed: false,
+    mpsFallback: true,
+    timedOut: false,
+  }, 'rewrite');
+
+  assert.match(out, /⚠ No candidate passed MPS ≥ 70 — selecting by highest MPS \(fallback\)/);
+  assert.match(out, /> Exit code: 4/);
+  assert.match(out, /\| claude \| 85 \| 65 \| ✅ best \|/);
 });


### PR DESCRIPTION
## Summary
- make `selectBest` return explicit `{ candidate, fallback }` selection metadata
- surface the MAX fallback warning when no candidate passes MPS ≥ 70
- keep exit code 4 covered for the fallback path

Closes #139.

## Verification
- `node --test tests/unit/max-mode.test.js tests/e2e/cli-api.test.js`
- `npm run lint:syntax`
- `npm run lint:eslint`
- `npm run typecheck`
- `git diff --check`
