### PR TITLE
patterns: add overlap audit matrix

### DIFF
--- a/patterns/en-language.md
+++ b/patterns/en-language.md
@@ -4,6 +4,19 @@ language: en
 name: Language Patterns
 version: 1.0.0
 patterns: 7
+dedupe-with:
+  - source: "en-language:7"
+    target: "en-filler:24"
+    owner: "en-filler:24"
+    reason: "The phrase 'stands as a testament' belongs to filler #24; language #7 keeps 'testament' only as one word in a broader AI-vocabulary cluster."
+  - source: "en-language:7"
+    target: "en-language:8"
+    owner: "en-language:8"
+    reason: "When 'testament' appears inside a copula-avoidance construction, pattern #8 owns the rewrite; pattern #7 only fires on a broader AI-vocabulary cluster."
+  - source: "en-language:8"
+    target: "en-filler:24"
+    owner: "en-filler:24"
+    reason: "The exact phrase 'stands as a testament' is a generic positive-conclusion marker when used as vague praise; pattern #8 still owns non-conclusion copula avoidance such as 'serves as'."
 ---
 
 # Language Patterns

--- a/patterns/ja-filler.md
+++ b/patterns/ja-filler.md
@@ -4,6 +4,11 @@ language: ja
 name: フィラー・ヘッジングパターン
 version: 1.1.0
 patterns: 4
+dedupe-with:
+  - source: "ja-filler:22"
+    target: "ja-filler:31"
+    owner: "ja-filler:31"
+    reason: "最終段落の結論マーカーは filler #31 が canonical owner。#22 は本文中で意味を足さないフィラー句を扱う。"
 ---
 
 # フィラー・ヘッジングパターン

--- a/patterns/ja-language.md
+++ b/patterns/ja-language.md
@@ -4,6 +4,23 @@ language: ja
 name: 言語・文法パターン
 version: 1.1.0
 patterns: 7
+dedupe-with:
+  - source: "ja-language:7"
+    target: "ja-style:13"
+    owner: "ja-style:13"
+    reason: "接続表現は style #13 が canonical owner。language #7 では他のAI語彙と同時に出る場合の補助信号として扱う。"
+  - source: "ja-language:7"
+    target: "ja-language:8"
+    owner: "ja-language:8"
+    reason: "「〜的」形容詞の連続は language #8 が canonical owner。language #7 は他のAI高頻度語と混ざる場合の広域クラスタ信号として扱う。"
+  - source: "ja-language:7"
+    target: "ja-language:12"
+    owner: "ja-language:12"
+    reason: "カタカナ外来語の過多は language #12 が canonical owner。language #7 は抽象的AI語彙の広域クラスタだけを担当する。"
+  - source: "ja-language:8"
+    target: "ja-language:12"
+    owner: "ja-language:8"
+    reason: "ビジネス文脈では「〜的」形容詞とカタカナ外来語が共起しやすいが、rewrite の優先度は文法的な「〜的」連鎖を先にほどき、残った外来語を #12 で処理する。"
 ---
 
 # 言語・文法パターン

--- a/patterns/ko-language.md
+++ b/patterns/ko-language.md
@@ -4,6 +4,15 @@ language: ko
 name: 언어/문법 패턴
 version: 1.1.0
 patterns: 7
+dedupe-with:
+  - source: "ko-language:7"
+    target: "ko-style:13"
+    owner: "ko-style:13"
+    reason: "연결 표현은 style #13이 canonical owner이고, language #7에서는 다른 AI 어휘와 함께 군집으로 나타날 때만 보조 신호로 본다."
+  - source: "ko-language:7"
+    target: "ko-language:8"
+    owner: "ko-language:8"
+    reason: "\"~적\" 한자어 형용사 연쇄는 language #8이 canonical owner이고, language #7은 다른 AI 고빈도 어휘와 함께 나타나는 넓은 군집 신호로만 본다."
 ---
 
 # 언어/문법 패턴

--- a/patterns/zh-style.md
+++ b/patterns/zh-style.md
@@ -4,6 +4,15 @@ language: zh
 name: 风格模式
 version: 1.0.0
 patterns: 6
+dedupe-with:
+  - source: "zh-style:13"
+    target: "zh-filler:22"
+    owner: "zh-filler:22"
+    reason: "断言型填充词由 filler #22 作为 canonical owner；style #13 仅在它们承担段落连接/过渡功能时作为辅助信号。"
+  - source: "zh-style:13"
+    target: "zh-filler:31"
+    owner: "zh-filler:31"
+    reason: "结论信号词由 filler #31 作为 canonical owner；style #13 仅记录其作为过渡词密集出现时的共现。"
 ---
 
 # 风格模式

--- a/scripts/qa/pattern-overlap.js
+++ b/scripts/qa/pattern-overlap.js
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, resolve, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../..');
+const DEFAULT_CORPUS = resolve(REPO_ROOT, 'tests/fixtures/pattern-overlap/corpus.json');
+const DEFAULT_SCOPE = new Set(['language', 'style', 'filler']);
+
+function parseArgs(argv) {
+  const out = { threshold: 0.3, corpus: DEFAULT_CORPUS, json: false, all: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--threshold') out.threshold = Number(argv[++i]);
+    else if (arg === '--corpus') out.corpus = resolve(process.cwd(), argv[++i]);
+    else if (arg === '--json') out.json = true;
+    else if (arg === '--all') out.all = true;
+    else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!Number.isFinite(out.threshold) || out.threshold < 0 || out.threshold > 1) {
+    throw new Error('--threshold must be a number between 0 and 1');
+  }
+  return out;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/qa/pattern-overlap.js [--threshold 0.3] [--corpus path] [--all] [--json]\n\nRuns each pattern independently against a fixture corpus using its watch-word list,\nthen prints a pairwise overlap matrix. Default scope is language/style/filler packs.`);
+}
+
+function splitFrontmatter(raw, file) {
+  const match = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+  if (!match) throw new Error(`${file} is missing YAML frontmatter`);
+  return { frontmatter: yaml.load(match[1]) || {}, body: match[2] };
+}
+
+function patternFiles() {
+  const dir = resolve(REPO_ROOT, 'patterns');
+  return readdirSync(dir)
+    .filter((name) => name.endsWith('.md'))
+    .map((name) => resolve(dir, name))
+    .sort();
+}
+
+function numberedSections(body) {
+  const headings = [...body.matchAll(/^###\s+(\d+)\.\s+(.+)$/gm)];
+  return headings.map((heading, index) => ({
+    number: heading[1],
+    title: heading[2].trim(),
+    body: body.slice((heading.index ?? 0) + heading[0].length, headings[index + 1]?.index ?? body.length),
+  }));
+}
+
+function isWatchLabel(label) {
+  const normalized = label.replace(/[：:]/g, '').trim().toLowerCase();
+  return [
+    'watch words',
+    '주의 어휘',
+    '고빈도 ai 어휘',
+    '고빈도 어휘',
+    '고빈도 표현',
+    '高频词汇',
+    '注意词汇',
+    '注意词',
+    '高頻度語彙',
+    '注意語彙',
+    '注意語',
+  ].some((needle) => normalized.includes(needle.toLowerCase()));
+}
+
+function cleanTerm(term) {
+  return term
+    .replace(/^[\s`*_"'“”‘’「」『』()（）]+|[\s`*_"'“”‘’「」『』()（）.。]+$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function extractWatchTerms(sectionBody) {
+  const terms = [];
+  for (const line of sectionBody.split('\n')) {
+    const match = line.match(/^\*\*([^*]+)\*\*\s*(.+)$/);
+    if (!match || !isWatchLabel(match[1])) continue;
+    const value = match[2].replace(/\s+—\s+/g, ', ');
+    for (const raw of value.split(/[,，、;]/)) {
+      const term = cleanTerm(raw);
+      if (term.length >= 2) terms.push(term);
+    }
+  }
+  return [...new Set(terms)];
+}
+
+function loadPatterns({ all }) {
+  const patterns = [];
+  const dedupe = new Map();
+  for (const file of patternFiles()) {
+    const raw = readFileSync(file, 'utf8');
+    const { frontmatter, body } = splitFrontmatter(raw, file);
+    const language = frontmatter.language;
+    const pack = frontmatter.pack;
+    const category = pack?.replace(`${language}-`, '');
+    for (const item of frontmatter['dedupe-with'] || []) {
+      const source = item.source;
+      const target = item.target;
+      if (!source || !target) continue;
+      dedupe.set(pairKey(source, target), {
+        source,
+        target,
+        owner: item.owner || source,
+        reason: item.reason || '',
+      });
+    }
+    if (!all && !DEFAULT_SCOPE.has(category)) continue;
+    for (const section of numberedSections(body)) {
+      const id = `${pack}:${section.number}`;
+      patterns.push({
+        id,
+        language,
+        pack,
+        category,
+        number: section.number,
+        title: section.title,
+        file: relative(REPO_ROOT, file),
+        terms: extractWatchTerms(section.body),
+      });
+    }
+  }
+  return { patterns, dedupe };
+}
+
+function normalizeText(text, lang) {
+  return /^(en)$/.test(lang) ? text.toLowerCase() : text;
+}
+
+function termMatches(text, term, lang) {
+  const haystack = normalizeText(text, lang);
+  const needle = normalizeText(term, lang);
+  return haystack.includes(needle);
+}
+
+function hitsFor(pattern, corpus) {
+  const hits = new Set();
+  if (pattern.terms.length === 0) return hits;
+  for (const doc of corpus) {
+    if (doc.lang !== pattern.language) continue;
+    if (pattern.terms.some((term) => termMatches(doc.text, term, pattern.language))) {
+      hits.add(doc.id);
+    }
+  }
+  return hits;
+}
+
+function intersectionSize(a, b) {
+  let count = 0;
+  for (const item of a) if (b.has(item)) count += 1;
+  return count;
+}
+
+function unionSize(a, b) {
+  return new Set([...a, ...b]).size;
+}
+
+function pairKey(a, b) {
+  return [a, b].sort().join('↔');
+}
+
+function pct(value) {
+  return `${Math.round(value * 100)}%`;
+}
+
+function buildMatrix(patterns, corpus, dedupe, threshold) {
+  const hitMap = new Map(patterns.map((pattern) => [pattern.id, hitsFor(pattern, corpus)]));
+  const rows = [];
+  for (let i = 0; i < patterns.length; i += 1) {
+    for (let j = i + 1; j < patterns.length; j += 1) {
+      const a = patterns[i];
+      const b = patterns[j];
+      if (a.language !== b.language) continue;
+      const aHits = hitMap.get(a.id);
+      const bHits = hitMap.get(b.id);
+      if (aHits.size === 0 || bHits.size === 0) continue;
+      const shared = intersectionSize(aHits, bHits);
+      if (shared === 0) continue;
+      const jaccard = shared / unionSize(aHits, bHits);
+      const overlap = shared / Math.min(aHits.size, bHits.size);
+      const documentation = dedupe.get(pairKey(a.id, b.id));
+      rows.push({
+        language: a.language,
+        a: a.id,
+        b: b.id,
+        aHits: aHits.size,
+        bHits: bHits.size,
+        shared,
+        jaccard,
+        overlap,
+        review: jaccard >= threshold,
+        owner: documentation?.owner || '',
+        status: jaccard >= threshold ? (documentation ? 'documented' : 'UNDOCUMENTED') : 'below-threshold',
+        reason: documentation?.reason || '',
+      });
+    }
+  }
+  return rows.sort((a, b) => b.jaccard - a.jaccard || a.language.localeCompare(b.language) || a.a.localeCompare(b.a));
+}
+
+function renderMarkdown(rows, opts) {
+  const corpusPath = relative(REPO_ROOT, opts.corpus);
+  const lines = [];
+  lines.push('# Pattern overlap matrix');
+  lines.push('');
+  lines.push(`- Fixture corpus: \`${corpusPath}\``);
+  lines.push(`- Scope: ${opts.all ? 'all pattern packs' : 'language/style/filler packs'}`);
+  lines.push(`- Review threshold: Jaccard >= ${pct(opts.threshold)}`);
+  lines.push('- Method: each pattern fires independently when any extracted watch term appears in a fixture document.');
+  lines.push('');
+  lines.push('| Lang | Pattern A | Pattern B | A hits | B hits | Shared | Jaccard | Overlap coeff. | Status | Owner |');
+  lines.push('|------|-----------|-----------|--------|--------|--------|---------|----------------|--------|-------|');
+  if (rows.length === 0) {
+    lines.push('| — | — | — | 0 | 0 | 0 | 0% | 0% | no overlaps | — |');
+  } else {
+    for (const row of rows) {
+      lines.push(`| ${row.language} | ${row.a} | ${row.b} | ${row.aHits} | ${row.bHits} | ${row.shared} | ${pct(row.jaccard)} | ${pct(row.overlap)} | ${row.status} | ${row.owner || '—'} |`);
+    }
+  }
+  const reviewRows = rows.filter((row) => row.review);
+  lines.push('');
+  lines.push(`Review pairs >= ${pct(opts.threshold)}: ${reviewRows.length}`);
+  const missing = reviewRows.filter((row) => row.status === 'UNDOCUMENTED');
+  lines.push(`Undocumented review pairs: ${missing.length}`);
+  if (missing.length > 0) {
+    lines.push('');
+    lines.push('## Undocumented pairs');
+    for (const row of missing) lines.push(`- ${row.a} ↔ ${row.b} (${pct(row.jaccard)} Jaccard)`);
+  }
+  const documented = reviewRows.filter((row) => row.status === 'documented');
+  if (documented.length > 0) {
+    lines.push('');
+    lines.push('## Documented review pairs');
+    for (const row of documented) {
+      lines.push(`- ${row.a} ↔ ${row.b}: owner=${row.owner}; ${row.reason}`);
+    }
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const corpus = JSON.parse(readFileSync(opts.corpus, 'utf8'));
+  const { patterns, dedupe } = loadPatterns(opts);
+  const rows = buildMatrix(patterns, corpus, dedupe, opts.threshold);
+  if (opts.json) console.log(JSON.stringify({ threshold: opts.threshold, rows }, null, 2));
+  else process.stdout.write(renderMarkdown(rows, opts));
+
+  if (rows.some((row) => row.review && row.status === 'UNDOCUMENTED')) {
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/scripts/qa/pattern-overlap.sh
+++ b/scripts/qa/pattern-overlap.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec node "$SCRIPT_DIR/pattern-overlap.js" "$@"

--- a/tests/fixtures/pattern-overlap/corpus.json
+++ b/tests/fixtures/pattern-overlap/corpus.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "ko-language-ai",
+    "lang": "ko",
+    "text": "다양한 혁신적인 기술이 활발하게 개발되고 있으며 체계적이고 효과적인 솔루션을 제공한다. 지속적인 노력은 주목할 만한 성과로 이어졌다."
+  },
+  {
+    "id": "ko-transition-a",
+    "lang": "ko",
+    "text": "이를 통해 기업의 경쟁력이 강화되었다. 이러한 맥락에서 향후 정책 방향에 대한 논의가 필요하다. 아울러 지역 사회와의 협력도 확대된다."
+  },
+  {
+    "id": "ko-transition-b",
+    "lang": "ko",
+    "text": "아울러 조직은 실행 계획을 조정했다. 이를 통해 업무 흐름을 정리했고, 이러한 맥락에서 다음 회의 안건도 바뀌었다."
+  },
+  {
+    "id": "ko-filler-conclusion",
+    "lang": "ko",
+    "text": "결론적으로 이 변화는 장기 계획의 일부다. 종합하면 다음 분기에는 세부 지표를 다시 확인해야 한다."
+  },
+  {
+    "id": "en-language-ai",
+    "lang": "en",
+    "text": "This comprehensive report delves into a multifaceted landscape and offers nuanced insights. Moreover, it leverages a robust framework to foster better decisions."
+  },
+  {
+    "id": "en-testament-close",
+    "lang": "en",
+    "text": "The launch stands as a testament to the team's transformative potential, and the best is yet to come for the community."
+  },
+  {
+    "id": "en-conclusion-signal",
+    "lang": "en",
+    "text": "In conclusion, the roadmap is ready. Ultimately, the team should revisit the metrics after launch."
+  },
+  {
+    "id": "en-emoji-style",
+    "lang": "en",
+    "text": "🚀 Launch checklist ✅ Ship docs ✨ Celebrate the milestone."
+  },
+  {
+    "id": "zh-language-ai",
+    "lang": "zh",
+    "text": "我们将深耕AI赛道，聚焦底层逻辑创新，全方位赋能产业生态，助力高质量发展。"
+  },
+  {
+    "id": "zh-transition-a",
+    "lang": "zh",
+    "text": "与此同时，公司加大了研发投入。此外，组织架构也进行了优化。不仅如此，企业文化也在调整。"
+  },
+  {
+    "id": "zh-assertion-filler",
+    "lang": "zh",
+    "text": "毋庸置疑，这项调整会带来明显变化。必须指出的是，现有流程仍然存在成本问题。"
+  },
+  {
+    "id": "zh-conclusion-signal",
+    "lang": "zh",
+    "text": "总而言之，项目需要继续推进。综上所述，团队下周应提交新的预算表。"
+  },
+  {
+    "id": "ja-language-ai",
+    "lang": "ja",
+    "text": "多様な革新的技術が活発に開発され、体系的かつ効果的なソリューションを提供している。持続的な取り組みも主導的な役割を果たしている。"
+  },
+  {
+    "id": "ja-transition-a",
+    "lang": "ja",
+    "text": "さらに、計画は更新された。これにより、関係部署の作業が整理された。加えて、次回会議の議題も変わった。"
+  },
+  {
+    "id": "ja-transition-b",
+    "lang": "ja",
+    "text": "これにより新しい手順が定着した。一方で、現場からは懸念も出ている。こうした中、追加の説明が必要になった。"
+  },
+  {
+    "id": "ja-filler-close",
+    "lang": "ja",
+    "text": "周知の通り、この判断には注意が必要だ。結論として、来週もう一度確認する。"
+  }
+]

--- a/tests/unit/pattern-overlap.test.js
+++ b/tests/unit/pattern-overlap.test.js
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../..');
+const SCRIPT = resolve(REPO_ROOT, 'scripts/qa/pattern-overlap.js');
+
+test('pattern overlap audit has documented owners for review-threshold pairs', () => {
+  const result = spawnSync(process.execPath, [SCRIPT, '--json'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  const { rows } = JSON.parse(result.stdout);
+  const reviewRows = rows.filter((row) => row.review);
+  assert.ok(reviewRows.length > 0, 'fixture corpus should exercise at least one review-threshold pair');
+
+  for (const row of reviewRows) {
+    assert.equal(row.status, 'documented', `${row.a} ↔ ${row.b} must be documented`);
+    assert.match(row.owner, /^[a-z]{2}-[a-z-]+:\d+$/, `${row.a} ↔ ${row.b} must name a canonical owner`);
+  }
+});


### PR DESCRIPTION
## Summary
- add `scripts/qa/pattern-overlap.{js,sh}` to run scoped language/style/filler pattern overlap audits against a fixture corpus
- add fixture corpus and a unit regression that fails if review-threshold pairs lack documented canonical owners
- document intentional ≥30% overlap pairs with `dedupe-with` frontmatter owners/reasons across en/ko/zh/ja packs

Closes #152

## Verification
- `npm run lint:syntax`
- `npm run lint:eslint`
- `npm run typecheck`
- `npm test`
- `npm run spellcheck`
- `scripts/qa/pattern-overlap.sh`
- `git diff --check`
