### PR TITLE
Use a transparent README brand mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 <p align="center">
-  <a href="README_KR.md"><b>한국어</b></a> ·
-  <a href="README_ZH.md"><b>中文</b></a> ·
-  <a href="README_JA.md"><b>日本語</b></a> ·
-  <b>English</b>
-</p>
-
-<p align="center">
-  <img src="assets/brand/patina-icon.svg" alt="patina icon" width="120">
+  <img src="assets/brand/patina-mark.svg" alt="patina mark" width="132">
 </p>
 
 <h1 align="center">patina</h1>
 
 <p align="center">
   <strong>Strip the AI packaging. Keep the meaning.</strong>
+</p>
+
+<p align="center">
+  <a href="README_KR.md"><b>한국어</b></a> ·
+  <a href="README_ZH.md"><b>中文</b></a> ·
+  <a href="README_JA.md"><b>日本語</b></a> ·
+  <b>English</b>
 </p>
 
 <p align="center">
@@ -46,7 +46,7 @@ It is not a black-box paraphraser. patina is **pattern-based and auditable**: it
 | Technical | “핵심적인 역할”, future-standard hype | GPU management, one-command provisioning, 5× result caveat |
 
 Try it quickly: [30-second terminal demo](docs/DEMO.md). More examples: [Before/After Gallery](docs/EXAMPLES.md) ([한국어](docs/EXAMPLES_KR.md)).
-Brand assets: [logo](assets/brand/patina-logo.svg), [icon](assets/brand/patina-icon.svg),
+Brand assets: [logo](assets/brand/patina-logo.svg), [mark](assets/brand/patina-mark.svg), [icon](assets/brand/patina-icon.svg),
 [social preview](assets/social/patina-og.svg), and [before/after card](assets/social/patina-before-after.svg).
 Usage notes: [BRANDING.md](docs/BRANDING.md).
 

--- a/assets/brand/patina-mark.svg
+++ b/assets/brand/patina-mark.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">patina mark</title>
+  <desc id="desc">A transparent copper-to-teal mark around a warm preserved-meaning core.</desc>
+
+  <path d="M92 196C160 86 320 74 420 164L346 238C288 190 218 198 174 258Z" fill="#c46a2a"/>
+  <path d="M420 316C352 426 192 438 92 348L160 270C224 322 294 314 338 254Z" fill="#2dd4bf"/>
+  <circle cx="252" cy="248" r="54" fill="#ffe6a8" stroke="#020617" stroke-width="10"/>
+</svg>

--- a/docs/BRANDING.md
+++ b/docs/BRANDING.md
@@ -7,18 +7,19 @@ Patina's production brand assets are hand-authored SVGs so maintainers can revie
 | Asset | Path | Use |
 |---|---|---|
 | Logo lockup | [`assets/brand/patina-logo.svg`](../assets/brand/patina-logo.svg) | Package pages and docs landing pages that need the full wordmark + tagline |
-| App icon | [`assets/brand/patina-icon.svg`](../assets/brand/patina-icon.svg) | README hero, favicon/app tile/avatar contexts |
+| Transparent mark | [`assets/brand/patina-mark.svg`](../assets/brand/patina-mark.svg) | README hero and other places where surrounding text already supplies the project name |
+| App icon | [`assets/brand/patina-icon.svg`](../assets/brand/patina-icon.svg) | Favicon/app tile/avatar contexts that need a dark backplate |
 | Social preview | [`assets/social/patina-og.svg`](../assets/social/patina-og.svg) | Open Graph / social card export source |
 | Before/after card | [`assets/social/patina-before-after.svg`](../assets/social/patina-before-after.svg) | Launch posts and docs examples |
 
-`patina-logo.svg` is the single canonical horizontal logo. README uses the square icon plus Markdown heading/tagline to avoid repeating the wordmark and tagline.
+`patina-logo.svg` is the single canonical horizontal logo. README uses the transparent mark plus Markdown heading/tagline to avoid repeating the wordmark and tagline.
 
 ## Accessibility checklist
 
 - Keep `role="img"` on standalone SVG assets.
 - Include `<title>` and `<desc>`, or an `aria-label` when a tiny decorative asset cannot carry children.
 - Keep the square icon recognizable at 32px.
-- Keep the logo on a dark backplate so it works on GitHub light and dark themes.
+- Keep the app icon and logo lockup on a dark backplate so they work on GitHub light and dark themes. The transparent mark is for layouts that already provide their own page background.
 - Use system font fallbacks in SVG text; GitHub does not load external web fonts inside `<img>` SVGs.
 
 ## Open Graph setup for a future docs site


### PR DESCRIPTION
## Summary

Refines the README hero so the brand mark sits cleanly on GitHub's page background and the language switcher reads as secondary navigation.

- adds `assets/brand/patina-mark.svg`, a transparent-background vector mark derived from the app icon artwork
- updates README to use the transparent mark instead of the dark app icon
- moves the language switcher below the title/tagline and above the badges
- updates branding guidance for when to use the logo lockup, transparent mark, and app icon

## Type

- [ ] Pattern change
- [ ] Benchmark / quality change
- [ ] CLI / API change
- [x] Docs only
- [ ] Bot / automation
- [ ] Other

## Language / scope

- [ ] ko
- [x] en
- [ ] zh
- [ ] ja
- [ ] cross-language
- [ ] not language-specific

## Pattern changes

No pattern files changed.

**Before:**

```text
N/A
```

**After:**

```text
N/A
```

False-positive risk: N/A.

## Verification

- [ ] `npm test`
- [ ] `npm run benchmark`
- [ ] `npm run quality:live` when relevant
- [x] Docs reviewed manually
- [x] `_KR` companion docs updated or not affected
- [x] `git diff --check`
- [x] `npm run lint:syntax`
- [x] `npm run dogfood`
- [ ] Not run — explain why:

## Meaning preservation

Not rewrite-related. This only changes README/branding presentation and adds a transparent SVG brand mark.

## Risks / follow-ups

- GitHub README rendering should be checked visually after merge to confirm the transparent mark reads well in both light and dark themes.
