### PR TITLE
test: add buildPrompt golden snapshots

### DIFF
--- a/tests/fixtures/prompt-snapshots/audit.md
+++ b/tests/fixtures/prompt-snapshots/audit.md
@@ -1,0 +1,70 @@
+You are an editor who detects and removes AI writing patterns from text, rewriting it into natural, human-written prose.
+
+## Tone Resolution (v3.10)
+
+- resolved_tone: null
+- tone_source: profile_only
+- tone_evidence: []
+- tone_confidence: null
+
+No tone specified — profile-only mode (regression-safe path). Phase 4.5b is skipped. Emit Phase 6 YAML footer with tone: null and tone_source: profile_only.
+
+## Configuration
+
+- Language: en
+- Profile: default
+- Output mode: audit
+- Blocklist: never say pivotal
+- Allowlist: OpenClaw
+
+## Pattern Packs
+
+### Pack: en-structure
+
+### 1. Metronomic Paragraph Rhythm
+**Watch words:** firstly, secondly, in conclusion
+**Fire condition:** adjacent paragraphs share the same sentence count.
+
+### Pack: en-content
+
+### 4. Promotional Adjectives
+**Watch words:** transformative, robust, scalable, pivotal
+**Fire condition:** praise words replace concrete evidence.
+
+### Pack: en-viral-hook
+
+### 2. Clickbait Mystery Close
+**Watch words:** why is everyone, nobody is talking about
+**Fire condition:** a cliffhanger substitutes for evidence.
+
+## Profile
+
+voice-overrides:
+  specificity: amplify
+  hype: reduce
+
+## Voice Guidelines
+
+- Prefer concrete nouns over broad abstractions.
+- Keep claims, polarity, causation, and numbers intact.
+
+## Instructions
+
+Process the following text according to the output mode "audit".
+
+Detect AI patterns ONLY — do not rewrite. Output a table.
+
+**Strict requirements:**
+- Use the EXACT pattern name AND number from the loaded Pattern Packs above. Format: `N. Pattern Name` (e.g., `30. Rhetorical Question Openers` or `13. Em Dash Overuse`). Do not paraphrase, abbreviate, or invent names.
+- The Category column must be the exact pack name from the loaded packs (e.g., `en-structure`, `ko-filler`, `zh-content`). Do not use generic category names like "Style", "Filler", or "Content".
+- If you suspect an AI tell that doesn't match any loaded pattern exactly, omit it from the table rather than coining a new name.
+
+Output format:
+| Pattern | Category | Severity | Location |
+|---------|----------|----------|----------|
+
+## Input Text
+
+<INPUT REDACTED>
+
+## Output

--- a/tests/fixtures/prompt-snapshots/diff.md
+++ b/tests/fixtures/prompt-snapshots/diff.md
@@ -1,0 +1,62 @@
+You are an editor who detects and removes AI writing patterns from text, rewriting it into natural, human-written prose.
+
+## Tone Resolution (v3.10)
+
+- resolved_tone: null
+- tone_source: profile_only
+- tone_evidence: []
+- tone_confidence: null
+
+No tone specified — profile-only mode (regression-safe path). Phase 4.5b is skipped. Emit Phase 6 YAML footer with tone: null and tone_source: profile_only.
+
+## Configuration
+
+- Language: en
+- Profile: default
+- Output mode: diff
+- Blocklist: never say pivotal
+- Allowlist: OpenClaw
+
+## Pattern Packs
+
+### Pack: en-structure
+
+### 1. Metronomic Paragraph Rhythm
+**Watch words:** firstly, secondly, in conclusion
+**Fire condition:** adjacent paragraphs share the same sentence count.
+
+### Pack: en-content
+
+### 4. Promotional Adjectives
+**Watch words:** transformative, robust, scalable, pivotal
+**Fire condition:** praise words replace concrete evidence.
+
+## Profile
+
+voice-overrides:
+  specificity: amplify
+  hype: reduce
+
+## Voice Guidelines
+
+- Prefer concrete nouns over broad abstractions.
+- Keep claims, polarity, causation, and numbers intact.
+
+## Instructions
+
+Process the following text according to the output mode "diff".
+
+Show what changed and why, pattern by pattern. For each change use this exact label format:
+
+Pattern: N. Pattern Name
+Removed: original text
+Added: corrected text
+Why: one short reason
+
+Use the exact `N. Pattern Name` from the loaded packs. Do not invent pattern names.
+
+## Input Text
+
+<INPUT REDACTED>
+
+## Output

--- a/tests/fixtures/prompt-snapshots/ouroboros.md
+++ b/tests/fixtures/prompt-snapshots/ouroboros.md
@@ -1,0 +1,104 @@
+You are an editor who detects and removes AI writing patterns from text, rewriting it into natural, human-written prose.
+
+## Tone Resolution (v3.10)
+
+- resolved_tone: null
+- tone_source: profile_only
+- tone_evidence: []
+- tone_confidence: null
+
+No tone specified — profile-only mode (regression-safe path). Phase 4.5b is skipped. Emit Phase 6 YAML footer with tone: null and tone_source: profile_only.
+
+## Configuration
+
+- Language: en
+- Profile: default
+- Output mode: ouroboros
+- Blocklist: never say pivotal
+- Allowlist: OpenClaw
+
+## Pattern Packs
+
+### Pack: en-structure
+
+### 1. Metronomic Paragraph Rhythm
+**Watch words:** firstly, secondly, in conclusion
+**Fire condition:** adjacent paragraphs share the same sentence count.
+
+### Pack: en-content
+
+### 4. Promotional Adjectives
+**Watch words:** transformative, robust, scalable, pivotal
+**Fire condition:** praise words replace concrete evidence.
+
+## Profile
+
+voice-overrides:
+  specificity: amplify
+  hype: reduce
+
+## Voice Guidelines
+
+- Prefer concrete nouns over broad abstractions.
+- Keep claims, polarity, causation, and numbers intact.
+
+## Scoring Algorithm
+
+Scoring reference:
+- Count detected pattern severity per category.
+- Preserve the configured category weights exactly.
+
+## Instructions
+
+Process the following text according to the output mode "ouroboros".
+
+Iterative self-improvement loop:
+
+1. Measure initial AI-likeness score
+2. If score ≤ 30, stop immediately
+3. Repeat (max 3 iterations):
+   a. Run Phase 1 → Phase 2 → Phase 3 pipeline
+   b. Score the result
+   c. delta = previous - current (positive = improvement)
+   d. Terminate if:
+      - Score ≤ 30 → target met
+      - delta < 0 → regression → rollback to previous
+      - 0 ≤ delta ≤ 10 → plateau
+      - iteration ≥ 3 → max iterations
+      - fidelity < 70 → fidelity violation → rollback
+      - MPS < 70 → MPS violation → rollback
+4. Output iteration log and final text
+
+Follow the 2-Phase pipeline:
+
+### Phase 1: Structure Scan
+
+Apply the structure patterns to fix document-level issues:
+- en-structure
+
+1. Scan paragraph layout, repetition, translationese, passive patterns
+2. Correct structural issues — diversify paragraph structure
+3. Verify core claims and logical flow survive structural changes
+4. Intentionally vary paragraph length and sentence count (burstiness)
+
+**Skip if**: text is ≤2 paragraphs OR no structure packs loaded.
+
+### Phase 2: Sentence/Lexical Rewrite
+
+Apply all remaining pattern packs (content, language, style, communication, filler):
+- en-content
+
+1. Scan all patterns for AI tells
+2. Rewrite AI-sounding expressions into natural alternatives
+3. Preserve core meaning, claims, polarity, causation, numbers
+4. Match profile tone
+5. Inject personality per voice guidelines
+6. Respect blocklist/allowlist and pattern overrides
+
+Output ONLY the final humanized text. Do not include analysis, pattern lists, or commentary — downstream evaluators handle that.
+
+## Input Text
+
+<INPUT REDACTED>
+
+## Output

--- a/tests/fixtures/prompt-snapshots/rewrite-minimal.md
+++ b/tests/fixtures/prompt-snapshots/rewrite-minimal.md
@@ -1,0 +1,28 @@
+This text reads like AI. Rewrite it so it sounds like a real person wrote it. If you spot any of the phrases below, swap them out for something natural. Don't over-paraphrase — keep the meaning, numbers, and causation intact.
+
+## AI signal words (reference)
+
+- **en-structure**: firstly, secondly, in conclusion
+- **en-content**: transformative, robust, scalable, pivotal
+
+## Tone & profile guide
+
+voice-overrides:
+  specificity: amplify
+  hype: reduce
+
+## Tone metadata
+- tone: null
+- source: profile_only
+
+## Output format
+
+1. 다듬은 본문을 `[BODY]` ... `[/BODY]` 안에. 본문만, 머리말·메타·"최종 결과물" 같은 라벨 없이.
+2. `[SELF_AUDIT]` ... `[/SELF_AUDIT]` 안에 짧게: 어떤 부분 손봤는지, 남은 AI 신호 있는지.
+3. 톤 정보가 있으면 마지막에 YAML 푸터: `---\ntone: ...\ntone_source: ...\ntone_evidence: [...]\ntone_confidence: ...\n---`
+
+## Input
+
+<INPUT REDACTED>
+
+## Output

--- a/tests/fixtures/prompt-snapshots/rewrite-strict.md
+++ b/tests/fixtures/prompt-snapshots/rewrite-strict.md
@@ -1,0 +1,114 @@
+You are an editor who detects and removes AI writing patterns from text, rewriting it into natural, human-written prose.
+
+## Tone Resolution (v3.10)
+
+- resolved_tone: null
+- tone_source: profile_only
+- tone_evidence: []
+- tone_confidence: null
+
+No tone specified — profile-only mode (regression-safe path). Phase 4.5b is skipped. Emit Phase 6 YAML footer with tone: null and tone_source: profile_only.
+
+## Configuration
+
+- Language: en
+- Profile: default
+- Output mode: rewrite
+- Blocklist: never say pivotal
+- Allowlist: OpenClaw
+
+## Pattern Packs
+
+### Pack: en-structure
+
+### 1. Metronomic Paragraph Rhythm
+**Watch words:** firstly, secondly, in conclusion
+**Fire condition:** adjacent paragraphs share the same sentence count.
+
+### Pack: en-content
+
+### 4. Promotional Adjectives
+**Watch words:** transformative, robust, scalable, pivotal
+**Fire condition:** praise words replace concrete evidence.
+
+## Profile
+
+voice-overrides:
+  specificity: amplify
+  hype: reduce
+
+## Voice Guidelines
+
+- Prefer concrete nouns over broad abstractions.
+- Keep claims, polarity, causation, and numbers intact.
+
+## Instructions
+
+Process the following text according to the output mode "rewrite".
+
+Follow the 3-Phase pipeline:
+
+### Phase 1: Structure Scan
+
+Apply the structure patterns to fix document-level issues:
+- en-structure
+
+1. Scan paragraph layout, repetition, translationese, passive patterns
+2. Correct structural issues — diversify paragraph structure
+3. Verify core claims and logical flow survive structural changes
+4. Intentionally vary paragraph length and sentence count (burstiness)
+
+**Skip if**: text is ≤2 paragraphs OR no structure packs loaded.
+
+### Phase 2: Sentence/Lexical Rewrite
+
+Apply all remaining pattern packs (content, language, style, communication, filler):
+- en-content
+
+1. Scan all patterns for AI tells
+2. Rewrite AI-sounding expressions into natural alternatives
+3. Preserve core meaning, claims, polarity, causation, numbers
+4. Match profile tone
+5. Inject personality per voice guidelines
+6. Respect blocklist/allowlist and pattern overrides
+
+### Phase 3: Self-Audit
+
+1. Scan for remaining AI tells
+2. Verify no polarity inversions (negation → positive or vice versa)
+3. Ensure Phase 1 corrections were not reverted in Phase 2
+4. Final check: meaning preserved?
+
+### Output format (STRICT — v3.11)
+
+Produce output in this exact order, with no other text outside the tagged blocks:
+
+1. The rewritten text wrapped in `[BODY]`/`[/BODY]` tags. The body block must contain ONLY the user-facing rewrite — no headings, no Phase labels, no preamble like "잔여 AI 티" or "최종 결과물".
+2. Self-audit notes wrapped in `[SELF_AUDIT]`/`[/SELF_AUDIT]` tags (brief: what still looks AI-written, which patterns were applied). This block is for downstream review — patina strips it before showing the user.
+3. The Phase 6 YAML footer if tone resolution requires it.
+
+Example shape (uses [BODY]/[/BODY]):
+
+```
+[BODY]
+<rewritten text>
+[/BODY]
+
+[SELF_AUDIT]
+- residual signals: ...
+- patterns applied: ...
+[/SELF_AUDIT]
+
+---
+tone: ...
+tone_source: ...
+tone_evidence: [...]
+tone_confidence: ...
+---
+```
+
+## Input Text
+
+<INPUT REDACTED>
+
+## Output

--- a/tests/fixtures/prompt-snapshots/score.md
+++ b/tests/fixtures/prompt-snapshots/score.md
@@ -1,0 +1,85 @@
+You are an editor who detects and removes AI writing patterns from text, rewriting it into natural, human-written prose.
+
+## Tone Resolution (v3.10)
+
+- resolved_tone: null
+- tone_source: profile_only
+- tone_evidence: []
+- tone_confidence: null
+
+No tone specified — profile-only mode (regression-safe path). Phase 4.5b is skipped. Emit Phase 6 YAML footer with tone: null and tone_source: profile_only.
+
+## Configuration
+
+- Language: en
+- Profile: default
+- Output mode: score
+- Blocklist: never say pivotal
+- Allowlist: OpenClaw
+
+## Pattern Packs
+
+### Pack: en-structure
+
+### 1. Metronomic Paragraph Rhythm
+**Watch words:** firstly, secondly, in conclusion
+**Fire condition:** adjacent paragraphs share the same sentence count.
+
+### Pack: en-content
+
+### 4. Promotional Adjectives
+**Watch words:** transformative, robust, scalable, pivotal
+**Fire condition:** praise words replace concrete evidence.
+
+### Pack: en-viral-hook
+
+### 2. Clickbait Mystery Close
+**Watch words:** why is everyone, nobody is talking about
+**Fire condition:** a cliffhanger substitutes for evidence.
+
+## Profile
+
+voice-overrides:
+  specificity: amplify
+  hype: reduce
+
+## Voice Guidelines
+
+- Prefer concrete nouns over broad abstractions.
+- Keep claims, polarity, causation, and numbers intact.
+
+## Scoring Algorithm
+
+Scoring reference:
+- Count detected pattern severity per category.
+- Preserve the configured category weights exactly.
+
+## Instructions
+
+Process the following text according to the output mode "score".
+
+Calculate an AI-likeness score (0-100) using EXACTLY these category weights. Do NOT invent extra categories (no "discord", no "tone", no "general"). Use only the categories listed:
+
+- content: 0.25
+- style: 0.25
+- structure: 0.25
+- communication: 0.25
+
+Severity scale: Low=1, Medium=2, High=3 points per detection.
+Category score = (sum of adjusted severities / (pattern_count × 3)) × 100
+Overall = weighted average using the EXACT weights above (sum should equal 1.00).
+
+**Short-text boost (input ≤200 chars OR ≤3 paragraphs):** for register-sensitive categories (`language`, `style`, `viral-hook`) apply a 1.5x severity multiplier per detection (cap at 3). This surfaces voice/register shifts (e.g., `~다` ↔ `~습니다` swap) that the long-text formula otherwise undercounts.
+
+Output format (the Weight column must echo the values above verbatim):
+| Category | Weight | Detected | Raw Score | Weighted |
+|----------|--------|----------|-----------|----------|
+| **Overall** | | | | **XX.X (±10)** |
+
+Interpretation: 0-15 human | 16-30 mostly human | 31-50 mixed | 51-70 AI-like | 71-100 heavily AI
+
+## Input Text
+
+<INPUT REDACTED>
+
+## Output

--- a/tests/unit/prompt-builder.snapshot.test.js
+++ b/tests/unit/prompt-builder.snapshot.test.js
@@ -1,0 +1,172 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildPrompt } from '../../src/prompt-builder.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SNAPSHOT_DIR = resolve(__dirname, '../fixtures/prompt-snapshots');
+const UPDATE_SNAPSHOTS = process.env.UPDATE_PROMPT_SNAPSHOTS === '1';
+
+const CASES = [
+  { name: 'rewrite strict', file: 'rewrite-strict.md', mode: 'rewrite', promptMode: 'strict' },
+  { name: 'rewrite minimal', file: 'rewrite-minimal.md', mode: 'rewrite', promptMode: 'minimal' },
+  { name: 'diff', file: 'diff.md', mode: 'diff', promptMode: 'strict' },
+  { name: 'audit', file: 'audit.md', mode: 'audit', promptMode: 'strict' },
+  { name: 'score', file: 'score.md', mode: 'score', promptMode: 'strict' },
+  { name: 'ouroboros', file: 'ouroboros.md', mode: 'ouroboros', promptMode: 'strict' },
+];
+
+const config = {
+  language: 'en',
+  profile: 'default',
+  blocklist: ['never say pivotal'],
+  allowlist: ['OpenClaw'],
+  ouroboros: {
+    'target-score': 30,
+    'max-iterations': 3,
+    'plateau-threshold': 10,
+    'fidelity-floor': 70,
+    'mps-floor': 70,
+    'category-weights': {
+      en: {
+        content: 0.25,
+        style: 0.25,
+        structure: 0.25,
+        communication: 0.25,
+      },
+    },
+  },
+};
+
+const patterns = [
+  {
+    file: 'en-structure.md',
+    isStructure: true,
+    isScoreOnly: false,
+    frontmatter: { pack: 'en-structure' },
+    body: [
+      '### 1. Metronomic Paragraph Rhythm',
+      '**Watch words:** firstly, secondly, in conclusion',
+      '**Fire condition:** adjacent paragraphs share the same sentence count.',
+    ].join('\n'),
+  },
+  {
+    file: 'en-content.md',
+    isStructure: false,
+    isScoreOnly: false,
+    frontmatter: { pack: 'en-content' },
+    body: [
+      '### 4. Promotional Adjectives',
+      '**Watch words:** transformative, robust, scalable, pivotal',
+      '**Fire condition:** praise words replace concrete evidence.',
+    ].join('\n'),
+  },
+  {
+    file: 'en-viral-hook.md',
+    isStructure: false,
+    isScoreOnly: true,
+    frontmatter: { pack: 'en-viral-hook' },
+    body: [
+      '### 2. Clickbait Mystery Close',
+      '**Watch words:** why is everyone, nobody is talking about',
+      '**Fire condition:** a cliffhanger substitutes for evidence.',
+    ].join('\n'),
+  },
+];
+
+const profile = {
+  body: [
+    'voice-overrides:',
+    '  specificity: amplify',
+    '  hype: reduce',
+  ].join('\n'),
+};
+
+const voice = {
+  body: [
+    '- Prefer concrete nouns over broad abstractions.',
+    '- Keep claims, polarity, causation, and numbers intact.',
+  ].join('\n'),
+};
+
+const scoring = {
+  body: [
+    'Scoring reference:',
+    '- Count detected pattern severity per category.',
+    '- Preserve the configured category weights exactly.',
+  ].join('\n'),
+};
+
+const tone = {
+  tone: null,
+  tone_source: 'profile_only',
+  tone_evidence: [],
+  tone_confidence: null,
+};
+
+const inputText = [
+  'AI coding tools represent a transformative leap forward for every team.',
+  'They provide a robust and scalable foundation for future work.',
+  'OpenClaw reached 250K stars in 60 days without paid promotion.',
+  'Why is everyone talking about it now?',
+].join('\n\n');
+
+export function redactInputSection(prompt) {
+  const sections = [
+    ['## Input Text', '## Output'],
+    ['## Input', '## Output'],
+  ];
+
+  for (const [start, end] of sections) {
+    const pattern = new RegExp(`${escapeRegExp(start)}\\n\\n[\\s\\S]*?\\n\\n${escapeRegExp(end)}\\n\\n`, 'u');
+    if (pattern.test(prompt)) {
+      return prompt.replace(pattern, `${start}\n\n<INPUT REDACTED>\n\n${end}\n\n`);
+    }
+  }
+
+  throw new Error('Prompt snapshot redaction failed: input/output section not found');
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildSnapshot({ mode, promptMode }) {
+  const prompt = buildPrompt({
+    config,
+    patterns,
+    profile,
+    voice,
+    scoring,
+    text: inputText,
+    mode,
+    tone,
+    promptMode,
+  });
+  return `${redactInputSection(prompt).trim()}\n`;
+}
+
+describe('buildPrompt golden snapshots', () => {
+  for (const testCase of CASES) {
+    it(`matches ${testCase.name} snapshot`, () => {
+      const snapshotPath = resolve(SNAPSHOT_DIR, testCase.file);
+      const actual = buildSnapshot(testCase);
+
+      if (UPDATE_SNAPSHOTS) {
+        mkdirSync(SNAPSHOT_DIR, { recursive: true });
+        writeFileSync(snapshotPath, actual);
+      }
+
+      assert.ok(
+        existsSync(snapshotPath),
+        `Missing prompt snapshot ${testCase.file}; run UPDATE_PROMPT_SNAPSHOTS=1 node --test tests/unit/prompt-builder.snapshot.test.js`
+      );
+
+      const expected = readFileSync(snapshotPath, 'utf8');
+      assert.equal(actual, expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add golden snapshot coverage for buildPrompt rewrite strict/minimal, diff, audit, score, and ouroboros paths
- redact input sections so fixture churn only reflects prompt-template changes
- include structure, lexical, and score-only synthetic packs in the prompt fixtures

Closes #169.

## Notes
- The rewrite-minimal English snapshot preserves the current mixed-language output-format behavior instead of changing prompt semantics in this test-only change.

## Verification
- node --test tests/unit/prompt-builder.snapshot.test.js
- git diff --check
- npm run lint:syntax
- npm test