### PR TITLE
profiles: add zh ja override parity

### DIFF
--- a/profiles/blog.md
+++ b/profiles/blog.md
@@ -23,6 +23,18 @@ pattern-overrides:
     17: reduce                  # Emojis — occasional use tolerated in personal blogs
     7: amplify                  # AI vocabulary words — especially jarring in casual blog prose
     8: amplify                  # Copula avoidance — blog prose should use simple "is", not "serves as"
+  zh:
+    14: suppress                # 加粗 — 博客常用于提高可读性，不默认纠正
+    15: reduce                  # 内联标题 — 博客小节可部分保留
+    17: reduce                  # 表情符号 — 个人博客中少量使用可接受
+    18: amplify                 # 书面/公文体 — 博客里特别生硬，积极纠正
+    7: amplify                  # AI高频词 — 个人语气中“赋能/生态”更刺眼
+  ja:
+    14: suppress                # 太字 — ブログでは読みやすさのために使われるため既定では直さない
+    15: reduce                  # インラインヘッダー — ブログの小見出しとして一部許容
+    17: reduce                  # 絵文字 — 個人ブログでの少量使用は許容
+    18: amplify                 # 硬質文体 — ブログでは不自然なので積極的に直す
+    7: amplify                  # AI語彙 — 個人文では特に浮くため強めに検出
 ---
 
 # 블로그/에세이 프로필

--- a/profiles/casual-conversation.md
+++ b/profiles/casual-conversation.md
@@ -22,6 +22,17 @@ pattern-overrides:
     8: amplify                  # Copula avoidance
     7: amplify                  # AI vocabulary
     14: suppress                # Boldface
+  zh:
+    7: amplify                  # AI高频词 — 亲密对话里“赋能/生态”特别不像人话
+    18: amplify                 # 书面/公文体 — 朋友语气中应换成口语
+    14: suppress                # 加粗 — 聊天/SNS语气中不作为AI痕迹处理
+    19: reduce                  # 聊天机器人痕迹 — 亲切服务语可少量保留
+  ja:
+    7: amplify                  # AI語彙 — 親しい会話では特に不自然
+    18: amplify                 # 硬質文体 — 友人向けなら口語へ寄せる
+    16: amplify                 # 過剰敬語 — 親密な会話では距離が出るため強めに直す
+    14: suppress                # 太字 — 会話調ではAI判定の主因にしない
+    19: reduce                  # チャットボット痕跡 — 親切な一言は一部許容
 ---
 
 # 친한 대화체 프로필 (`casual-conversation`)

--- a/profiles/formal.md
+++ b/profiles/formal.md
@@ -22,6 +22,18 @@ pattern-overrides:
     15: reduce                 # Inline-header lists — bold labels are standard in resumes
     14: reduce                 # Boldface — job titles, company names in bold is convention
     16: suppress               # Title Case — formal document headings conventionally use title case
+  zh:
+    25: suppress               # 结构性重复 — 简历/报告条目可有统一结构
+    15: reduce                 # 内联标题 — “职责/成果”标签是正式文档惯例
+    14: reduce                 # 加粗 — 职位/公司名加粗可接受
+    18: reduce                 # 书面/公文体 — 正式文档允许适度正式
+    8: reduce                  # 四字格 — 正式文档中少量四字格可接受
+  ja:
+    25: suppress               # 構造的繰り返し — 職務経歴や提案書では統一構造が自然
+    15: reduce                 # インラインヘッダー — 役割/成果ラベルは正式文書の慣例
+    14: reduce                 # 太字 — 役職名・会社名の強調は許容
+    18: reduce                 # 硬質文体 — 正式文書では適度な硬さを許容
+    8: reduce                  # 〜的 — 正式文書では一部許容
 ---
 
 # 정형 문서 프로필

--- a/profiles/instructional.md
+++ b/profiles/instructional.md
@@ -23,6 +23,18 @@ pattern-overrides:
     28: suppress               # Over-qualifying — clarity requires commitment
     15: allow                  # Inline-header lists — useful for step delineation
     14: reduce                 # Boldface — allow for key terms/commands, correct overuse
+  zh:
+    25: allow                  # 结构/编号 — 教程需要清晰步骤，编号结构必须保留
+    22: reduce                 # 填充表达 — 指令文里减少铺垫和寒暄
+    23: amplify                # 过度弱化 — 步骤说明需要明确，不要层层对冲
+    15: allow                  # 内联标题 — 可用于步骤/参数分区
+    14: reduce                 # 加粗 — 命令、文件名、关键提醒可加粗，滥用才纠正
+  ja:
+    25: allow                  # 構造/番号 — 手順説明では番号構造が必要
+    22: reduce                 # フィラー — 手順では前置きや緩衝表現を減らす
+    23: amplify                # 過剰ヘッジ — 手順は明確さを優先する
+    15: allow                  # インラインヘッダー — 手順やパラメータ整理に有用
+    14: reduce                 # 太字 — コマンド/ファイル名/注意点の強調は許容
 ---
 
 # 인스트럭셔널/하우투 프로필

--- a/profiles/narrative.md
+++ b/profiles/narrative.md
@@ -24,6 +24,18 @@ pattern-overrides:
     14: suppress               # Boldface — unnecessary in essay prose
     15: suppress               # Inline-header lists — breaks narrative continuity
     25: suppress               # Numbered structure — not appropriate for essays
+  zh:
+    26: reduce                 # 翻译腔 — 叙事里可保留少量口语化/外来节奏
+    13: reduce                 # 连接词 — 叙事推进中少量“后来/然后”可自然存在
+    14: suppress               # 加粗 — 叙事散文里强调标记通常不需要
+    15: suppress               # 内联标题 — 会打断叙事连续性
+    25: suppress               # 结构性重复 — 编号/模板段落不适合个人叙事
+  ja:
+    26: reduce                 # 翻訳調 — 語りの中では少量の会話調を許容
+    13: reduce                 # 接続表現 — 時間の流れを示す接続は一部許容
+    14: suppress               # 太字 — エッセイ本文では不要
+    15: suppress               # インラインヘッダー — 物語の流れを切る
+    25: suppress               # 構造的繰り返し — 番号/テンプレ段落は個人叙事に不向き
 ---
 
 # 내러티브/에세이 프로필

--- a/tests/e2e/cli.test.js
+++ b/tests/e2e/cli.test.js
@@ -80,12 +80,45 @@ describe('Pattern Loading', () => {
 });
 
 describe('Profile Loading', () => {
-  it('should load all 10 profiles', () => {
-    const names = ['default', 'blog', 'academic', 'technical', 'social', 'email', 'formal', 'legal', 'medical', 'marketing'];
+  it('should load all checked-in profiles', () => {
+    const names = [
+      'default',
+      'blog',
+      'academic',
+      'technical',
+      'social',
+      'email',
+      'formal',
+      'legal',
+      'medical',
+      'marketing',
+      'casual-conversation',
+      'instructional',
+      'narrative',
+    ];
     for (const name of names) {
       const profile = loadProfile(REPO_ROOT, name);
       assert.ok(profile, `Profile ${name} should load`);
       assert.ok(profile.frontmatter || profile.body, `Profile ${name} should have content`);
+    }
+  });
+
+  it('should provide zh/ja pattern overrides for multilingual profile parity', () => {
+    const names = ['blog', 'casual-conversation', 'formal', 'instructional', 'narrative'];
+    const documentedValues = new Set(['suppress', 'reduce', 'amplify']);
+    for (const name of names) {
+      const profile = loadProfile(REPO_ROOT, name);
+      const overrides = profile.frontmatter?.['pattern-overrides'];
+      assert.ok(overrides, `Profile ${name} should define pattern-overrides`);
+      for (const lang of ['zh', 'ja']) {
+        assert.ok(overrides[lang], `Profile ${name} should define ${lang} overrides`);
+        const values = Object.values(overrides[lang]);
+        assert.ok(values.length > 0, `Profile ${name} ${lang} overrides should not be empty`);
+        assert.ok(
+          values.some((value) => documentedValues.has(value)),
+          `Profile ${name} ${lang} should document suppress/reduce/amplify behavior`
+        );
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary
- add `zh:` and `ja:` pattern-overrides to blog, casual-conversation, formal, instructional, and narrative profiles
- document each override choice inline with suppress/reduce/amplify rationale
- extend profile-loading coverage so all 13 checked-in profiles load and target profiles keep zh/ja parity

## Spot-test
- blog/ko prompt-builder check: included `ko-language` and 5 ko blog overrides
- blog/ja prompt-builder check: included `ja-language` and 5 ja blog overrides

## Verification
- npm run lint:syntax
- npm run lint:eslint
- npm run typecheck
- npm test
- npm run spellcheck
- git diff --check

Closes #149
