### PR TITLE
cli: launch backend auth login flows

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -7,7 +7,7 @@ patina runs through one of several backends. Pick whichever matches your existin
 | Backend | Setup | Cost |
 |---------|-------|------|
 | `codex-cli` | `codex login` | **Free** (ChatGPT OAuth) |
-| `claude-cli` | `claude` (one-time interactive OAuth) | **Free** (Claude subscription) |
+| `claude-cli` | `claude auth login` (one-time interactive OAuth) | **Free** (Claude subscription) |
 | `gemini-cli` | `gemini` (one-time interactive OAuth) or `GEMINI_API_KEY=...` | **Free** (Code Assist OAuth or AI Studio) |
 | OpenAI-compatible HTTP | `PATINA_API_KEY=...` | Per provider |
 | Google Gemini (HTTP) | `GEMINI_API_KEY=...` + `--provider gemini` | Free tier |
@@ -18,6 +18,7 @@ patina runs through one of several backends. Pick whichever matches your existin
 ```bash
 patina auth status         # backend availability + auth state
 patina auth login          # per-backend login instructions
+patina auth login codex-cli # confirm, then run `codex login`
 patina --list-providers    # preset providers + key status
 ```
 
@@ -39,6 +40,7 @@ patina dispatches via the local [`codex`](https://github.com/openai/codex) CLI, 
 
 ```bash
 codex login                                # one-time
+patina auth login codex-cli                # same, with confirmation
 patina --backend codex-cli --lang ko input.txt
 patina --model codex --lang ko input.txt   # same — auto-routes by model name
 ```
@@ -48,7 +50,8 @@ patina --model codex --lang ko input.txt   # same — auto-routes by model name
 Spawns local [`claude`](https://docs.anthropic.com/en/docs/claude-code) `-p` with the patina prompt on stdin. Free for anyone with a Claude subscription.
 
 ```bash
-claude                                     # one-time interactive OAuth
+claude auth login                          # one-time interactive OAuth
+patina auth login claude-cli               # same, with confirmation
 patina --backend claude-cli --lang ko input.txt
 patina --model claude-sonnet-4-6 --lang ko input.txt   # auto-routes
 ```
@@ -61,9 +64,16 @@ Spawns local [`gemini`](https://github.com/google-gemini/gemini-cli) `-p '' --ou
 
 ```bash
 gemini                                     # one-time interactive OAuth, OR
+patina auth login gemini-cli               # same, with confirmation
 export GEMINI_API_KEY="..."                # AI Studio key
 patina --backend gemini-cli --lang ko input.txt
 patina --model gemini-3-flash-preview --lang ko input.txt   # auto-routes
+```
+
+Use `--yes` only for automation where the launch is already intentional:
+
+```bash
+patina auth login codex-cli --yes
 ```
 
 Notes: patina passes `--skip-trust` because the prompt runs from a fresh temp directory (containment for prompt-injection in user text). Default timeout is higher than other CLIs because gemini's startup latency is longer.

--- a/docs/AUTHENTICATION_KR.md
+++ b/docs/AUTHENTICATION_KR.md
@@ -7,7 +7,7 @@ patina는 여러 backend 중 하나를 통해 실행됩니다. 이미 쓰고 있
 | Backend | Setup | Cost |
 |---------|-------|------|
 | `codex-cli` | `codex login` | **Free** (ChatGPT OAuth) |
-| `claude-cli` | `claude` (one-time interactive OAuth) | **Free** (Claude subscription) |
+| `claude-cli` | `claude auth login` (one-time interactive OAuth) | **Free** (Claude subscription) |
 | `gemini-cli` | `gemini` (one-time interactive OAuth) or `GEMINI_API_KEY=...` | **Free** (Code Assist OAuth or AI Studio) |
 | OpenAI-compatible HTTP | `PATINA_API_KEY=...` | Per provider |
 | Google Gemini (HTTP) | `GEMINI_API_KEY=...` + `--provider gemini` | Free tier |
@@ -18,6 +18,7 @@ patina는 여러 backend 중 하나를 통해 실행됩니다. 이미 쓰고 있
 ```bash
 patina auth status         # backend availability + auth state
 patina auth login          # per-backend login instructions
+patina auth login codex-cli # confirm 후 `codex login` 실행
 patina --list-providers    # preset providers + key status
 ```
 
@@ -39,6 +40,7 @@ patina는 local [`codex`](https://github.com/openai/codex) CLI를 통해 dispatc
 
 ```bash
 codex login                                # one-time
+patina auth login codex-cli                # same, with confirmation
 patina --backend codex-cli --lang ko input.txt
 patina --model codex --lang ko input.txt   # same — auto-routes by model name
 ```
@@ -48,7 +50,8 @@ patina --model codex --lang ko input.txt   # same — auto-routes by model name
 local [`claude`](https://docs.anthropic.com/en/docs/claude-code) `-p`를 실행하고 patina prompt를 stdin으로 넘깁니다. Claude subscription이 있으면 무료로 사용할 수 있습니다.
 
 ```bash
-claude                                     # one-time interactive OAuth
+claude auth login                          # one-time interactive OAuth
+patina auth login claude-cli               # same, with confirmation
 patina --backend claude-cli --lang ko input.txt
 patina --model claude-sonnet-4-6 --lang ko input.txt   # auto-routes
 ```
@@ -61,9 +64,16 @@ local [`gemini`](https://github.com/google-gemini/gemini-cli) `-p '' --output-fo
 
 ```bash
 gemini                                     # one-time interactive OAuth, OR
+patina auth login gemini-cli               # same, with confirmation
 export GEMINI_API_KEY="..."                # AI Studio key
 patina --backend gemini-cli --lang ko input.txt
 patina --model gemini-3-flash-preview --lang ko input.txt   # auto-routes
+```
+
+자동화에서 이미 실행 의도가 명확할 때만 `--yes`를 사용하세요.
+
+```bash
+patina auth login codex-cli --yes
 ```
 
 Notes: patina는 user text 안의 prompt-injection을 격리하기 위해 새 temp directory에서 prompt를 실행하고 `--skip-trust`를 넘깁니다. gemini는 startup latency가 더 길어 default timeout이 다른 CLI보다 높습니다.

--- a/src/backends/claude-cli.js
+++ b/src/backends/claude-cli.js
@@ -2,9 +2,11 @@ import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { DEFAULT_BACKEND_TIMEOUT_MS } from './contract.js';
+import { DEFAULT_BACKEND_TIMEOUT_MS, runInteractiveCommand } from './contract.js';
 
 export const name = 'claude-cli';
+export const loginCommand = 'claude auth login';
+export const installHint = 'Install Claude Code first, then run `patina auth login claude-cli` again.';
 
 export function isAvailable() {
   try {
@@ -23,7 +25,17 @@ export function isAuthenticated() {
 }
 
 export function authHint() {
-  return 'Run `claude` once interactively and follow the OAuth prompt to authenticate (uses your Claude subscription, no API key needed).';
+  return `Run \`${loginCommand}\` and follow the OAuth prompt to authenticate (uses your Claude subscription, no API key needed).`;
+}
+
+export function login(options = {}) {
+  return runInteractiveCommand({
+    backendName: name,
+    command: 'claude',
+    args: ['auth', 'login'],
+    notFoundHint: installHint,
+    ...options,
+  });
 }
 
 export async function invoke({ prompt, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS } = {}) {

--- a/src/backends/codex-cli.js
+++ b/src/backends/codex-cli.js
@@ -2,9 +2,11 @@ import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { DEFAULT_BACKEND_TIMEOUT_MS } from './contract.js';
+import { DEFAULT_BACKEND_TIMEOUT_MS, runInteractiveCommand } from './contract.js';
 
 export const name = 'codex-cli';
+export const loginCommand = 'codex login';
+export const installHint = 'Install it from https://github.com/openai/codex, then run `patina auth login codex-cli` again.';
 
 export function isAvailable() {
   try {
@@ -20,7 +22,17 @@ export function isAuthenticated() {
 }
 
 export function authHint() {
-  return 'Run `codex login` to authenticate (uses your ChatGPT Plus account, no API key needed).';
+  return `Run \`${loginCommand}\` to authenticate (uses your ChatGPT Plus account, no API key needed).`;
+}
+
+export function login(options = {}) {
+  return runInteractiveCommand({
+    backendName: name,
+    command: 'codex',
+    args: ['login'],
+    notFoundHint: installHint,
+    ...options,
+  });
 }
 
 export async function invoke({ prompt, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS } = {}) {

--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -1,3 +1,5 @@
+import { spawn } from 'node:child_process';
+
 export const DEFAULT_BACKEND_TIMEOUT_MS = 180_000;
 
 export function isRetryableBackendError(err, { attemptIndex = 0, signal } = {}) {
@@ -18,4 +20,42 @@ function extractStatus(err) {
   if (Number.isFinite(direct)) return direct;
   const match = String(err?.message || '').match(/\bHTTP\s+(429|503)\b/);
   return match ? Number(match[1]) : null;
+}
+
+export function runInteractiveCommand({
+  backendName,
+  command,
+  args = [],
+  cwd = process.cwd(),
+  env = process.env,
+  stdio = 'inherit',
+  notFoundHint,
+} = {}) {
+  if (!backendName || !command) {
+    throw new Error('interactive backend command requires backendName and command');
+  }
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, { cwd, env, stdio });
+
+    proc.on('error', (err) => {
+      if (err.code === 'ENOENT') {
+        reject(new Error(`${backendName}: \`${command}\` CLI not found. ${notFoundHint || 'Install the CLI and try again.'}`));
+        return;
+      }
+      reject(new Error(`${backendName}: failed to spawn ${command} (${err.message})`));
+    });
+
+    proc.on('close', (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      if (signal) {
+        reject(new Error(`${backendName}: ${command} was terminated by ${signal}`));
+        return;
+      }
+      reject(new Error(`${backendName}: ${command} exited with code ${code}`));
+    });
+  });
 }

--- a/src/backends/gemini-cli.js
+++ b/src/backends/gemini-cli.js
@@ -2,9 +2,11 @@ import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { DEFAULT_BACKEND_TIMEOUT_MS } from './contract.js';
+import { DEFAULT_BACKEND_TIMEOUT_MS, runInteractiveCommand } from './contract.js';
 
 export const name = 'gemini-cli';
+export const loginCommand = 'gemini';
+export const installHint = 'Install Gemini CLI first, then run `patina auth login gemini-cli` again.';
 
 export function isAvailable() {
   try {
@@ -28,7 +30,17 @@ export function authHint() {
   if (process.env.GEMINI_API_KEY) {
     return 'Authenticated via GEMINI_API_KEY env var.';
   }
-  return 'Run `gemini` once interactively to log in via Google OAuth, or set GEMINI_API_KEY.';
+  return `Run \`${loginCommand}\` once interactively to log in via Google OAuth, or set GEMINI_API_KEY.`;
+}
+
+export function login(options = {}) {
+  return runInteractiveCommand({
+    backendName: name,
+    command: 'gemini',
+    args: [],
+    notFoundHint: installHint,
+    ...options,
+  });
 }
 
 export async function invoke({ prompt, model, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS } = {}) {

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -146,7 +146,7 @@ export async function invokeBackendChain({
   throw lastError || new Error('backend fallback chain failed without an error');
 }
 
-function resolveBackend(name) {
+export function resolveBackend(name) {
   const backend = REGISTRY[name];
   if (!backend) {
     throw inputError(

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,7 +8,7 @@ import {
   toneToBackboneProfile,
 } from './loader.js';
 import { buildPrompt } from './prompt-builder.js';
-import { invokeBackendChain, selectBackendChain, listBackends, listBackendNames } from './backends/index.js';
+import { invokeBackendChain, selectBackendChain, listBackends, listBackendNames, resolveBackend } from './backends/index.js';
 import { selectProvider, resolveProviderConfig, PROVIDERS } from './providers.js';
 import { validateBaseURL, applyInsecureBaseURLOptIn, applyPrivateBaseURLOptIn } from './security.js';
 import { formatOutput, validateScoreWeights } from './output.js';
@@ -26,6 +26,7 @@ import { createLogger } from './logger.js';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, basename, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createInterface } from 'node:readline/promises';
 
 const PACKAGE_VERSION = JSON.parse(
   readFileSync(resolve(getRepoRoot(), 'package.json'), 'utf8')
@@ -906,6 +907,8 @@ COMMANDS
   patina doctor [--json]  Check Node, backends, tmux, and auth setup
   patina auth status      Show backend availability and authentication status
   patina auth login       Print per-backend authentication instructions
+  patina auth login <backend> [--yes]
+                         Launch a backend login flow after confirmation
 
 MODES
   --diff                  Show changes pattern by pattern
@@ -1257,13 +1260,19 @@ function providerKeySource(provider) {
   return source.ok ? source.source : 'missing';
 }
 
-function handleAuth(subArgs) {
+async function handleAuth(subArgs) {
   const sub = subArgs[0] || 'status';
   if (sub === 'status') {
     printBackendStatus();
     return;
   }
   if (sub === 'login') {
+    const parsed = parseAuthLoginArgs(subArgs.slice(1));
+    if (parsed.backendName) {
+      await runAuthLogin(parsed);
+      return;
+    }
+
     console.log('To authenticate a backend, follow the per-backend instructions:\n');
     for (const b of listBackends()) {
       const status = b.authenticated ? '✓ already authenticated' : '✗ not authenticated';
@@ -1275,8 +1284,99 @@ function handleAuth(subArgs) {
   throw inputError(
     `unknown auth subcommand ${sub}`,
     'Supported auth subcommands are status and login.',
-    'Try `patina auth status` or `patina auth login`.'
+    'Try `patina auth status`, `patina auth login`, or `patina auth login codex-cli`.'
   );
+}
+
+function parseAuthLoginArgs(args) {
+  let assumeYes = false;
+  let backendName = null;
+
+  for (const arg of args) {
+    if (arg === '--yes' || arg === '-y') {
+      assumeYes = true;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      throw inputError(
+        `unknown auth login option ${arg}`,
+        'Only --yes/-y is supported for non-interactive confirmation.',
+        'Run `patina auth login <backend> --yes` or omit --yes to confirm interactively.'
+      );
+    }
+    if (backendName) {
+      throw inputError(
+        'auth login expects at most one backend',
+        `Received both ${backendName} and ${arg}.`,
+        `Available backends are: ${listBackendNames().join(', ')}.`
+      );
+    }
+    backendName = arg;
+  }
+
+  return { backendName, assumeYes };
+}
+
+async function runAuthLogin({ backendName, assumeYes }) {
+  const backend = resolveBackend(backendName);
+  if (typeof backend.login !== 'function') {
+    throw inputError(
+      `${backend.name} does not support interactive login`,
+      backend.authHint ? backend.authHint() : 'This backend authenticates outside local CLI OAuth.',
+      'Set PATINA_API_KEY, PATINA_API_KEY_FILE, or the provider-specific API key env var for HTTP backends.'
+    );
+  }
+
+  if (!backend.isAvailable()) {
+    throw runtimeError(
+      `${backend.name} CLI is not installed or not on PATH`,
+      backend.installHint || backend.authHint(),
+      'Install the CLI named above, then rerun this command.'
+    );
+  }
+
+  const commandLabel = backend.loginCommand || backend.name;
+  const confirmed = await confirmAuthLogin(commandLabel, { assumeYes });
+  if (!confirmed) {
+    console.log('Cancelled.');
+    return;
+  }
+
+  const wasAuthenticated = backend.isAuthenticated();
+  await backend.login();
+  const authenticated = backend.isAuthenticated();
+
+  if (authenticated) {
+    console.log(`${backend.name}: authenticated.`);
+  } else if (wasAuthenticated) {
+    console.log(`${backend.name}: login command completed; previous authentication is still present.`);
+  } else {
+    console.log(`${backend.name}: login command completed, but patina could not confirm authentication yet.`);
+    console.log(`→ ${backend.authHint()}`);
+  }
+}
+
+async function confirmAuthLogin(commandLabel, { assumeYes = false } = {}) {
+  if (assumeYes) {
+    console.log(`Run ${commandLabel}? yes (--yes)`);
+    return true;
+  }
+
+  if (!process.stdin.isTTY) {
+    throw inputError(
+      `cannot confirm ${commandLabel} in a non-interactive session`,
+      'patina will not launch an interactive OAuth flow without explicit confirmation.',
+      `Rerun with \`patina auth login <backend> --yes\` if you intentionally want to start ${commandLabel}.`
+    );
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await rl.question(`Run ${commandLabel}? [Y/n] `);
+    return answer.trim() === '' || /^y(es)?$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
 }
 
 // Self-invocation guard (#113): when run directly via `node src/cli.js ...`,

--- a/tests/e2e/auth-login.test.js
+++ b/tests/e2e/auth-login.test.js
@@ -1,0 +1,145 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { main } from '../../src/cli.js';
+
+async function withEnv(envOverrides, fn) {
+  const original = {};
+  for (const key of Object.keys(envOverrides)) {
+    original[key] = process.env[key];
+    if (envOverrides[key] === undefined) delete process.env[key];
+    else process.env[key] = envOverrides[key];
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const key of Object.keys(original)) {
+      if (original[key] === undefined) delete process.env[key];
+      else process.env[key] = original[key];
+    }
+  }
+}
+
+async function captureConsole(fn) {
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => logs.push(args.join(' '));
+  try {
+    await fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return logs.join('\n');
+}
+
+function writeFakeCli(binDir, name) {
+  const script = `#!/usr/bin/env node
+import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+
+const cli = basename(process.argv[1]);
+const args = process.argv.slice(2);
+appendFileSync(process.env.PATINA_FAKE_LOGIN_LOG, cli + ' ' + args.join(' ') + '\\n');
+
+if (args[0] === '--version') process.exit(0);
+
+if (cli === 'codex' && args.join(' ') === 'login') {
+  mkdirSync(join(homedir(), '.codex'), { recursive: true });
+  writeFileSync(join(homedir(), '.codex', 'auth.json'), '{}');
+  process.exit(0);
+}
+if (cli === 'claude' && args.join(' ') === 'auth login') {
+  mkdirSync(join(homedir(), '.claude'), { recursive: true });
+  writeFileSync(join(homedir(), '.claude', '.credentials.json'), '{}');
+  process.exit(0);
+}
+if (cli === 'gemini' && args.length === 0) {
+  mkdirSync(join(homedir(), '.gemini'), { recursive: true });
+  writeFileSync(join(homedir(), '.gemini', 'gemini-credentials.json'), '{}');
+  process.exit(0);
+}
+
+process.exit(64);
+`;
+  const path = join(binDir, name);
+  writeFileSync(path, script);
+  chmodSync(path, 0o755);
+}
+
+function makeFakeCliEnv() {
+  const root = mkdtempSync(join(tmpdir(), 'patina-auth-login-'));
+  const binDir = join(root, 'bin');
+  const home = join(root, 'home');
+  const log = join(root, 'login.log');
+  mkdirSync(binDir);
+  mkdirSync(home);
+  for (const name of ['codex', 'claude', 'gemini']) writeFakeCli(binDir, name);
+  return {
+    HOME: home,
+    PATH: `${binDir}:${process.env.PATH || ''}`,
+    PATINA_FAKE_LOGIN_LOG: log,
+    GEMINI_API_KEY: undefined,
+    log,
+    home,
+  };
+}
+
+describe('patina auth login <backend>', () => {
+  it('keeps no-arg login as a per-backend instruction listing', async () => {
+    const output = await captureConsole(async () => {
+      await main(['auth', 'login']);
+    });
+
+    assert.match(output, /To authenticate a backend/);
+    assert.match(output, /codex-cli/);
+    assert.match(output, /claude-cli/);
+    assert.match(output, /gemini-cli/);
+  });
+
+  it('launches codex login and re-checks authentication', async () => {
+    const env = makeFakeCliEnv();
+    const output = await withEnv(env, () => captureConsole(async () => {
+      await main(['auth', 'login', 'codex-cli', '--yes']);
+    }));
+
+    assert.match(readFileSync(env.log, 'utf8'), /codex --version\ncodex login\n/);
+    assert.ok(existsSync(join(env.home, '.codex', 'auth.json')));
+    assert.match(output, /codex-cli: authenticated/);
+  });
+
+  it('launches claude auth login and gemini interactive login', async () => {
+    const env = makeFakeCliEnv();
+    const output = await withEnv(env, () => captureConsole(async () => {
+      await main(['auth', 'login', 'claude-cli', '--yes']);
+      await main(['auth', 'login', 'gemini-cli', '--yes']);
+    }));
+
+    const log = readFileSync(env.log, 'utf8');
+    assert.match(log, /claude --version\nclaude auth login\n/);
+    assert.match(log, /gemini --version\ngemini \n/);
+    assert.ok(existsSync(join(env.home, '.claude', '.credentials.json')));
+    assert.ok(existsSync(join(env.home, '.gemini', 'gemini-credentials.json')));
+    assert.match(output, /claude-cli: authenticated/);
+    assert.match(output, /gemini-cli: authenticated/);
+  });
+
+  it('reports unsupported HTTP login instead of spawning', async () => {
+    await assert.rejects(
+      () => main(['auth', 'login', 'openai-http', '--yes']),
+      /does not support interactive login/
+    );
+  });
+
+  it('fails gracefully when the requested CLI is not installed', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'patina-auth-missing-'));
+    await withEnv({ PATH: root, HOME: root }, async () => {
+      await assert.rejects(
+        () => main(['auth', 'login', 'codex-cli', '--yes']),
+        /codex-cli CLI is not installed or not on PATH/
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `patina auth login <backend>` with confirmation and `--yes` automation path
- launch codex/claude/gemini login commands with inherited stdio, then re-check auth state
- keep no-arg `patina auth login` as the instruction listing and document targeted login commands

Closes #186

## Verification
- npm run lint
- npm test
- node --test tests/e2e/auth-login.test.js tests/e2e/backends.test.js tests/e2e/cli-api.test.js