### PR TITLE
feat(cli): cancel in-flight work on SIGINT

### DIFF
--- a/src/backends/claude-cli.js
+++ b/src/backends/claude-cli.js
@@ -25,10 +25,11 @@ export function authHint() {
   return 'Run `claude` once interactively and follow the OAuth prompt to authenticate (uses your Claude subscription, no API key needed).';
 }
 
-export async function invoke({ prompt, timeout = 180000 } = {}) {
+export async function invoke({ prompt, signal, timeout = 180000 } = {}) {
   if (!prompt || typeof prompt !== 'string') {
     throw new Error('claude-cli backend: prompt must be a non-empty string');
   }
+  throwIfAborted(signal);
 
   // Spawn from a fresh temp directory so a prompt-injection in user text
   // cannot read or write inside the caller's repo. claude -p prints to
@@ -43,30 +44,32 @@ export async function invoke({ prompt, timeout = 180000 } = {}) {
     proc.stdout.on('data', (chunk) => { stdout += chunk; });
     proc.stderr.on('data', (chunk) => { stderr += chunk; });
 
+    let settled = false;
+    let cleanupSignal = () => {};
     const timer = setTimeout(() => {
-      proc.kill('SIGKILL');
-      cleanup();
-      reject(new Error(`claude-cli backend: timed out after ${timeout}ms`));
+      finishReject(new Error(`claude-cli backend: timed out after ${timeout}ms`), { kill: true });
     }, timeout);
+    if (signal) {
+      const onAbort = () => finishReject(abortError('claude-cli backend: aborted'), { kill: true });
+      signal.addEventListener('abort', onAbort, { once: true });
+      cleanupSignal = () => signal.removeEventListener('abort', onAbort);
+    }
 
     proc.on('error', (err) => {
-      clearTimeout(timer);
-      cleanup();
       if (err.code === 'ENOENT') {
-        reject(new Error('claude-cli backend: `claude` CLI not found. Install Claude Code first.'));
+        finishReject(new Error('claude-cli backend: `claude` CLI not found. Install Claude Code first.'));
       } else {
-        reject(new Error(`claude-cli backend: failed to spawn claude (${err.message})`));
+        finishReject(new Error(`claude-cli backend: failed to spawn claude (${err.message})`));
       }
     });
 
     proc.on('close', (code) => {
-      clearTimeout(timer);
-      cleanup();
+      if (settled) return;
       if (code !== 0) {
-        reject(new Error(`claude-cli backend: claude exited with code ${code}\n${stderr}`));
+        finishReject(new Error(`claude-cli backend: claude exited with code ${code}\n${stderr}`));
         return;
       }
-      resolve(stdout);
+      finishResolve(stdout);
     });
 
     proc.stdin.write(prompt);
@@ -75,5 +78,34 @@ export async function invoke({ prompt, timeout = 180000 } = {}) {
     function cleanup() {
       try { rmSync(dir, { recursive: true, force: true }); } catch {}
     }
+
+    function finishReject(err, { kill = false } = {}) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cleanupSignal();
+      if (kill) proc.kill('SIGKILL');
+      cleanup();
+      reject(err);
+    }
+
+    function finishResolve(content) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cleanupSignal();
+      cleanup();
+      resolve(content);
+    }
   });
+}
+
+function abortError(message) {
+  const err = new Error(message);
+  err.name = 'AbortError';
+  return err;
+}
+
+function throwIfAborted(signal) {
+  if (signal?.aborted) throw abortError('claude-cli backend: aborted');
 }

--- a/src/backends/codex-cli.js
+++ b/src/backends/codex-cli.js
@@ -22,10 +22,11 @@ export function authHint() {
   return 'Run `codex login` to authenticate (uses your ChatGPT Plus account, no API key needed).';
 }
 
-export async function invoke({ prompt, timeout = 180000 } = {}) {
+export async function invoke({ prompt, signal, timeout = 180000 } = {}) {
   if (!prompt || typeof prompt !== 'string') {
     throw new Error('codex-cli backend: prompt must be a non-empty string');
   }
+  throwIfAborted(signal);
 
   // Run codex from a fresh temp directory with the read-only sandbox so that
   // a prompt-injection in user text cannot read the caller's repo or write
@@ -46,37 +47,37 @@ export async function invoke({ prompt, timeout = 180000 } = {}) {
     let stderr = '';
     proc.stderr.on('data', (chunk) => { stderr += chunk; });
 
+    let settled = false;
+    let cleanupSignal = () => {};
     const timer = setTimeout(() => {
-      proc.kill('SIGKILL');
-      cleanup();
-      reject(new Error(`codex-cli backend: timed out after ${timeout}ms`));
+      finishReject(new Error(`codex-cli backend: timed out after ${timeout}ms`), { kill: true });
     }, timeout);
+    if (signal) {
+      const onAbort = () => finishReject(abortError('codex-cli backend: aborted'), { kill: true });
+      signal.addEventListener('abort', onAbort, { once: true });
+      cleanupSignal = () => signal.removeEventListener('abort', onAbort);
+    }
 
     proc.on('error', (err) => {
-      clearTimeout(timer);
-      cleanup();
       if (err.code === 'ENOENT') {
-        reject(new Error('codex-cli backend: `codex` CLI not found. Install it from https://github.com/openai/codex'));
+        finishReject(new Error('codex-cli backend: `codex` CLI not found. Install it from https://github.com/openai/codex'));
       } else {
-        reject(new Error(`codex-cli backend: failed to spawn codex (${err.message})`));
+        finishReject(new Error(`codex-cli backend: failed to spawn codex (${err.message})`));
       }
     });
 
     proc.on('close', (code) => {
-      clearTimeout(timer);
+      if (settled) return;
       if (code !== 0) {
-        cleanup();
-        reject(new Error(`codex-cli backend: codex exited with code ${code}\n${stderr}`));
+        finishReject(new Error(`codex-cli backend: codex exited with code ${code}\n${stderr}`));
         return;
       }
 
       try {
         const content = readFileSync(outFile, 'utf8');
-        cleanup();
-        resolve(content);
+        finishResolve(content);
       } catch (err) {
-        cleanup();
-        reject(new Error(`codex-cli backend: failed to read output file (${err.message})`));
+        finishReject(new Error(`codex-cli backend: failed to read output file (${err.message})`));
       }
     });
 
@@ -86,6 +87,34 @@ export async function invoke({ prompt, timeout = 180000 } = {}) {
     function cleanup() {
       try { rmSync(dir, { recursive: true, force: true }); } catch {}
     }
+
+    function finishReject(err, { kill = false } = {}) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cleanupSignal();
+      if (kill) proc.kill('SIGKILL');
+      cleanup();
+      reject(err);
+    }
+
+    function finishResolve(content) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cleanupSignal();
+      cleanup();
+      resolve(content);
+    }
   });
 }
 
+function abortError(message) {
+  const err = new Error(message);
+  err.name = 'AbortError';
+  return err;
+}
+
+function throwIfAborted(signal) {
+  if (signal?.aborted) throw abortError('codex-cli backend: aborted');
+}

--- a/src/backends/gemini-cli.js
+++ b/src/backends/gemini-cli.js
@@ -30,10 +30,11 @@ export function authHint() {
   return 'Run `gemini` once interactively to log in via Google OAuth, or set GEMINI_API_KEY.';
 }
 
-export async function invoke({ prompt, model, timeout = 240000 } = {}) {
+export async function invoke({ prompt, model, signal, timeout = 240000 } = {}) {
   if (!prompt || typeof prompt !== 'string') {
     throw new Error('gemini-cli backend: prompt must be a non-empty string');
   }
+  throwIfAborted(signal);
 
   // gemini -p '' reads the prompt from stdin (when -p arg is empty, stdin is
   // appended). --output-format text avoids JSON wrapping. Spawn from a temp
@@ -54,30 +55,32 @@ export async function invoke({ prompt, model, timeout = 240000 } = {}) {
     proc.stdout.on('data', (chunk) => { stdout += chunk; });
     proc.stderr.on('data', (chunk) => { stderr += chunk; });
 
+    let settled = false;
+    let cleanupSignal = () => {};
     const timer = setTimeout(() => {
-      proc.kill('SIGKILL');
-      cleanup();
-      reject(new Error(`gemini-cli backend: timed out after ${timeout}ms`));
+      finishReject(new Error(`gemini-cli backend: timed out after ${timeout}ms`), { kill: true });
     }, timeout);
+    if (signal) {
+      const onAbort = () => finishReject(abortError('gemini-cli backend: aborted'), { kill: true });
+      signal.addEventListener('abort', onAbort, { once: true });
+      cleanupSignal = () => signal.removeEventListener('abort', onAbort);
+    }
 
     proc.on('error', (err) => {
-      clearTimeout(timer);
-      cleanup();
       if (err.code === 'ENOENT') {
-        reject(new Error('gemini-cli backend: `gemini` CLI not found. Install Gemini CLI first.'));
+        finishReject(new Error('gemini-cli backend: `gemini` CLI not found. Install Gemini CLI first.'));
       } else {
-        reject(new Error(`gemini-cli backend: failed to spawn gemini (${err.message})`));
+        finishReject(new Error(`gemini-cli backend: failed to spawn gemini (${err.message})`));
       }
     });
 
     proc.on('close', (code) => {
-      clearTimeout(timer);
-      cleanup();
+      if (settled) return;
       if (code !== 0) {
-        reject(new Error(`gemini-cli backend: gemini exited with code ${code}\n${stderr}`));
+        finishReject(new Error(`gemini-cli backend: gemini exited with code ${code}\n${stderr}`));
         return;
       }
-      resolve(stripGeminiNoise(stdout));
+      finishResolve(stripGeminiNoise(stdout));
     });
 
     proc.stdin.write(prompt);
@@ -86,7 +89,36 @@ export async function invoke({ prompt, model, timeout = 240000 } = {}) {
     function cleanup() {
       try { rmSync(dir, { recursive: true, force: true }); } catch {}
     }
+
+    function finishReject(err, { kill = false } = {}) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cleanupSignal();
+      if (kill) proc.kill('SIGKILL');
+      cleanup();
+      reject(err);
+    }
+
+    function finishResolve(content) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cleanupSignal();
+      cleanup();
+      resolve(content);
+    }
   });
+}
+
+function abortError(message) {
+  const err = new Error(message);
+  err.name = 'AbortError';
+  return err;
+}
+
+function throwIfAborted(signal) {
+  if (signal?.aborted) throw abortError('gemini-cli backend: aborted');
 }
 
 // Gemini CLI prepends benign warnings to stdout (e.g. "Ripgrep is not

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -10,8 +10,8 @@ const openaiHttp = {
   isAvailable: () => true,
   isAuthenticated: () => inspectHttpApiKeySource().ok,
   authHint: () => inspectHttpApiKeySource().detail,
-  invoke: ({ prompt, apiKey, baseURL, model, timeout }) =>
-    callLLM({ prompt, apiKey, baseURL, model, timeout }),
+  invoke: ({ prompt, apiKey, baseURL, model, signal, timeout }) =>
+    callLLM({ prompt, apiKey, baseURL, model, signal, timeout }),
 };
 
 const REGISTRY = {

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,7 +10,7 @@ import { runOuroboros } from './ouroboros.js';
 import { buildManifest, appendResult, writeManifest } from './manifest.js';
 import { runDoctor } from './commands/doctor.js';
 import { runInit } from './commands/init.js';
-import { inputError, runtimeError, renderCliError, getExitCode } from './errors.js';
+import { PatinaCliError, inputError, runtimeError, renderCliError, getExitCode } from './errors.js';
 import { inspectHttpApiKeySource, providerHttpKeyEnvVars, resolveHttpApiKey } from './auth.js';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, basename, extname } from 'node:path';
@@ -132,135 +132,149 @@ export async function main(args) {
     : 'rewrite';
 
   const inputTexts = await loadInputs(parsed);
+  const cancellation = createCancellationController();
 
-  for (const { path, text } of inputTexts) {
-    const prompt = buildPrompt({
-      config,
-      patterns,
-      profile: profile.body ? profile : null,
-      voice: voice.body ? voice : null,
-      scoring: scoring.body ? scoring : null,
-      text,
-      mode,
-      tone: toneResolution,
-      promptMode: resolvePromptMode(
-        parsed.promptMode || config['prompt-mode'] || 'strict',
-        { backend: parsed.backend ?? config.backend, model: resolved.model }
-      ),
-      variants: parsed.variants || 1,
-    });
-
-    let result;
-
-    if (parsed.models) {
-      result = await runMaxMode({
-        prompt,
-        sourceText: text,
-        models: parsed.models,
-        apiKey: resolved.apiKey,
-        baseURL: resolved.baseURL,
-        config,
-        patterns,
-        maxConcurrency: parsed.maxConcurrency,
-        wallClockBudgetMs: parsed.maxTimeoutSeconds === undefined ? undefined : parsed.maxTimeoutSeconds * 1000,
-      });
-    } else if (parsed.ouroboros) {
-      result = await runOuroboros({
+  cancellation.install();
+  try {
+    for (const { path, text } of inputTexts) {
+      cancellation.throwIfCanceled();
+      const prompt = buildPrompt({
         config,
         patterns,
         profile: profile.body ? profile : null,
         voice: voice.body ? voice : null,
         scoring: scoring.body ? scoring : null,
         text,
-        apiKey: resolved.apiKey,
-        baseURL: resolved.baseURL,
-        model: resolved.model,
-      });
-    } else {
-      const { backend, autoSelected, reason } = selectBackend({
-        name: parsed.backend ?? config.backend,
-        model: resolved.model,
+        mode,
+        tone: toneResolution,
+        promptMode: resolvePromptMode(
+          parsed.promptMode || config['prompt-mode'] || 'strict',
+          { backend: parsed.backend ?? config.backend, model: resolved.model }
+        ),
+        variants: parsed.variants || 1,
       });
 
-      if (autoSelected) {
-        console.error(`[patina] Using ${backend.name} backend (${reason}). Run \`patina auth status\` for details.`);
+      let result;
+
+      if (parsed.models) {
+        result = await runMaxMode({
+          prompt,
+          sourceText: text,
+          models: parsed.models,
+          apiKey: resolved.apiKey,
+          baseURL: resolved.baseURL,
+          config,
+          patterns,
+          maxConcurrency: parsed.maxConcurrency,
+          wallClockBudgetMs: parsed.maxTimeoutSeconds === undefined ? undefined : parsed.maxTimeoutSeconds * 1000,
+          signal: cancellation.signal,
+        });
+      } else if (parsed.ouroboros) {
+        result = await runOuroboros({
+          config,
+          patterns,
+          profile: profile.body ? profile : null,
+          voice: voice.body ? voice : null,
+          scoring: scoring.body ? scoring : null,
+          text,
+          apiKey: resolved.apiKey,
+          baseURL: resolved.baseURL,
+          model: resolved.model,
+          signal: cancellation.signal,
+        });
+      } else {
+        const { backend, autoSelected, reason } = selectBackend({
+          name: parsed.backend ?? config.backend,
+          model: resolved.model,
+        });
+
+        if (autoSelected) {
+          console.error(`[patina] Using ${backend.name} backend (${reason}). Run \`patina auth status\` for details.`);
+        }
+
+        if (backend.name === 'openai-http' && !resolved.apiKey) {
+          const msg = ['No API key found. Set PATINA_API_KEY, PATINA_API_KEY_FILE, OPENAI_API_KEY, or pass --api-key.'];
+          if (provider) {
+            msg.push(`(--provider ${provider.name} expects ${provider.apiKeyEnv} or PATINA_API_KEY.)`);
+          }
+          const codex = listBackends().find((b) => b.name === 'codex-cli');
+          if (codex && codex.available && codex.authenticated) {
+            msg.push('Or pass `--backend codex-cli` to use the codex-cli backend (no key needed).');
+          } else if (codex && codex.available && !codex.authenticated) {
+            msg.push('Or run `codex login`, then pass `--backend codex-cli`.');
+          } else if (codex && !codex.available) {
+            msg.push('Or install `codex` from https://github.com/openai/codex and pass `--backend codex-cli`.');
+          }
+          throw runtimeError(
+            'no API key found',
+            msg[0],
+            msg.slice(1).join(' ') || 'Set PATINA_API_KEY or pass --backend codex-cli after logging in.'
+          );
+        }
+
+        result = await backend.invoke({
+          prompt,
+          apiKey: resolved.apiKey,
+          baseURL: resolved.baseURL,
+          model: resolved.model,
+          signal: cancellation.signal,
+        });
+      }
+      cancellation.throwIfCanceled();
+
+      let output;
+      let scoreValidationOutput = null;
+      if (parsed.ouroboros) {
+        const ouroborosBody = formatOuroborosOutput(result);
+        output = formatOutput(ouroborosBody, mode, parsed, { tone: toneResolution });
+        scoreValidationOutput = ouroborosBody;
+      } else {
+        output = formatOutput(result, mode, parsed, { tone: toneResolution });
+        if (mode === 'score') {
+          scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' });
+        }
       }
 
-      if (backend.name === 'openai-http' && !resolved.apiKey) {
-        const msg = ['No API key found. Set PATINA_API_KEY, PATINA_API_KEY_FILE, OPENAI_API_KEY, or pass --api-key.'];
-        if (provider) {
-          msg.push(`(--provider ${provider.name} expects ${provider.apiKeyEnv} or PATINA_API_KEY.)`);
-        }
-        const codex = listBackends().find((b) => b.name === 'codex-cli');
-        if (codex && codex.available && codex.authenticated) {
-          msg.push('Or pass `--backend codex-cli` to use the codex-cli backend (no key needed).');
-        } else if (codex && codex.available && !codex.authenticated) {
-          msg.push('Or run `codex login`, then pass `--backend codex-cli`.');
-        } else if (codex && !codex.available) {
-          msg.push('Or install `codex` from https://github.com/openai/codex and pass `--backend codex-cli`.');
-        }
-        throw runtimeError(
-          'no API key found',
-          msg[0],
-          msg.slice(1).join(' ') || 'Set PATINA_API_KEY or pass --backend codex-cli after logging in.'
-        );
-      }
-
-      result = await backend.invoke({
-        prompt,
-        apiKey: resolved.apiKey,
-        baseURL: resolved.baseURL,
-        model: resolved.model,
-      });
-    }
-
-    let output;
-    let scoreValidationOutput = null;
-    if (parsed.ouroboros) {
-      const ouroborosBody = formatOuroborosOutput(result);
-      output = formatOutput(ouroborosBody, mode, parsed, { tone: toneResolution });
-      scoreValidationOutput = ouroborosBody;
-    } else {
-      output = formatOutput(result, mode, parsed, { tone: toneResolution });
+      // v3.11 Phase 1.3: surface weight drift between config and the score
+      // table the model emitted. Warnings only — does not alter the output.
       if (mode === 'score') {
-        scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' });
-      }
-    }
+        const configWeights = config.ouroboros?.['category-weights']?.[lang] || {};
+        const warnings = validateScoreWeights(scoreValidationOutput || output, configWeights);
+        for (const w of warnings) {
+          console.error(`[patina] ${w}`);
+        }
 
-    // v3.11 Phase 1.3: surface weight drift between config and the score
-    // table the model emitted. Warnings only — does not alter the output.
-    if (mode === 'score') {
-      const configWeights = config.ouroboros?.['category-weights']?.[lang] || {};
-      const warnings = validateScoreWeights(scoreValidationOutput || output, configWeights);
-      for (const w of warnings) {
-        console.error(`[patina] ${w}`);
+        if (parsed.gate !== undefined) {
+          applyScoreGate(result, output, parsed.gate);
+        }
       }
 
-      if (parsed.gate !== undefined) {
-        applyScoreGate(result, output, parsed.gate);
+      if (result?.type === 'max-mode' && (result.allFailed || result.mpsFallback)) {
+        process.exitCode = Math.max(Number(process.exitCode) || 0, 4);
+      }
+
+      if (parsed.saveRun) {
+        const idx = manifestResults.length + 1;
+        const outputName = `output-${idx}.txt`;
+        appendResult(manifestResults, {
+          inputPath: path,
+          prompt,
+          outputRef: { kind: 'file', name: outputName },
+        });
+        manifestOutputs.push({ name: outputName, content: output });
+      }
+
+      if (parsed.batch) {
+        await writeBatchOutput(parsed, path, output);
+      } else {
+        console.log(output);
       }
     }
-
-    if (result?.type === 'max-mode' && (result.allFailed || result.mpsFallback)) {
-      process.exitCode = Math.max(Number(process.exitCode) || 0, 4);
-    }
-
-    if (parsed.saveRun) {
-      const idx = manifestResults.length + 1;
-      const outputName = `output-${idx}.txt`;
-      appendResult(manifestResults, {
-        inputPath: path,
-        prompt,
-        outputRef: { kind: 'file', name: outputName },
-      });
-      manifestOutputs.push({ name: outputName, content: output });
-    }
-
-    if (parsed.batch) {
-      await writeBatchOutput(parsed, path, output);
-    } else {
-      console.log(output);
-    }
+  } catch (err) {
+    if (cancellation.signal.aborted) throw cancellationError();
+    throw err;
+  } finally {
+    cancellation.cleanup();
   }
 
   if (parsed.saveRun) {
@@ -534,6 +548,65 @@ function parseArgs(args) {
   return parsed;
 }
 
+function cancellationError() {
+  return new PatinaCliError({
+    what: 'interrupted',
+    why: 'Ctrl-C canceled the in-flight patina request.',
+    action: 'Any running backend process or HTTP request was asked to stop.',
+    exitCode: 130,
+  });
+}
+
+export function createCancellationController({
+  processObj = process,
+  stderr = process.stderr,
+} = {}) {
+  const controller = new AbortController();
+  let sigintCount = 0;
+  let installed = false;
+
+  const writeStatus = (message) => {
+    if (stderr && typeof stderr.write === 'function') stderr.write(message);
+    else console.error(message.trimEnd());
+  };
+
+  const onSigint = () => {
+    sigintCount++;
+    if (sigintCount === 1) {
+      processObj.exitCode = 130;
+      writeStatus('[patina] cancelling… press Ctrl-C again to exit immediately\n');
+      controller.abort();
+      return;
+    }
+
+    cleanup();
+    processObj.exit(130);
+  };
+
+  function install() {
+    if (!installed && typeof processObj.on === 'function') {
+      processObj.on('SIGINT', onSigint);
+      installed = true;
+    }
+  }
+
+  function cleanup() {
+    if (installed && typeof processObj.removeListener === 'function') {
+      processObj.removeListener('SIGINT', onSigint);
+      installed = false;
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    install,
+    cleanup,
+    throwIfCanceled() {
+      if (controller.signal.aborted) throw cancellationError();
+    },
+  };
+}
+
 function readOptionValue(args, index, option, { allowFlagLike = false } = {}) {
   const value = args[index + 1];
   if (value === undefined || (!allowFlagLike && value.startsWith('-'))) {
@@ -770,7 +843,7 @@ ENVIRONMENT
   OPENAI_API_KEY, GEMINI_API_KEY, GROQ_API_KEY, TOGETHER_API_KEY
 
 EXIT CODES
-  0 success · 1 runtime/backend · 2 input/usage · 3 score gate exceeded · 4 MAX MPS fallback/all candidates failed
+  0 success · 1 runtime/backend · 2 input/usage · 3 score gate exceeded · 4 MAX MPS fallback/all candidates failed · 130 interrupted
 
 If no API key is set, pass --backend codex-cli to use a logged-in codex CLI
 (no key required). Auto-fallback was removed in v3.9 to keep agent-mode

--- a/src/max-mode.js
+++ b/src/max-mode.js
@@ -19,10 +19,21 @@ export async function runMaxMode({
   callLLMMultipleImpl = callLLMMultiple,
   scoreTextImpl = scoreText,
   scoreMPSImpl = scoreMPS,
+  signal,
 }) {
   console.error(`[patina-max] Dispatching to ${models.length} models: ${models.join(', ')}`);
 
   const controller = new AbortController();
+  const abortFromCaller = () => controller.abort();
+  let cleanupCallerSignal = () => {};
+  if (signal) {
+    if (signal.aborted) {
+      controller.abort();
+    } else {
+      signal.addEventListener('abort', abortFromCaller, { once: true });
+      cleanupCallerSignal = () => signal.removeEventListener('abort', abortFromCaller);
+    }
+  }
   const deadline = now() + wallClockBudgetMs;
   let timedOut = false;
   const timeout = setTimeout(() => {
@@ -100,6 +111,7 @@ export async function runMaxMode({
     }
   } finally {
     clearTimeout(timeout);
+    cleanupCallerSignal();
   }
 
   const { candidate: best, fallback } = selectBest(candidates);

--- a/src/ouroboros.js
+++ b/src/ouroboros.js
@@ -15,6 +15,7 @@ export async function runOuroboros({
   callLLM = defaultCallLLM,
   now,
   sleep,
+  signal,
 }) {
   const ouroborosConfig = config.ouroboros || {};
   const targetScore = ouroborosConfig['target-score'] ?? 30;
@@ -35,6 +36,7 @@ export async function runOuroboros({
     callLLM,
     now,
     sleep,
+    signal,
   });
 
   const initialScore = initialScoreResult?.overall ?? 100;
@@ -88,6 +90,7 @@ export async function runOuroboros({
       model,
       now,
       sleep,
+      signal,
     });
 
     const scoreResult = await scoreText({
@@ -100,6 +103,7 @@ export async function runOuroboros({
       callLLM,
       now,
       sleep,
+      signal,
     });
 
     let currentScore = scoreResult?.overall ?? 100;
@@ -115,6 +119,7 @@ export async function runOuroboros({
         callLLM,
         now,
         sleep,
+        signal,
       }),
       scoreFidelity({
         original: text,
@@ -125,6 +130,7 @@ export async function runOuroboros({
         callLLM,
         now,
         sleep,
+        signal,
       }),
     ]);
 

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -128,6 +128,7 @@ ${text}
     });
     return parsed;
   } catch (e) {
+    rethrowIfAborted(e, signal);
     console.error(`[patina] scoreText schema failure after retry: ${e.message}`);
     return { overall: null, error: 'schema-failure', raw: e.raw };
   }
@@ -190,6 +191,7 @@ ${rewritten}
     });
     return parsed;
   } catch (e) {
+    rethrowIfAborted(e, signal);
     console.error(`[patina] scoreMPS schema failure after retry: ${e.message}`);
     return { mps: null, error: 'schema-failure', raw: e.raw };
   }
@@ -272,6 +274,7 @@ ${rewritten}
     });
     parsed = result.parsed;
   } catch (e) {
+    rethrowIfAborted(e, signal);
     console.error(`[patina] scoreFidelity schema failure after retry: ${e.message}`);
     schemaError = e;
   }
@@ -301,6 +304,10 @@ export function clamp03(v) {
   if (n < 0) return 0;
   if (n > 3) return 3;
   return Math.round(n);
+}
+
+function rethrowIfAborted(err, signal) {
+  if (signal?.aborted || err?.name === 'AbortError') throw err;
 }
 
 // Combined score per core/scoring.md §13: AI-likeness × ai_weight + (100 - fidelity) × fidelity_weight.

--- a/tests/e2e/cli-cancellation.test.js
+++ b/tests/e2e/cli-cancellation.test.js
@@ -1,0 +1,63 @@
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../..');
+const BIN = resolve(REPO_ROOT, 'bin/patina.js');
+
+test('SIGINT cancels an in-flight HTTP backend request and exits 130', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'patina-sigint-'));
+  const inputPath = join(dir, 'input.txt');
+  writeFileSync(inputPath, 'This draft should wait on the mock backend.\n');
+
+  let sawRequest;
+  const requestSeen = new Promise((resolveRequest) => {
+    sawRequest = resolveRequest;
+  });
+  const server = createServer((req) => {
+    req.resume();
+    sawRequest();
+    // Keep the response open so SIGINT has an in-flight fetch to abort.
+  });
+
+  try {
+    await new Promise((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+    const port = server.address().port;
+    const child = spawn(process.execPath, [
+      BIN,
+      '--lang', 'en',
+      '--api-key', 'test-key',
+      '--base-url', `http://127.0.0.1:${port}`,
+      '--model', 'gpt-5',
+      inputPath,
+    ], {
+      cwd: REPO_ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+
+    await requestSeen;
+    child.kill('SIGINT');
+
+    const { code } = await new Promise((resolveClose) => {
+      child.on('close', (closeCode, signal) => resolveClose({ code: closeCode, signal }));
+    });
+
+    assert.equal(code, 130);
+    assert.equal(stdout, '');
+    assert.match(stderr, /\[patina\] cancelling…/);
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+    rmSync(dir, { recursive: true, force: true });
+  }
+}, { timeout: 10000 });

--- a/tests/unit/backend-cancellation.test.js
+++ b/tests/unit/backend-cancellation.test.js
@@ -1,0 +1,53 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import * as claudeCli from '../../src/backends/claude-cli.js';
+import * as codexCli from '../../src/backends/codex-cli.js';
+import * as geminiCli from '../../src/backends/gemini-cli.js';
+
+const BACKENDS = [
+  { command: 'claude', backend: claudeCli },
+  { command: 'codex', backend: codexCli },
+  { command: 'gemini', backend: geminiCli },
+];
+
+test('CLI backends reject AbortSignal cancellation and kill their child process', async () => {
+  const binDir = mkdtempSync(join(tmpdir(), 'patina-fake-cli-'));
+  const oldPath = process.env.PATH;
+
+  try {
+    for (const { command } of BACKENDS) {
+      const path = join(binDir, command);
+      writeFileSync(path, [
+        '#!/usr/bin/env node',
+        'process.stdin.resume();',
+        'setInterval(() => {}, 1000);',
+        '',
+      ].join('\n'));
+      chmodSync(path, 0o755);
+    }
+    process.env.PATH = `${binDir}:${oldPath || ''}`;
+
+    for (const { command, backend } of BACKENDS) {
+      const controller = new AbortController();
+      const promise = backend.invoke({
+        prompt: 'rewrite this',
+        signal: controller.signal,
+        timeout: 5000,
+      });
+      setTimeout(() => controller.abort(), 20);
+
+      await assert.rejects(
+        promise,
+        (err) => err?.name === 'AbortError' && err.message === `${command}-cli backend: aborted`,
+        `${command} should reject with AbortError on external abort`
+      );
+    }
+  } finally {
+    process.env.PATH = oldPath;
+    rmSync(binDir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/cli-cancellation.test.js
+++ b/tests/unit/cli-cancellation.test.js
@@ -1,0 +1,31 @@
+import { EventEmitter } from 'node:events';
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { createCancellationController } from '../../src/cli.js';
+
+test('createCancellationController aborts on first SIGINT and exits 130 on second', () => {
+  const processObj = new EventEmitter();
+  const writes = [];
+  let exitCode = null;
+  processObj.exit = (code) => {
+    exitCode = code;
+    throw new Error(`exit ${code}`);
+  };
+
+  const cancellation = createCancellationController({
+    processObj,
+    stderr: { write: (text) => writes.push(text) },
+  });
+
+  cancellation.install();
+  processObj.emit('SIGINT');
+
+  assert.equal(cancellation.signal.aborted, true);
+  assert.equal(processObj.exitCode, 130);
+  assert.match(writes.join(''), /cancelling…/);
+
+  assert.throws(() => processObj.emit('SIGINT'), /exit 130/);
+  assert.equal(exitCode, 130);
+  cancellation.cleanup();
+});


### PR DESCRIPTION
## Summary
- install a CLI-owned SIGINT cancellation controller for in-flight runs
- pass AbortSignal through HTTP, MAX mode, Ouroboros, scoring, and single-backend calls
- make codex/claude/gemini CLI backends reject on abort and kill child processes

Closes #133.

## Verification
- node --check src/cli.js src/max-mode.js src/ouroboros.js src/scoring.js src/backends/codex-cli.js src/backends/claude-cli.js src/backends/gemini-cli.js tests/unit/cli-cancellation.test.js tests/unit/backend-cancellation.test.js tests/e2e/cli-cancellation.test.js
- node --test tests/unit/cli-cancellation.test.js tests/unit/backend-cancellation.test.js tests/e2e/cli-cancellation.test.js tests/unit/max-mode.test.js tests/unit/ouroboros.test.js tests/unit/scoring.test.js tests/unit/api.test.js
- npm run lint:syntax
- npm run lint:eslint
- npm test
- git diff --check