### PR TITLE
profiles: add dev-native genre profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ patina --lang <ko|en|zh|ja> [mode] [--profile <name>] input.txt
 | `--diff` | Show changes pattern by pattern |
 | `--ouroboros` | Iterate the rewrite until score converges (with MPS rollback) |
 | `--lang <ko\|en\|zh\|ja>` | Select language (default: `ko`) |
-| `--profile <name>` | Tone preset: `blog`, `academic`, `technical`, `formal`, `social`, `email`, `legal`, `medical`, `marketing`, `narrative`, `instructional`, `casual-conversation` |
+| `--profile <name>` | Tone preset: `blog`, `academic`, `technical`, `formal`, `social`, `email`, `legal`, `medical`, `marketing`, `narrative`, `instructional`, `casual-conversation`, `code-comment`, `commit-message`, `release-notes` |
 | `--tone <name>` | Tone category: `casual`, `professional`, `academic`, `narrative`, `marketing`, `instructional`, `auto` |
 | `--batch` | Treat positional args as a list of files (e.g. `--batch docs/*.md`) |
 | `--format json\|text\|markdown` | Select machine-readable JSON, plain text, or default Markdown output |
@@ -177,6 +177,9 @@ patina --lang <ko|en|zh|ja> [mode] [--profile <name>] input.txt
 | `--variants <1-5>` | Generate multiple rewrite variants with the same facts and meaning anchors |
 
 `patina --help` for the full flag list. `patina doctor --json` checks Node/backend/tmux/API-key readiness without making an LLM call, and `patina init` writes a project `.patina.yaml`.
+
+Dev-native profile shortcuts are available for Markdown-heavy engineering workflows:
+`code-comment` tightens inline comments/docstrings, `commit-message` rewrites Git history text around intent and verification, and `release-notes` turns changelog bullets into user-impact notes with migration risks visible.
 
 ### Score-only patterns
 

--- a/profiles/code-comment.md
+++ b/profiles/code-comment.md
@@ -1,0 +1,104 @@
+---
+profile: code-comment
+name: 코드 주석/docstring 프로필
+version: 1.0.0
+scope: 코드 주석, docstring, JSDoc/TSDoc, inline comment, TODO/FIXME 주석
+voice-overrides:
+  first-person: suppress        # 주석은 작성자가 아니라 코드 동작을 설명한다
+  opinions: suppress            # 평가·감상 대신 invariant/edge case를 적는다
+  rhythm-variation: reduce      # 짧고 일정한 호흡 허용
+  humor: suppress               # 코드 옆 농담은 유지보수 소음이 되기 쉽다
+  messiness: suppress           # 불완전 문장보다 정확한 조건·이유 우선
+  concrete-emotions: suppress   # 감정 표현 비해당
+  specificity: amplify          # 입력, 출력, 예외, 불변조건을 구체화
+pattern-overrides:
+  ko:
+    7: amplify                  # AI 고빈도 어휘 — 주석에서는 특히 소음
+    8: amplify                  # ~적 접미사 — 동작/조건으로 풀기
+    19: suppress                # 챗봇 표현 — 주석에서는 비해당
+    22: amplify                 # 필러 — 삭제 우선
+  en:
+    7: amplify                  # AI vocabulary — comments should avoid decorative adjectives
+    8: amplify                  # Copula avoidance — prefer direct code-action verbs
+    19: suppress                # Chatbot phrasing — not relevant in code comments
+    22: amplify                 # Filler — remove rather than polish
+  zh:
+    7: amplify                  # AI高频词 — 注释中应换成具体条件/行为
+    18: amplify                 # 书面/公文体 — 注释不需要公文口吻
+    19: suppress                # 聊天机器人痕迹 — 注释中不适用
+    22: amplify                 # 填充表达 — 优先删除
+  ja:
+    7: amplify                  # AI語彙 — コメントでは具体的な動作へ置換
+    8: amplify                  # 「〜的」形容詞 — 条件・処理内容に分解
+    16: suppress                # 敬語 — コードコメントでは不要
+    22: amplify                 # フィラー — 削除優先
+---
+
+# 코드 주석/docstring 프로필 (`code-comment`)
+
+코드 옆 텍스트는 산문이 아니라 유지보수 단서다. 이 프로필은 주석을 짧게 만들되, **왜 이 코드가 필요한지**, **어떤 edge case를 막는지**, **입출력·불변조건이 무엇인지**를 남긴다.
+
+## 범위
+
+- inline comment, block comment, docstring, JSDoc/TSDoc, TODO/FIXME 주석
+- README, API 문서, 튜토리얼은 `technical` 또는 `instructional` 프로필을 쓴다.
+- 커밋 메시지는 `commit-message`, 릴리스 노트는 `release-notes` 프로필을 쓴다.
+
+## 적극 교정할 genre tell
+
+1. **Stock preamble** — `This function...`, `Returns the...`, `This method is used to...`처럼 선언부를 반복하는 말.
+2. **Uninformative inline summary** — 코드가 이미 말하는 내용을 그대로 읽는 주석.
+3. **AI-flavored TODO** — `TODO: consider improving this later`처럼 담당자, 조건, 실패 모드가 없는 TODO.
+4. **Decorative assurance** — `robustly`, `seamlessly`, `효율적으로`, `체계적으로` 같은 형용사만 있고 조건이 없는 설명.
+
+## 작성 규칙
+
+- 함수명·타입에서 이미 알 수 있는 말은 지운다.
+- 남길 주석은 "왜" 또는 "주의할 조건"을 말해야 한다.
+- TODO/FIXME는 owner, issue id, trigger condition 중 최소 하나를 포함한다.
+- 예외·fallback·security boundary는 삭제하지 않는다. 간결하게 다시 쓴다.
+
+## Before / After
+
+### Stock preamble
+
+**Before**
+```js
+// This function validates the user input and returns a boolean value.
+function isValidUser(input) { ... }
+```
+
+**After**
+```js
+// Reject empty OAuth subject IDs before they reach the account linker.
+function isValidUser(input) { ... }
+```
+
+### Uninformative inline summary
+
+**Before**
+```js
+count += 1; // increment count by one
+```
+
+**After**
+```js
+count += 1;
+```
+
+### AI-flavored TODO
+
+**Before**
+```js
+// TODO: consider optimizing this in the future for better performance.
+```
+
+**After**
+```js
+// TODO(#421): cache permission lookups once the authz key includes tenant_id.
+```
+
+## 보존 주의
+
+- 주석을 지우기 전에 코드만으로 같은 정보를 회복할 수 있는지 확인한다.
+- 보안, 데이터 손실, race condition, 호환성 우회 설명은 짧아져도 남겨야 한다.

--- a/profiles/commit-message.md
+++ b/profiles/commit-message.md
@@ -1,0 +1,99 @@
+---
+profile: commit-message
+name: 커밋 메시지 프로필
+version: 1.0.0
+scope: Git commit subject/body, squash message, revert message, PR squash summary
+voice-overrides:
+  first-person: suppress        # 작성자 중심 대신 변경 의도 중심
+  opinions: suppress            # 평가보다 결정·근거·검증
+  rhythm-variation: reduce      # 짧은 subject + 필요한 body
+  humor: suppress               # 히스토리는 장기 기록
+  messiness: suppress           # 모호한 WIP/cleanup 표현 억제
+  concrete-emotions: suppress   # 감정 표현 비해당
+  intent-first: amplify         # 왜 바꿨는지 먼저
+pattern-overrides:
+  ko:
+    7: amplify                  # AI 고빈도 어휘 — 커밋에서는 특히 모호함
+    22: amplify                 # 필러 — 히스토리에서는 삭제
+    24: amplify                 # 낙관 결론 — 커밋 메시지에 불필요
+    31: amplify                 # 결론 신호어 — subject/body에서 제거
+  en:
+    7: amplify                  # AI vocabulary — commit history needs precise nouns/verbs
+    22: amplify                 # Filler — remove from commit bodies
+    24: amplify                 # Generic positive conclusions — not useful in history
+    31: amplify                 # Conclusion signals — no "In conclusion" in commits
+  zh:
+    7: amplify                  # AI高频词 — 提交记录需要具体动词
+    22: amplify                 # 填充表达 — 删除
+    24: amplify                 # 空泛乐观结尾 — 不适合提交历史
+    31: amplify                 # 结论信号词 — 删除
+  ja:
+    7: amplify                  # AI語彙 — コミット履歴では具体語へ
+    22: amplify                 # フィラー — 削除
+    24: amplify                 # 空虚な楽観結論 — 不要
+    31: amplify                 # 結論シグナル — 削除
+---
+
+# 커밋 메시지 프로필 (`commit-message`)
+
+커밋 메시지는 변경 diff의 제목이 아니라 미래 디버깅을 위한 결정 기록이다. subject는 **명령형 또는 의도형**으로 짧게 쓰고, body는 제약·검증·기각한 대안을 남긴다.
+
+## 범위
+
+Git commit subject/body, squash message, revert message, PR squash summary. 릴리스 노트나 사용자-facing changelog는 `release-notes` 프로필을 쓴다.
+
+## 적극 교정할 genre tell
+
+1. **AI narrator preamble** — `This commit...`, `This change...`, `이 커밋은...`으로 시작하는 설명.
+2. **Meaningless cleanup subject** — `Refactor code`, `Update files`, `Improve implementation`처럼 diff를 다시 말하는 제목.
+3. **Inflated future promise** — `sets the stage`, `paves the way`, `향후 발전을 위한 기반` 같은 근거 없는 전망.
+4. **Verification fog** — 테스트를 했는지, 안 했는지 알 수 없는 `various tests were run`류 표현.
+
+## 작성 규칙
+
+- subject는 72자 안팎으로, 가능한 한 "왜"를 말한다.
+- `This commit`으로 시작하지 않는다. 바로 의도나 보호하려는 invariant를 쓴다.
+- body가 필요하면 `Tested:`, `Constraint:`, `Rejected:` 같은 짧은 trailer를 선호한다.
+- issue/PR 번호, 마이그레이션 위험, 배포 순서가 있으면 보존한다.
+
+## Before / After
+
+### Preamble 제거
+
+**Before**
+```text
+This commit refactors the auth code to improve reliability.
+```
+
+**After**
+```text
+Auth retries need one owner for backoff state
+```
+
+### 모호한 cleanup 구체화
+
+**Before**
+```text
+Improve tests and update files
+```
+
+**After**
+```text
+Score gates need a fixture that fails on invented categories
+
+Tested: npm test; npm run lint:syntax.
+```
+
+### 전망 부풀리기 제거
+
+**Before**
+```text
+This change lays the foundation for a more robust and scalable future.
+```
+
+**After**
+```text
+Persist cache keys with model and temperature
+
+Constraint: cache entries must stay portable across API hosts.
+```

--- a/profiles/release-notes.md
+++ b/profiles/release-notes.md
@@ -1,0 +1,98 @@
+---
+profile: release-notes
+name: 릴리스 노트 프로필
+version: 1.0.0
+scope: changelog, release notes, GitHub Releases, npm/GHCR release announcement
+voice-overrides:
+  first-person: reduce          # 팀/제품 중심, 과한 1인칭 억제
+  opinions: reduce              # 사용자 영향과 migration 중심
+  rhythm-variation: normal      # 항목별 길이 차이 허용
+  humor: suppress               # 릴리스 공지는 명확성 우선
+  messiness: reduce             # 섹션/목록 구조 유지
+  concrete-emotions: reduce     # 감정 대신 영향·조치
+  user-impact: amplify          # 변경의 사용자 영향 명시
+pattern-overrides:
+  ko:
+    14: reduce                  # 볼드체 — 릴리스 노트 heading/emphasis 일부 허용
+    15: reduce                  # 인라인 헤더 — 변경 분류에 허용
+    24: amplify                 # 낙관 결론 — 구체적 영향으로 교체
+    25: reduce                  # 번호/목록 구조 — 릴리스 노트에서는 표준
+  en:
+    14: reduce                  # Boldface — allowed for headings/emphasis
+    15: reduce                  # Inline headers — standard in release notes
+    24: amplify                 # Generic optimism — replace with user impact
+    25: reduce                  # Numbered/list structure — legitimate here
+  zh:
+    14: reduce                  # 加粗 — 发布说明中可作为强调
+    15: reduce                  # 内联标题 — 变更分类中可保留
+    24: amplify                 # 空泛乐观结尾 — 改写为具体影响
+    25: reduce                  # 列表结构 — 发布说明中正常
+  ja:
+    14: reduce                  # 太字 — リリースノートでは一部許容
+    15: reduce                  # インラインヘッダー — 変更分類として許容
+    24: amplify                 # 空虚な楽観結論 — 具体的な影響へ
+    25: reduce                  # 箇条書き構造 — リリースノートでは標準
+---
+
+# 릴리스 노트 프로필 (`release-notes`)
+
+릴리스 노트는 마케팅 카피와 운영 공지의 중간이다. 사용자가 궁금해하는 것은 "무엇이 바뀌었나"보다 **내가 무엇을 해야 하나**, **무엇이 깨질 수 있나**, **왜 업그레이드해야 하나**다.
+
+## 범위
+
+CHANGELOG 항목, GitHub Releases, npm/GHCR 릴리스 공지, 버전 업그레이드 안내. 내부 커밋 메시지는 `commit-message`, 긴 기술 설명은 `technical` 프로필을 쓴다.
+
+## 적극 교정할 genre tell
+
+1. **Generic excitement** — `We're excited to announce`, `a new chapter`, `앞으로가 기대됩니다`만 있고 영향이 없는 문장.
+2. **Feature dump** — 항목은 많은데 사용자 영향, migration, breaking change가 빠진 목록.
+3. **Hidden risk** — 버전·호환성·수동 조치가 필요한데 마지막에 흐리게 말하는 표현.
+4. **Commit-log leakage** — `refactor`, `cleanup`, `internal improvements`만 있고 사용자-facing 변화가 없는 항목.
+
+## 작성 규칙
+
+- 각 항목은 가능하면 `Changed → Impact → Action` 순서로 쓴다.
+- breaking change, deprecation, migration step은 숨기지 않는다.
+- "excited"류 도입문은 삭제하거나 실제 사용자 이득으로 바꾼다.
+- 구조화된 heading/bullet은 허용한다. 단, 모든 bullet이 같은 템플릿으로 끝나면 리듬을 바꾼다.
+
+## Before / After
+
+### Generic excitement 제거
+
+**Before**
+```markdown
+We're excited to announce a powerful new release that unlocks a better future for all users.
+```
+
+**After**
+```markdown
+This release adds JSON score output and a CI gate, so PR workflows can fail when `overall` exceeds your threshold.
+```
+
+### Feature dump를 사용자 영향으로 전환
+
+**Before**
+```markdown
+- Refactored cache internals
+- Updated provider logic
+- Improved reliability
+```
+
+**After**
+```markdown
+- Cache keys now include model, temperature, and API host. Re-run cached benchmarks once after upgrading.
+- Provider fallback now stops on auth errors instead of retrying another backend with the same bad secret.
+```
+
+### 숨은 위험 드러내기
+
+**Before**
+```markdown
+Some old settings may need to be adjusted for compatibility.
+```
+
+**After**
+```markdown
+Breaking: `--gate` now exits with code 3 when the score is over the threshold. CI jobs that treated any non-zero as infrastructure failure should allow exit 3 as a content gate.
+```

--- a/src/cli.js
+++ b/src/cli.js
@@ -927,7 +927,8 @@ LANGUAGE & PROFILE
   --lang <code>           Language: ko, en, zh, ja (default: ko)
   --profile <name>        Profile: default, blog, academic, technical, formal,
                           social, email, legal, medical, marketing,
-                          narrative, instructional
+                          narrative, instructional, casual-conversation,
+                          code-comment, commit-message, release-notes
   --tone <name>           Tone: casual, professional, academic, narrative,
                           marketing, instructional, auto. Resolution:
                           --tone > config tone > config profile.

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -22,6 +22,10 @@ const PROFILES = [
   'marketing',
   'narrative',
   'instructional',
+  'casual-conversation',
+  'code-comment',
+  'commit-message',
+  'release-notes',
 ];
 const TONES = ['profile-only', 'casual', 'professional', 'academic', 'narrative', 'marketing', 'instructional', 'auto'];
 const DISPATCH_MODES = ['omc', 'direct', 'api'];

--- a/tests/e2e/cli.test.js
+++ b/tests/e2e/cli.test.js
@@ -95,11 +95,36 @@ describe('Profile Loading', () => {
       'casual-conversation',
       'instructional',
       'narrative',
+      'code-comment',
+      'commit-message',
+      'release-notes',
     ];
     for (const name of names) {
       const profile = loadProfile(REPO_ROOT, name);
       assert.ok(profile, `Profile ${name} should load`);
       assert.ok(profile.frontmatter || profile.body, `Profile ${name} should have content`);
+    }
+  });
+
+  it('should ship dev-native genre profiles with targeted guidance and examples', () => {
+    const expected = {
+      'code-comment': ['This function', 'TODO(#421)', 'Uninformative inline summary'],
+      'commit-message': ['This commit', 'Tested:', 'Inflated future promise'],
+      'release-notes': ['Generic excitement', 'Changed → Impact → Action', 'Breaking:'],
+    };
+
+    for (const [name, markers] of Object.entries(expected)) {
+      const profile = loadProfile(REPO_ROOT, name);
+      const overrides = profile.frontmatter?.['pattern-overrides'];
+      assert.ok(overrides, `Profile ${name} should define pattern-overrides`);
+      for (const lang of ['ko', 'en', 'zh', 'ja']) {
+        assert.ok(overrides[lang], `Profile ${name} should define ${lang} overrides`);
+      }
+      for (const marker of markers) {
+        assert.match(profile.body, new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      }
+      assert.match(profile.body, /\*\*Before\*\*/);
+      assert.match(profile.body, /\*\*After\*\*/);
     }
   });
 


### PR DESCRIPTION
## Summary
- add the top three dev-native genre profiles: `code-comment`, `commit-message`, and `release-notes`
- each profile ships multilingual pattern-overrides plus targeted genre tells and before/after examples
- expose the profiles in CLI help, guided init profile choices, README, and profile-loading regression coverage

Closes #153

## Verification
- `npm run lint:syntax`
- `npm run lint:eslint`
- `npm run typecheck`
- `npm test`
- `npm run spellcheck`
- `node bin/patina.js --help`
- `git diff --check`
