### PR TITLE
Enlarge the README brand mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/brand/patina-mark.svg" alt="patina mark" width="132">
+  <img src="assets/brand/patina-mark.svg" alt="patina mark" width="172">
 </p>
 
 <h1 align="center">patina</h1>


### PR DESCRIPTION
## Summary

Makes the README transparent brand mark roughly 30% larger so it reads as the primary hero element.

- changes README mark width from 132px to 172px
- leaves the SVG asset unchanged

## Type

- [ ] Pattern change
- [ ] Benchmark / quality change
- [ ] CLI / API change
- [x] Docs only
- [ ] Bot / automation
- [ ] Other

## Language / scope

- [ ] ko
- [x] en
- [ ] zh
- [ ] ja
- [ ] cross-language
- [ ] not language-specific

## Pattern changes

No pattern files changed.

**Before:**

```text
N/A
```

**After:**

```text
N/A
```

False-positive risk: N/A.

## Verification

- [ ] `npm test`
- [ ] `npm run benchmark`
- [ ] `npm run quality:live` when relevant
- [x] Docs reviewed manually
- [x] `_KR` companion docs updated or not affected
- [x] `git diff --check`
- [x] `npm run lint:syntax`
- [ ] Not run — explain why:

## Meaning preservation

Not rewrite-related. This is a visual README-only size adjustment.

## Risks / follow-ups

- Confirm visually on GitHub after merge; if it feels too large on mobile, reduce slightly.
