### PR TITLE
feat(scoring): add deterministic shadow score

### DIFF
--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -81,6 +81,14 @@ max-models:
 #       - Model IDs configurable via PATINA_MODEL_* env vars
 dispatch: omc
 
+# Scoring: LLM score remains canonical, with a deterministic shadow score
+# from src/features/* for reproducible drift checks.
+scoring:
+  deterministic:
+    enabled: true
+    divergence-threshold: 20  # warn and prefer the more pessimistic score above this delta
+    combined-weight: 0        # default off for combinedScore; users may opt in (e.g. 0.2)
+
 # Ouroboros: iterative self-improvement loop
 # Runs the full humanization pipeline repeatedly until the AI score converges.
 # Enable via config or CLI flag: --ouroboros

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ In rewrite mode, the model emits its self-audit notes inside `[SELF_AUDIT]`/`[/S
 
 ### Score weight drift detection (v3.11)
 
-`--score` runs cross-check the Weight column the model emits against your config's `category-weights`. If the model invents a category (e.g., `discord`) or substitutes a different number, `[patina]` warnings hit stderr — observability only, the score itself isn't altered.
+`--score` runs cross-check the Weight column the model emits against your config's `category-weights`. If the model invents a category (e.g., `discord`) or substitutes a different number, `[patina]` warnings hit stderr — observability only, the weight check itself doesn't alter the score. A deterministic shadow score from `src/features/*` is also recorded; when it differs from the LLM score by more than 20 points, patina warns and uses the more pessimistic value for gates.
 
 ## Tones
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -42,6 +42,7 @@ patina --lang en --score --exit-on 30 draft.md
 ```
 
 - `overall` and `categories[]` are populated when patina can parse them from score JSON or score tables.
+- Score JSON may include `scores.llm`, `scores.deterministic`, and `scores.preference` when deterministic shadow scoring is available.
 - `mps` is populated for MAX-mode results when available.
 - `gateResult` is `null` unless `--exit-on` / `--gate` is used.
 - `--save-run <dir>` writes `manifest.json` plus `output-N.txt` files for reproducible audit trails.

--- a/src/cli.js
+++ b/src/cli.js
@@ -7,6 +7,7 @@ import { validateBaseURL, applyInsecureBaseURLOptIn, applyPrivateBaseURLOptIn } 
 import { formatOutput, validateScoreWeights } from './output.js';
 import { runMaxMode } from './max-mode.js';
 import { runOuroboros } from './ouroboros.js';
+import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals } from './scoring.js';
 import { buildManifest, appendResult, writeManifest } from './manifest.js';
 import { runDoctor } from './commands/doctor.js';
 import { runInit } from './commands/init.js';
@@ -236,6 +237,15 @@ export async function main(args) {
       }
       cancellation.throwIfCanceled();
 
+      if (mode === 'score' && !parsed.models && !parsed.ouroboros) {
+        result = withDeterministicScore(result, {
+          text,
+          config,
+          repoRoot,
+          logger,
+        });
+      }
+
       let output;
       let scoreValidationOutput = null;
       if (parsed.ouroboros) {
@@ -274,6 +284,7 @@ export async function main(args) {
           inputPath: path,
           prompt,
           outputRef: { kind: 'file', name: outputName },
+          scores: manifestScoreDetails(result),
         });
         manifestOutputs.push({ name: outputName, content: output });
       }
@@ -881,6 +892,38 @@ backends opt-in (issue #88).
 `);
 }
 
+function withDeterministicScore(rawResult, { text, config, repoRoot, logger }) {
+  const deterministicScore = scoreDeterministicSignals({ text, config, repoRoot });
+  const llmOverall = extractScoreOverall(rawResult, rawResult);
+  const reconciliation = reconcileScoreOverall({
+    llmOverall,
+    deterministicScore,
+    config,
+    logger,
+  });
+  const overall = reconciliation.overall ?? llmOverall;
+  return {
+    raw: String(rawResult || '').trim(),
+    overall,
+    llmScore: {
+      overall: llmOverall,
+      interpretation: llmOverall === null ? null : interpretScore(llmOverall),
+    },
+    deterministicScore,
+    ...(reconciliation.scorePreference ? { scorePreference: reconciliation.scorePreference } : {}),
+  };
+}
+
+function manifestScoreDetails(result) {
+  if (!result || typeof result !== 'object') return null;
+  if (!result.llmScore && !result.deterministicScore && !result.scorePreference) return null;
+  return {
+    llm: result.llmScore ?? null,
+    deterministic: result.deterministicScore ?? null,
+    preference: result.scorePreference ?? null,
+  };
+}
+
 function applyScoreGate(result, output, gate, logger = createLogger()) {
   const overall = extractScoreOverall(result, output);
   if (overall === null) {
@@ -901,12 +944,16 @@ function extractScoreOverall(result, output) {
   const parsedOverall = toFiniteScore(parsed?.overall);
   if (parsedOverall !== null) return parsedOverall;
 
+  const table = text.match(/(?:^|\n)\|\s*(?:\*\*)?Overall(?:\*\*)?\s*\|[^|]*\|[^|]*\|[^|]*\|\s*(?:\*\*)?([0-9]+(?:\.[0-9]+)?)/i);
+  if (table) return Number(table[1]);
+
   const match = text.match(/(?:^|[\s|{,"])overall(?:["\s]*[:|]|\s+score\s*[:|]?)\s*(\d+(?:\.\d+)?)/i);
   if (!match) return null;
   return Number(match[1]);
 }
 
 function toFiniteScore(value) {
+  if (value === null || value === undefined || value === '') return null;
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
 }

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -52,12 +52,14 @@ export function buildManifest({
 
 // Add one input/output pair's hash + ref to the running results array.
 // Mutates the input array for convenience.
-export function appendResult(results, { inputPath, prompt, outputRef }) {
-  results.push({
+export function appendResult(results, { inputPath, prompt, outputRef, scores }) {
+  const entry = {
     input: inputPath,
     promptHash: hashSha256(prompt),
     output: outputRef,
-  });
+  };
+  if (scores) entry.scores = scores;
+  results.push(entry);
   return results;
 }
 

--- a/src/ouroboros.js
+++ b/src/ouroboros.js
@@ -73,6 +73,7 @@ export async function runOuroboros({
     fidelity: 100,
     profile: config.profile,
     config,
+    deterministicScore: initialScoreResult?.deterministicScore,
   });
 
   for (let iteration = 1; iteration <= maxIterations; iteration++) {
@@ -154,6 +155,7 @@ export async function runOuroboros({
       fidelity,
       profile: config.profile,
       config,
+      deterministicScore: scoreResult?.deterministicScore,
     });
     const combinedDelta = previousCombined - combined;
 

--- a/src/output.js
+++ b/src/output.js
@@ -229,11 +229,25 @@ function renderBody(result) {
     return result.trim();
   }
 
+  if (result && typeof result === 'object' && 'raw' in result) {
+    return String(result.raw).trim();
+  }
+
   if (result?.type === 'max-mode') {
     return formatMaxModeOutput(result);
   }
 
   return String(result).trim();
+}
+
+function extractScoreDetails(result) {
+  if (!result || typeof result !== 'object') return null;
+  if (!result.llmScore && !result.deterministicScore && !result.scorePreference) return null;
+  return {
+    llm: result.llmScore ?? null,
+    deterministic: result.deterministicScore ?? null,
+    preference: result.scorePreference ?? null,
+  };
 }
 
 function formatTextOutput(body, tone) {
@@ -264,6 +278,9 @@ function formatJsonOutput({ result, mode, body, tone, gate }) {
     gateResult: buildGateResult(overall, gate),
     output: body,
   };
+
+  const scoreDetails = extractScoreDetails(result);
+  if (scoreDetails) payload.scores = scoreDetails;
 
   if (result?.type === 'max-mode') {
     payload.max = {

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,5 +1,9 @@
 import { callLLM as defaultCallLLM } from './api.js';
+import { getRepoRoot } from './config.js';
+import { analyzeText } from './features/index.js';
 import { createLogger } from './logger.js';
+
+export const DEFAULT_DETERMINISTIC_DIVERGENCE_THRESHOLD = 20;
 
 class SchemaError extends Error {
   constructor(message, raw) {
@@ -88,6 +92,7 @@ export async function scoreText({
 }) {
   const lang = config.language || 'ko';
   const weights = config.ouroboros?.['category-weights']?.[lang] || {};
+  const deterministicScore = scoreDeterministicSignals({ text, config });
 
   const prompt = `You are an AI-likeness scoring engine. Score the following text for AI-writing patterns.
 
@@ -132,14 +137,148 @@ ${text}
       now,
       sleep,
     });
-    return parsed;
+    return withShadowScore(parsed, { deterministicScore, config, logger });
   } catch (e) {
     rethrowIfAborted(e, signal);
     logger.warn('score.text_schema_failure', {
       message: `[patina] scoreText schema failure after retry: ${e.message}`,
     });
-    return { overall: null, error: 'schema-failure', raw: e.raw };
+    return {
+      overall: null,
+      llmScore: { overall: null, interpretation: null, error: 'schema-failure' },
+      deterministicScore,
+      error: 'schema-failure',
+      raw: e.raw,
+    };
   }
+}
+
+export function scoreDeterministicSignals({
+  text,
+  config = {},
+  repoRoot = getRepoRoot(),
+  analyzer = analyzeText,
+} = {}) {
+  const options = deterministicScoringOptions(config);
+  if (!options.enabled) return null;
+
+  const lang = config.language || 'ko';
+  const enabledLanguages = config.stylometry?.languages;
+  if (Array.isArray(enabledLanguages) && !enabledLanguages.includes(lang)) {
+    return {
+      overall: null,
+      interpretation: null,
+      skipped: true,
+      skipReason: 'language-disabled',
+      paragraphCount: 0,
+      hotParagraphs: 0,
+      bands: emptyDeterministicBands(),
+    };
+  }
+
+  try {
+    const result = analyzer(String(text || ''), {
+      lang,
+      repoRoot,
+      burstinessBands: config.stylometry?.burstiness?.bands,
+      mattrBands: config.stylometry?.ttr?.bands,
+      mattrWindow: config.stylometry?.ttr?.window,
+      lexiconDensityThreshold: config.lexicon?.density_threshold,
+    });
+    const paragraphs = Array.isArray(result?.paragraphs) ? result.paragraphs : [];
+    const paragraphCount = paragraphs.length;
+    const hotParagraphs = paragraphs.filter((p) => p.hot).length;
+    const overall = paragraphCount > 0 ? roundScore((hotParagraphs / paragraphCount) * 100) : 0;
+
+    return {
+      overall,
+      interpretation: interpretScore(overall),
+      skipped: Boolean(result?.skipped),
+      skipReason: result?.skipReason ?? null,
+      paragraphCount,
+      hotParagraphs,
+      bands: {
+        burstiness: countBands(paragraphs.map((p) => p.burstiness?.band)),
+        mattr: countBands(paragraphs.map((p) => p.mattr?.band)),
+        lexicon: {
+          hot: paragraphs.filter((p) => p.lexicon?.hot).length,
+          threshold: config.lexicon?.density_threshold ?? null,
+        },
+      },
+    };
+  } catch (err) {
+    return {
+      overall: null,
+      interpretation: null,
+      skipped: true,
+      skipReason: 'deterministic-failure',
+      paragraphCount: 0,
+      hotParagraphs: 0,
+      bands: emptyDeterministicBands(),
+      error: err?.message || 'deterministic scoring failed',
+    };
+  }
+}
+
+export function withShadowScore(parsed, { deterministicScore, config = {}, logger } = {}) {
+  const llmOverall = toFiniteScore(parsed?.overall);
+  const llmScore = {
+    overall: llmOverall,
+    interpretation: parsed?.interpretation ?? (llmOverall === null ? null : interpretScore(llmOverall)),
+    categories: parsed?.categories ?? null,
+  };
+  const reconciliation = reconcileScoreOverall({
+    llmOverall,
+    deterministicScore,
+    config,
+    logger,
+  });
+  const overall = reconciliation.overall ?? llmOverall;
+  return {
+    ...parsed,
+    overall,
+    interpretation: overall === null
+      ? parsed?.interpretation ?? null
+      : interpretScore(overall),
+    llmScore,
+    deterministicScore,
+    ...(reconciliation.scorePreference ? { scorePreference: reconciliation.scorePreference } : {}),
+  };
+}
+
+export function reconcileScoreOverall({
+  llmOverall,
+  deterministicScore,
+  config = {},
+  logger,
+} = {}) {
+  const llm = toFiniteScore(llmOverall);
+  const deterministic = toFiniteScore(deterministicScore?.overall);
+  if (llm === null) return { overall: null, scorePreference: null };
+  if (deterministic === null) return { overall: llm, scorePreference: null };
+  if (deterministicScore?.skipped) return { overall: llm, scorePreference: null };
+
+  const threshold = deterministicScoringOptions(config).divergenceThreshold;
+  const delta = Math.abs(llm - deterministic);
+  if (delta <= threshold) return { overall: llm, scorePreference: null };
+
+  const overall = Math.max(llm, deterministic);
+  const selected = overall === deterministic ? 'deterministic' : 'llm';
+  const scorePreference = {
+    reason: 'deterministic-divergence',
+    selected,
+    threshold,
+    llmOverall: llm,
+    deterministicOverall: deterministic,
+    overall,
+  };
+  logger?.warn?.('score.deterministic_divergence', {
+    message: `[patina] deterministic score diverged from LLM score (${llm} vs ${deterministic}); using pessimistic ${overall}`,
+    llm_overall: llm,
+    deterministic_overall: deterministic,
+    selected,
+  });
+  return { overall, scorePreference };
 }
 
 export async function scoreMPS({
@@ -328,10 +467,65 @@ function rethrowIfAborted(err, signal) {
 
 // Combined score per core/scoring.md §13: AI-likeness × ai_weight + (100 - fidelity) × fidelity_weight.
 // Lower is better. Falls back to default weights if profile not configured.
-export function combinedScore({ aiLikeness, fidelity, profile, config }) {
+export function combinedScore({ aiLikeness, fidelity, profile, config, deterministicScore }) {
   const profileWeights = config?.ouroboros?.['combined-weights']?.[profile];
   const ai = profileWeights?.['ai-likeness'] ?? 0.6;
   const fid = profileWeights?.fidelity ?? 0.4;
+  const deterministicWeight = deterministicScoringOptions(config).combinedWeight;
+  const deterministic = toFiniteScore(deterministicScore?.overall ?? deterministicScore);
   const fidelityInverted = 100 - fidelity;
-  return Math.round((aiLikeness * ai + fidelityInverted * fid) * 10) / 10;
+  if (deterministicWeight > 0 && deterministic !== null) {
+    const totalWeight = ai + fid + deterministicWeight;
+    return roundScore(
+      (aiLikeness * ai + fidelityInverted * fid + deterministic * deterministicWeight) /
+        totalWeight
+    );
+  }
+  return roundScore(aiLikeness * ai + fidelityInverted * fid);
+}
+
+function deterministicScoringOptions(config = {}) {
+  const cfg = config.scoring?.deterministic || {};
+  const enabled = cfg.enabled !== false;
+  const divergenceThreshold = Math.max(0, positiveNumber(
+    cfg['divergence-threshold'] ?? cfg.divergenceThreshold,
+    DEFAULT_DETERMINISTIC_DIVERGENCE_THRESHOLD
+  ));
+  const combinedWeight = Math.max(0, positiveNumber(
+    cfg['combined-weight'] ?? cfg.combinedWeight,
+    0
+  ));
+  return { enabled, divergenceThreshold, combinedWeight };
+}
+
+function positiveNumber(value, fallback) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function countBands(values) {
+  const counts = { low: 0, mid: 0, high: 0, null: 0 };
+  for (const value of values) {
+    if (value === 'low' || value === 'mid' || value === 'high') counts[value]++;
+    else counts.null++;
+  }
+  return counts;
+}
+
+function emptyDeterministicBands() {
+  return {
+    burstiness: { low: 0, mid: 0, high: 0, null: 0 },
+    mattr: { low: 0, mid: 0, high: 0, null: 0 },
+    lexicon: { hot: 0, threshold: null },
+  };
+}
+
+function toFiniteScore(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function roundScore(value) {
+  return Math.round(value * 10) / 10;
 }

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -3,7 +3,9 @@ import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import { main } from '../../src/cli.js';
 import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../..');
@@ -305,6 +307,31 @@ describe('CLI End-to-End with Mock API', () => {
 
     assert.strictEqual(JSON.parse(logs.join('\n')).overall, 23);
     assert.ok(!errors.some((line) => line.includes('weight check')), errors.join('\n'));
+    await stopMockServer();
+    await startMockServer('This is the humanized result.');
+  });
+
+  it('should record LLM and deterministic scores in save-run manifests', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+    await stopMockServer();
+    await startMockServer('{ "overall": 23, "interpretation": "mostly human" }');
+
+    const outDir = mkdtempSync(join(tmpdir(), 'patina-save-run-'));
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+    await captureConsole(() => main([
+      '--lang', 'en',
+      '--score',
+      '--save-run', outDir,
+      '--api-key', 'test-key',
+      '--base-url', `http://127.0.0.1:${mockPort}`,
+      testFile,
+    ]));
+
+    const manifest = JSON.parse(readFileSync(resolve(outDir, 'manifest.json'), 'utf8'));
+    const scores = manifest.results[0].scores;
+    assert.strictEqual(scores.llm.overall, 23);
+    assert.equal(typeof scores.deterministic.overall, 'number');
     await stopMockServer();
     await startMockServer('This is the humanized result.');
   });

--- a/tests/unit/manifest.test.js
+++ b/tests/unit/manifest.test.js
@@ -81,11 +81,19 @@ test('appendResult records input + prompt hash + output ref', () => {
     inputPath: 'foo.md',
     prompt: 'PROMPT BODY',
     outputRef: { kind: 'file', name: 'output-1.txt' },
+    scores: {
+      llm: { overall: 23 },
+      deterministic: { overall: 40 },
+    },
   });
   assert.equal(results.length, 1);
   assert.equal(results[0].input, 'foo.md');
   assert.match(results[0].promptHash, /^sha256:[0-9a-f]{64}$/);
   assert.deepEqual(results[0].output, { kind: 'file', name: 'output-1.txt' });
+  assert.deepEqual(results[0].scores, {
+    llm: { overall: 23 },
+    deterministic: { overall: 40 },
+  });
 });
 
 test('writeManifest creates dir, writes manifest.json + outputs', () => {

--- a/tests/unit/scoring.test.js
+++ b/tests/unit/scoring.test.js
@@ -92,6 +92,20 @@ test('combinedScore uses default and profile-specific config weights', () => {
     combinedScore({ aiLikeness: 40, fidelity: 80, profile: 'marketing', config }),
     33
   );
+
+  assert.strictEqual(
+    combinedScore({
+      aiLikeness: 40,
+      fidelity: 80,
+      deterministicScore: { overall: 90 },
+      profile: 'legal',
+      config: {
+        ...config,
+        scoring: { deterministic: { 'combined-weight': 0.25 } },
+      },
+    }),
+    39.6
+  );
 });
 
 test('score helpers accept an injected callLLM implementation', async () => {
@@ -140,7 +154,30 @@ test('score helpers accept an injected callLLM implementation', async () => {
   });
 
   assert.strictEqual(score.overall, 22);
+  assert.strictEqual(score.llmScore.overall, 22);
+  assert.equal(typeof score.deterministicScore.overall, 'number');
   assert.strictEqual(mps.mps, 91);
   assert.strictEqual(fidelity.fidelity, 100);
   assert.strictEqual(seen.length, 3);
+});
+
+test('scoreText warns on deterministic divergence and keeps the pessimistic score', async () => {
+  const warnings = [];
+  const score = await scoreText({
+    text: [
+      'The tool is useful. The model is helpful. The system is reliable. The page is stable. The flow is simple.',
+      'The draft is useful. The note is helpful. The copy is reliable. The line is stable. The page is simple.',
+      'The output is useful. The result is helpful. The answer is reliable. The plan is stable. The text is simple.',
+    ].join('\n\n'),
+    config: loadConfig(),
+    patterns: [],
+    callLLM: async () => '{ "overall": 10, "interpretation": "human" }',
+    logger: { warn: (event, fields) => warnings.push({ event, ...fields }) },
+  });
+
+  assert.strictEqual(score.llmScore.overall, 10);
+  assert.strictEqual(score.deterministicScore.overall, 100);
+  assert.strictEqual(score.overall, 100);
+  assert.strictEqual(score.scorePreference.selected, 'deterministic');
+  assert.ok(warnings.some((entry) => entry.event === 'score.deterministic_divergence'));
 });

--- a/tests/unit/tone.test.js
+++ b/tests/unit/tone.test.js
@@ -179,14 +179,21 @@ test('formatOutput: text format omits YAML footer', () => {
 
 test('formatOutput: json format exposes score contract fields', () => {
   const tone = { tone: null, tone_source: 'profile_only', tone_evidence: [], tone_confidence: null };
-  const out = formatOutput('{ "overall": 18, "categories": { "style": { "score": 9 } } }', 'score', {
+  const out = formatOutput({
+    raw: '{ "overall": 18, "categories": { "style": { "score": 9 } } }',
+    overall: 21,
+    llmScore: { overall: 18 },
+    deterministicScore: { overall: 21, bands: { burstiness: { low: 1 } } },
+  }, 'score', {
     format: 'json',
     gate: 30,
   }, { tone });
   const parsed = JSON.parse(out);
-  assert.equal(parsed.overall, 18);
+  assert.equal(parsed.overall, 21);
   assert.equal(parsed.categories[0].name, 'style');
-  assert.deepEqual(parsed.gateResult, { threshold: 30, overall: 18, passed: true, exitCode: 0 });
+  assert.deepEqual(parsed.gateResult, { threshold: 30, overall: 21, passed: true, exitCode: 0 });
+  assert.equal(parsed.scores.llm.overall, 18);
+  assert.equal(parsed.scores.deterministic.overall, 21);
   assert.equal(parsed.tone.tone_source, 'profile_only');
 });
 


### PR DESCRIPTION
## Summary\n- wire src/features/* into scoreText and direct CLI --score runs as a deterministic shadow score\n- return llmScore and deterministicScore with band summaries\n- warn and prefer the more pessimistic score when LLM and deterministic scores diverge past the configured threshold\n- record score details in JSON output and save-run manifests\n- add config-gated deterministic component support to combinedScore, default off\n\nCloses #136\n\n## Verification\n- npm run lint:syntax\n- npm run lint:eslint\n- npm run typecheck\n- npm test\n- git diff --check