### PR TITLE
docs: add Korean primary doc companions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,6 +44,7 @@ False-positive risk:
 - [ ] `npm run benchmark`
 - [ ] `npm run quality:live` when relevant
 - [ ] Docs reviewed manually
+- [ ] `_KR` companion docs updated or not affected
 - [ ] Not run — explain why:
 
 ## Meaning preservation
@@ -51,4 +52,3 @@ False-positive risk:
 For rewrite-related changes, explain how claims, polarity, causation, numbers, and negations are preserved.
 
 ## Risks / follow-ups
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,18 @@ User-facing documentation lives in `README*.md`, `docs/`, `examples/`, `patterns
 
 When moving a root-level Markdown file, either link it from `README.md` if it is public, or place it under `docs/internal/` with a short status note explaining its audience.
 
+## Korean Translation Policy
+
+Primary user docs should keep a Korean companion when they explain installation, support, contribution, examples, or troubleshooting. The required pairs are:
+
+- `README.md` → `README_KR.md`
+- `CONTRIBUTING.md` → `CONTRIBUTING_KR.md`
+- `docs/FAQ.md` → `docs/FAQ_KR.md`
+- `docs/AUTHENTICATION.md` → `docs/AUTHENTICATION_KR.md`
+- `docs/EXAMPLES.md` → `docs/EXAMPLES_KR.md`
+
+When a PR changes one of these English files, update the Korean pair in the same PR or explain why the translation can safely lag. Keep commands, paths, config keys, issue numbers, and code fences unchanged unless the source file itself changes them.
+
 ## Adding a New Pattern
 
 1. **Pick the right pack.** Patterns live in `patterns/{lang}-{category}.md`. Categories: content, language, style, structure, communication, filler.

--- a/CONTRIBUTING_KR.md
+++ b/CONTRIBUTING_KR.md
@@ -1,0 +1,141 @@
+# Patina에 기여하기
+
+기여를 검토해 주셔서 감사합니다. Patina는 패턴 기반 도구이므로 가장 큰 도움이 되는 기여는 새 패턴, 더 나은 예시, 프로필 개선인 경우가 많습니다.
+
+## 공개 문서와 내부 문서
+
+사용자용 문서는 `README*.md`, `docs/`, `examples/`, `patterns/`, `profiles/`, 스킬 엔트리포인트에 둡니다. 유지보수자나 에이전트용 메모는 `docs/internal/` 아래에 두며, 공개 문서 목록으로 승격하기 전까지는 설치, CLI, API 계약으로 보지 않습니다.
+
+루트의 Markdown 파일을 옮길 때는 공개 문서라면 `README.md`에서 링크하거나, 내부 문서라면 `docs/internal/`로 옮기고 대상 독자를 짧게 적습니다.
+
+## 한국어 번역 정책
+
+설치, 지원, 기여, 예시, 문제 해결을 설명하는 주요 사용자 문서는 한국어 쌍을 유지해야 합니다. 필수 쌍은 다음과 같습니다.
+
+- `README.md` → `README_KR.md`
+- `CONTRIBUTING.md` → `CONTRIBUTING_KR.md`
+- `docs/FAQ.md` → `docs/FAQ_KR.md`
+- `docs/AUTHENTICATION.md` → `docs/AUTHENTICATION_KR.md`
+- `docs/EXAMPLES.md` → `docs/EXAMPLES_KR.md`
+
+PR에서 위 영어 문서를 바꾸면 같은 PR에서 한국어 쌍도 갱신하거나, 번역이 잠시 뒤처져도 안전한 이유를 설명하세요. 명령어, 경로, 설정 키, 이슈 번호, 코드 펜스는 원문이 바뀌지 않는 한 그대로 둡니다.
+
+## 새 패턴 추가
+
+1. **올바른 팩을 고릅니다.** 패턴은 `patterns/{lang}-{category}.md`에 있습니다. 카테고리: content, language, style, structure, communication, filler.
+
+2. **템플릿을 따릅니다.** 각 패턴에는 다음이 필요합니다.
+   - 번호(다음 번호, 예: #30)
+   - Watch words
+   - Fire condition(언제 감지해야 하는가?)
+   - Exclusion condition(언제 감지하지 않아야 하는가?)
+   - 문제 설명
+   - before/after 예시
+
+3. **가능한 언어에 추가합니다.** 현재 언어 팩은 4개(ko, en, zh, ja)입니다. 한 언어만 알아도 괜찮습니다. 해당 언어 PR을 만들고 나머지는 번역이 필요하다고 적어 주세요.
+
+4. **카운트를 맞춥니다.** 패턴을 추가한 뒤:
+   - 팩 헤더의 `patterns:` 수를 올립니다.
+   - README.md와 README_KR.md의 패턴 표와 총계를 갱신합니다.
+   - SKILL.md 설명에 하드코딩된 총계가 있으면 갱신합니다.
+
+5. **예시를 추가합니다.** 가능하면 `examples/{lang}-{number}-success-01.md`와 `examples/{lang}-{number}-failure-01.md`(오탐 사례)를 추가합니다.
+
+## 기존 패턴 개선
+
+가장 흔한 개선은 더 나은 before/after 예시입니다. "after" 텍스트는 원래 의미를 보존해야 하며, 다른 내용으로 바꾸면 안 됩니다.
+
+간단한 확인법: 누군가 "after"만 읽어도 "before"와 같은 핵심 내용을 이해할 수 있나요? 감정 방향이 뒤집히면 나쁜 예시입니다.
+
+## 패턴 평가 체크리스트
+
+패턴 PR을 열기 전에 확인하세요.
+
+- **Fire condition:** 실제 AI 생성 예시 2-3개 이상에서 감지될 수 있나요?
+- **Exclusion condition:** 사람이 쓴, 해당 장르에 자연스러운 예시가 감지를 피할 수 있나요?
+- **Semantic risk:** rewrite가 손상할 수 있는 사실, 숫자, 극성, 인과, 도메인 용어는 무엇인가요?
+- **Before/after pair:** after가 단순 동의어 교체가 아니라 같은 주장을 보존하나요?
+- **Count sync:** 팩 frontmatter의 `patterns:`가 번호가 붙은 `### N.` 패턴 heading 수와 같아야 합니다.
+
+## 오탐 분류 절차
+
+학술, 백과사전식, 법률, 기업, 강하게 편집된 문체에서는 오탐이 생길 수 있습니다. 오탐을 보고하려면:
+
+1. false-positive 이슈 템플릿을 사용합니다.
+2. 언어, 장르/문체, score/audit excerpt, 과하게 감지된 패턴을 포함합니다.
+3. 비공개 텍스트를 제거하거나 재배포 가능한 최소 발췌로 바꿉니다.
+4. 수정 방향이 exclusion rule, 낮은 severity, profile override, benchmark fixture 중 무엇인지 제안합니다.
+
+유지보수자는 패턴을 바로 삭제하기보다 exclusion을 좁히는 쪽을 우선해야 합니다.
+
+## 벤치마크 fixture 추가
+
+Suspect-zone fixture는 `tests/fixtures/suspect-zones/{lang}/{ai|natural}/` 아래에 둡니다.
+
+각 fixture에는 YAML frontmatter가 필요합니다.
+
+```yaml
+---
+fixture_id: en-ai-07-example
+language: en
+class: ai
+expected_hot: true
+why_designed_this_way: |
+  Explain which deterministic signal should fire and why.
+expected_metrics:
+  cv_band: low
+---
+```
+
+그다음 실행합니다.
+
+```bash
+npm run benchmark:report
+```
+
+이 명령은 `tests/quality/results.json`, `docs/benchmarks/latest.json`, `docs/benchmarks/latest.md`를 다시 생성합니다.
+
+## 예시 번역
+
+- 숫자, 엔티티, 부정, 인과, 양태 같은 원문의 semantic anchor를 보존합니다.
+- 영어 AI tell을 대상 언어에서 tell이 아닌데 직역하지 않습니다.
+- 어떤 표현이 해당 문체에서는 정상이라면 대상 언어의 오탐 메모를 추가합니다.
+- 예시는 재배포 가능해야 합니다. 비공개 사용자 텍스트를 붙여 넣지 마세요.
+
+## 프로필 추가
+
+프로필은 `profiles/{name}.md`에 있습니다. 기존 파일(예: `blog.md`)을 복사한 뒤 조정합니다.
+- `voice-overrides`: 어떤 voice dimension을 키우거나 줄일지
+- `pattern-overrides`: 언어별 패턴 severity 조정
+
+## 패턴 노후화
+
+AI 문체 패턴은 모델이 미세 조정되면서 바뀝니다. 어떤 패턴은 약해지고(예: "delve"가 밈이 된 뒤), 새 패턴이 나타나기도 합니다.
+
+처리 방식:
+- **커뮤니티 보고:** 더 이상 reliable signal이 아닌 패턴을 발견하면 이슈를 엽니다.
+- **새 패턴 제안:** 새 AI tell을 발견하면 실제 예시 3개 이상과 함께 이슈를 엽니다.
+- **버전 메모:** 각 패턴 팩에는 `version` 필드가 있습니다. 패턴이 바뀌면 올립니다.
+- **대체 없는 삭제 금지:** 패턴을 바로 제거하지 않습니다. `low` severity로 낮추거나 프로필에서 `reduce`로 옮깁니다.
+
+## 버전 정책
+
+Patina는 CLI 동작과 패턴 팩 호환성에 semantic versioning을 사용합니다.
+
+- **Major:** 패턴 삭제/재번호 매기기, config/result schema 변경, 공개 CLI 의미 변경, 기존 패턴 팩과의 호환성 파괴.
+- **Minor:** 패턴, 언어, 프로필, 모드, 백엔드, benchmark schema field, 기여자용 workflow 추가.
+- **Patch:** 버그 수정, severity/exclusion 조정, 예시 명확화, schema 변경 없는 docs 갱신 또는 benchmark fixture refresh.
+
+각 changelog 항목에는 짧은 semver rationale line을 넣어 downstream 사용자가 pin, test, upgrade 중 무엇을 해야 하는지 알 수 있게 합니다.
+
+## 행동 강령
+
+도움이 되게 행동하세요. 불필요하게 날을 세우지 마세요. AI 문체 패턴은 도덕적 결함이 아닙니다. 우리는 도구를 만드는 것이지 재판을 여는 것이 아닙니다.
+
+## PR 절차
+
+1. `main`에서 fork/branch를 만듭니다.
+2. 변경합니다.
+3. 패턴 카운트가 일치하는지 확인합니다.
+4. 명확한 설명과 함께 PR을 엽니다.
+5. 보너스: 변경을 보여 주는 before/after 예시를 포함합니다.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ It is not a black-box paraphraser. patina is **pattern-based and auditable**: it
 | Academic | “획기적인 성과”, broad significance claims | 60 GitHub projects, 72h→10m setup time, p<0.01, limits noted |
 | Technical | “핵심적인 역할”, future-standard hype | GPU management, one-command provisioning, 5× result caveat |
 
-Try it quickly: [30-second terminal demo](docs/DEMO.md). More examples: [Before/After Gallery](docs/EXAMPLES.md).
+Try it quickly: [30-second terminal demo](docs/DEMO.md). More examples: [Before/After Gallery](docs/EXAMPLES.md) ([한국어](docs/EXAMPLES_KR.md)).
 Brand assets: [logo](assets/brand/patina-logo.svg), [icon](assets/brand/patina-icon.svg),
 [social preview](assets/social/patina-og.svg), and [before/after card](assets/social/patina-before-after.svg).
 Usage notes: [BRANDING.md](docs/BRANDING.md).
@@ -274,7 +274,7 @@ Pattern packs are auto-discovered by language prefix. `.patina.yaml` in the work
 - **[Glossary](docs/GLOSSARY.md)** — short definitions for MPS, fidelity, burstiness, MATTR, modes, and other recurring terms
 - **[Demo](docs/DEMO.md)** — terminal transcript and multi-genre before/after snapshots
 - **[Patterns](docs/PATTERNS.md)** — full 146-pattern catalog
-- **[Authentication](docs/AUTHENTICATION.md)** — backends, providers, free-tier setup
+- **[Authentication](docs/AUTHENTICATION.md)** ([한국어](docs/AUTHENTICATION_KR.md)) — backends, providers, free-tier setup
 - **[GitHub Action](docs/integrations/github-action.md)** — PR hotspot comments without a live model key
 - **[Pre-commit](docs/integrations/pre-commit.md)** — pre-commit, Husky, and Lefthook score-only recipes
 - **[Docker](docs/integrations/docker.md)** — GHCR image usage and release tags
@@ -283,7 +283,7 @@ Pattern packs are auto-discovered by language prefix. `.patina.yaml` in the work
 - **[Flag Parity](docs/FLAG-PARITY.md)** — standalone CLI vs `/patina` vs `/patina-max` option support
 - **[Exit Codes](docs/EXIT-CODES.md)** — process code contract for CI and editor integrations
 - **[Ethics](docs/ETHICS.md)** — intended use, non-use, and disclosure stance
-- **[FAQ](docs/FAQ.md)** — detector-bypass concerns, MPS, false positives, contribution starting points
+- **[FAQ](docs/FAQ.md)** ([한국어](docs/FAQ_KR.md)) — detector-bypass concerns, MPS, false positives, contribution starting points
 - **[Comparison](docs/COMPARISON.md)** — factual comparison with common paraphraser/humanizer tools
 - **[Branding](docs/BRANDING.md)** — canonical logo/social assets and OG setup notes
 - **[Design](DESIGN.md)** — product/brand source of truth for repo-native SVG and README surfaces
@@ -296,7 +296,7 @@ Pattern packs are auto-discovered by language prefix. `.patina.yaml` in the work
 - **[Stylometry](core/stylometry.md)** — burstiness + MATTR + AI-lexicon algorithm
 - **[Scoring](core/scoring.md)** — AI-likeness + fidelity + MPS
 - **[Changelog](CHANGELOG.md)** — release notes and methodology
-- **[Contributing](CONTRIBUTING.md)** — pattern submissions, false-positive triage, benchmark fixtures, versioning
+- **[Contributing](CONTRIBUTING.md)** ([한국어](CONTRIBUTING_KR.md)) — pattern submissions, false-positive triage, benchmark fixtures, versioning
 - **[Governance](GOVERNANCE.md)** / **[Maintainers](MAINTAINERS.md)** — lightweight project decision rules
 
 ## Acknowledgements

--- a/README_KR.md
+++ b/README_KR.md
@@ -225,11 +225,11 @@ max-models: [claude, gemini]
 - **[Glossary](docs/GLOSSARY.md)** — MPS, fidelity, burstiness, MATTR, 모드 등 반복 용어의 짧은 정의
 - **[Demo](docs/DEMO.md)** — 터미널 transcript와 여러 장르의 before/after 스냅샷
 - **[Patterns](docs/PATTERNS.md)** — 146개 패턴 카탈로그
-- **[Authentication](docs/AUTHENTICATION.md)** — 백엔드, 프로바이더, 무료 티어 설정
+- **[Authentication](docs/AUTHENTICATION_KR.md)** ([English](docs/AUTHENTICATION.md)) — 백엔드, 프로바이더, 무료 티어 설정
 - **[CLI Contract](docs/CLI.md)** — score gate, exit code, 자동화에 안전한 표면
 - **[Flag Parity](docs/FLAG-PARITY.md)** — standalone CLI, `/patina`, `/patina-max` 옵션 지원 범위
 - **[Ethics](docs/ETHICS.md)** — 의도한 사용, 금지 사용, disclosure 입장
-- **[FAQ](docs/FAQ.md)** — detector-bypass 우려, MPS, 오탐, 기여 시작점
+- **[FAQ](docs/FAQ_KR.md)** ([English](docs/FAQ.md)) — detector-bypass 우려, MPS, 오탐, 기여 시작점
 - **[Comparison](docs/COMPARISON.md)** — 일반 paraphraser/humanizer 도구와의 사실 기반 비교
 - **[Branding](docs/BRANDING.md)** — canonical 로고/소셜 asset과 OG 설정 메모
 - **[Design](DESIGN.md)** — repo-native SVG와 README surface의 제품/브랜드 기준
@@ -240,7 +240,8 @@ max-models: [claude, gemini]
 - **[Stylometry](core/stylometry.md)** — burstiness + MATTR + AI 어휘 알고리즘
 - **[Scoring](core/scoring.md)** — AI 유사도 + 충실도 + MPS
 - **[Changelog](CHANGELOG.md)** — 릴리스 노트와 방법론
-- **[Contributing](CONTRIBUTING.md)** — 패턴 제출, 오탐 triage, 벤치마크 fixture, 버전 관리
+- **[Examples](docs/EXAMPLES_KR.md)** ([English](docs/EXAMPLES.md)) — before/after 갤러리와 예시 fixture 안내
+- **[Contributing](CONTRIBUTING_KR.md)** ([English](CONTRIBUTING.md)) — 패턴 제출, 오탐 triage, 벤치마크 fixture, 버전 관리
 - **[Governance](GOVERNANCE.md)** / **[Maintainers](MAINTAINERS.md)** — 가벼운 프로젝트 의사결정 규칙
 
 ## 영감

--- a/docs/AUTHENTICATION_KR.md
+++ b/docs/AUTHENTICATION_KR.md
@@ -1,0 +1,105 @@
+# 인증과 백엔드
+
+patina는 여러 backend 중 하나를 통해 실행됩니다. 이미 쓰고 있는 도구에 맞는 방식을 고르세요.
+
+## Backend matrix
+
+| Backend | Setup | Cost |
+|---------|-------|------|
+| `codex-cli` | `codex login` | **Free** (ChatGPT OAuth) |
+| `claude-cli` | `claude` (one-time interactive OAuth) | **Free** (Claude subscription) |
+| `gemini-cli` | `gemini` (one-time interactive OAuth) or `GEMINI_API_KEY=...` | **Free** (Code Assist OAuth or AI Studio) |
+| OpenAI-compatible HTTP | `PATINA_API_KEY=...` | Per provider |
+| Google Gemini (HTTP) | `GEMINI_API_KEY=...` + `--provider gemini` | Free tier |
+| Groq | `GROQ_API_KEY=...` + `--provider groq` | Free tier |
+| Together AI | `TOGETHER_API_KEY=...` + `--provider together` | Free models available |
+| OpenRouter | `--base-url https://openrouter.ai/api/v1` + key | Per provider (mix any provider) |
+
+```bash
+patina auth status         # backend availability + auth state
+patina auth login          # per-backend login instructions
+patina --list-providers    # preset providers + key status
+```
+
+Backend selection에는 명시적인 신호가 필요합니다. `--backend <name>`을 직접 넘기거나, `--model <prefix>`를 사용하세요. `codex-*`, `claude-*`, `gemini-*`는 각각 맞는 local CLI로 라우팅됩니다. flag도 API key도 없으면 patina는 coding agent로 조용히 보내지 않고 오류로 종료합니다. 이유는 [issue #88](https://github.com/devswha/patina/issues/88)를 참고하세요.
+
+## Environment variables
+
+```bash
+PATINA_API_KEY=...                            # required for HTTP backend
+PATINA_API_BASE=https://api.openai.com/v1     # or proxy / OpenRouter / etc.
+PATINA_MODEL=gpt-4o                           # default model
+```
+
+`--base-url`, `--model`, `--api-key`, `--provider` flag는 실행마다 이 값을 덮어씁니다.
+
+## codex-cli backend
+
+patina는 local [`codex`](https://github.com/openai/codex) CLI를 통해 dispatch합니다. 이 CLI는 OpenAI/ChatGPT OAuth로 인증하므로 API key가 필요 없습니다.
+
+```bash
+codex login                                # one-time
+patina --backend codex-cli --lang ko input.txt
+patina --model codex --lang ko input.txt   # same — auto-routes by model name
+```
+
+## claude-cli backend
+
+local [`claude`](https://docs.anthropic.com/en/docs/claude-code) `-p`를 실행하고 patina prompt를 stdin으로 넘깁니다. Claude subscription이 있으면 무료로 사용할 수 있습니다.
+
+```bash
+claude                                     # one-time interactive OAuth
+patina --backend claude-cli --lang ko input.txt
+patina --model claude-sonnet-4-6 --lang ko input.txt   # auto-routes
+```
+
+Auth file: `~/.claude/.credentials.json` (OAuth flow가 만듭니다).
+
+## gemini-cli backend
+
+local [`gemini`](https://github.com/google-gemini/gemini-cli) `-p '' --output-format text`를 실행하고 patina prompt를 stdin으로 넘깁니다. 무료 Code Assist OAuth tier 또는 `GEMINI_API_KEY`로 동작합니다.
+
+```bash
+gemini                                     # one-time interactive OAuth, OR
+export GEMINI_API_KEY="..."                # AI Studio key
+patina --backend gemini-cli --lang ko input.txt
+patina --model gemini-3-flash-preview --lang ko input.txt   # auto-routes
+```
+
+Notes: patina는 user text 안의 prompt-injection을 격리하기 위해 새 temp directory에서 prompt를 실행하고 `--skip-trust`를 넘깁니다. gemini는 startup latency가 더 길어 default timeout이 다른 CLI보다 높습니다.
+
+> **v1 limitation:** `codex-cli`, `claude-cli`, `gemini-cli`는 모두 single-mode rewrite만 지원합니다. `--audit`, `--score`, `--diff`, `--ouroboros`, `--models`/MAX는 여전히 HTTP backend를 사용합니다.
+
+## Free-tier providers
+
+API key를 한 번 발급받으면 무료 tier로 사용할 수 있습니다.
+
+```bash
+# Google Gemini — https://aistudio.google.com/app/apikey
+export GEMINI_API_KEY="..."
+patina --provider gemini --lang ko input.txt
+
+# Groq (free tier with rate limits)
+export GROQ_API_KEY="..."
+patina --provider groq --lang ko input.txt
+
+# Together AI (free models suffixed with "-Free")
+export TOGETHER_API_KEY="..."
+patina --provider together --lang ko input.txt
+```
+
+`--provider`는 알맞은 base URL, default model을 설정하고 provider-specific API key env var를 읽습니다. `--base-url`, `--model`, `--api-key`로 각각 덮어쓸 수 있습니다.
+
+## MAX mode dispatch
+
+Claude Code `/patina-max` skill은 HTTP를 완전히 우회합니다. local CLI로 dispatch합니다.
+
+| Model | Dispatch | Auth |
+|-------|----------|------|
+| `claude` | `claude -p` | Claude Code |
+| `codex` | `codex exec --skip-git-repo-check --output-last-message` | ChatGPT OAuth |
+| `gemini` | `gemini -p '' --output-format text` | Google AI Studio |
+
+Claude Code 경로에서는 `PATINA_API_KEY`가 필요 없습니다.
+
+Standalone CLI MAX(`patina --models <list>`)는 같은 `--base-url` endpoint를 통해 모델을 호출하므로, 나열된 모든 모델이 그 endpoint에서 제공되어야 합니다. provider를 섞으려면(OpenAI + Anthropic + Google) `--base-url`을 OpenRouter나 다른 multi-provider gateway로 지정하세요.

--- a/docs/EXAMPLES_KR.md
+++ b/docs/EXAMPLES_KR.md
@@ -1,0 +1,130 @@
+# Before/After Gallery
+
+patina는 예시로 보는 편이 가장 쉽습니다. 주장은 남고, AI 포장은 사라집니다.
+
+## English: 부풀린 제품 카피
+
+**Before**
+
+> AI coding tools represent a transformative leap forward in the software development lifecycle, enabling teams to streamline workflows, enhance collaboration, and unlock unprecedented levels of productivity across the organization.
+
+**After**
+
+> AI coding tools are useful for the boring parts: test stubs, config files, small refactors. They do not fix a messy codebase, but they can save time when someone still checks the output.
+
+**제거한 패턴**: 부풀린 중요도, 기업식 추상어, 세 갈래 장점 나열.
+
+## Korean: 장점 나열
+
+**Before**
+
+> 본 솔루션은 사용자의 업무 효율성을 극대화하고, 생산성 향상을 도모하며, 더 나은 협업 경험을 제공하는 혁신적인 도구입니다.
+
+**After**
+
+> 이 도구는 반복 작업을 줄여준다. 문서 정리, 초안 작성, 간단한 협업 흐름처럼 사람이 굳이 매번 손으로 할 필요 없는 일에 잘 맞는다.
+
+**제거한 패턴**: `혁신적인`, `도모`, 추상적인 장점 나열, 딱딱한 명사형 문장.
+
+## English: 흐릿한 균형감
+
+**Before**
+
+> While there are challenges to consider, it is important to recognize that this technology has the potential to create meaningful value when implemented thoughtfully.
+
+**After**
+
+> The tool is useful, but only if someone checks the output. Without tests or review, it just makes wrong answers arrive faster.
+
+**제거한 패턴**: 일반적인 caveat, 흐릿한 upside, 빈 균형감.
+
+## Technical: 아키텍처 주장
+
+**Before**
+
+> This architecture provides a robust and scalable foundation for future enhancements, ensuring that teams can effectively adapt to evolving requirements while maintaining operational excellence.
+
+**After**
+
+> The architecture leaves room for new backends without touching the CLI entry point. That is the useful part. The tradeoff is more config surface, so the defaults need to stay boring and safe.
+
+**제거한 패턴**: `robust and scalable foundation`, future-proofing 주장, operational-excellence filler.
+
+## Korean: instructional / tutorial register
+
+**Before**
+
+> Git stash는 작업 중인 변경사항을 임시로 저장할 수 있는 매우 유용한 기능입니다. 본 명령어를 활용함으로써 사용자는 현재 작업 내용을 손실 없이 다른 브랜치로 신속하게 전환할 수 있게 됩니다.
+
+**After**
+
+> Git stash로 작업 중인 변경사항을 잠시 보관하세요. 커밋하기 애매한 수정이 있을 때 유용합니다. stash에 넣어두면 변경사항을 잃지 않고 다른 브랜치로 이동할 수 있습니다.
+
+**제거한 패턴**: `매우 유용한` (ko-content #4 promotional adjective), `본 명령어를 활용함으로써` (ko-style noun-heavy formal connector), `~할 수 있게 됩니다` (ko-structure #25 inflated future-tense). 튜토리얼이 명령을 *언제* 쓰는지 알려 주도록 사용 맥락("커밋하기 애매한 수정이 있을 때")을 추가했습니다.
+
+## Korean: 1인칭 회고 — abstract metaphor → sensory detail
+
+**Before**
+
+> 처음 코드 리뷰를 받았던 날을 떠올리면 여전히 마음 한구석이 묘해지는 것을 느낀다. 선배의 피드백 한 줄 한 줄이 마치 거대한 산처럼 다가왔으며, 그 순간은 개발자로서의 성장에 있어 잊을 수 없는 의미 있는 전환점이었다고 표현할 수 있을 것이다.
+
+**After**
+
+> 처음 코드 리뷰를 받던 날이 아직도 가끔 떠오른다. 선배가 남긴 피드백은 한 줄씩 읽을 때마다 이상하게 크게 느껴졌다. 모니터 앞에서 댓글을 하나씩 열어보던 장면이 선명하다. 손은 마우스 위에 있었고, 머릿속은 자꾸 하얘졌다. 지금 생각하면 그날은 대단한 사건이라기보다, 내가 처음으로 내 코드를 남의 눈으로 본 날에 가까웠다.
+
+**제거한 패턴**: `마치 거대한 산처럼` (ko-content abstract metaphor), `의미 있는 전환점이었다고 표현할 수 있을 것이다` (ko-structure #25 hedge stack + ko-content inflated significance). 구체적인 신체 디테일(`손은 마우스 위에`, `머릿속은 자꾸 하얘졌다`)로 바꿨습니다. narrative profile의 `concrete-emotions: amplify` 설정입니다.
+
+## Korean: SNS marketing — viral-hook signals
+
+**Before**
+
+> GitHub 역사상 이런 속도는 없었다. 단 60일 만에 별 25만 개. OpenClaw라는 도구가 세운 기록임. 광고 한 번 안 하고 전 세계 개발자들이 미친 듯이 달려든 이유가 뭘까.
+
+**After**
+
+> GitHub에서 이런 속도는 거의 못 봤다. 60일 만에 별 25만 개. OpenClaw가 만든 기록이다. 광고로 뜬 게 아니다. 개발자들이 새벽 3시에 버그 잡다가 짜증 나던 부분을 정확히 긁었다.
+
+**제거한 패턴**: `역사상 ... 없었다` (ko-viral-hook #3 source-skipping authority claim), `미친 듯이 달려든` (ko-viral-hook #5 hyperbolic engagement lexicon), `이유가 뭘까` (ko-viral-hook #2 clickbait mystery close → 구체적 설명으로 해결). viral-hook pack은 **score-only**지만, content/style pack이 적용된 regular rewrite에서도 모델이 이런 신호를 다시 잡아냅니다.
+
+## English: chatbot register
+
+**Before**
+
+> I'd be happy to help you understand Git stash! That's a great question. Git stash is a very useful command that allows you to temporarily save your changes. Let me know if you have any other questions!
+
+**After**
+
+> Git stash temporarily saves your in-progress changes so you can switch branches without committing or losing them. It's most useful when a fix or quick task pulls you off the work you're already doing.
+
+**제거한 패턴**: `I'd be happy to help` + `That's a great question` (en-communication #19 chatbot expressions, #21 sycophancy), `very useful` (en-content promotional adjective), `Let me know if you have any other questions` (en-communication closing politeness). chat affect를 걷어내고 실제 답변만 남겼습니다.
+
+## English: viral-hook authority claim
+
+**Before**
+
+> The fastest growth GitHub has ever seen — devs around the world are absolutely losing their minds. Why is everyone flocking to OpenClaw without any marketing?
+
+**After**
+
+> OpenClaw hit 250K stars in 60 days with no paid promotion. The popularity didn't come from marketing — it came from one shipped command that replaces a few hours of cluster setup. NVIDIA has since picked it up, which makes the timing easier to read.
+
+**제거한 패턴**: `the fastest GitHub has ever seen` (en-viral-hook #3 source-skipping authority claim), `absolutely losing their minds` (en-viral-hook #5 hyperbolic lexicon), `Why is everyone ... without any marketing?` (en-viral-hook #2 clickbait mystery close). 근거 없는 절대 표현을 구체적인 숫자와 확인 가능한 보강 사실로 바꿨습니다. 위 Korean SNS 예시처럼 viral-hook은 score-only이며, rewrite는 인접한 content/style pattern을 통해 이를 줄입니다.
+
+## 갤러리 추가 자료
+
+이 페이지는 표준 짧은 예시를 보여 줍니다. repo에는 복사해서 볼 수 있는 더 긴 fixture와 case study도 있습니다.
+
+- **`examples/short/`** — 네 개의 짧은 Korean fixture(marketing, tutorial, essay, email)와 짝을 이루는 `*-rewritten.md` 파일.
+- **`examples/genres/`** — 세 개의 긴 Korean genre(technical, academic, narrative)와 짝을 이루는 rewrite.
+- **`examples/tones/`** — 같은 입력을 여섯 tone(`casual`, `professional`, `academic`, `narrative`, `marketing`, `instructional`)과 `auto`로 rewrite한 결과. 나란히 보려면 `examples/tones/RESULTS.md`를 참고하세요.
+- **`examples/viral-hook/`** — iterative improvement workflow를 다루는 case study(`case-01`부터 `case-09`): viral-hook detection, codex/claude/gemini comparison, voice profile, multi-genre validation.
+- **`examples/sample-rewritten-*.md`** — 같은 장문의 Korean SNS marketing post를 Codex / Claude / Gemini-3로 rewrite한 결과. `case-03`에서 cross-model comparison에 사용합니다.
+
+## patina가 확인하는 것
+
+- rewrite가 AI-writing pattern을 제거했나요?
+- rewrite가 원래 주장을 유지했나요?
+- rewrite가 source에 없던 내용을 추가했나요?
+- 변경을 `--audit`, `--diff`, `--score`로 검토할 수 있나요?
+
+목표는 editing quality이지 detector evasion이 아닙니다. AI detector는 잡음이 많습니다. patina는 score를 대략적인 신호로 보고, diff를 실제로 유용한 산출물로 봅니다.

--- a/docs/FAQ_KR.md
+++ b/docs/FAQ_KR.md
@@ -1,0 +1,65 @@
+# FAQ
+
+용어가 낯설다면 먼저 [Glossary](GLOSSARY.md)를 보세요. MPS, fidelity, burstiness, MATTR, 모드 등 반복해서 나오는 용어를 짧게 설명합니다.
+
+## patina는 AI detector 우회 도구인가요?
+
+아닙니다. patina는 편집과 audit을 위한 도구입니다.
+
+AI detector는 잡음이 많습니다. patina는 어떤 score도 텍스트가 사람이나 AI가 썼다는 증거로 보지 않습니다. 유용한 산출물은 audit, diff, meaning-preservation check입니다. 무엇이 바뀌었는지, 왜 바뀌었는지, 원래 주장이 살아남았는지를 보는 데 씁니다.
+
+## "Strip the AI packaging"은 무슨 뜻인가요?
+
+모델 출력에는 비슷한 겉습관이 자주 나타납니다. 부풀린 중요도, 흐릿한 균형감, 장점 나열, 기업식 추상어, 박자감이 일정한 문단, filler transition 같은 것들입니다. patina는 이런 패턴을 찾아 해당 구간을 더 담백한 문장으로 바꿉니다.
+
+목표는 텍스트를 속이기 좋게 만드는 것이 아닙니다. 실제 메시지는 유지하면서 일반적인 모델 말투를 걷어내는 것입니다.
+
+## patina는 의미를 어떻게 보존하나요?
+
+patina는 rewrite 전에 semantic anchor를 뽑습니다. 주장, 극성, 인과, 숫자, 부정, 그 밖의 위험도가 높은 세부 정보를 추적합니다. 각 rewrite 단계 뒤에는 그 anchor가 여전히 있는지, 극성이 그대로인지 확인합니다.
+
+rewrite가 anchor를 약화하거나 삭제하거나 뒤집으면, patina는 해당 구간을 다시 시도하거나 되돌립니다.
+
+## MPS가 무엇인가요?
+
+MPS는 Meaning Preservation Score입니다. rewrite 쪽 안전 신호로, 추출한 anchor 중 얼마나 많이 편집 후에도 살아남았는지 추정합니다.
+
+MPS가 높다고 해서 문장이 완벽하다는 뜻은 아닙니다. patina가 추적하던 주장을 rewrite가 명백히 떨어뜨리거나 뒤집지 않았다는 뜻입니다.
+
+## AI-likeness score는 무엇을 뜻하나요?
+
+score는 0부터 100까지의 대략적인 편집 신호입니다. 낮을수록 AI처럼 덜 들립니다.
+
+이 값은 진실 판정기가 아닙니다. scoring formula는 deterministic이지만 severity assignment는 모델 실행 사이에 대략 8-10점 정도 달라질 수 있습니다. 정확한 숫자보다 범위와 하이라이트된 패턴을 더 중요하게 보세요.
+
+## 정확도는 어느 정도인가요?
+
+현재 calibration은 한국어 AI 텍스트에서 91% editing-hotspot recall [84.0-95.4%], HC3 English ChatGPT 샘플에서 76% [66.7-83.3%]를 보고합니다. 각각 n=100, binomial 95% CI입니다. 사람 글 오탐은 문체별 13-25% point-estimate range로 따로 추적합니다.
+
+오탐은 예상되는 일입니다. 특히 백과사전식, 기업 문서, 학술 문서, 강하게 편집된 글에서 그렇습니다. patina는 수상한 구간을 편집하는 데 쓰는 도구이지, 작성자를 비난하는 도구가 아닙니다.
+
+의도한 사용 입장은 [ETHICS.md](ETHICS.md)를 참고하세요.
+
+## API key 없이도 동작하나요?
+
+네. 이미 Codex CLI를 설치하고 로그인했다면 가능합니다. installer는 patina를 Codex CLI backend에 연결할 수 있으므로 이 경로에서는 별도 API key가 필요하지 않습니다.
+
+다른 provider는 문서화된 backend/provider 설정으로 구성할 수 있습니다.
+
+## Claude Code에서만 동작하나요?
+
+아닙니다. patina는 Claude Code, Codex CLI, Cursor, OpenCode용 skill로 동작하고, standalone Node.js CLI로도 사용할 수 있습니다.
+
+## 어떤 언어를 지원하나요?
+
+한국어, 영어, 중국어, 일본어를 지원합니다. 패턴 팩은 언어 접두사로 자동 탐색되므로 새 언어는 새 패턴 파일을 기여해 추가할 수 있습니다.
+
+## 내 문체나 패턴을 추가할 수 있나요?
+
+네. voice preference에는 custom profile을, 로컬 규칙에는 custom pattern pack을 사용하세요. repo는 built-in pattern과 사용자 custom 설정을 분리합니다.
+
+## 기여자는 무엇부터 시작하면 좋나요?
+
+가장 쉬운 기여는 근거가 있는 작은 예시입니다. before/after 쌍, 오탐 사례, 빠진 AI-writing pattern, 모델 출력에 반복해서 보이는 언어별 표현이 좋습니다.
+
+좋은 패턴 기여에는 실패 예시와 성공적인 rewrite가 둘 다 있어야 합니다.


### PR DESCRIPTION
## Summary
- document which primary docs require `_KR` companion files
- add Korean companion docs for contributing, FAQ, authentication, and examples
- link the new Korean companion docs from README/README_KR and add a PR-template reminder

Closes #202.

## Translation notes
- Commands, paths, env vars, config keys, issue numbers, tables, and code fences were kept unchanged.
- English before/after quote blocks in `docs/EXAMPLES_KR.md` stay in English because they are source examples being analyzed.

## Verification
- structural heading/fence/table parity check for all EN→KR pairs
- `node scripts/precommit-score.mjs CONTRIBUTING.md CONTRIBUTING_KR.md docs/FAQ_KR.md docs/AUTHENTICATION_KR.md docs/EXAMPLES_KR.md README.md README_KR.md .github/PULL_REQUEST_TEMPLATE.md --gate 30`
- `git diff --check`
- `npm run lint:syntax`
- `npm run dogfood`
- `npm test`
