### PR TITLE
release: keep v3.11 npm publish path npm-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       publish:
-        description: Publish npm packages and GHCR image instead of running a dry-run.
+        description: Publish npm packages instead of running a dry-run.
+        type: boolean
+        default: false
+      publish_ghcr:
+        description: Also publish the experimental GHCR image. Keep false for npm-only releases.
         type: boolean
         default: false
 
@@ -83,7 +87,7 @@ jobs:
   ghcr:
     needs: verify
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+    if: github.event_name == 'workflow_dispatch' && inputs.publish_ghcr == true
     permissions:
       contents: read
       packages: write

--- a/README.md
+++ b/README.md
@@ -127,11 +127,13 @@ steps:
       comment: true
 ```
 
-Docker release images are published to GHCR on version tags:
+Docker image publishing is tracked separately from the npm release path. Until
+the GHCR image is published, build the local image when you need a container:
 
 ```bash
+docker build -t patina:local .
 printf '%s\n' 'Coffee has emerged as a pivotal cultural phenomenon.' \
-  | docker run --rm -i -e PATINA_API_KEY ghcr.io/devswha/patina:3.11.0 --lang en --provider openai
+  | docker run --rm -i -e PATINA_API_KEY patina:local --lang en --provider openai
 ```
 
 Pre-commit, Husky, Lefthook, Docker, and release workflow notes live in [docs/integrations/](docs/integrations/).

--- a/docs/integrations/docker.md
+++ b/docs/integrations/docker.md
@@ -1,15 +1,19 @@
 # Docker image
 
-The release job publishes `ghcr.io/devswha/patina` when a maintainer pushes a version tag.
+The npm release job does not publish Docker images automatically. GHCR
+publishing is tracked separately so the first npm release can stay npm-only.
+
+Until the image is published, build the local image:
 
 ```bash
+docker build -t patina:local .
 printf '%s\n' 'Coffee has emerged as a pivotal cultural phenomenon.' \
-  | docker run --rm -i -e PATINA_API_KEY ghcr.io/devswha/patina:3.11.0 --lang en --provider openai
+  | docker run --rm -i -e PATINA_API_KEY patina:local --lang en --provider openai
 ```
 
-Tags:
+Planned tags after the GHCR publishing issue is closed:
 
-- `ghcr.io/devswha/patina:3.11.0` — version tag from `v3.11.0`.
+- `ghcr.io/devswha/patina:<version>` — version tag from `v<version>`.
 - `ghcr.io/devswha/patina:latest` — latest release tag.
 
 The image uses `node:18-alpine`. It does **not** include codex, claude, or gemini CLI binaries, and it never carries local login state. For container runs, use an API-backed provider or mount your own authenticated tools explicitly.

--- a/docs/integrations/release.md
+++ b/docs/integrations/release.md
@@ -1,11 +1,11 @@
 # Release
 
-`release.yml` is the maintainer path for distribution artifacts.
+`release.yml` is the maintainer path for npm distribution artifacts.
 
 ## Dry run
 
 ```bash
-gh workflow run release.yml -f publish=false
+gh workflow run release.yml -f publish=false -f publish_ghcr=false
 ```
 
 The dry run verifies:
@@ -18,7 +18,7 @@ The dry run verifies:
 
 ## Publish
 
-Publishing is intended for `v*.*.*` tags:
+Publishing the npm packages is intended for `v*.*.*` tags:
 
 ```bash
 git tag v3.11.0
@@ -32,5 +32,12 @@ Required secret:
 The publish job uploads:
 
 - `patina-cli` to npm;
-- `patina-humanizer` alias to npm;
-- `ghcr.io/devswha/patina:latest` and `ghcr.io/devswha/patina:<version>`.
+- `patina-humanizer` alias to npm.
+
+Docker / GHCR publishing is intentionally decoupled from npm releases while
+the container distribution issue is still open. Maintainers can run the
+experimental image path manually after npm verification:
+
+```bash
+gh workflow run release.yml --ref v3.11.0 -f publish=false -f publish_ghcr=true
+```


### PR DESCRIPTION
## Summary
- make the tag-triggered release path npm-only for the first package release
- keep the GHCR image behind an explicit manual `publish_ghcr` workflow input while #209 remains open
- update README and integration docs to avoid claiming a published Docker image before GHCR is actually shipped

Part of #203. The actual npm publish still requires `NPM_TOKEN` and the `v3.11.0` tag after this lands.

## Verification
- `npm run release:check`
- `npm run lint:syntax`
- `npm run dogfood`
- `npm pack --dry-run`
- `cd packages/patina-humanizer && npm pack --dry-run`
- `git diff --check`
