### PR TITLE
feat(observability): write manifest schema v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ In rewrite mode, the model emits its self-audit notes inside `[SELF_AUDIT]`/`[/S
 
 `--score` runs cross-check the Weight column the model emits against your config's `category-weights`. If the model invents a category (e.g., `discord`) or substitutes a different number, `[patina]` warnings hit stderr — observability only, the weight check itself doesn't alter the score. A deterministic shadow score from `src/features/*` is also recorded; when it differs from the LLM score by more than 20 points, patina warns and uses the more pessimistic value for gates.
 
+`--save-run <dir>` now writes manifest schema v2: result entries include prompt and response hashes, available input/output token counts, temperature/seed, score details, per-call cost when a provider returns it, and Ouroboros iteration logs.
+
 ## Tones
 
 `--tone` selects a named voice axis applied on top of pattern rewriting. Resolution order: `--tone` CLI > `tone:` config > `profile:` config.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -45,7 +45,7 @@ patina --lang en --score --exit-on 30 draft.md
 - Score JSON may include `scores.llm`, `scores.deterministic`, and `scores.preference` when deterministic shadow scoring is available.
 - `mps` is populated for MAX-mode results when available.
 - `gateResult` is `null` unless `--exit-on` / `--gate` is used.
-- `--save-run <dir>` writes `manifest.json` plus `output-N.txt` files for reproducible audit trails.
+- `--save-run <dir>` writes a schema-v2 `manifest.json` plus `output-N.txt` files for reproducible audit trails. Each result records prompt/response hashes, available token usage, temperature/seed, score details, per-call cost when providers return it, and the Ouroboros iteration log when used.
 - `patina doctor --json` emits setup diagnostics for CI without making an LLM call.
 
 ## Stderr logs

--- a/src/api.js
+++ b/src/api.js
@@ -4,6 +4,7 @@ const DEFAULT_TIMEOUT = 120000;
 const DEFAULT_MAX_RETRIES = 2;
 const DEFAULT_BASE_BACKOFF_MS = 1000;
 const DEFAULT_MAX_BACKOFF_MS = 30000;
+export const DEFAULT_TEMPERATURE = 0.7;
 
 // Status codes that warrant a retry. Network errors (no status, AbortError)
 // are also retryable; auth / validation 4xxs are not.
@@ -133,12 +134,14 @@ export async function callLLM({
   apiKey,
   baseURL = 'https://api.openai.com/v1',
   model = 'gpt-4o',
-  temperature = 0.7,
+  temperature = DEFAULT_TEMPERATURE,
+  seed,
   timeout = DEFAULT_TIMEOUT,
   maxRetries = DEFAULT_MAX_RETRIES,
   deadline,
   signal,
   allowInsecureBaseURL = false,
+  onResponse,
   // Allows tests to inject a deterministic delay function.
   sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
   now = () => Date.now(),
@@ -150,6 +153,7 @@ export async function callLLM({
     messages: [{ role: 'user', content: prompt }],
     temperature,
   };
+  if (seed !== undefined && seed !== null) body.seed = seed;
 
   let lastError;
   let attemptsMade = 0;
@@ -204,6 +208,17 @@ export async function callLLM({
         throw new Error('Empty response from LLM API');
       }
 
+      onResponse?.({
+        provider: 'openai-http',
+        model: data.model ?? model,
+        requestedModel: model,
+        temperature,
+        seed: seed ?? null,
+        usage: data.usage ?? null,
+        rawResponse: data,
+        content,
+      });
+
       return content;
     } catch (err) {
       lastError = err;
@@ -240,7 +255,8 @@ export async function callLLMMultiple({
   models,
   apiKey,
   baseURL = 'https://api.openai.com/v1',
-  temperature = 0.7,
+  temperature = DEFAULT_TEMPERATURE,
+  seed,
   timeout = DEFAULT_TIMEOUT,
   allowInsecureBaseURL = false,
   deadline,
@@ -248,6 +264,7 @@ export async function callLLMMultiple({
   maxConcurrency,
   onStart,
   onComplete,
+  onResponse,
   callLLM: callLLMImpl = callLLM,
   sleep,
   now = () => Date.now(),
@@ -268,10 +285,12 @@ export async function callLLMMultiple({
         baseURL,
         model,
         temperature,
+        seed,
         timeout,
         deadline,
         signal,
         allowInsecureBaseURL,
+        onResponse,
         sleep,
         now,
       });

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -15,8 +15,18 @@ const openaiHttp = {
   isAvailable: () => true,
   isAuthenticated: () => inspectHttpApiKeySource().ok,
   authHint: () => inspectHttpApiKeySource().detail,
-  invoke: ({ prompt, apiKey, baseURL, model, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS }) =>
-    callLLM({ prompt, apiKey, baseURL, model, signal, timeout }),
+  invoke: ({
+    prompt,
+    apiKey,
+    baseURL,
+    model,
+    signal,
+    timeout = DEFAULT_BACKEND_TIMEOUT_MS,
+    temperature,
+    seed,
+    onResponse,
+  }) =>
+    callLLM({ prompt, apiKey, baseURL, model, signal, timeout, temperature, seed, onResponse }),
 };
 
 const REGISTRY = {
@@ -101,6 +111,9 @@ export async function invokeBackendChain({
   model,
   signal,
   timeout = DEFAULT_BACKEND_TIMEOUT_MS,
+  temperature,
+  seed,
+  onResponse,
   logger,
 }) {
   if (!Array.isArray(backends) || backends.length === 0) {
@@ -115,7 +128,7 @@ export async function invokeBackendChain({
   for (let attemptIndex = 0; attemptIndex < backends.length; attemptIndex++) {
     const backend = backends[attemptIndex];
     try {
-      return await backend.invoke({ prompt, apiKey, baseURL, model, signal, timeout });
+      return await backend.invoke({ prompt, apiKey, baseURL, model, signal, timeout, temperature, seed, onResponse });
     } catch (err) {
       lastError = err;
       const next = backends[attemptIndex + 1];

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,7 +8,8 @@ import { formatOutput, validateScoreWeights } from './output.js';
 import { runMaxMode } from './max-mode.js';
 import { runOuroboros } from './ouroboros.js';
 import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals } from './scoring.js';
-import { buildManifest, appendResult, writeManifest } from './manifest.js';
+import { callLLM, DEFAULT_TEMPERATURE } from './api.js';
+import { buildManifest, appendResult, writeManifest, hashSha256 } from './manifest.js';
 import { runDoctor } from './commands/doctor.js';
 import { runInit } from './commands/init.js';
 import { PatinaCliError, inputError, runtimeError, renderCliError, getExitCode } from './errors.js';
@@ -97,6 +98,8 @@ export async function main(args) {
   const startedAt = new Date().toISOString();
   const manifestResults = [];
   const manifestOutputs = [];
+  const manifestTemperature = DEFAULT_TEMPERATURE;
+  const manifestSeed = null;
 
   const repoRoot = getRepoRoot();
   const lang = config.language || 'ko';
@@ -141,6 +144,17 @@ export async function main(args) {
   try {
     for (const { path, text } of inputTexts) {
       cancellation.throwIfCanceled();
+      const manifestCalls = [];
+      const recordManifestCall = parsed.saveRun ? createManifestCallRecorder(manifestCalls) : null;
+      const trackedCallLLM = parsed.saveRun
+        ? (args) => callLLM({
+          ...args,
+          onResponse: (metadata) => {
+            args.onResponse?.(metadata);
+            recordManifestCall(metadata);
+          },
+        })
+        : undefined;
       const prompt = buildPrompt({
         config,
         patterns,
@@ -170,6 +184,7 @@ export async function main(args) {
           patterns,
           maxConcurrency: parsed.maxConcurrency,
           wallClockBudgetMs: parsed.maxTimeoutSeconds === undefined ? undefined : parsed.maxTimeoutSeconds * 1000,
+          callLLM: trackedCallLLM,
           signal: cancellation.signal,
           logger,
         });
@@ -184,6 +199,7 @@ export async function main(args) {
           apiKey: resolved.apiKey,
           baseURL: resolved.baseURL,
           model: resolved.model,
+          callLLM: trackedCallLLM,
           signal: cancellation.signal,
           logger,
         });
@@ -232,6 +248,9 @@ export async function main(args) {
           baseURL: resolved.baseURL,
           model: resolved.model,
           signal: cancellation.signal,
+          temperature: manifestTemperature,
+          seed: manifestSeed,
+          onResponse: recordManifestCall,
           logger,
         });
       }
@@ -283,8 +302,16 @@ export async function main(args) {
         appendResult(manifestResults, {
           inputPath: path,
           prompt,
+          response: manifestResponseText(result, output),
           outputRef: { kind: 'file', name: outputName },
+          tokensIn: sumManifestCalls(manifestCalls, 'tokensIn'),
+          tokensOut: sumManifestCalls(manifestCalls, 'tokensOut'),
+          temperature: manifestTemperature,
+          seed: manifestSeed,
+          cost: sumManifestCallCost(manifestCalls),
           scores: manifestScoreDetails(result),
+          iterationLog: manifestIterationLog(result),
+          calls: manifestCalls.length > 0 ? manifestCalls : undefined,
         });
         manifestOutputs.push({ name: outputName, content: output });
       }
@@ -317,6 +344,8 @@ export async function main(args) {
       patterns,
       results: manifestResults,
       startedAt,
+      temperature: manifestTemperature,
+      seed: manifestSeed,
     });
     const manifestPath = writeManifest(
       resolve(process.cwd(), parsed.saveRun),
@@ -921,6 +950,92 @@ function manifestScoreDetails(result) {
     llm: result.llmScore ?? null,
     deterministic: result.deterministicScore ?? null,
     preference: result.scorePreference ?? null,
+  };
+}
+
+function createManifestCallRecorder(calls) {
+  return (metadata = {}) => {
+    calls.push({
+      provider: metadata.provider ?? null,
+      model: metadata.model ?? null,
+      requestedModel: metadata.requestedModel ?? null,
+      temperature: metadata.temperature ?? null,
+      seed: metadata.seed ?? null,
+      responseHash: hashSha256(metadata.content),
+      tokensIn: extractUsageToken(metadata.usage, ['prompt_tokens', 'input_tokens', 'tokens_in']),
+      tokensOut: extractUsageToken(metadata.usage, ['completion_tokens', 'output_tokens', 'tokens_out']),
+      cost: extractResponseCost(metadata.rawResponse),
+    });
+  };
+}
+
+function extractUsageToken(usage, keys) {
+  if (!usage || typeof usage !== 'object') return null;
+  for (const key of keys) {
+    const value = Number(usage[key]);
+    if (Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function extractResponseCost(rawResponse) {
+  const usage = rawResponse?.usage && typeof rawResponse.usage === 'object' ? rawResponse.usage : {};
+  const candidates = [
+    ['usage.cost_usd', usage.cost_usd, 'USD'],
+    ['usage.total_cost_usd', usage.total_cost_usd, 'USD'],
+    ['usage.cost', usage.cost, usage.currency],
+    ['usage.total_cost', usage.total_cost, usage.currency],
+    ['cost_usd', rawResponse?.cost_usd, 'USD'],
+    ['cost', rawResponse?.cost, rawResponse?.currency],
+  ];
+
+  for (const [source, value, currency] of candidates) {
+    const amount = Number(value);
+    if (Number.isFinite(amount)) {
+      return {
+        amount,
+        currency: currency || 'USD',
+        source,
+      };
+    }
+  }
+  return null;
+}
+
+function manifestResponseText(result, output) {
+  if (result?.type === 'max-mode') return result.best?.result ?? output;
+  if (typeof result?.finalText === 'string') return result.finalText;
+  if (typeof result?.raw === 'string') return result.raw;
+  if (typeof result === 'string') return result;
+  return output;
+}
+
+function manifestIterationLog(result) {
+  return Array.isArray(result?.log) ? result.log : null;
+}
+
+function sumManifestCalls(calls, key) {
+  const values = calls
+    .map((call) => call[key])
+    .filter((value) => value !== null && value !== undefined)
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value));
+  if (values.length === 0) return null;
+  return values.reduce((sum, value) => sum + value, 0);
+}
+
+function sumManifestCallCost(calls) {
+  const costs = calls
+    .map((call) => call.cost)
+    .filter((cost) => cost && Number.isFinite(Number(cost.amount)));
+  if (costs.length === 0) return null;
+
+  const currency = costs[0].currency || 'USD';
+  if (!costs.every((cost) => (cost.currency || 'USD') === currency)) return null;
+  return {
+    amount: costs.reduce((sum, cost) => sum + Number(cost.amount), 0),
+    currency,
+    source: 'sum',
   };
 }
 

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -4,10 +4,10 @@
 // callers and tooling can detect breaking shape changes.
 
 import { createHash } from 'node:crypto';
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-export const MANIFEST_SCHEMA_VERSION = '1';
+export const MANIFEST_SCHEMA_VERSION = '2';
 
 export function hashSha256(input) {
   if (input == null) return null;
@@ -31,6 +31,8 @@ export function buildManifest({
   results,
   startedAt,
   finishedAt = new Date().toISOString(),
+  temperature = null,
+  seed = null,
 }) {
   return {
     manifestVersion: MANIFEST_SCHEMA_VERSION,
@@ -43,6 +45,8 @@ export function buildManifest({
     provider: provider ?? null,
     backend: backend ?? null,
     model: model ?? null,
+    temperature,
+    seed,
     configPath: configPath ?? null,
     configHash: hashSha256(config),
     patterns: (patterns ?? []).map((p) => p.frontmatter?.pack || p.file),
@@ -52,15 +56,99 @@ export function buildManifest({
 
 // Add one input/output pair's hash + ref to the running results array.
 // Mutates the input array for convenience.
-export function appendResult(results, { inputPath, prompt, outputRef, scores }) {
+export function appendResult(
+  results,
+  {
+    inputPath,
+    prompt,
+    outputRef,
+    response,
+    tokensIn = null,
+    tokensOut = null,
+    temperature = null,
+    seed = null,
+    cost = null,
+    scores,
+    iterationLog,
+    calls,
+  }
+) {
   const entry = {
     input: inputPath,
     promptHash: hashSha256(prompt),
+    responseHash: hashSha256(response),
     output: outputRef,
+    tokensIn,
+    tokensOut,
+    temperature,
+    seed,
+    cost,
   };
   if (scores) entry.scores = scores;
+  if (iterationLog) entry.iterationLog = iterationLog;
+  if (calls) entry.calls = calls;
   results.push(entry);
   return results;
+}
+
+export function readManifest(path) {
+  return normalizeManifest(JSON.parse(readFileSync(path, 'utf8')));
+}
+
+export function normalizeManifest(manifest) {
+  if (!manifest || typeof manifest !== 'object') {
+    throw new Error('Manifest must be a JSON object');
+  }
+
+  const version = String(manifest.manifestVersion ?? '1');
+  if (version === MANIFEST_SCHEMA_VERSION) {
+    return {
+      ...manifest,
+      results: normalizeV2Results(manifest.results),
+    };
+  }
+
+  if (version === '1') {
+    return {
+      ...manifest,
+      manifestVersion: '1',
+      temperature: manifest.temperature ?? null,
+      seed: manifest.seed ?? null,
+      results: normalizeV1Results(manifest.results),
+    };
+  }
+
+  throw new Error(`Unsupported manifest schema version: ${version}`);
+}
+
+function normalizeV1Results(results) {
+  return (results ?? []).map((entry) => ({
+    input: entry.input ?? null,
+    promptHash: entry.promptHash ?? null,
+    responseHash: entry.responseHash ?? null,
+    output: entry.output ?? null,
+    tokensIn: entry.tokensIn ?? null,
+    tokensOut: entry.tokensOut ?? null,
+    temperature: entry.temperature ?? null,
+    seed: entry.seed ?? null,
+    cost: entry.cost ?? null,
+    ...(entry.scores ? { scores: entry.scores } : {}),
+    ...(entry.iterationLog ? { iterationLog: entry.iterationLog } : {}),
+    ...(entry.calls ? { calls: entry.calls } : {}),
+  }));
+}
+
+function normalizeV2Results(results) {
+  return (results ?? []).map((entry) => ({
+    ...entry,
+    responseHash: entry.responseHash ?? null,
+    tokensIn: entry.tokensIn ?? null,
+    tokensOut: entry.tokensOut ?? null,
+    temperature: entry.temperature ?? null,
+    seed: entry.seed ?? null,
+    cost: entry.cost ?? null,
+    calls: entry.calls ?? [],
+  }));
 }
 
 export function writeManifest(dir, manifest, outputs = []) {

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -16,7 +16,7 @@ let callCount = 0;
 let lastRequestBody = null;
 let lastAuthorization = null;
 
-function startMockServer(responseText, statusCode = 200) {
+function startMockServer(responseText, statusCode = 200, extraResponse = {}) {
   return new Promise((resolve) => {
     mockServer = createServer((req, res) => {
       callCount++;
@@ -28,6 +28,7 @@ function startMockServer(responseText, statusCode = 200) {
         res.writeHead(statusCode, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
           choices: [{ message: { content: responseText } }],
+          ...extraResponse,
         }));
       });
     });
@@ -315,7 +316,14 @@ describe('CLI End-to-End with Mock API', () => {
     callCount = 0;
     lastRequestBody = null;
     await stopMockServer();
-    await startMockServer('{ "overall": 23, "interpretation": "mostly human" }');
+    await startMockServer('{ "overall": 23, "interpretation": "mostly human" }', 200, {
+      model: 'mock-score-model',
+      usage: {
+        prompt_tokens: 321,
+        completion_tokens: 12,
+        cost_usd: 0.0042,
+      },
+    });
 
     const outDir = mkdtempSync(join(tmpdir(), 'patina-save-run-'));
     const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
@@ -329,9 +337,17 @@ describe('CLI End-to-End with Mock API', () => {
     ]));
 
     const manifest = JSON.parse(readFileSync(resolve(outDir, 'manifest.json'), 'utf8'));
+    assert.strictEqual(manifest.manifestVersion, '2');
     const scores = manifest.results[0].scores;
     assert.strictEqual(scores.llm.overall, 23);
     assert.equal(typeof scores.deterministic.overall, 'number');
+    assert.match(manifest.results[0].responseHash, /^sha256:[0-9a-f]{64}$/);
+    assert.strictEqual(manifest.results[0].tokensIn, 321);
+    assert.strictEqual(manifest.results[0].tokensOut, 12);
+    assert.strictEqual(manifest.results[0].temperature, 0.7);
+    assert.strictEqual(manifest.results[0].cost.amount, 0.0042);
+    assert.strictEqual(manifest.results[0].calls[0].model, 'mock-score-model');
+    assert.strictEqual(manifest.results[0].calls[0].tokensIn, 321);
     await stopMockServer();
     await startMockServer('This is the humanized result.');
   });

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -244,3 +244,51 @@ test('callLLM preserves final HTTP status for backend fallback classification', 
     globalThis.fetch = originalFetch;
   }
 });
+
+test('callLLM reports usage metadata without changing string return value', async () => {
+  const originalFetch = globalThis.fetch;
+  const seen = [];
+  let requestBody;
+  globalThis.fetch = async (_url, opts) => {
+    requestBody = JSON.parse(opts.body);
+    return {
+      ok: true,
+      json: async () => ({
+        model: 'served-model',
+        choices: [{ message: { content: 'hello' } }],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 3,
+          cost_usd: 0.001,
+        },
+      }),
+    };
+  };
+
+  try {
+    const content = await callLLM({
+      prompt: 'x',
+      apiKey: 'test',
+      model: 'requested-model',
+      temperature: 0.2,
+      seed: 42,
+      onResponse: (metadata) => seen.push(metadata),
+    });
+
+    assert.equal(content, 'hello');
+    assert.equal(requestBody.seed, 42);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].model, 'served-model');
+    assert.equal(seen[0].requestedModel, 'requested-model');
+    assert.equal(seen[0].temperature, 0.2);
+    assert.equal(seen[0].seed, 42);
+    assert.deepEqual(seen[0].usage, {
+      prompt_tokens: 10,
+      completion_tokens: 3,
+      cost_usd: 0.001,
+    });
+    assert.equal(seen[0].content, 'hello');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/unit/manifest.test.js
+++ b/tests/unit/manifest.test.js
@@ -8,6 +8,8 @@ import {
   hashSha256,
   buildManifest,
   appendResult,
+  normalizeManifest,
+  readManifest,
   writeManifest,
   MANIFEST_SCHEMA_VERSION,
 } from '../../src/manifest.js';
@@ -42,6 +44,8 @@ test('buildManifest captures core run metadata + schema version', () => {
     model: 'gpt-4o',
     configPath: '/tmp/config.yaml',
     config: { language: 'ko' },
+    temperature: 0.7,
+    seed: 123,
     patterns: [
       { file: 'ko-structure.md', frontmatter: { pack: 'ko-structure' }, body: '' },
       { file: 'ko-content.md', frontmatter: {}, body: '' },
@@ -55,6 +59,8 @@ test('buildManifest captures core run metadata + schema version', () => {
   assert.equal(m.mode, 'rewrite');
   assert.equal(m.lang, 'ko');
   assert.equal(m.provider, 'openai');
+  assert.equal(m.temperature, 0.7);
+  assert.equal(m.seed, 123);
   assert.deepEqual(m.patterns, ['ko-structure', 'ko-content.md']); // falls back to file when no pack
   assert.match(m.configHash, /^sha256:[0-9a-f]{64}$/);
   assert.deepEqual(m.results, []);
@@ -80,19 +86,63 @@ test('appendResult records input + prompt hash + output ref', () => {
   appendResult(results, {
     inputPath: 'foo.md',
     prompt: 'PROMPT BODY',
+    response: 'MODEL RESPONSE',
     outputRef: { kind: 'file', name: 'output-1.txt' },
+    tokensIn: 101,
+    tokensOut: 23,
+    temperature: 0.7,
+    seed: null,
+    cost: { amount: 0.0012, currency: 'USD', source: 'usage.cost_usd' },
     scores: {
       llm: { overall: 23 },
       deterministic: { overall: 40 },
     },
+    iterationLog: [{ iteration: 0, after: 23, reason: 'Initial' }],
+    calls: [{
+      provider: 'openai-http',
+      responseHash: hashSha256('MODEL RESPONSE'),
+      tokensIn: 101,
+      tokensOut: 23,
+      cost: { amount: 0.0012, currency: 'USD', source: 'usage.cost_usd' },
+    }],
   });
   assert.equal(results.length, 1);
   assert.equal(results[0].input, 'foo.md');
   assert.match(results[0].promptHash, /^sha256:[0-9a-f]{64}$/);
+  assert.match(results[0].responseHash, /^sha256:[0-9a-f]{64}$/);
   assert.deepEqual(results[0].output, { kind: 'file', name: 'output-1.txt' });
+  assert.equal(results[0].tokensIn, 101);
+  assert.equal(results[0].tokensOut, 23);
+  assert.equal(results[0].temperature, 0.7);
+  assert.equal(results[0].cost.amount, 0.0012);
   assert.deepEqual(results[0].scores, {
     llm: { overall: 23 },
     deterministic: { overall: 40 },
+  });
+  assert.deepEqual(results[0].iterationLog, [{ iteration: 0, after: 23, reason: 'Initial' }]);
+  assert.equal(results[0].calls.length, 1);
+});
+
+test('normalizeManifest reads v1 manifests with v2-safe defaults', () => {
+  const legacy = normalizeManifest({
+    manifestVersion: '1',
+    patina: '3.9.0',
+    results: [{ input: 'a.md', promptHash: 'sha256:abc', output: { kind: 'file', name: 'out.txt' } }],
+  });
+
+  assert.equal(legacy.manifestVersion, '1');
+  assert.equal(legacy.temperature, null);
+  assert.equal(legacy.seed, null);
+  assert.deepEqual(legacy.results[0], {
+    input: 'a.md',
+    promptHash: 'sha256:abc',
+    responseHash: null,
+    output: { kind: 'file', name: 'out.txt' },
+    tokensIn: null,
+    tokensOut: null,
+    temperature: null,
+    seed: null,
+    cost: null,
   });
 });
 
@@ -114,4 +164,5 @@ test('writeManifest creates dir, writes manifest.json + outputs', () => {
   const onDisk = JSON.parse(readFileSync(path, 'utf8'));
   assert.equal(onDisk.manifestVersion, MANIFEST_SCHEMA_VERSION);
   assert.equal(onDisk.results[0].output.name, 'out.txt');
+  assert.equal(readManifest(path).manifestVersion, MANIFEST_SCHEMA_VERSION);
 });


### PR DESCRIPTION
Closes #134.\n\n## Summary\n- bump manifest schema to v2 and add v1-compatible read/normalize helpers\n- record response hashes, token totals, temperature/seed, per-call cost metadata, and call details in save-run manifests\n- surface HTTP usage metadata via an optional callback while preserving string return behavior\n- include Ouroboros iteration logs in manifest result entries\n\n## Verification\n- npm run lint:eslint\n- npm run lint:syntax\n- npm run typecheck\n- npm test