### PR TITLE
refactor(api): inject deterministic LLM seams

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -245,6 +245,9 @@ export async function callLLMMultiple({
   maxConcurrency,
   onStart,
   onComplete,
+  callLLM: callLLMImpl = callLLM,
+  sleep,
+  now = () => Date.now(),
 }) {
   validateBaseURL(baseURL, { allowInsecure: allowInsecureBaseURL });
   const effectiveMaxConcurrency =
@@ -256,7 +259,7 @@ export async function callLLMMultiple({
     const release = await sem.acquire();
     if (onStart) onStart(model);
     try {
-      const result = await callLLM({
+      const result = await callLLMImpl({
         prompt,
         apiKey,
         baseURL,
@@ -266,6 +269,8 @@ export async function callLLMMultiple({
         deadline,
         signal,
         allowInsecureBaseURL,
+        sleep,
+        now,
       });
       if (onComplete) onComplete(model, true);
       return { model, result, ok: true };

--- a/src/max-mode.js
+++ b/src/max-mode.js
@@ -1,4 +1,4 @@
-import { callLLMMultiple } from './api.js';
+import { callLLM as defaultCallLLM, callLLMMultiple } from './api.js';
 import { scoreText, scoreMPS } from './scoring.js';
 
 const DEFAULT_WALL_CLOCK_BUDGET_MS = 300_000;
@@ -13,6 +13,9 @@ export async function runMaxMode({
   patterns,
   maxConcurrency,
   wallClockBudgetMs = DEFAULT_WALL_CLOCK_BUDGET_MS,
+  callLLM = defaultCallLLM,
+  now = () => Date.now(),
+  sleep,
   callLLMMultipleImpl = callLLMMultiple,
   scoreTextImpl = scoreText,
   scoreMPSImpl = scoreMPS,
@@ -20,7 +23,7 @@ export async function runMaxMode({
   console.error(`[patina-max] Dispatching to ${models.length} models: ${models.join(', ')}`);
 
   const controller = new AbortController();
-  const deadline = Date.now() + wallClockBudgetMs;
+  const deadline = now() + wallClockBudgetMs;
   let timedOut = false;
   const timeout = setTimeout(() => {
     timedOut = true;
@@ -38,6 +41,9 @@ export async function runMaxMode({
       maxConcurrency,
       deadline,
       signal: controller.signal,
+      callLLM,
+      now,
+      sleep,
       onStart: (model) => console.error(`[patina-max] Starting ${model}...`),
       onComplete: (model, ok) => console.error(`[patina-max] ${model} ${ok ? 'completed' : 'failed'}`),
     });
@@ -61,6 +67,9 @@ export async function runMaxMode({
           model: r.model,
           deadline,
           signal: controller.signal,
+          callLLM,
+          now,
+          sleep,
         });
       }
 
@@ -73,6 +82,9 @@ export async function runMaxMode({
           model: r.model,
           deadline,
           signal: controller.signal,
+          callLLM,
+          now,
+          sleep,
         });
       }
 

--- a/src/ouroboros.js
+++ b/src/ouroboros.js
@@ -1,4 +1,4 @@
-import { callLLM } from './api.js';
+import { callLLM as defaultCallLLM } from './api.js';
 import { scoreText, scoreMPS, scoreFidelity, combinedScore } from './scoring.js';
 import { buildPrompt } from './prompt-builder.js';
 
@@ -12,6 +12,9 @@ export async function runOuroboros({
   apiKey,
   baseURL,
   model,
+  callLLM = defaultCallLLM,
+  now,
+  sleep,
 }) {
   const ouroborosConfig = config.ouroboros || {};
   const targetScore = ouroborosConfig['target-score'] ?? 30;
@@ -29,6 +32,9 @@ export async function runOuroboros({
     apiKey,
     baseURL,
     model,
+    callLLM,
+    now,
+    sleep,
   });
 
   const initialScore = initialScoreResult?.overall ?? 100;
@@ -80,6 +86,8 @@ export async function runOuroboros({
       apiKey,
       baseURL,
       model,
+      now,
+      sleep,
     });
 
     const scoreResult = await scoreText({
@@ -89,14 +97,35 @@ export async function runOuroboros({
       apiKey,
       baseURL,
       model,
+      callLLM,
+      now,
+      sleep,
     });
 
     let currentScore = scoreResult?.overall ?? 100;
     const delta = previousScore - currentScore;
 
     const [mpsResult, fidelityResult] = await Promise.all([
-      scoreMPS({ original: text, rewritten: humanized, apiKey, baseURL, model }),
-      scoreFidelity({ original: text, rewritten: humanized, apiKey, baseURL, model }),
+      scoreMPS({
+        original: text,
+        rewritten: humanized,
+        apiKey,
+        baseURL,
+        model,
+        callLLM,
+        now,
+        sleep,
+      }),
+      scoreFidelity({
+        original: text,
+        rewritten: humanized,
+        apiKey,
+        baseURL,
+        model,
+        callLLM,
+        now,
+        sleep,
+      }),
     ]);
 
     const mps = mpsResult?.mps ?? 100;

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,4 +1,4 @@
-import { callLLM } from './api.js';
+import { callLLM as defaultCallLLM } from './api.js';
 
 class SchemaError extends Error {
   constructor(message, raw) {
@@ -30,11 +30,32 @@ function parseStrictJson(text) {
 }
 
 // Call LLM and parse strict JSON. On schema failure, retry once at temperature 0.
-async function callAndParseJson({ prompt, apiKey, baseURL, model, temperature = 0.1, deadline, signal }) {
+async function callAndParseJson({
+  prompt,
+  apiKey,
+  baseURL,
+  model,
+  temperature = 0.1,
+  deadline,
+  signal,
+  callLLM = defaultCallLLM,
+  now,
+  sleep,
+}) {
   let lastError;
   for (let attempt = 0; attempt < 2; attempt++) {
     const t = attempt === 0 ? temperature : 0;
-    const result = await callLLM({ prompt, apiKey, baseURL, model, temperature: t, deadline, signal });
+    const result = await callLLM({
+      prompt,
+      apiKey,
+      baseURL,
+      model,
+      temperature: t,
+      deadline,
+      signal,
+      now,
+      sleep,
+    });
     try {
       return { parsed: parseStrictJson(result), raw: result };
     } catch (e) {
@@ -47,7 +68,19 @@ async function callAndParseJson({ prompt, apiKey, baseURL, model, temperature = 
   throw lastError;
 }
 
-export async function scoreText({ text, config, patterns, apiKey, baseURL, model, deadline, signal }) {
+export async function scoreText({
+  text,
+  config,
+  patterns,
+  apiKey,
+  baseURL,
+  model,
+  deadline,
+  signal,
+  callLLM = defaultCallLLM,
+  now,
+  sleep,
+}) {
   const lang = config.language || 'ko';
   const weights = config.ouroboros?.['category-weights']?.[lang] || {};
 
@@ -82,7 +115,17 @@ ${text}
 `;
 
   try {
-    const { parsed } = await callAndParseJson({ prompt, apiKey, baseURL, model, deadline, signal });
+    const { parsed } = await callAndParseJson({
+      prompt,
+      apiKey,
+      baseURL,
+      model,
+      deadline,
+      signal,
+      callLLM,
+      now,
+      sleep,
+    });
     return parsed;
   } catch (e) {
     console.error(`[patina] scoreText schema failure after retry: ${e.message}`);
@@ -90,7 +133,18 @@ ${text}
   }
 }
 
-export async function scoreMPS({ original, rewritten, apiKey, baseURL, model, deadline, signal }) {
+export async function scoreMPS({
+  original,
+  rewritten,
+  apiKey,
+  baseURL,
+  model,
+  deadline,
+  signal,
+  callLLM = defaultCallLLM,
+  now,
+  sleep,
+}) {
   const prompt = `You are a Meaning Preservation evaluator. Compare the ORIGINAL text with the REWRITTEN text.
 
 Extract semantic anchors from the original (claims, polarity, causation, quantifiers, negations) and check if each is preserved in the rewritten text.
@@ -123,7 +177,17 @@ ${rewritten}
 `;
 
   try {
-    const { parsed } = await callAndParseJson({ prompt, apiKey, baseURL, model, deadline, signal });
+    const { parsed } = await callAndParseJson({
+      prompt,
+      apiKey,
+      baseURL,
+      model,
+      deadline,
+      signal,
+      callLLM,
+      now,
+      sleep,
+    });
     return parsed;
   } catch (e) {
     console.error(`[patina] scoreMPS schema failure after retry: ${e.message}`);
@@ -149,7 +213,18 @@ export function lengthRatioPoints(original, rewritten) {
   return 0;
 }
 
-export async function scoreFidelity({ original, rewritten, apiKey, baseURL, model }) {
+export async function scoreFidelity({
+  original,
+  rewritten,
+  apiKey,
+  baseURL,
+  model,
+  deadline,
+  signal,
+  callLLM = defaultCallLLM,
+  now,
+  sleep,
+}) {
   // Length is deterministic; only ask LLM for the three judgment criteria.
   const lengthPoints = lengthRatioPoints(original, rewritten);
   const lengthRatio = original ? Math.round((rewritten.length / original.length) * 100) : 100;
@@ -184,7 +259,17 @@ ${rewritten}
   let parsed = null;
   let schemaError = null;
   try {
-    const result = await callAndParseJson({ prompt, apiKey, baseURL, model });
+    const result = await callAndParseJson({
+      prompt,
+      apiKey,
+      baseURL,
+      model,
+      deadline,
+      signal,
+      callLLM,
+      now,
+      sleep,
+    });
     parsed = result.parsed;
   } catch (e) {
     console.error(`[patina] scoreFidelity schema failure after retry: ${e.message}`);

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -119,6 +119,31 @@ test('callLLMMultiple defaults to a safe concurrency cap of min(models, 3)', asy
   }
 });
 
+test('callLLMMultiple accepts callLLM, now, and sleep injectables', async () => {
+  const seen = [];
+  const now = () => 456;
+  const sleep = async () => {};
+  const results = await callLLMMultiple({
+    prompt: 'x',
+    apiKey: 'test',
+    models: ['m1', 'm2'],
+    callLLM: async (args) => {
+      seen.push(args);
+      assert.strictEqual(args.now, now);
+      assert.strictEqual(args.sleep, sleep);
+      return `ok:${args.model}`;
+    },
+    now,
+    sleep,
+  });
+
+  assert.deepStrictEqual(results, [
+    { model: 'm1', result: 'ok:m1', ok: true },
+    { model: 'm2', result: 'ok:m2', ok: true },
+  ]);
+  assert.strictEqual(seen.length, 2);
+});
+
 test('createSemaphore enforces concurrency cap and drains the queue', async () => {
   const sem = createSemaphore(2);
   let active = 0;

--- a/tests/unit/max-mode.test.js
+++ b/tests/unit/max-mode.test.js
@@ -72,6 +72,43 @@ test('runMaxMode aborts dispatch and returns partial results on wall-clock timeo
   assert.equal(result.best, null);
 });
 
+test('runMaxMode uses callLLM, now, and sleep injectables across dispatch and scoring', async () => {
+  const seen = [];
+  const now = () => 1_000;
+  const sleep = async () => {};
+  const result = await runMaxMode({
+    prompt: 'rewrite this',
+    sourceText: 'source text',
+    models: ['model-a'],
+    apiKey: 'test',
+    baseURL: 'https://example.com/v1',
+    config: { language: 'en', ouroboros: { 'category-weights': { en: {} } } },
+    patterns: [],
+    wallClockBudgetMs: 1_000,
+    now,
+    sleep,
+    callLLM: async (args) => {
+      seen.push(args);
+      assert.equal(args.now, now);
+      assert.equal(args.sleep, sleep);
+
+      if (args.prompt.includes('AI-likeness scoring engine')) {
+        return '{ "overall": 12, "interpretation": "human" }';
+      }
+      if (args.prompt.includes('Meaning Preservation evaluator')) {
+        return '{ "anchors": [], "pass_count": 1, "total_count": 1, "polarity_pass_count": 0, "polarity_total_count": 0, "mps": 94 }';
+      }
+      return 'Humanized result.';
+    },
+  });
+
+  assert.equal(result.best.model, 'model-a');
+  assert.equal(result.best.aiScore, 12);
+  assert.equal(result.best.mps, 94);
+  assert.equal(result.mpsFallback, false);
+  assert.equal(seen.length, 3);
+});
+
 test('formatOutput surfaces the MAX MPS fallback warning', () => {
   const out = formatOutput({
     type: 'max-mode',

--- a/tests/unit/ouroboros.test.js
+++ b/tests/unit/ouroboros.test.js
@@ -1,0 +1,177 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { runOuroboros } from '../../src/ouroboros.js';
+
+const BASE_TEXT = 'Original claim text.';
+
+function baseConfig(overrides = {}) {
+  return {
+    language: 'en',
+    profile: 'default',
+    ouroboros: {
+      'target-score': 30,
+      'max-iterations': 3,
+      'plateau-threshold': 10,
+      'fidelity-floor': 70,
+      'mps-floor': 70,
+      'combined-weights': {
+        default: {
+          'ai-likeness': 0.6,
+          fidelity: 0.4,
+        },
+      },
+      ...overrides,
+    },
+  };
+}
+
+function createLLMFixture({
+  scores,
+  rewrites = [],
+  mps = [],
+  fidelityGrades = [],
+}) {
+  const calls = {
+    score: [],
+    rewrite: [],
+    mps: [],
+    fidelity: [],
+  };
+
+  const next = (items, label) => {
+    assert.ok(items.length > 0, `missing fake ${label} response`);
+    return items.shift();
+  };
+
+  const callLLM = async ({ prompt }) => {
+    if (prompt.includes('AI-likeness scoring engine')) {
+      calls.score.push(prompt);
+      return JSON.stringify({
+        categories: {},
+        overall: next(scores, 'score'),
+        interpretation: 'test',
+      });
+    }
+
+    if (prompt.includes('Meaning Preservation evaluator')) {
+      calls.mps.push(prompt);
+      return JSON.stringify({
+        anchors: [],
+        pass_count: 1,
+        total_count: 1,
+        polarity_pass_count: 0,
+        polarity_total_count: 0,
+        mps: next(mps, 'MPS'),
+      });
+    }
+
+    if (prompt.includes('Fidelity evaluator')) {
+      calls.fidelity.push(prompt);
+      const grade = next(fidelityGrades, 'fidelity');
+      return JSON.stringify({
+        claims_preserved: grade,
+        no_fabrication: grade,
+        tone_match: grade,
+        rationale: 'test fixture',
+      });
+    }
+
+    calls.rewrite.push(prompt);
+    return next(rewrites, 'rewrite');
+  };
+
+  return { calls, callLLM };
+}
+
+function runWithFixture(fixture, config = baseConfig()) {
+  return runOuroboros({
+    config,
+    patterns: [],
+    profile: null,
+    voice: null,
+    scoring: null,
+    text: BASE_TEXT,
+    apiKey: 'test-key',
+    baseURL: 'https://example.com/v1',
+    model: 'test-model',
+    callLLM: fixture.callLLM,
+  });
+}
+
+test('runOuroboros exits early when the initial score already meets target', async () => {
+  const fixture = createLLMFixture({ scores: [20] });
+
+  const result = await runWithFixture(fixture);
+
+  assert.equal(result.finalText, BASE_TEXT);
+  assert.equal(result.finalScore, 20);
+  assert.equal(result.iterations, 0);
+  assert.match(result.reason, /Already at target/);
+  assert.equal(fixture.calls.score.length, 1);
+  assert.equal(fixture.calls.rewrite.length, 0);
+});
+
+test('runOuroboros stops on plateau and keeps the latest non-rollback text', async () => {
+  const fixture = createLLMFixture({
+    scores: [80, 75],
+    rewrites: ['Rewritten claim text.'],
+    mps: [100],
+    fidelityGrades: [3],
+  });
+
+  const result = await runWithFixture(fixture);
+
+  assert.equal(result.finalText, 'Rewritten claim text.');
+  assert.equal(result.finalScore, 75);
+  assert.equal(result.iterations, 1);
+  assert.equal(result.reason, 'Plateau');
+});
+
+test('runOuroboros rolls back on combined-score regression', async () => {
+  const fixture = createLLMFixture({
+    scores: [40, 50],
+    rewrites: ['Regression claim text.'],
+    mps: [100],
+    fidelityGrades: [3],
+  });
+
+  const result = await runWithFixture(fixture);
+
+  assert.equal(result.finalText, BASE_TEXT);
+  assert.equal(result.finalScore, 40);
+  assert.equal(result.iterations, 1);
+  assert.match(result.reason, /^Regression/);
+});
+
+test('runOuroboros rolls back on fidelity-floor violation', async () => {
+  const fixture = createLLMFixture({
+    scores: [80, 20],
+    rewrites: ['Fidelity bad text.'],
+    mps: [100],
+    fidelityGrades: [1],
+  });
+
+  const result = await runWithFixture(fixture, baseConfig({ 'target-score': 5 }));
+
+  assert.equal(result.finalText, BASE_TEXT);
+  assert.equal(result.finalScore, 80);
+  assert.equal(result.iterations, 1);
+  assert.equal(result.reason, 'Fidelity floor violation');
+});
+
+test('runOuroboros rolls back on MPS-floor violation', async () => {
+  const fixture = createLLMFixture({
+    scores: [80, 20],
+    rewrites: ['MPS bad claim text.'],
+    mps: [50],
+    fidelityGrades: [3],
+  });
+
+  const result = await runWithFixture(fixture, baseConfig({ 'target-score': 5 }));
+
+  assert.equal(result.finalText, BASE_TEXT);
+  assert.equal(result.finalScore, 80);
+  assert.equal(result.iterations, 1);
+  assert.equal(result.reason, 'MPS floor violation');
+});

--- a/tests/unit/scoring.test.js
+++ b/tests/unit/scoring.test.js
@@ -5,6 +5,9 @@ import {
   combinedScore,
   interpretScore,
   lengthRatioPoints,
+  scoreFidelity,
+  scoreMPS,
+  scoreText,
 } from '../../src/scoring.js';
 import { loadConfig } from '../../src/config.js';
 
@@ -89,4 +92,55 @@ test('combinedScore uses default and profile-specific config weights', () => {
     combinedScore({ aiLikeness: 40, fidelity: 80, profile: 'marketing', config }),
     33
   );
+});
+
+test('score helpers accept an injected callLLM implementation', async () => {
+  const seen = [];
+  const now = () => 123;
+  const sleep = async () => {};
+  const callLLM = async (args) => {
+    seen.push(args);
+    assert.strictEqual(args.now, now);
+    assert.strictEqual(args.sleep, sleep);
+
+    if (args.prompt.includes('AI-likeness scoring engine')) {
+      return '{ "overall": 22, "interpretation": "mostly human" }';
+    }
+    if (args.prompt.includes('Meaning Preservation evaluator')) {
+      return '{ "anchors": [], "pass_count": 1, "total_count": 1, "polarity_pass_count": 0, "polarity_total_count": 0, "mps": 91 }';
+    }
+    return '{ "claims_preserved": 3, "no_fabrication": 3, "tone_match": 3, "rationale": "ok" }';
+  };
+
+  const config = loadConfig();
+  const common = {
+    apiKey: 'test-key',
+    baseURL: 'https://example.com/v1',
+    model: 'test-model',
+    callLLM,
+    now,
+    sleep,
+  };
+
+  const score = await scoreText({
+    text: 'Example text.',
+    config,
+    patterns: [],
+    ...common,
+  });
+  const mps = await scoreMPS({
+    original: 'Example text.',
+    rewritten: 'Example text.',
+    ...common,
+  });
+  const fidelity = await scoreFidelity({
+    original: 'Example text.',
+    rewritten: 'Example text.',
+    ...common,
+  });
+
+  assert.strictEqual(score.overall, 22);
+  assert.strictEqual(mps.mps, 91);
+  assert.strictEqual(fidelity.fidelity, 100);
+  assert.strictEqual(seen.length, 3);
 });


### PR DESCRIPTION
## Summary
- thread `callLLM`, `now`, and `sleep` injectables through scoring, MAX, and Ouroboros paths while keeping production defaults
- let `callLLMMultiple` and MAX reuse an injected LLM implementation for deterministic tests
- add deterministic Ouroboros unit coverage for target-met early exit, plateau, regression rollback, fidelity-floor rollback, and MPS-floor rollback

Closes #130.

## Verification
- `npm test`
- `npm run lint:syntax`
- `npm run lint:eslint`
- `npm run typecheck`
- `git diff --check`
