### PR TITLE
docs: document external solicitation issue policy

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -21,3 +21,16 @@ Please include:
 - expected vs actual output.
 
 Do not paste private, confidential, or legally sensitive text into public issues.
+
+## External promotion and solicitation
+
+Public issues are for concrete patina bugs, pattern work, docs gaps, benchmarks, and integrations. Issues that mainly advertise a third-party service, ask for a listing, request cross-promotion, recruit contributors for another platform, or solicit a partnership without a concrete patina change are out of scope.
+
+Maintainers may close those issues as not planned or spam without preserving the promotional body text. If there is a real patina integration or research proposal, use the closest issue template and include:
+
+- the user problem inside patina;
+- the specific docs, code, benchmark, or process change being proposed;
+- privacy, security, and maintenance implications;
+- redistributable evidence or a reproducible evaluation protocol.
+
+Commercial, recruiting, sponsorship, or partnership outreach should not be filed as a public issue unless it includes a concrete open-source change that can be reviewed on its own.


### PR DESCRIPTION
## Summary
- document how maintainers should handle public issues that are mainly third-party promotion, solicitation, recruiting, or partnership outreach
- keep a review path for concrete patina integration or research proposals with privacy/security/maintenance evidence

Closes #245.

## Verification
- `git diff --check`
- `npm run lint:syntax`
- `node scripts/precommit-score.mjs SUPPORT.md --gate 30`
