### PR TITLE
Use icon-only README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <img src="assets/brand/patina-logo.svg" alt="patina — Strip the AI packaging. Keep the meaning." width="440">
+  <img src="assets/brand/patina-icon.svg" alt="patina icon" width="120">
 </p>
 
 <h1 align="center">patina</h1>

--- a/docs/BRANDING.md
+++ b/docs/BRANDING.md
@@ -6,12 +6,12 @@ Patina's production brand assets are hand-authored SVGs so maintainers can revie
 
 | Asset | Path | Use |
 |---|---|---|
-| Logo lockup | [`assets/brand/patina-logo.svg`](../assets/brand/patina-logo.svg) | README hero, package pages, docs landing pages |
-| App icon | [`assets/brand/patina-icon.svg`](../assets/brand/patina-icon.svg) | Favicon/app tile/avatar contexts |
+| Logo lockup | [`assets/brand/patina-logo.svg`](../assets/brand/patina-logo.svg) | Package pages and docs landing pages that need the full wordmark + tagline |
+| App icon | [`assets/brand/patina-icon.svg`](../assets/brand/patina-icon.svg) | README hero, favicon/app tile/avatar contexts |
 | Social preview | [`assets/social/patina-og.svg`](../assets/social/patina-og.svg) | Open Graph / social card export source |
 | Before/after card | [`assets/social/patina-before-after.svg`](../assets/social/patina-before-after.svg) | Launch posts and docs examples |
 
-`patina-logo.svg` is the single canonical horizontal logo. Do not reintroduce README-only duplicates unless the variant is visibly different and documented here.
+`patina-logo.svg` is the single canonical horizontal logo. README uses the square icon plus Markdown heading/tagline to avoid repeating the wordmark and tagline.
 
 ## Accessibility checklist
 


### PR DESCRIPTION
## Summary

Replaces the README hero image with the square patina icon so the top of the README no longer repeats the wordmark and tagline twice.

- README now uses `assets/brand/patina-icon.svg` above the existing `patina` heading and tagline
- branding docs now describe the icon as the README hero asset
- the full logo lockup remains reserved for package/docs landing contexts that need the wordmark + tagline together

## Type

- [ ] Pattern change
- [ ] Benchmark / quality change
- [ ] CLI / API change
- [x] Docs only
- [ ] Bot / automation
- [ ] Other

## Language / scope

- [ ] ko
- [x] en
- [ ] zh
- [ ] ja
- [ ] cross-language
- [ ] not language-specific

## Pattern changes

No pattern files changed.

**Before:**

```text
N/A
```

**After:**

```text
N/A
```

False-positive risk: N/A.

## Verification

- [ ] `npm test`
- [ ] `npm run benchmark`
- [ ] `npm run quality:live` when relevant
- [x] Docs reviewed manually
- [x] `_KR` companion docs updated or not affected
- [x] `git diff --check`
- [x] `npm run lint:syntax`
- [ ] Not run — explain why:

## Meaning preservation

Not rewrite-related. This only changes README/branding presentation.

## Risks / follow-ups

- GitHub README rendering should be checked visually after merge to confirm the 120px icon size feels right on desktop and mobile.
