### PR TITLE
docs: point CI prose review at patina-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ Patina also ships a no-key, deterministic CI check for prose review:
 # .github/workflows/patina.yml
 steps:
   - uses: actions/checkout@v6
-  - uses: devswha/patina@main # pin to @v1 after the release tag exists
+  - uses: devswha/patina-action@main # use @v1 after npm publish + action tag
     with:
-      gate: 30
+      patina-package: github:devswha/patina # remove after patina-cli@latest is on npm
+      report-threshold: 30
       comment: true
 ```
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -97,9 +97,10 @@ Patina には、live model key なしで使える deterministic な prose review
 # .github/workflows/patina.yml
 steps:
   - uses: actions/checkout@v6
-  - uses: devswha/patina@main # release tag ができたら @v1 などに pin
+  - uses: devswha/patina-action@main # npm publish + Action タグ後は @v1 を使用
     with:
-      gate: 30
+      patina-package: github:devswha/patina # patina-cli@latest が npm に出たら削除
+      report-threshold: 30
       comment: true
 ```
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -95,9 +95,10 @@ Patina는 live model key 없이도 prose review용 결정론적 CI 체크를 제
 # .github/workflows/patina.yml
 steps:
   - uses: actions/checkout@v6
-  - uses: devswha/patina@main # 릴리스 태그가 생기면 @v1 등으로 pin
+  - uses: devswha/patina-action@main # npm publish + Action 태그 후 @v1 사용
     with:
-      gate: 30
+      patina-package: github:devswha/patina # patina-cli@latest npm 공개 후 제거
+      report-threshold: 30
       comment: true
 ```
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -97,9 +97,10 @@ Patina 提供不需要 live model key 的确定性 CI prose review：
 # .github/workflows/patina.yml
 steps:
   - uses: actions/checkout@v6
-  - uses: devswha/patina@main # 发布标签存在后可 pin 到 @v1
+  - uses: devswha/patina-action@main # npm 发布并打 Action 标签后改用 @v1
     with:
-      gate: 30
+      patina-package: github:devswha/patina # patina-cli@latest 发布到 npm 后删除
+      report-threshold: 30
       comment: true
 ```
 

--- a/docs/integrations/github-action.md
+++ b/docs/integrations/github-action.md
@@ -1,8 +1,8 @@
 # GitHub Action
 
-Patina ships a composite Action for pull request prose review. No model call is required. It leaves a sticky comment with file-level hotspot scores, so docs reviewers can spot stiff or repetitive paragraphs before merge instead of finding them after publication. The check runs locally in the Action process and does not send text to a live model.
+Patina's standalone Action repository is [`devswha/patina-action`](https://github.com/devswha/patina-action). It runs pull request prose review without a live model call, leaves a sticky comment with file-level hotspot scores, and can fail above an optional score threshold.
 
-> The checked-in Action can be used from this repository immediately with `@main`. After a release tag is cut, pin to `@v1` or a full version tag.
+> The Action defaults to `patina-cli@latest`, so the `@v1` tag should be cut after the npm publish in #203. Until then, pre-release workflows can use `@main` with `patina-package: github:devswha/patina`.
 
 ```yaml
 name: Patina prose score
@@ -23,26 +23,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: devswha/patina@main # replace with @v1 after the v1 tag exists
+      - uses: devswha/patina-action@main # replace with @v1 after npm publish + action tag
         with:
-          gate: 30
+          patina-package: github:devswha/patina # remove after patina-cli@latest is on npm
+          report-threshold: 30
           lang: auto
           comment: true
-          fail-on-gate: false
+```
+
+Once `patina-cli` is on npm and `devswha/patina-action@v1` is tagged, the stable form is:
+
+```yaml
+- uses: actions/checkout@v6
+- uses: devswha/patina-action@v1
+  with:
+    score-threshold: 30
+    comment: true
 ```
 
 ## Inputs
 
 | Input | Default | Meaning |
 |---|---:|---|
-| `files` | changed PR files | Optional newline/comma-separated file list. |
+| `github-token` | `${{ github.token }}` | Token for changed-file detection and comments. |
+| `files` | changed PR Markdown | Optional newline/comma/JSON file list; overrides paths-filter. |
 | `lang` | `auto` | `auto`, `ko`, `en`, `zh`, or `ja`. |
-| `gate` | `30` | Maximum hot-paragraph percentage per file. |
-| `max-files` | `50` | Limit for large PRs. |
+| `score-threshold` | unset | If set, fail when any file score is above this percentage. |
+| `report-threshold` | `30` | Advisory report gate when `score-threshold` is unset. |
+| `max-files` | `50` | Maximum Markdown files to score. |
 | `comment` | `true` | Create/update a sticky PR comment. |
-| `fail-on-gate` | `false` | Fail the check when any file exceeds `gate`. |
-| `token` | `${{ github.token }}` | Token used to list PR files and write comments. |
+| `patina-package` | `patina-cli@latest` | npm package spec used by `npx`. |
 
 ## What it measures
 
-The Action uses the same deterministic burstiness, MATTR, and AI-lexicon signals as the checked-in benchmark. Read the table as a review queue. Open the highest row, check the surrounding paragraph, and decide whether the prose actually needs editing for your audience. It reports **editing hotspots**, not proof that text was AI-written.
+The Action uses `dorny/paths-filter@v4` to find changed Markdown files, runs Patina's deterministic `patina-score` command through `npx`, and updates a sticky comment with `peter-evans/create-or-update-comment@v5`. Read the table as a review queue. Open the highest row, check the surrounding paragraph, and decide whether the prose actually needs editing for your audience. It reports **editing hotspots**, not proof that text was AI-written.


### PR DESCRIPTION
## Summary
- point README CI snippets at the new standalone `devswha/patina-action` repository
- document the pre-v1 `patina-package: github:devswha/patina` override while npm publish is still blocked
- refresh `docs/integrations/github-action.md` with the new Action inputs, paths-filter flow, and sticky-comment behavior

## Related external repo
- Created: https://github.com/devswha/patina-action
- CI there is passing on `main`
- `@v1` tag is intentionally pending until #203 publishes `patina-cli@latest` to npm

## Verification
- `npm run dogfood`
- `npm run lint:syntax`
- `git diff --check`
