### PR TITLE
refactor(cli): centralize stderr logging and progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ patina --lang <ko|en|zh|ja> [mode] [--profile <name>] input.txt
 | `--tone <name>` | Tone category: `casual`, `professional`, `academic`, `narrative`, `marketing`, `instructional`, `auto` |
 | `--batch` | Treat positional args as a list of files (e.g. `--batch docs/*.md`) |
 | `--format json\|text\|markdown` | Select machine-readable JSON, plain text, or default Markdown output |
+| `--quiet` | Suppress status, warning, and progress logs on stderr |
+| `--json-logs` | Emit stderr logs as NDJSON with `level`, `event`, `model`, and `latency_ms` fields |
 | `--prompt-mode strict\|minimal\|auto` | Choose full pattern-pack prompting, compressed prompting, or backend-aware auto |
 | `--variants <1-5>` | Generate multiple rewrite variants with the same facts and meaning anchors |
 
@@ -200,7 +202,7 @@ In rewrite mode, the model emits its self-audit notes inside `[SELF_AUDIT]`/`[/S
 
 ### Machine-readable output and exit codes
 
-`--format json` wraps every mode in a stable envelope with `overall`, `categories[]`, `tone`, `mps`, `gateResult`, and the cleaned `output` body. `--format markdown` is the default; `--format text` keeps the user-facing body without the YAML tone footer. Exit codes are standardized in [EXIT-CODES.md](docs/EXIT-CODES.md): `0` success, `1` runtime/backend, `2` input/usage, `3` score gate exceeded, `4` MAX MPS fallback/all-candidates-failed.
+`--format json` wraps every mode in a stable envelope with `overall`, `categories[]`, `tone`, `mps`, `gateResult`, and the cleaned `output` body. `--json-logs` keeps stderr machine-readable as NDJSON, while `--quiet` silences status/warning/progress logs for scripts that only want stdout. `--format markdown` is the default; `--format text` keeps the user-facing body without the YAML tone footer. Exit codes are standardized in [EXIT-CODES.md](docs/EXIT-CODES.md): `0` success, `1` runtime/backend, `2` input/usage, `3` score gate exceeded, `4` MAX MPS fallback/all-candidates-failed.
 
 ### Score weight drift detection (v3.11)
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -47,4 +47,15 @@ patina --lang en --score --exit-on 30 draft.md
 - `--save-run <dir>` writes `manifest.json` plus `output-N.txt` files for reproducible audit trails.
 - `patina doctor --json` emits setup diagnostics for CI without making an LLM call.
 
+## Stderr logs
+
+Human-facing status, warnings, and progress indicators go to stderr so stdout
+stays reserved for the transformed text or JSON envelope.
+
+- `--quiet` suppresses stderr logs, including MAX/Ouroboros progress.
+- `--json-logs` emits newline-delimited JSON records with stable fields:
+  `ts`, `level`, `event`, `model`, `latency_ms`, and optional `message`.
+- MAX mode (`--models`) reports elapsed per-model status (`...`, `✓`, `✗`).
+- Ouroboros reports per-iteration score movement and latency.
+
 See [EXIT-CODES.md](EXIT-CODES.md) for the full process contract.

--- a/docs/FLAG-PARITY.md
+++ b/docs/FLAG-PARITY.md
@@ -13,6 +13,8 @@ Basis: local checkout `2e1fc04` plus `node bin/patina.js --help`, `SKILL.md`, an
 | `--ouroboros` | ✓ | ✓ | documented compatible | `/patina-max` can feed its winner into the existing convergence loop when used with `/patina` behavior. |
 | `--format <markdown\|text\|json>` | ✓ | — | — | CLI output-envelope feature. |
 | `--json` | ✓ | — | — | CLI alias for `--format json`; `patina doctor --json` also exists. |
+| `--quiet` | ✓ | — | — | CLI stderr log suppression for scripts. |
+| `--json-logs` | ✓ | — | — | CLI structured stderr logs for automation. |
 | `--batch` | ✓ | ✓ | — | Multi-file CLI/skill rewrite flow. |
 | `--in-place` | ✓ | ✓ | — | Batch-only write mode. |
 | `--suffix <ext>` | ✓ | ✓ | — | Batch-only alternate output naming. |

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,6 +12,7 @@ import { runDoctor } from './commands/doctor.js';
 import { runInit } from './commands/init.js';
 import { PatinaCliError, inputError, runtimeError, renderCliError, getExitCode } from './errors.js';
 import { inspectHttpApiKeySource, providerHttpKeyEnvVars, resolveHttpApiKey } from './auth.js';
+import { createLogger } from './logger.js';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, basename, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -36,6 +37,7 @@ export async function main(args) {
   }
 
   const parsed = parseArgs(args);
+  const logger = createLogger({ quiet: parsed.quiet, json: parsed.jsonLogs });
 
   if (parsed.help) {
     printHelp();
@@ -80,7 +82,7 @@ export async function main(args) {
   if (parsed.profile) config.profile = parsed.profile;
 
   const provider = selectProvider(parsed.provider ?? config.provider);
-  const apiKey = resolveApiKey(parsed, provider);
+  const apiKey = resolveApiKey(parsed, provider, logger);
   const resolved = resolveProviderConfig({
     provider,
     apiKey,
@@ -103,7 +105,7 @@ export async function main(args) {
   // zh/ja + explicit tone → unsupported_language_fallback (warn + profile-only path).
   const toneResolution = resolveTone({ cliTone: parsed.tone, configTone: config.tone, lang });
   if (toneResolution.warning) {
-    console.error(`[patina] ${toneResolution.warning}`);
+    logger.warn('tone.warning', { message: `[patina] ${toneResolution.warning}` });
   }
 
   // Backbone profile mapping: explicit user tone (not auto, not fallback) maps to a
@@ -131,8 +133,8 @@ export async function main(args) {
     : parsed.ouroboros ? 'ouroboros'
     : 'rewrite';
 
-  const inputTexts = await loadInputs(parsed);
-  const cancellation = createCancellationController();
+  const inputTexts = await loadInputs(parsed, logger);
+  const cancellation = createCancellationController({ logger });
 
   cancellation.install();
   try {
@@ -168,6 +170,7 @@ export async function main(args) {
           maxConcurrency: parsed.maxConcurrency,
           wallClockBudgetMs: parsed.maxTimeoutSeconds === undefined ? undefined : parsed.maxTimeoutSeconds * 1000,
           signal: cancellation.signal,
+          logger,
         });
       } else if (parsed.ouroboros) {
         result = await runOuroboros({
@@ -181,6 +184,7 @@ export async function main(args) {
           baseURL: resolved.baseURL,
           model: resolved.model,
           signal: cancellation.signal,
+          logger,
         });
       } else {
         const { backend, autoSelected, reason } = selectBackend({
@@ -189,7 +193,9 @@ export async function main(args) {
         });
 
         if (autoSelected) {
-          console.error(`[patina] Using ${backend.name} backend (${reason}). Run \`patina auth status\` for details.`);
+          logger.info('backend.selected', {
+            message: `[patina] Using ${backend.name} backend (${reason}). Run \`patina auth status\` for details.`,
+          });
         }
 
         if (backend.name === 'openai-http' && !resolved.apiKey) {
@@ -226,12 +232,12 @@ export async function main(args) {
       let scoreValidationOutput = null;
       if (parsed.ouroboros) {
         const ouroborosBody = formatOuroborosOutput(result);
-        output = formatOutput(ouroborosBody, mode, parsed, { tone: toneResolution });
+        output = formatOutput(ouroborosBody, mode, parsed, { tone: toneResolution, logger });
         scoreValidationOutput = ouroborosBody;
       } else {
-        output = formatOutput(result, mode, parsed, { tone: toneResolution });
+        output = formatOutput(result, mode, parsed, { tone: toneResolution, logger });
         if (mode === 'score') {
-          scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' });
+          scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' }, { logger });
         }
       }
 
@@ -241,11 +247,11 @@ export async function main(args) {
         const configWeights = config.ouroboros?.['category-weights']?.[lang] || {};
         const warnings = validateScoreWeights(scoreValidationOutput || output, configWeights);
         for (const w of warnings) {
-          console.error(`[patina] ${w}`);
+          logger.warn('score.weight_check', { message: `[patina] ${w}` });
         }
 
         if (parsed.gate !== undefined) {
-          applyScoreGate(result, output, parsed.gate);
+          applyScoreGate(result, output, parsed.gate, logger);
         }
       }
 
@@ -275,6 +281,7 @@ export async function main(args) {
     throw err;
   } finally {
     cancellation.cleanup();
+    logger.closeProgress();
   }
 
   if (parsed.saveRun) {
@@ -297,7 +304,7 @@ export async function main(args) {
       manifest,
       manifestOutputs
     );
-    console.error(`[patina] wrote manifest to ${manifestPath}`);
+    logger.info('manifest.written', { message: `[patina] wrote manifest to ${manifestPath}` });
   }
 }
 
@@ -367,6 +374,12 @@ function parseArgs(args) {
       }
       case '--json':
         parsed.format = 'json';
+        break;
+      case '--quiet':
+        parsed.quiet = true;
+        break;
+      case '--json-logs':
+        parsed.jsonLogs = true;
         break;
       case '--gate': {
         const value = readOptionValue(args, i, arg, { allowFlagLike: true });
@@ -560,14 +573,18 @@ function cancellationError() {
 export function createCancellationController({
   processObj = process,
   stderr = process.stderr,
+  logger = null,
 } = {}) {
   const controller = new AbortController();
   let sigintCount = 0;
   let installed = false;
 
   const writeStatus = (message) => {
+    if (logger) {
+      logger.warn('cli.cancel', { message: message.trimEnd() });
+      return;
+    }
     if (stderr && typeof stderr.write === 'function') stderr.write(message);
-    else console.error(message.trimEnd());
   };
 
   const onSigint = () => {
@@ -638,7 +655,7 @@ export function resolvePromptMode(mode, { backend, model }) {
 // of argv and shell history (CWE-214). Precedence: --api-key-file >
 // PATINA_API_KEY_FILE > --api-key (with deprecation warning) > provider/default
 // env vars.
-function resolveApiKey(parsed, provider) {
+function resolveApiKey(parsed, provider, logger = createLogger()) {
   const hasApiKeyFile = Boolean(parsed.apiKeyFile || process.env.PATINA_API_KEY_FILE);
   const apiKey = resolveHttpApiKey({
     explicitApiKey: parsed.apiKey,
@@ -646,18 +663,20 @@ function resolveApiKey(parsed, provider) {
     envVars: providerHttpKeyEnvVars(provider?.apiKeyEnv),
   });
   if (hasApiKeyFile && parsed.apiKey) {
-    console.error('[patina] both --api-key-file and --api-key were provided; using --api-key-file');
+    logger.warn('auth.api_key_file_precedence', {
+      message: '[patina] both --api-key-file and --api-key were provided; using --api-key-file',
+    });
   }
   if (parsed.apiKey && !hasApiKeyFile) {
-    console.error(
-      '[patina] warning: --api-key exposes the secret in shell history and `ps` output.\n' +
-      '         Prefer PATINA_API_KEY env var, --api-key-file <path>, or PATINA_API_KEY_FILE.'
-    );
+    logger.warn('auth.argv_secret_warning', {
+      message: '[patina] warning: --api-key exposes the secret in shell history and `ps` output.\n' +
+        '         Prefer PATINA_API_KEY env var, --api-key-file <path>, or PATINA_API_KEY_FILE.',
+    });
   }
   return apiKey;
 }
 
-async function loadInputs(parsed) {
+async function loadInputs(parsed, logger = createLogger()) {
   if (parsed.files.length === 0) {
     if (process.stdin.isTTY) {
       if (parsed.noInteractive) {
@@ -667,7 +686,7 @@ async function loadInputs(parsed) {
           'Pass a file path, pipe text via stdin, or omit --no-interactive to paste text and press Ctrl-D.'
         );
       }
-      console.error('[patina] Paste text, then press Ctrl-D to run (Ctrl-C to cancel).');
+      logger.info('stdin.prompt', { message: '[patina] Paste text, then press Ctrl-D to run (Ctrl-C to cancel).' });
     }
     const stdin = await readStdin({ interactive: Boolean(process.stdin.isTTY) });
     if (!stdin.trim()) {
@@ -792,6 +811,8 @@ MODES
 OUTPUT & BATCH
   --format <fmt>          Output format: markdown (default), text, json
   --json                  Alias for --format json
+  --quiet                 Suppress patina status/warning logs on stderr
+  --json-logs             Emit stderr logs as NDJSON objects
   --batch                 Process multiple files
   --in-place              Overwrite original files (with --batch)
   --suffix <ext>          Save as {name}{ext}{extname}
@@ -851,13 +872,13 @@ backends opt-in (issue #88).
 `);
 }
 
-function applyScoreGate(result, output, gate) {
+function applyScoreGate(result, output, gate, logger = createLogger()) {
   const overall = extractScoreOverall(result, output);
   if (overall === null) {
     throw new Error('--gate could not find a numeric `overall` value in --score output.');
   }
   if (overall > gate) {
-    console.error(`[patina] score gate failed: overall ${overall} > ${gate}`);
+    logger.warn('score.gate_failed', { message: `[patina] score gate failed: overall ${overall} > ${gate}` });
     process.exitCode = Math.max(Number(process.exitCode) || 0, 3);
   }
 }
@@ -986,7 +1007,7 @@ function handleAuth(subArgs) {
 // the exports.
 if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
   main(process.argv.slice(2)).catch((err) => {
-    console.error(renderCliError(err));
+    createLogger().error('cli.error', { message: renderCliError(err) });
     process.exit(getExitCode(err));
   });
 }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -6,6 +6,7 @@ import { stdin as input, stdout as output } from 'node:process';
 import yaml from 'js-yaml';
 import { listBackends } from '../backends/index.js';
 import { inputError } from '../errors.js';
+import { createLogger } from '../logger.js';
 
 const LANGUAGES = ['ko', 'en', 'zh', 'ja'];
 const PROFILES = [
@@ -25,7 +26,7 @@ const PROFILES = [
 const TONES = ['profile-only', 'casual', 'professional', 'academic', 'narrative', 'marketing', 'instructional', 'auto'];
 const DISPATCH_MODES = ['omc', 'direct', 'api'];
 
-export async function runInit(args = []) {
+export async function runInit(args = [], { logger = createLogger() } = {}) {
   const parsed = parseInitArgs(args);
   if (parsed.help) {
     printInitHelp();
@@ -46,10 +47,10 @@ export async function runInit(args = []) {
   const detected = detectInitDefaults();
   const answers = parsed.defaults
     ? detected
-    : await promptForConfig(detected, { target, force: parsed.force });
+    : await promptForConfig(detected, { target, force: parsed.force, logger });
 
   if (!answers) {
-    console.error('[patina] kept existing .patina.yaml');
+    logger.info('init.kept_existing', { message: '[patina] kept existing .patina.yaml' });
     return;
   }
 
@@ -109,7 +110,7 @@ function parseInitArgs(args) {
   return parsed;
 }
 
-async function promptForConfig(defaults, { target, force }) {
+async function promptForConfig(defaults, { target, force, logger = createLogger() }) {
   if (!process.stdin.isTTY) {
     throw inputError(
       'init needs an interactive terminal',
@@ -121,42 +122,42 @@ async function promptForConfig(defaults, { target, force }) {
   const rl = createInterface({ input, output });
   try {
     if (existsSync(target) && !force) {
-      const overwrite = await ask(rl, `Overwrite existing .patina.yaml?`, 'no', ['yes', 'no']);
+      const overwrite = await ask(rl, `Overwrite existing .patina.yaml?`, 'no', ['yes', 'no'], logger);
       if (overwrite !== 'yes') return null;
     }
 
-    const language = await ask(rl, 'Language', defaults.language, LANGUAGES);
-    const profile = await ask(rl, 'Profile', defaults.profile, PROFILES);
-    const tone = await ask(rl, 'Tone', defaults.tone, TONES);
+    const language = await ask(rl, 'Language', defaults.language, LANGUAGES, logger);
+    const profile = await ask(rl, 'Profile', defaults.profile, PROFILES, logger);
+    const tone = await ask(rl, 'Tone', defaults.tone, TONES, logger);
     const backendChoices = listBackends().map((b) => b.name);
-    const backend = await ask(rl, 'Backend', defaults.backend, backendChoices);
-    const maxModels = await askMulti(rl, 'MAX models', defaults.maxModels, ['claude', 'codex', 'gemini']);
-    const dispatch = await ask(rl, 'Dispatch mode', defaults.dispatch, DISPATCH_MODES);
+    const backend = await ask(rl, 'Backend', defaults.backend, backendChoices, logger);
+    const maxModels = await askMulti(rl, 'MAX models', defaults.maxModels, ['claude', 'codex', 'gemini'], logger);
+    const dispatch = await ask(rl, 'Dispatch mode', defaults.dispatch, DISPATCH_MODES, logger);
     return { language, profile, tone, backend, maxModels, dispatch };
   } finally {
     rl.close();
   }
 }
 
-async function ask(rl, label, defaultValue, choices) {
+async function ask(rl, label, defaultValue, choices, logger = createLogger()) {
   const choiceHint = choices ? ` (${choices.join('/')})` : '';
   const raw = (await rl.question(`${label}${choiceHint} [${defaultValue}]: `)).trim();
   const value = raw || defaultValue;
   if (choices && !choices.includes(value)) {
-    console.error(`[patina] ${label}: unknown value "${value}", keeping ${defaultValue}`);
+    logger.warn('init.unknown_value', { message: `[patina] ${label}: unknown value "${value}", keeping ${defaultValue}` });
     return defaultValue;
   }
   return value;
 }
 
-async function askMulti(rl, label, defaultValues, choices) {
+async function askMulti(rl, label, defaultValues, choices, logger = createLogger()) {
   const raw = (await rl.question(`${label} (${choices.join(',')}) [${defaultValues.join(',')}]: `)).trim();
   const values = (raw ? raw.split(',') : defaultValues)
     .map((value) => value.trim())
     .filter(Boolean);
   const valid = values.filter((value) => choices.includes(value));
   if (valid.length === 0) {
-    console.error(`[patina] ${label}: no valid values, keeping ${defaultValues.join(',')}`);
+    logger.warn('init.no_valid_values', { message: `[patina] ${label}: no valid values, keeping ${defaultValues.join(',')}` });
     return defaultValues;
   }
   return [...new Set(valid)];

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,70 @@
+const LEVELS = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  silent: Infinity,
+};
+
+export function createLogger({
+  level = process.env.PATINA_LOG_LEVEL || 'info',
+  quiet = false,
+  json = false,
+  stream = process.stderr,
+} = {}) {
+  const threshold = quiet ? LEVELS.silent : (LEVELS[String(level).toLowerCase()] ?? LEVELS.info);
+  let progressOpen = false;
+
+  const emit = (levelName, event, fields = {}) => {
+    if (LEVELS[levelName] < threshold) return;
+    closeProgress();
+    if (json) {
+      console.error(JSON.stringify(record(levelName, event, fields)));
+      return;
+    }
+    if (fields.message) console.error(fields.message);
+  };
+
+  const progress = (event, fields = {}) => {
+    if (LEVELS.info < threshold) return;
+    if (json) {
+      console.error(JSON.stringify(record('info', event, fields)));
+      return;
+    }
+    if (!fields.message || !stream?.write) return;
+    stream.write(`\r${fields.message}`);
+    progressOpen = true;
+  };
+
+  function closeProgress() {
+    if (progressOpen && stream?.write) stream.write('\n');
+    progressOpen = false;
+  }
+
+  return {
+    debug: (event, fields) => emit('debug', event, fields),
+    info: (event, fields) => emit('info', event, fields),
+    warn: (event, fields) => emit('warn', event, fields),
+    error: (event, fields) => emit('error', event, fields),
+    progress,
+    closeProgress,
+    child(extra = {}) {
+      return createLogger({ level, quiet, json, stream, ...extra });
+    },
+  };
+}
+
+function record(level, event, fields = {}) {
+  const { message, model = null, latency_ms = null, ...rest } = fields;
+  return {
+    ts: new Date().toISOString(),
+    level,
+    event,
+    model,
+    latency_ms,
+    ...(message ? { message } : {}),
+    ...rest,
+  };
+}
+
+export const defaultLogger = createLogger();

--- a/src/max-mode.js
+++ b/src/max-mode.js
@@ -1,5 +1,6 @@
 import { callLLM as defaultCallLLM, callLLMMultiple } from './api.js';
 import { scoreText, scoreMPS } from './scoring.js';
+import { createLogger } from './logger.js';
 
 const DEFAULT_WALL_CLOCK_BUDGET_MS = 300_000;
 
@@ -20,8 +21,11 @@ export async function runMaxMode({
   scoreTextImpl = scoreText,
   scoreMPSImpl = scoreMPS,
   signal,
+  logger = createLogger(),
 }) {
-  console.error(`[patina-max] Dispatching to ${models.length} models: ${models.join(', ')}`);
+  logger.info('max.dispatch', {
+    message: `[patina-max] Dispatching to ${models.length} models: ${models.join(', ')}`,
+  });
 
   const controller = new AbortController();
   const abortFromCaller = () => controller.abort();
@@ -35,12 +39,24 @@ export async function runMaxMode({
     }
   }
   const deadline = now() + wallClockBudgetMs;
+  const progressStartedAt = now();
+  const modelStatus = new Map(models.map((model) => [model, '...']));
+  const modelStartedAt = new Map();
   let timedOut = false;
   const timeout = setTimeout(() => {
     timedOut = true;
     controller.abort();
-    console.error(`[patina-max] MAX wall-clock timeout reached; returning partial results`);
+    logger.warn('max.timeout', { message: '[patina-max] MAX wall-clock timeout reached; returning partial results' });
   }, wallClockBudgetMs);
+
+  const renderProgress = () => {
+    const statuses = models.map((model) => `${model} ${modelStatus.get(model) || '...'}`).join('  ');
+    const elapsedSeconds = Math.max(0, Math.round((now() - progressStartedAt) / 1000));
+    logger.progress('max.progress', {
+      message: `[patina-max] ${statuses}  (${elapsedSeconds}s)`,
+      elapsed_ms: Math.max(0, now() - progressStartedAt),
+    });
+  };
 
   const candidates = [];
   try {
@@ -55,8 +71,20 @@ export async function runMaxMode({
       callLLM,
       now,
       sleep,
-      onStart: (model) => console.error(`[patina-max] Starting ${model}...`),
-      onComplete: (model, ok) => console.error(`[patina-max] ${model} ${ok ? 'completed' : 'failed'}`),
+      onStart: (model) => {
+        modelStartedAt.set(model, now());
+        modelStatus.set(model, '...');
+        renderProgress();
+      },
+      onComplete: (model, ok) => {
+        const latencyMs = modelStartedAt.has(model) ? Math.max(0, now() - modelStartedAt.get(model)) : undefined;
+        modelStatus.set(model, ok ? '✓' : '✗');
+        logger.progress('max.model_complete', {
+          message: formatMaxProgress(models, modelStatus, progressStartedAt, now),
+          model,
+          latency_ms: latencyMs,
+        });
+      },
     });
 
     for (const r of results) {
@@ -79,6 +107,7 @@ export async function runMaxMode({
           deadline,
           signal: controller.signal,
           callLLM,
+          logger,
           now,
           sleep,
         });
@@ -94,6 +123,7 @@ export async function runMaxMode({
           deadline,
           signal: controller.signal,
           callLLM,
+          logger,
           now,
           sleep,
         });
@@ -112,9 +142,12 @@ export async function runMaxMode({
   } finally {
     clearTimeout(timeout);
     cleanupCallerSignal();
+    logger.closeProgress();
   }
 
-  const { candidate: best, fallback } = selectBest(candidates);
+  const { candidate: best, fallback } = selectBest(candidates, {
+    log: (message) => logger.warn('max.selection_tie', { message }),
+  });
   const allFailed = best === null;
 
   return {
@@ -127,7 +160,10 @@ export async function runMaxMode({
   };
 }
 
-export function selectBest(candidates, { log = console.error } = {}) {
+export function selectBest(
+  candidates,
+  { log = (message) => createLogger().warn('max.selection_tie', { message }) } = {}
+) {
   const valid = candidates.filter((c) => c.ok && c.aiScore !== null);
 
   if (valid.length === 0) {
@@ -162,4 +198,10 @@ export function selectBest(candidates, { log = console.error } = {}) {
   }
 
   return { candidate: best, fallback: true };
+}
+
+function formatMaxProgress(models, modelStatus, startedAt, now) {
+  const statuses = models.map((model) => `${model} ${modelStatus.get(model) || '...'}`).join('  ');
+  const elapsedSeconds = Math.max(0, Math.round((now() - startedAt) / 1000));
+  return `[patina-max] ${statuses}  (${elapsedSeconds}s)`;
 }

--- a/src/ouroboros.js
+++ b/src/ouroboros.js
@@ -1,6 +1,7 @@
 import { callLLM as defaultCallLLM } from './api.js';
 import { scoreText, scoreMPS, scoreFidelity, combinedScore } from './scoring.js';
 import { buildPrompt } from './prompt-builder.js';
+import { createLogger } from './logger.js';
 
 export async function runOuroboros({
   config,
@@ -16,6 +17,7 @@ export async function runOuroboros({
   now,
   sleep,
   signal,
+  logger = createLogger(),
 }) {
   const ouroborosConfig = config.ouroboros || {};
   const targetScore = ouroborosConfig['target-score'] ?? 30;
@@ -37,6 +39,7 @@ export async function runOuroboros({
     now,
     sleep,
     signal,
+    logger,
   });
 
   const initialScore = initialScoreResult?.overall ?? 100;
@@ -83,6 +86,7 @@ export async function runOuroboros({
       mode: 'rewrite',
     });
 
+    const iterationStartedAt = now ? now() : Date.now();
     const humanized = await callLLM({
       prompt,
       apiKey,
@@ -104,10 +108,17 @@ export async function runOuroboros({
       now,
       sleep,
       signal,
+      logger,
     });
 
     let currentScore = scoreResult?.overall ?? 100;
     const delta = previousScore - currentScore;
+    const latencyMs = Math.max(0, (now ? now() : Date.now()) - iterationStartedAt);
+    logger.info('ouroboros.iteration', {
+      message: `[ouroboros] iter ${iteration}/${maxIterations} score ${previousScore} → ${currentScore} (${formatElapsed(latencyMs)})`,
+      model,
+      latency_ms: latencyMs,
+    });
 
     const [mpsResult, fidelityResult] = await Promise.all([
       scoreMPS({
@@ -120,6 +131,7 @@ export async function runOuroboros({
         now,
         sleep,
         signal,
+        logger,
       }),
       scoreFidelity({
         original: text,
@@ -131,6 +143,7 @@ export async function runOuroboros({
         now,
         sleep,
         signal,
+        logger,
       }),
     ]);
 
@@ -209,4 +222,8 @@ export async function runOuroboros({
     reason: iterationLog[iterationLog.length - 1]?.reason || 'Completed',
     log: iterationLog,
   };
+}
+
+function formatElapsed(ms) {
+  return `${Math.round(ms / 100) / 10}s`;
 }

--- a/src/output.js
+++ b/src/output.js
@@ -1,3 +1,5 @@
+import { createLogger } from './logger.js';
+
 export function formatOutput(result, mode, parsed = {}, opts = {}) {
   const tone = opts.tone || null;
   const format = parsed.format || 'markdown';
@@ -20,7 +22,7 @@ function renderFormattedBody(result, mode, parsed = {}, opts = {}) {
   // emit tables and don't need the extraction step.
   if (mode === 'rewrite' || mode === 'ouroboros') {
     const variants = extractVariants(body);
-    body = variants.length > 0 ? formatVariants(variants, body) : stripSelfAudit(body);
+    body = variants.length > 0 ? formatVariants(variants, body) : stripSelfAudit(body, { logger: opts.logger });
   }
   if (mode === 'diff') {
     body = colorizeDiff(body, { parsed, env: opts.env, stdout: opts.stdout });
@@ -199,16 +201,16 @@ function normalizeCategoryName(raw) {
 // We extract the body block and drop the audit so callers get clean text.
 // If the model didn't honor the tags (older runs, mocked tests, etc.), we
 // fall back to returning the full output untouched.
-export function stripSelfAudit(body) {
+export function stripSelfAudit(body, { logger = createLogger() } = {}) {
   if (!body) return body;
   const bodyOpen = body.indexOf('[BODY]');
   const bodyClose = body.indexOf('[/BODY]', bodyOpen);
   if (bodyOpen < 0 || bodyClose <= bodyOpen) {
     const stripped = removeSelfAuditBlocks(body).trim();
     if (stripped !== body.trim()) {
-      console.error(
-        `[patina] warning: model output omitted [BODY] tags (${body.length} chars); stripped [SELF_AUDIT]. Re-run with --prompt-mode strict if the output looks wrong.`
-      );
+      logger.warn('output.missing_body_tags', {
+        message: `[patina] warning: model output omitted [BODY] tags (${body.length} chars); stripped [SELF_AUDIT]. Re-run with --prompt-mode strict if the output looks wrong.`,
+      });
       return stripped;
     }
     return body;

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,4 +1,5 @@
 import { callLLM as defaultCallLLM } from './api.js';
+import { createLogger } from './logger.js';
 
 class SchemaError extends Error {
   constructor(message, raw) {
@@ -39,6 +40,7 @@ async function callAndParseJson({
   deadline,
   signal,
   callLLM = defaultCallLLM,
+  logger = createLogger(),
   now,
   sleep,
 }) {
@@ -61,7 +63,9 @@ async function callAndParseJson({
     } catch (e) {
       lastError = e;
       if (attempt === 0) {
-        console.error(`[patina] score JSON parse failed (${e.message}); retrying at temperature 0`);
+        logger.warn('score.json_parse_retry', {
+          message: `[patina] score JSON parse failed (${e.message}); retrying at temperature 0`,
+        });
       }
     }
   }
@@ -78,6 +82,7 @@ export async function scoreText({
   deadline,
   signal,
   callLLM = defaultCallLLM,
+  logger = createLogger(),
   now,
   sleep,
 }) {
@@ -123,13 +128,16 @@ ${text}
       deadline,
       signal,
       callLLM,
+      logger,
       now,
       sleep,
     });
     return parsed;
   } catch (e) {
     rethrowIfAborted(e, signal);
-    console.error(`[patina] scoreText schema failure after retry: ${e.message}`);
+    logger.warn('score.text_schema_failure', {
+      message: `[patina] scoreText schema failure after retry: ${e.message}`,
+    });
     return { overall: null, error: 'schema-failure', raw: e.raw };
   }
 }
@@ -143,6 +151,7 @@ export async function scoreMPS({
   deadline,
   signal,
   callLLM = defaultCallLLM,
+  logger = createLogger(),
   now,
   sleep,
 }) {
@@ -186,13 +195,16 @@ ${rewritten}
       deadline,
       signal,
       callLLM,
+      logger,
       now,
       sleep,
     });
     return parsed;
   } catch (e) {
     rethrowIfAborted(e, signal);
-    console.error(`[patina] scoreMPS schema failure after retry: ${e.message}`);
+    logger.warn('score.mps_schema_failure', {
+      message: `[patina] scoreMPS schema failure after retry: ${e.message}`,
+    });
     return { mps: null, error: 'schema-failure', raw: e.raw };
   }
 }
@@ -224,6 +236,7 @@ export async function scoreFidelity({
   deadline,
   signal,
   callLLM = defaultCallLLM,
+  logger = createLogger(),
   now,
   sleep,
 }) {
@@ -269,13 +282,16 @@ ${rewritten}
       deadline,
       signal,
       callLLM,
+      logger,
       now,
       sleep,
     });
     parsed = result.parsed;
   } catch (e) {
     rethrowIfAborted(e, signal);
-    console.error(`[patina] scoreFidelity schema failure after retry: ${e.message}`);
+    logger.warn('score.fidelity_schema_failure', {
+      message: `[patina] scoreFidelity schema failure after retry: ${e.message}`,
+    });
     schemaError = e;
   }
 

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -233,6 +233,8 @@ describe('CLI End-to-End with Mock API', () => {
     assert.ok(help.includes('EXAMPLES'), 'help should include examples');
     assert.ok(help.includes('--gate <n>'), 'help should document score gate');
     assert.ok(help.includes('--format <fmt>'), 'help should document output format');
+    assert.ok(help.includes('--quiet'), 'help should document quiet logs');
+    assert.ok(help.includes('--json-logs'), 'help should document structured stderr logs');
     assert.ok(help.includes('--max-timeout <sec>'), 'help should document MAX wall-clock timeout');
     assert.ok(help.includes('--no-color'), 'help should document diff color opt-out');
     assert.ok(
@@ -307,6 +309,24 @@ describe('CLI End-to-End with Mock API', () => {
     await startMockServer('This is the humanized result.');
   });
 
+  it('should suppress stderr status and warnings with --quiet', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+    const { errors, logs } = await captureConsole(() => main([
+      '--lang', 'en',
+      '--quiet',
+      '--api-key', 'test-key',
+      '--base-url', `http://127.0.0.1:${mockPort}`,
+      testFile,
+    ]));
+
+    assert.strictEqual(callCount, 1, 'Should make exactly one API call');
+    assert.deepStrictEqual(errors, []);
+    assert.match(logs.join('\n'), /This is the humanized result\./);
+  });
+
   it('should set exit code 3 when --score gate fails', async () => {
     callCount = 0;
     lastRequestBody = null;
@@ -328,6 +348,41 @@ describe('CLI End-to-End with Mock API', () => {
 
       assert.strictEqual(process.exitCode, 3);
       assert.ok(errors.some((line) => line.includes('score gate failed')));
+    } finally {
+      process.exitCode = oldExitCode;
+    }
+    await stopMockServer();
+    await startMockServer('This is the humanized result.');
+  });
+
+  it('should emit stderr logs as NDJSON with stable fields', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+    await stopMockServer();
+    await startMockServer('{ "overall": 42, "interpretation": "mixed" }');
+
+    const oldExitCode = process.exitCode;
+    process.exitCode = undefined;
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+    try {
+      const { errors } = await captureConsole(() => main([
+        '--lang', 'en',
+        '--score',
+        '--gate', '30',
+        '--json-logs',
+        '--api-key', 'test-key',
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        testFile,
+      ]));
+
+      assert.strictEqual(process.exitCode, 3);
+      const records = errors.map((line) => JSON.parse(line));
+      assert.ok(records.some((record) => record.event === 'auth.argv_secret_warning'));
+      const gate = records.find((record) => record.event === 'score.gate_failed');
+      assert.ok(gate);
+      assert.strictEqual(gate.level, 'warn');
+      assert.strictEqual(gate.model, null);
+      assert.strictEqual(gate.latency_ms, null);
     } finally {
       process.exitCode = oldExitCode;
     }

--- a/tests/unit/logger.test.js
+++ b/tests/unit/logger.test.js
@@ -1,0 +1,51 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { createLogger } from '../../src/logger.js';
+
+function captureConsoleError(fn) {
+  const original = console.error;
+  const lines = [];
+  console.error = (message) => lines.push(String(message));
+  try {
+    fn();
+  } finally {
+    console.error = original;
+  }
+  return lines;
+}
+
+test('logger respects quiet and PATINA_LOG_LEVEL', () => {
+  const previous = process.env.PATINA_LOG_LEVEL;
+  process.env.PATINA_LOG_LEVEL = 'warn';
+  try {
+    const lines = captureConsoleError(() => {
+      const logger = createLogger();
+      logger.info('hidden', { message: '[patina] hidden' });
+      logger.warn('shown', { message: '[patina] shown' });
+      createLogger({ quiet: true }).error('also_hidden', { message: '[patina] hidden error' });
+    });
+    assert.deepEqual(lines, ['[patina] shown']);
+  } finally {
+    if (previous === undefined) delete process.env.PATINA_LOG_LEVEL;
+    else process.env.PATINA_LOG_LEVEL = previous;
+  }
+});
+
+test('logger emits NDJSON records with stable fields', () => {
+  const lines = captureConsoleError(() => {
+    const logger = createLogger({ json: true });
+    logger.info('max.model_complete', {
+      message: '[patina-max] claude ✓  (1s)',
+      model: 'claude',
+      latency_ms: 1234,
+    });
+  });
+
+  assert.equal(lines.length, 1);
+  const record = JSON.parse(lines[0]);
+  assert.equal(record.level, 'info');
+  assert.equal(record.event, 'max.model_complete');
+  assert.equal(record.model, 'claude');
+  assert.equal(record.latency_ms, 1234);
+});

--- a/tests/unit/max-mode.test.js
+++ b/tests/unit/max-mode.test.js
@@ -109,6 +109,54 @@ test('runMaxMode uses callLLM, now, and sleep injectables across dispatch and sc
   assert.equal(seen.length, 3);
 });
 
+test('runMaxMode reports elapsed per-model progress through the logger', async () => {
+  let currentTime = 1_000;
+  const progress = [];
+  const logger = {
+    info() {},
+    warn() {},
+    progress(event, fields) {
+      progress.push({ event, ...fields });
+    },
+    closeProgress() {},
+  };
+
+  const result = await runMaxMode({
+    prompt: 'rewrite this',
+    sourceText: 'source text',
+    models: ['claude', 'gemini'],
+    apiKey: 'test',
+    baseURL: 'https://example.com/v1',
+    config: { language: 'en' },
+    patterns: [],
+    wallClockBudgetMs: 1_000,
+    now: () => currentTime,
+    logger,
+    callLLMMultipleImpl: async ({ onStart, onComplete }) => {
+      onStart('claude');
+      currentTime += 1_500;
+      onComplete('claude', true);
+      onStart('gemini');
+      currentTime += 500;
+      onComplete('gemini', false);
+      return [
+        { model: 'claude', ok: true, result: 'Humanized result.' },
+        { model: 'gemini', ok: false, error: 'backend failed' },
+      ];
+    },
+    scoreTextImpl: async () => ({ overall: 12 }),
+    scoreMPSImpl: async () => ({ mps: 94 }),
+  });
+
+  assert.equal(result.best.model, 'claude');
+  assert.ok(progress.some((entry) => entry.event === 'max.progress'));
+  const completed = progress.filter((entry) => entry.event === 'max.model_complete');
+  assert.equal(completed.length, 2);
+  assert.equal(completed.at(-1).message, '[patina-max] claude ✓  gemini ✗  (2s)');
+  assert.equal(completed[0].model, 'claude');
+  assert.equal(completed[0].latency_ms, 1500);
+});
+
 test('formatOutput surfaces the MAX MPS fallback warning', () => {
   const out = formatOutput({
     type: 'max-mode',

--- a/tests/unit/ouroboros.test.js
+++ b/tests/unit/ouroboros.test.js
@@ -175,3 +175,47 @@ test('runOuroboros rolls back on MPS-floor violation', async () => {
   assert.equal(result.iterations, 1);
   assert.equal(result.reason, 'MPS floor violation');
 });
+
+test('runOuroboros logs per-iteration score progress and latency', async () => {
+  const fixture = createLLMFixture({
+    scores: [80, 70],
+    rewrites: ['Lower score claim text.'],
+    mps: [100],
+    fidelityGrades: [3],
+  });
+  const records = [];
+  const logger = {
+    info(event, fields) {
+      records.push({ event, ...fields });
+    },
+    warn() {},
+    progress() {},
+    closeProgress() {},
+  };
+  let currentTime = 1_000;
+
+  const result = await runOuroboros({
+    config: baseConfig({ 'target-score': 75 }),
+    patterns: [],
+    profile: null,
+    voice: null,
+    scoring: null,
+    text: BASE_TEXT,
+    apiKey: 'test-key',
+    baseURL: 'https://example.com/v1',
+    model: 'test-model',
+    now: () => currentTime,
+    logger,
+    callLLM: async (args) => {
+      currentTime += 250;
+      return fixture.callLLM(args);
+    },
+  });
+
+  assert.equal(result.reason, 'Target met');
+  assert.equal(records.length, 1);
+  assert.equal(records[0].event, 'ouroboros.iteration');
+  assert.equal(records[0].model, 'test-model');
+  assert.equal(records[0].latency_ms, 500);
+  assert.match(records[0].message, /\[ouroboros\] iter 1\/3 score 80 → 70 \(0\.5s\)/);
+});


### PR DESCRIPTION
## Summary
- introduce a shared CLI logger with --quiet, PATINA_LOG_LEVEL, and --json-logs support
- route existing patina warnings/status logs through structured events
- add elapsed MAX per-model progress and Ouroboros iteration score progress
- document script-facing stderr logging behavior

Closes #132
Closes #180

## Verification
- npm test
- npm run lint:syntax
- npm run lint:eslint
- npm run typecheck
- git diff --check

## Constraints
- no new dependencies
- core skill pipeline unchanged