### PR TITLE
refactor(backends): add explicit fallback chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ printf '%s\n' 'Coffee has emerged as a pivotal cultural phenomenon that has fund
   | patina --lang en --backend codex-cli
 ```
 
-> 🆓 **No API key required** if you have any of [`codex`](https://github.com/openai/codex), [`claude`](https://docs.anthropic.com/en/docs/claude-code), or [`gemini`](https://github.com/google-gemini/gemini-cli) CLIs logged in. Pick one with `--backend codex-cli | claude-cli | gemini-cli`, or let the model heuristic route automatically (`--model claude-*` → claude-cli, etc.). See [AUTHENTICATION.md](docs/AUTHENTICATION.md) for the full backend list.
+> 🆓 **No API key required** if you have any of [`codex`](https://github.com/openai/codex), [`claude`](https://docs.anthropic.com/en/docs/claude-code), or [`gemini`](https://github.com/google-gemini/gemini-cli) CLIs logged in. Pick one with `--backend codex-cli | claude-cli | gemini-cli`, declare an explicit fallback chain such as `--backend claude-cli,codex-cli`, or let the model heuristic route automatically (`--model claude-*` → claude-cli, etc.). See [AUTHENTICATION.md](docs/AUTHENTICATION.md) for the full backend list.
 
 ### CI integrations
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -21,7 +21,7 @@ patina auth login          # per-backend login instructions
 patina --list-providers    # preset providers + key status
 ```
 
-Backend selection requires an explicit signal: pass `--backend <name>` directly, or use `--model <prefix>` (`codex-*`, `claude-*`, `gemini-*` route to the matching local CLI). With no flags and no API key, patina exits with an error rather than silently dispatching to a coding agent. See [issue #88](https://github.com/devswha/patina/issues/88) for the rationale.
+Backend selection requires an explicit signal: pass `--backend <name>` directly, pass a comma-separated fallback chain such as `--backend claude-cli,codex-cli`, or use `--model <prefix>` (`codex-*`, `claude-*`, `gemini-*` route to the matching local CLI). With no flags and no API key, patina exits with an error rather than silently dispatching to a coding agent. See [issue #88](https://github.com/devswha/patina/issues/88) for the rationale.
 
 ## Environment variables
 

--- a/docs/AUTHENTICATION_KR.md
+++ b/docs/AUTHENTICATION_KR.md
@@ -21,7 +21,7 @@ patina auth login          # per-backend login instructions
 patina --list-providers    # preset providers + key status
 ```
 
-Backend selection에는 명시적인 신호가 필요합니다. `--backend <name>`을 직접 넘기거나, `--model <prefix>`를 사용하세요. `codex-*`, `claude-*`, `gemini-*`는 각각 맞는 local CLI로 라우팅됩니다. flag도 API key도 없으면 patina는 coding agent로 조용히 보내지 않고 오류로 종료합니다. 이유는 [issue #88](https://github.com/devswha/patina/issues/88)를 참고하세요.
+Backend selection에는 명시적인 신호가 필요합니다. `--backend <name>`을 직접 넘기거나, `--backend claude-cli,codex-cli`처럼 comma-separated fallback chain을 넘기거나, `--model <prefix>`를 사용하세요. `codex-*`, `claude-*`, `gemini-*`는 각각 맞는 local CLI로 라우팅됩니다. flag도 API key도 없으면 patina는 coding agent로 조용히 보내지 않고 오류로 종료합니다. 이유는 [issue #88](https://github.com/devswha/patina/issues/88)를 참고하세요.
 
 ## Environment variables
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -58,4 +58,20 @@ stays reserved for the transformed text or JSON envelope.
 - MAX mode (`--models`) reports elapsed per-model status (`...`, `✓`, `✗`).
 - Ouroboros reports per-iteration score movement and latency.
 
+## Backend fallback chains
+
+`--backend <name>` selects one backend. `--backend a,b,c` selects an explicit
+fallback chain and tries each backend in order only for retryable failures:
+HTTP `429`, HTTP `503`, and a first-backend `AbortError`. User cancellation via
+Ctrl-C stops the chain instead of falling through.
+
+```bash
+patina --backend claude-cli,codex-cli --lang en draft.md
+```
+
+All backends share the same invocation contract:
+`invoke({ prompt, model, signal, timeout }): Promise<string>`. Local CLI
+backends honor `AbortSignal` by killing their child process; the HTTP backend
+bridges the same signal into fetch.
+
 See [EXIT-CODES.md](EXIT-CODES.md) for the full process contract.

--- a/docs/FLAG-PARITY.md
+++ b/docs/FLAG-PARITY.md
@@ -30,7 +30,7 @@ Basis: local checkout `2e1fc04` plus `node bin/patina.js --help`, `SKILL.md`, an
 | `--api-key <key>` | ✓ | — | — | Deprecated CLI auth escape hatch; prefer env/file. |
 | `--api-key-file <path>` | ✓ | — | — | CLI auth. |
 | `--base-url <url>` | ✓ | — | — | CLI provider/backend config. |
-| `--backend <name>` | ✓ | — | — | CLI backend selection (`openai-http`, `codex-cli`, `claude-cli`, `gemini-cli`). |
+| `--backend <name[,name]>` | ✓ | — | — | CLI backend selection and explicit fallback chains (`openai-http`, `codex-cli`, `claude-cli`, `gemini-cli`). |
 | `--list-backends` | ✓ | — | — | CLI diagnostics. |
 | `--provider <name>` | ✓ | — | — | CLI provider preset. |
 | `--list-providers` | ✓ | — | — | CLI diagnostics. |

--- a/src/api.js
+++ b/src/api.js
@@ -229,7 +229,10 @@ export async function callLLM({
     }
   }
 
-  throw new Error(`LLM API failed after ${attemptsMade || 1} attempts: ${lastError?.message ?? 'unknown'}`);
+  const err = new Error(`LLM API failed after ${attemptsMade || 1} attempts: ${lastError?.message ?? 'unknown'}`);
+  if (lastError?.name === 'AbortError') err.name = 'AbortError';
+  if (typeof lastError?.status === 'number') err.status = lastError.status;
+  throw err;
 }
 
 export async function callLLMMultiple({

--- a/src/backends/claude-cli.js
+++ b/src/backends/claude-cli.js
@@ -2,6 +2,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { DEFAULT_BACKEND_TIMEOUT_MS } from './contract.js';
 
 export const name = 'claude-cli';
 
@@ -25,7 +26,7 @@ export function authHint() {
   return 'Run `claude` once interactively and follow the OAuth prompt to authenticate (uses your Claude subscription, no API key needed).';
 }
 
-export async function invoke({ prompt, signal, timeout = 180000 } = {}) {
+export async function invoke({ prompt, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS } = {}) {
   if (!prompt || typeof prompt !== 'string') {
     throw new Error('claude-cli backend: prompt must be a non-empty string');
   }

--- a/src/backends/codex-cli.js
+++ b/src/backends/codex-cli.js
@@ -2,6 +2,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { DEFAULT_BACKEND_TIMEOUT_MS } from './contract.js';
 
 export const name = 'codex-cli';
 
@@ -22,7 +23,7 @@ export function authHint() {
   return 'Run `codex login` to authenticate (uses your ChatGPT Plus account, no API key needed).';
 }
 
-export async function invoke({ prompt, signal, timeout = 180000 } = {}) {
+export async function invoke({ prompt, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS } = {}) {
   if (!prompt || typeof prompt !== 'string') {
     throw new Error('codex-cli backend: prompt must be a non-empty string');
   }

--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -1,0 +1,21 @@
+export const DEFAULT_BACKEND_TIMEOUT_MS = 180_000;
+
+export function isRetryableBackendError(err, { attemptIndex = 0, signal } = {}) {
+  if (signal?.aborted) return false;
+  const status = extractStatus(err);
+  if (status === 429 || status === 503) return true;
+  return err?.name === 'AbortError' && attemptIndex === 0;
+}
+
+export function describeBackendError(err) {
+  const status = extractStatus(err);
+  if (status) return `HTTP ${status}`;
+  return err?.name || 'error';
+}
+
+function extractStatus(err) {
+  const direct = Number(err?.status);
+  if (Number.isFinite(direct)) return direct;
+  const match = String(err?.message || '').match(/\bHTTP\s+(429|503)\b/);
+  return match ? Number(match[1]) : null;
+}

--- a/src/backends/gemini-cli.js
+++ b/src/backends/gemini-cli.js
@@ -2,6 +2,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { DEFAULT_BACKEND_TIMEOUT_MS } from './contract.js';
 
 export const name = 'gemini-cli';
 
@@ -30,7 +31,7 @@ export function authHint() {
   return 'Run `gemini` once interactively to log in via Google OAuth, or set GEMINI_API_KEY.';
 }
 
-export async function invoke({ prompt, model, signal, timeout = 240000 } = {}) {
+export async function invoke({ prompt, model, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS } = {}) {
   if (!prompt || typeof prompt !== 'string') {
     throw new Error('gemini-cli backend: prompt must be a non-empty string');
   }
@@ -41,8 +42,6 @@ export async function invoke({ prompt, model, signal, timeout = 240000 } = {}) {
   // directory for the same prompt-injection containment reason as codex-cli;
   // --skip-trust is required because the temp dir isn't in gemini's trusted
   // workspace list (otherwise gemini exits 55).
-  // Default timeout is higher than other CLIs because gemini's startup latency
-  // is longer (model warmup + auth check on each invocation).
   const dir = mkdtempSync(join(tmpdir(), 'patina-gemini-'));
   const args = ['-p', '', '--output-format', 'text', '--skip-trust'];
   if (model) args.push('-m', model);

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -4,13 +4,18 @@ import * as claudeCli from './claude-cli.js';
 import * as geminiCli from './gemini-cli.js';
 import { inspectHttpApiKeySource } from '../auth.js';
 import { inputError } from '../errors.js';
+import {
+  DEFAULT_BACKEND_TIMEOUT_MS,
+  describeBackendError,
+  isRetryableBackendError,
+} from './contract.js';
 
 const openaiHttp = {
   name: 'openai-http',
   isAvailable: () => true,
   isAuthenticated: () => inspectHttpApiKeySource().ok,
   authHint: () => inspectHttpApiKeySource().detail,
-  invoke: ({ prompt, apiKey, baseURL, model, signal, timeout }) =>
+  invoke: ({ prompt, apiKey, baseURL, model, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS }) =>
     callLLM({ prompt, apiKey, baseURL, model, signal, timeout }),
 };
 
@@ -39,14 +44,7 @@ export function listBackendNames() {
 
 export function selectBackend({ name, model } = {}) {
   if (name) {
-    const backend = REGISTRY[name];
-    if (!backend) {
-      throw inputError(
-        `Unknown backend: ${name}`,
-        `Available backends are: ${Object.keys(REGISTRY).join(', ')}.`,
-        'Run `patina --list-backends` to inspect local availability.'
-      );
-    }
+    const backend = resolveBackend(name);
     return { backend, autoSelected: false, reason: 'explicit' };
   }
 
@@ -65,4 +63,82 @@ export function selectBackend({ name, model } = {}) {
   // API, so require an explicit `--backend <name>` (or `--model <prefix>`).
   // See issue #88.
   return { backend: REGISTRY['openai-http'], autoSelected: false, reason: 'default' };
+}
+
+export function selectBackendChain({ name, model } = {}) {
+  if (name) {
+    const names = String(name)
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    if (names.length === 0) {
+      throw inputError(
+        '--backend expects at least one backend name',
+        'The comma-separated backend list was empty.',
+        `Available backends are: ${Object.keys(REGISTRY).join(', ')}.`
+      );
+    }
+    return {
+      backends: names.map(resolveBackend),
+      autoSelected: false,
+      reason: names.length > 1 ? 'explicit chain' : 'explicit',
+    };
+  }
+
+  const selected = selectBackend({ model });
+  return {
+    backends: [selected.backend],
+    autoSelected: selected.autoSelected,
+    reason: selected.reason,
+  };
+}
+
+export async function invokeBackendChain({
+  backends,
+  prompt,
+  apiKey,
+  baseURL,
+  model,
+  signal,
+  timeout = DEFAULT_BACKEND_TIMEOUT_MS,
+  logger,
+}) {
+  if (!Array.isArray(backends) || backends.length === 0) {
+    throw inputError(
+      'no backend selected',
+      'patina could not resolve a backend to run.',
+      'Pass --backend openai-http, codex-cli, claude-cli, or gemini-cli.'
+    );
+  }
+
+  let lastError = null;
+  for (let attemptIndex = 0; attemptIndex < backends.length; attemptIndex++) {
+    const backend = backends[attemptIndex];
+    try {
+      return await backend.invoke({ prompt, apiKey, baseURL, model, signal, timeout });
+    } catch (err) {
+      lastError = err;
+      const next = backends[attemptIndex + 1];
+      if (!next || !isRetryableBackendError(err, { attemptIndex, signal })) {
+        throw err;
+      }
+      logger?.warn?.('backend.fallback', {
+        message: `[patina] ${backend.name} failed with ${describeBackendError(err)}; falling back to ${next.name}`,
+      });
+    }
+  }
+
+  throw lastError || new Error('backend fallback chain failed without an error');
+}
+
+function resolveBackend(name) {
+  const backend = REGISTRY[name];
+  if (!backend) {
+    throw inputError(
+      `Unknown backend: ${name}`,
+      `Available backends are: ${Object.keys(REGISTRY).join(', ')}.`,
+      'Run `patina --list-backends` to inspect local availability.'
+    );
+  }
+  return backend;
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
 import { loadConfig, getRepoRoot, resolveTone } from './config.js';
 import { loadPatterns, loadProfile, loadCoreFile, loadInputText, toneToBackboneProfile } from './loader.js';
 import { buildPrompt } from './prompt-builder.js';
-import { selectBackend, listBackends, listBackendNames } from './backends/index.js';
+import { invokeBackendChain, selectBackendChain, listBackends, listBackendNames } from './backends/index.js';
 import { selectProvider, resolveProviderConfig, PROVIDERS } from './providers.js';
 import { validateBaseURL, applyInsecureBaseURLOptIn, applyPrivateBaseURLOptIn } from './security.js';
 import { formatOutput, validateScoreWeights } from './output.js';
@@ -187,14 +187,20 @@ export async function main(args) {
           logger,
         });
       } else {
-        const { backend, autoSelected, reason } = selectBackend({
+        const { backends, autoSelected, reason } = selectBackendChain({
           name: parsed.backend ?? config.backend,
           model: resolved.model,
         });
+        const backend = backends[0];
 
         if (autoSelected) {
           logger.info('backend.selected', {
             message: `[patina] Using ${backend.name} backend (${reason}). Run \`patina auth status\` for details.`,
+          });
+        }
+        if (backends.length > 1) {
+          logger.info('backend.chain', {
+            message: `[patina] Backend fallback chain: ${backends.map((b) => b.name).join(' → ')}`,
           });
         }
 
@@ -218,12 +224,14 @@ export async function main(args) {
           );
         }
 
-        result = await backend.invoke({
+        result = await invokeBackendChain({
+          backends,
           prompt,
           apiKey: resolved.apiKey,
           baseURL: resolved.baseURL,
           model: resolved.model,
           signal: cancellation.signal,
+          logger,
         });
       }
       cancellation.throwIfCanceled();
@@ -835,7 +843,8 @@ MODEL & AUTH
                           PATINA_API_KEY env or --api-key-file)
   --api-key-file <path>   Read API key from file (recommended)
   --base-url <url>        API base URL (or PATINA_API_BASE env)
-  --backend <name>        Backend: ${backendChoices} (default: openai-http)
+  --backend <name[,name]> Backend or explicit fallback chain:
+                          ${backendChoices} (default: openai-http)
   --list-backends         List available backends and their availability
   --provider <name>       Provider preset: openai, gemini, groq, together
   --list-providers        List provider presets and which keys are set

--- a/tests/e2e/backends.test.js
+++ b/tests/e2e/backends.test.js
@@ -1,6 +1,12 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { selectBackend, listBackends } from '../../src/backends/index.js';
+import {
+  invokeBackendChain,
+  selectBackend,
+  selectBackendChain,
+  listBackends,
+} from '../../src/backends/index.js';
+import { DEFAULT_BACKEND_TIMEOUT_MS } from '../../src/backends/contract.js';
 import { isAvailable as codexAvailable, isAuthenticated as codexAuthd } from '../../src/backends/codex-cli.js';
 
 describe('Backend Selection', () => {
@@ -66,6 +72,19 @@ describe('Backend Selection', () => {
     assert.strictEqual(selectBackend({ name: 'gemini-cli' }).backend.name, 'gemini-cli');
   });
 
+  it('parses an explicit comma-separated backend fallback chain', () => {
+    const { backends, reason } = selectBackendChain({ name: 'claude-cli,codex-cli,openai-http' });
+    assert.deepStrictEqual(backends.map((b) => b.name), ['claude-cli', 'codex-cli', 'openai-http']);
+    assert.strictEqual(reason, 'explicit chain');
+  });
+
+  it('rejects unknown names inside a backend fallback chain', () => {
+    assert.throws(
+      () => selectBackendChain({ name: 'claude-cli,not-real' }),
+      /Unknown backend: not-real/
+    );
+  });
+
   it('explicit --backend overrides --model heuristic', () => {
     const { backend } = selectBackend({ name: 'openai-http', model: 'codex' });
     assert.strictEqual(backend.name, 'openai-http');
@@ -73,6 +92,101 @@ describe('Backend Selection', () => {
 
   it('throws on unknown backend name', () => {
     assert.throws(() => selectBackend({ name: 'invented-backend' }), /Unknown backend/);
+  });
+});
+
+describe('Backend Fallback Chain', () => {
+  it('passes the shared default timeout through the backend contract', async () => {
+    let seenTimeout = null;
+    const result = await invokeBackendChain({
+      backends: [
+        {
+          name: 'first',
+          invoke: async ({ timeout }) => {
+            seenTimeout = timeout;
+            return 'ok';
+          },
+        },
+      ],
+      prompt: 'rewrite this',
+    });
+
+    assert.strictEqual(result, 'ok');
+    assert.strictEqual(seenTimeout, DEFAULT_BACKEND_TIMEOUT_MS);
+  });
+
+  it('falls through 429/503 backend errors to the next backend', async () => {
+    const events = [];
+    const logger = { warn: (event, fields) => events.push({ event, ...fields }) };
+    const result = await invokeBackendChain({
+      backends: [
+        {
+          name: 'first',
+          invoke: async () => {
+            const err = new Error('rate limited');
+            err.status = 429;
+            throw err;
+          },
+        },
+        { name: 'second', invoke: async () => 'ok' },
+      ],
+      prompt: 'rewrite this',
+      logger,
+    });
+
+    assert.strictEqual(result, 'ok');
+    assert.deepStrictEqual(events.map((entry) => entry.event), ['backend.fallback']);
+    assert.match(events[0].message, /first failed with HTTP 429; falling back to second/);
+  });
+
+  it('does not fall through non-retryable backend errors', async () => {
+    let secondCalled = false;
+    await assert.rejects(
+      invokeBackendChain({
+        backends: [
+          {
+            name: 'first',
+            invoke: async () => {
+              const err = new Error('unauthorized');
+              err.status = 401;
+              throw err;
+            },
+          },
+          { name: 'second', invoke: async () => { secondCalled = true; } },
+        ],
+        prompt: 'rewrite this',
+      }),
+      /unauthorized/
+    );
+    assert.strictEqual(secondCalled, false);
+  });
+
+  it('only treats AbortError as fallbackable for the first backend', async () => {
+    await assert.rejects(
+      invokeBackendChain({
+        backends: [
+          {
+            name: 'first',
+            invoke: async () => {
+              const err = new Error('timeout');
+              err.name = 'AbortError';
+              throw err;
+            },
+          },
+          {
+            name: 'second',
+            invoke: async () => {
+              const err = new Error('timeout again');
+              err.name = 'AbortError';
+              throw err;
+            },
+          },
+          { name: 'third', invoke: async () => 'should not run' },
+        ],
+        prompt: 'rewrite this',
+      }),
+      /timeout again/
+    );
   });
 });
 

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -221,3 +221,26 @@ test('callLLM honors an externally passed AbortSignal before fetch', async () =>
     globalThis.fetch = originalFetch;
   }
 });
+
+test('callLLM preserves final HTTP status for backend fallback classification', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: false,
+    status: 503,
+    headers: { get: () => null },
+    text: async () => 'busy',
+  });
+
+  try {
+    await assert.rejects(
+      callLLM({
+        prompt: 'x',
+        apiKey: 'test',
+        maxRetries: 0,
+      }),
+      (err) => err.status === 503 && /HTTP 503/.test(err.message)
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary\n- add a shared backend invocation contract with one timeout default\n- support explicit comma-separated backend fallback chains via `--backend a,b,c`\n- fall through only for HTTP 429, HTTP 503, and first-backend AbortError; cancellation/auth failures stop\n- document the new CLI/auth surface\n\nCloses #131\n\n## Verification\n- npm run lint:syntax\n- npm run lint:eslint\n- npm run typecheck\n- npm test\n- git diff --check