### PR TITLE
feat(api): add opt-in prompt response cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ In rewrite mode, the model emits its self-audit notes inside `[SELF_AUDIT]`/`[/S
 
 `--save-run <dir>` now writes manifest schema v2: result entries include prompt and response hashes, available input/output token counts, temperature/seed, score details, per-call cost when a provider returns it, and Ouroboros iteration logs.
 
+For repeat benchmarks, opt into the HTTP response cache with `--cache <dir>` or `PATINA_CACHE_DIR`. Cache keys include prompt, model, temperature, and API host; `--cache-ttl <sec>` controls expiry and `--no-cache` bypasses it for fresh runs. Patina prints hit/miss/write stats at the end of cached runs.
+
 ## Tones
 
 `--tone` selects a named voice axis applied on top of pattern rewriting. Resolution order: `--tone` CLI > `tone:` config > `profile:` config.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -46,6 +46,7 @@ patina --lang en --score --exit-on 30 draft.md
 - `mps` is populated for MAX-mode results when available.
 - `gateResult` is `null` unless `--exit-on` / `--gate` is used.
 - `--save-run <dir>` writes a schema-v2 `manifest.json` plus `output-N.txt` files for reproducible audit trails. Each result records prompt/response hashes, available token usage, temperature/seed, score details, per-call cost when providers return it, and the Ouroboros iteration log when used.
+- `--cache <dir>` or `PATINA_CACHE_DIR` enables an opt-in persistent HTTP response cache keyed by prompt, model, temperature, and API host. `--cache-ttl <sec>` / `PATINA_CACHE_TTL_SECONDS` set expiry, and `--no-cache` forces a fresh run.
 - `patina doctor --json` emits setup diagnostics for CI without making an LLM call.
 
 ## Stderr logs

--- a/src/api.js
+++ b/src/api.js
@@ -142,6 +142,7 @@ export async function callLLM({
   signal,
   allowInsecureBaseURL = false,
   onResponse,
+  cache,
   // Allows tests to inject a deterministic delay function.
   sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
   now = () => Date.now(),
@@ -154,6 +155,22 @@ export async function callLLM({
     temperature,
   };
   if (seed !== undefined && seed !== null) body.seed = seed;
+
+  const cached = cache?.get?.({ prompt, model, temperature, baseURL });
+  if (cached) {
+    onResponse?.({
+      provider: 'cache',
+      model: cached.responseModel ?? cached.model ?? model,
+      requestedModel: model,
+      temperature,
+      seed: seed ?? null,
+      usage: cached.usage ?? null,
+      rawResponse: null,
+      content: cached.content,
+      cache: { hit: true, key: cached.key, path: cached.path },
+    });
+    return cached.content;
+  }
 
   let lastError;
   let attemptsMade = 0;
@@ -208,7 +225,7 @@ export async function callLLM({
         throw new Error('Empty response from LLM API');
       }
 
-      onResponse?.({
+      const metadata = {
         provider: 'openai-http',
         model: data.model ?? model,
         requestedModel: model,
@@ -217,7 +234,10 @@ export async function callLLM({
         usage: data.usage ?? null,
         rawResponse: data,
         content,
-      });
+        cache: cache ? { hit: false } : null,
+      };
+      cache?.set?.({ prompt, model, temperature, baseURL }, content, metadata);
+      onResponse?.(metadata);
 
       return content;
     } catch (err) {
@@ -265,6 +285,7 @@ export async function callLLMMultiple({
   onStart,
   onComplete,
   onResponse,
+  cache,
   callLLM: callLLMImpl = callLLM,
   sleep,
   now = () => Date.now(),
@@ -291,6 +312,7 @@ export async function callLLMMultiple({
         signal,
         allowInsecureBaseURL,
         onResponse,
+        cache,
         sleep,
         now,
       });

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -25,8 +25,9 @@ const openaiHttp = {
     temperature,
     seed,
     onResponse,
+    cache,
   }) =>
-    callLLM({ prompt, apiKey, baseURL, model, signal, timeout, temperature, seed, onResponse }),
+    callLLM({ prompt, apiKey, baseURL, model, signal, timeout, temperature, seed, onResponse, cache }),
 };
 
 const REGISTRY = {
@@ -114,6 +115,7 @@ export async function invokeBackendChain({
   temperature,
   seed,
   onResponse,
+  cache,
   logger,
 }) {
   if (!Array.isArray(backends) || backends.length === 0) {
@@ -128,7 +130,7 @@ export async function invokeBackendChain({
   for (let attemptIndex = 0; attemptIndex < backends.length; attemptIndex++) {
     const backend = backends[attemptIndex];
     try {
-      return await backend.invoke({ prompt, apiKey, baseURL, model, signal, timeout, temperature, seed, onResponse });
+      return await backend.invoke({ prompt, apiKey, baseURL, model, signal, timeout, temperature, seed, onResponse, cache });
     } catch (err) {
       lastError = err;
       const next = backends[attemptIndex + 1];

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,106 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export const CACHE_SCHEMA_VERSION = 1;
+export const DEFAULT_CACHE_TTL_SECONDS = 24 * 60 * 60;
+
+export function createResponseCache({
+  dir,
+  ttlSeconds = DEFAULT_CACHE_TTL_SECONDS,
+  now = () => Date.now(),
+} = {}) {
+  if (!dir) return null;
+  const stats = {
+    hits: 0,
+    misses: 0,
+    writes: 0,
+    expired: 0,
+    errors: 0,
+  };
+
+  return {
+    dir,
+    ttlSeconds,
+    stats,
+    get(args) {
+      const key = responseCacheKey(args);
+      const path = responseCachePath(dir, key);
+      try {
+        const entry = JSON.parse(readFileSync(path, 'utf8'));
+        const expiresAt = Date.parse(entry.expiresAt || '');
+        if (Number.isFinite(expiresAt) && expiresAt <= now()) {
+          stats.misses++;
+          stats.expired++;
+          return null;
+        }
+        if (typeof entry.response !== 'string') {
+          stats.misses++;
+          return null;
+        }
+        stats.hits++;
+        return {
+          ...entry,
+          key,
+          path,
+          content: entry.response,
+        };
+      } catch (err) {
+        if (err?.code !== 'ENOENT') stats.errors++;
+        stats.misses++;
+        return null;
+      }
+    },
+    set(args, response, metadata = {}) {
+      const key = responseCacheKey(args);
+      const path = responseCachePath(dir, key);
+      const createdAt = new Date(now()).toISOString();
+      const expiresAt = new Date(now() + ttlSeconds * 1000).toISOString();
+      const entry = {
+        cacheVersion: CACHE_SCHEMA_VERSION,
+        key,
+        createdAt,
+        expiresAt,
+        baseURLHost: baseURLHost(args.baseURL),
+        model: args.model ?? null,
+        temperature: args.temperature ?? null,
+        response,
+        usage: metadata.usage ?? null,
+        responseModel: metadata.model ?? null,
+      };
+
+      try {
+        mkdirSync(dir, { recursive: true });
+        const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
+        writeFileSync(tmp, JSON.stringify(entry, null, 2) + '\n');
+        renameSync(tmp, path);
+        stats.writes++;
+      } catch {
+        stats.errors++;
+      }
+      return { key, path };
+    },
+  };
+}
+
+export function responseCacheKey({ prompt, model, temperature, baseURL } = {}) {
+  const input = [
+    String(prompt ?? ''),
+    String(model ?? ''),
+    String(temperature ?? ''),
+    baseURLHost(baseURL),
+  ].join('\0');
+  return `sha256:${createHash('sha256').update(input).digest('hex')}`;
+}
+
+export function responseCachePath(dir, key) {
+  return resolve(dir, `${String(key).replace(/^sha256:/, '')}.json`);
+}
+
+export function baseURLHost(baseURL) {
+  try {
+    return new URL(baseURL || 'https://api.openai.com/v1').host;
+  } catch {
+    return String(baseURL || '');
+  }
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,6 +9,7 @@ import { runMaxMode } from './max-mode.js';
 import { runOuroboros } from './ouroboros.js';
 import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals } from './scoring.js';
 import { callLLM, DEFAULT_TEMPERATURE } from './api.js';
+import { createResponseCache, DEFAULT_CACHE_TTL_SECONDS } from './cache.js';
 import { buildManifest, appendResult, writeManifest, hashSha256 } from './manifest.js';
 import { runDoctor } from './commands/doctor.js';
 import { runInit } from './commands/init.js';
@@ -100,6 +101,7 @@ export async function main(args) {
   const manifestOutputs = [];
   const manifestTemperature = DEFAULT_TEMPERATURE;
   const manifestSeed = null;
+  const responseCache = resolveResponseCache(parsed);
 
   const repoRoot = getRepoRoot();
   const lang = config.language || 'ko';
@@ -146,12 +148,13 @@ export async function main(args) {
       cancellation.throwIfCanceled();
       const manifestCalls = [];
       const recordManifestCall = parsed.saveRun ? createManifestCallRecorder(manifestCalls) : null;
-      const trackedCallLLM = parsed.saveRun
+      const trackedCallLLM = (parsed.saveRun || responseCache)
         ? (args) => callLLM({
           ...args,
+          cache: responseCache,
           onResponse: (metadata) => {
             args.onResponse?.(metadata);
-            recordManifestCall(metadata);
+            recordManifestCall?.(metadata);
           },
         })
         : undefined;
@@ -251,6 +254,7 @@ export async function main(args) {
           temperature: manifestTemperature,
           seed: manifestSeed,
           onResponse: recordManifestCall,
+          cache: responseCache,
           logger,
         });
       }
@@ -321,6 +325,10 @@ export async function main(args) {
       } else {
         console.log(output);
       }
+    }
+
+    if (responseCache) {
+      logger.info('cache.stats', { message: formatCacheStats(responseCache.stats) });
     }
   } catch (err) {
     if (cancellation.signal.aborted) throw cancellationError();
@@ -561,6 +569,27 @@ function parseArgs(args) {
       case '--save-run':
         parsed.saveRun = readOptionValue(args, i, arg);
         i++;
+        break;
+      case '--cache':
+        parsed.cacheDir = readOptionValue(args, i, arg);
+        i++;
+        break;
+      case '--cache-ttl': {
+        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
+        i++;
+        const n = Number(value);
+        if (!Number.isFinite(n) || n <= 0) {
+          throw inputError(
+            '--cache-ttl expects a positive number of seconds',
+            `Received ${value === undefined ? 'no value' : `"${value}"`}.`,
+            'Use `--cache-ttl 86400` for a one-day response cache.'
+          );
+        }
+        parsed.cacheTtlSeconds = n;
+        break;
+      }
+      case '--no-cache':
+        parsed.noCache = true;
         break;
       case '--prompt-mode': {
         const m = readOptionValue(args, i, arg);
@@ -866,6 +895,9 @@ OUTPUT & BATCH
   --suffix <ext>          Save as {name}{ext}{extname}
   --outdir <dir>          Save results to directory
   --save-run <dir>        Write manifest.json + output-N.txt for reproducibility
+  --cache <dir>           Opt into persistent HTTP response cache
+  --cache-ttl <sec>       Cache TTL in seconds (default: ${DEFAULT_CACHE_TTL_SECONDS})
+  --no-cache              Bypass PATINA_CACHE_DIR / --cache for a fresh run
   --no-interactive        Do not wait for TTY stdin; exit 2 when no input is given
 
 LANGUAGE & PROFILE
@@ -910,6 +942,7 @@ EXAMPLES
 
 ENVIRONMENT
   PATINA_API_KEY, PATINA_API_KEY_FILE, PATINA_API_BASE, PATINA_MODEL
+  PATINA_CACHE_DIR, PATINA_CACHE_TTL_SECONDS
   OPENAI_API_KEY, GEMINI_API_KEY, GROQ_API_KEY, TOGETHER_API_KEY
 
 EXIT CODES
@@ -953,6 +986,41 @@ function manifestScoreDetails(result) {
   };
 }
 
+function resolveResponseCache(parsed) {
+  if (parsed.noCache) return null;
+  const dir = parsed.cacheDir ?? process.env.PATINA_CACHE_DIR;
+  if (!dir) return null;
+
+  const ttlSeconds =
+    parsed.cacheTtlSeconds ??
+    parseOptionalPositiveNumber(process.env.PATINA_CACHE_TTL_SECONDS, 'PATINA_CACHE_TTL_SECONDS') ??
+    DEFAULT_CACHE_TTL_SECONDS;
+
+  return createResponseCache({
+    dir: resolve(process.cwd(), dir),
+    ttlSeconds,
+  });
+}
+
+function parseOptionalPositiveNumber(value, name) {
+  if (value === undefined || value === null || value === '') return null;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw inputError(
+      `${name} expects a positive number of seconds`,
+      `Received "${value}".`,
+      `Set ${name}=86400 or omit it for the default.`
+    );
+  }
+  return n;
+}
+
+function formatCacheStats(stats) {
+  const expired = stats.expired ? `, expired ${stats.expired}` : '';
+  const errors = stats.errors ? `, errors ${stats.errors}` : '';
+  return `[patina] cache hits ${stats.hits}, misses ${stats.misses}, writes ${stats.writes}${expired}${errors}`;
+}
+
 function createManifestCallRecorder(calls) {
   return (metadata = {}) => {
     calls.push({
@@ -964,7 +1032,8 @@ function createManifestCallRecorder(calls) {
       responseHash: hashSha256(metadata.content),
       tokensIn: extractUsageToken(metadata.usage, ['prompt_tokens', 'input_tokens', 'tokens_in']),
       tokensOut: extractUsageToken(metadata.usage, ['completion_tokens', 'output_tokens', 'tokens_out']),
-      cost: extractResponseCost(metadata.rawResponse),
+      cost: extractResponseCost(metadata.rawResponse, metadata.usage),
+      cache: metadata.cache ?? null,
     });
   };
 }
@@ -978,8 +1047,10 @@ function extractUsageToken(usage, keys) {
   return null;
 }
 
-function extractResponseCost(rawResponse) {
-  const usage = rawResponse?.usage && typeof rawResponse.usage === 'object' ? rawResponse.usage : {};
+function extractResponseCost(rawResponse, fallbackUsage) {
+  const usage = rawResponse?.usage && typeof rawResponse.usage === 'object'
+    ? rawResponse.usage
+    : (fallbackUsage && typeof fallbackUsage === 'object' ? fallbackUsage : {});
   const candidates = [
     ['usage.cost_usd', usage.cost_usd, 'USD'],
     ['usage.total_cost_usd', usage.total_cost_usd, 'USD'],

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -352,6 +352,66 @@ describe('CLI End-to-End with Mock API', () => {
     await startMockServer('This is the humanized result.');
   });
 
+  it('uses --cache for repeated prompt/model/temperature calls and reports stats', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+    await stopMockServer();
+    await startMockServer('Cached humanized result.');
+
+    const cacheDir = mkdtempSync(join(tmpdir(), 'patina-response-cache-'));
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+    const args = [
+      '--lang', 'en',
+      '--cache', cacheDir,
+      '--cache-ttl', '3600',
+      '--api-key', 'test-key',
+      '--base-url', `http://127.0.0.1:${mockPort}`,
+      testFile,
+    ];
+
+    const first = await captureConsole(() => main(args));
+    const second = await captureConsole(() => main(args));
+
+    assert.strictEqual(callCount, 1, 'second identical run should use cache');
+    assert.match(first.errors.join('\n'), /cache hits 0, misses 1, writes 1/);
+    assert.match(second.errors.join('\n'), /cache hits 1, misses 0, writes 0/);
+    assert.match(second.logs.join('\n'), /Cached humanized result\./);
+
+    await stopMockServer();
+    await startMockServer('This is the humanized result.');
+  });
+
+  it('uses PATINA_CACHE_DIR and lets --no-cache bypass it', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+    await stopMockServer();
+    await startMockServer('Env cached result.');
+
+    const cacheDir = mkdtempSync(join(tmpdir(), 'patina-env-cache-'));
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+    await withEnv({ PATINA_CACHE_DIR: cacheDir, PATINA_CACHE_TTL_SECONDS: '3600' }, async () => {
+      await captureConsole(() => main([
+        '--lang', 'en',
+        '--api-key', 'test-key',
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        testFile,
+      ]));
+      const bypass = await captureConsole(() => main([
+        '--lang', 'en',
+        '--no-cache',
+        '--api-key', 'test-key',
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        testFile,
+      ]));
+
+      assert.strictEqual(callCount, 2, '--no-cache should force a fresh HTTP call');
+      assert.ok(!bypass.errors.some((line) => line.includes('cache hits')), bypass.errors.join('\n'));
+    });
+
+    await stopMockServer();
+    await startMockServer('This is the humanized result.');
+  });
+
   it('should suppress stderr status and warnings with --quiet', async () => {
     callCount = 0;
     lastRequestBody = null;

--- a/tests/unit/cache.test.js
+++ b/tests/unit/cache.test.js
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+import {
+  baseURLHost,
+  createResponseCache,
+  responseCacheKey,
+} from '../../src/cache.js';
+
+test('responseCacheKey includes prompt, model, temperature, and base URL host', () => {
+  const base = responseCacheKey({
+    prompt: 'prompt',
+    model: 'gpt-4o',
+    temperature: 0.7,
+    baseURL: 'https://api.example.com/v1',
+  });
+
+  assert.match(base, /^sha256:[0-9a-f]{64}$/);
+  assert.equal(base, responseCacheKey({
+    prompt: 'prompt',
+    model: 'gpt-4o',
+    temperature: 0.7,
+    baseURL: 'https://api.example.com/other',
+  }));
+  assert.notEqual(base, responseCacheKey({
+    prompt: 'prompt',
+    model: 'gpt-4o',
+    temperature: 0,
+    baseURL: 'https://api.example.com/v1',
+  }));
+});
+
+test('baseURLHost preserves host and port for cache partitioning', () => {
+  assert.equal(baseURLHost('http://127.0.0.1:1234/v1'), '127.0.0.1:1234');
+});
+
+test('createResponseCache stores hits and expires entries by TTL', () => {
+  const dir = mkdtempSync(resolve(tmpdir(), 'patina-cache-'));
+  let currentTime = 1_700_000_000_000;
+  const cache = createResponseCache({
+    dir,
+    ttlSeconds: 1,
+    now: () => currentTime,
+  });
+  const args = {
+    prompt: 'prompt',
+    model: 'gpt-4o',
+    temperature: 0.7,
+    baseURL: 'https://api.example.com/v1',
+  };
+
+  assert.equal(cache.get(args), null);
+  cache.set(args, 'cached response', {
+    model: 'served-model',
+    usage: { prompt_tokens: 3, completion_tokens: 2 },
+  });
+
+  const hit = cache.get(args);
+  assert.equal(hit.content, 'cached response');
+  assert.equal(hit.responseModel, 'served-model');
+  assert.deepEqual(hit.usage, { prompt_tokens: 3, completion_tokens: 2 });
+
+  currentTime += 1001;
+  assert.equal(cache.get(args), null);
+  assert.deepEqual(cache.stats, {
+    hits: 1,
+    misses: 2,
+    writes: 1,
+    expired: 1,
+    errors: 0,
+  });
+});


### PR DESCRIPTION
Closes #135.\n\n## Summary\n- add persistent HTTP response cache keyed by prompt, model, temperature, and API host\n- wire --cache, PATINA_CACHE_DIR, --cache-ttl / PATINA_CACHE_TTL_SECONDS, and --no-cache\n- print cache hit/miss/write stats at the end of cached runs\n- keep callLLM returning strings while exposing cache metadata to save-run manifests\n\n## Verification\n- npm run lint:syntax\n- npm run lint:eslint\n- npm run typecheck\n- npm test