### PR TITLE
Sync roadmap with the live backlog

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -250,12 +250,12 @@ Do not lead with “bypass AI detectors.” Lead with:
 
 ## 5. Immediate next actions
 
-Last triaged: 2026-05-21, after MAX stabilization closed issues #141, #143, and #144.
+Last triaged: 2026-05-21, after README brand cleanup and roadmap/memory sync.
 
 Current GitHub issue inventory:
 
-- 20 open issues; 122 closed issues; 142 tracked issues total.
-- Open priority split: 0 high, 7 medium, 13 low, and 0 without priority labels.
+- 19 open issues; 123 closed issues; 142 tracked issues total.
+- Open priority split: 0 high, 6 medium, 13 low, and 0 without priority labels.
 - No `priority: high` issues are currently open.
 
 Already done or mostly done:
@@ -263,6 +263,7 @@ Already done or mostly done:
 - README links to the roadmap, research notes, benchmark report, detector comparison, demo, launch copy, and community docs.
 - Issue templates, PR template, `SECURITY.md`, `SUPPORT.md`, `CODE_OF_CONDUCT.md`, and `CONTRIBUTING.md` exist.
 - Benchmark report generation exists via `npm run benchmark:report`.
+- Third-party detector comparison artifacts exist. Issue: [#163](https://github.com/devswha/patina/issues/163).
 - Logo, icon, and social preview SVGs live in `assets/brand/` and `assets/social/`.
 - A copy-paste terminal demo lives in [`docs/DEMO.md`](DEMO.md).
 - Launch copy drafts live in [`docs/social/patina-launch-copy.md`](social/patina-launch-copy.md).
@@ -276,11 +277,12 @@ Already done or mostly done:
 - README hero block is centered. Issue: [#241](https://github.com/devswha/patina/issues/241).
 - Korean companion docs exist for contributing, FAQ, authentication, and examples. Issue: [#202](https://github.com/devswha/patina/issues/202).
 - Priority labels were added for the last unlabeled queue items. Issues: [#99](https://github.com/devswha/patina/issues/99), [#104](https://github.com/devswha/patina/issues/104).
+- The roadmap is tied to GitHub issue/milestone state. Issue: [#195](https://github.com/devswha/patina/issues/195).
 - Test/backend hardening wave is complete: prompt snapshots, backend contract unification, SIGINT cancellation, structured logging, and progress indicators. Issues: [#169](https://github.com/devswha/patina/issues/169), [#131](https://github.com/devswha/patina/issues/131), [#133](https://github.com/devswha/patina/issues/133), [#132](https://github.com/devswha/patina/issues/132), [#180](https://github.com/devswha/patina/issues/180).
 - Scoring/stylometry quality wave is complete: zh/ja char n-grams, deterministic shadow scoring, manifest v2 observability, response cache, and voice anchors. Issues: [#151](https://github.com/devswha/patina/issues/151), [#136](https://github.com/devswha/patina/issues/136), [#134](https://github.com/devswha/patina/issues/134), [#135](https://github.com/devswha/patina/issues/135), [#137](https://github.com/devswha/patina/issues/137).
 - Pattern/profile wave is complete: zh/ja risk notes, comparison-adverb backport, zh/ja profile overrides, overlap audit, developer-prose profiles, and viral-hook expansion to 8 score-only patterns per language. Issues: [#147](https://github.com/devswha/patina/issues/147), [#148](https://github.com/devswha/patina/issues/148), [#149](https://github.com/devswha/patina/issues/149), [#152](https://github.com/devswha/patina/issues/152), [#153](https://github.com/devswha/patina/issues/153), [#154](https://github.com/devswha/patina/issues/154).
 
-Next executable wave order (snapshot: 2026-05-21 after the MAX stabilization wave):
+Next executable wave order (snapshot: 2026-05-21 after the README brand cleanup and roadmap/memory sync):
 
 ### Completed release wave
 
@@ -292,7 +294,6 @@ Next executable wave order (snapshot: 2026-05-21 after the MAX stabilization wav
 1. Add zh/ja AI-lexicon files for stylometry overlap detection. Issue: [#104](https://github.com/devswha/patina/issues/104).
 2. Make `patina auth login <backend>` launch the real login flow. Issue: [#186](https://github.com/devswha/patina/issues/186).
 3. Add JSDoc public exports and publish generated API reference. Issue: [#191](https://github.com/devswha/patina/issues/191).
-4. Tie this roadmap to a GitHub Project board or Milestones. Issue: [#195](https://github.com/devswha/patina/issues/195).
 
 ### Wave 2 — research calibration, parked unless explicitly scheduled
 
@@ -306,6 +307,6 @@ These are medium-priority but research-heavy. Keep them out of the critical path
 
 Do not start these until the remaining medium auth/docs work and research calibration wave have a stable release path:
 
-- False-positive and benchmark calibration: [#99](https://github.com/devswha/patina/issues/99), [#156](https://github.com/devswha/patina/issues/156), [#157](https://github.com/devswha/patina/issues/157), [#158](https://github.com/devswha/patina/issues/158), [#159](https://github.com/devswha/patina/issues/159), [#163](https://github.com/devswha/patina/issues/163).
+- False-positive and benchmark calibration: [#99](https://github.com/devswha/patina/issues/99), [#156](https://github.com/devswha/patina/issues/156), [#157](https://github.com/devswha/patina/issues/157), [#158](https://github.com/devswha/patina/issues/158), [#159](https://github.com/devswha/patina/issues/159).
 - Documentation site exploration: [#199](https://github.com/devswha/patina/issues/199).
 - Editor/platform integrations and distribution experiments: [#206](https://github.com/devswha/patina/issues/206), [#207](https://github.com/devswha/patina/issues/207), [#208](https://github.com/devswha/patina/issues/208), [#209](https://github.com/devswha/patina/issues/209), [#210](https://github.com/devswha/patina/issues/210), [#211](https://github.com/devswha/patina/issues/211), [#212](https://github.com/devswha/patina/issues/212).


### PR DESCRIPTION
## Summary

Wave 0 of the backlog campaign: refreshes `docs/ROADMAP.md` against the current GitHub issue state.

- updates the snapshot to 19 open / 123 closed / 142 total issues
- updates priority split to high=0, medium=6, low=13, unlabeled=0
- moves closed #195 and #163 out of active backlog context
- keeps the executable medium wave focused on #104, #186, and #191

Memory note: `memory/projects/patina.md` was updated locally for this operator workspace, but `memory/` remains ignored by repo policy and is not part of this PR.

## Type

- [ ] Pattern change
- [ ] Benchmark / quality change
- [ ] CLI / API change
- [x] Docs only
- [ ] Bot / automation
- [ ] Other

## Language / scope

- [ ] ko
- [x] en
- [ ] zh
- [ ] ja
- [ ] cross-language
- [ ] not language-specific

## Pattern changes

No pattern files changed.

**Before:**

```text
N/A
```

**After:**

```text
N/A
```

False-positive risk: N/A.

## Verification

- [ ] `npm test`
- [ ] `npm run benchmark`
- [ ] `npm run quality:live` when relevant
- [x] Docs reviewed manually
- [x] `_KR` companion docs updated or not affected
- [x] `git diff --check`
- [x] `npm run lint:syntax`
- [x] `npm run dogfood`
- [ ] Not run — explain why:

## Meaning preservation

Not rewrite-related. This only updates roadmap bookkeeping.

## Risks / follow-ups

- Issue counts are a 2026-05-21 point-in-time snapshot and may drift as this campaign closes more issues.
