### PR TITLE
docs: add launch playbook and channel copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Pattern packs are auto-discovered by language prefix. `.patina.yaml` in the work
 - **[AI/Human Metrics Research](docs/research/ai-human-metrics.md)** — benchmark design notes for measuring AI-like writing signals
 - **[2025+ Re-baseline Plan](docs/research/2025-rebaseline-plan.md)** — evidence gate before broader model-era claims
 - **[zh/ja Lexicon Calibration](docs/research/zh-ja-lexicon-calibration.md)** — starter lexicon gate and remaining corpus risk
-- **[Launch Copy](docs/social/patina-launch-copy.md)** — Show HN, Reddit, X, Korean community drafts
+- **[Launch Copy](docs/social/patina-launch-copy.md)** — launch sequence, score gate, and Show HN/Product Hunt/Reddit/X/Korean drafts
 - **[Stylometry](core/stylometry.md)** — burstiness + MATTR + AI-lexicon algorithm
 - **[Scoring](core/scoring.md)** — AI-likeness + fidelity + MPS
 - **[Changelog](CHANGELOG.md)** — release notes and methodology

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -250,27 +250,29 @@ Do not lead with “bypass AI detectors.” Lead with:
 
 ## 5. Immediate next actions
 
-Last triaged: 2026-05-21, after the final high-ultragoal backlog campaign sync.
+Last triaged: 2026-05-21, after Launch Wave 1 score-badge/playbook work.
 
 Current GitHub issue inventory:
 
-- 17 open issues; 131 closed issues; 148 tracked issues total.
+- 16 open issues; 132 closed issues; 148 tracked issues total.
 - Open PRs: 0.
-- Open priority split: 2 high, 5 medium, 10 low, and 0 without priority labels.
-- Current high-priority issues: #282 README score badge, #286 launch tracking/playbook.
+- Open priority split: 1 high, 5 medium, 10 low, and 0 without priority labels.
+- Current high-priority issue: #286 launch tracking/playbook.
 
 Campaign state:
 
 - Merged campaign PRs: #281, #287, #288, #289, #290, #292, #293.
 - Concurrent cleanup merged during the final gate: #294 closed #291.
 - Final review blocker cleanup: #295.
+- Launch Wave 1 badge work: #297 closed #282; companion patina-action#1 added `badge-json` / `badge-branch`.
+- #286 now has a checked-in launch playbook/copy source and remains open as the launch execution tracker until #208/#283/#285 are ready or explicitly waived.
 - Closed or verified during the campaign: #99, #165, #186, #191, #199, #209, #210.
 - Kept open with explicit blocker comments: #104, #155, #156, #157, #158, #159, #160, #206, #207, #208, #211, #212.
 - Legacy bot/harness notes were removed from the public repo; restart autonomous bot work only from a fresh, tracked design if it becomes necessary.
 
 Next recommended order:
 
-1. Resolve the two high-priority launch issues (#282, #286).
-2. Continue medium research/content items (#104, #155, #160, #283, #285).
+1. Keep #286 as the launch execution tracker; do not broad-launch until #208 has a URL, or explicitly waive the playground dependency.
+2. Continue launch-support medium items (#283 share card generator, #285 educational guide), then research/process items (#104, #155, #160).
 3. Treat low-priority research/ecosystem items (#156-#159, #206-#208, #211, #212, #284) as parked until corpus, external repo, hosting, or governance prerequisites exist.
 4. Keep new campaign PRs short-lived: green checks, merged, or explicitly blocked with issue comments.

--- a/docs/social/patina-launch-copy.md
+++ b/docs/social/patina-launch-copy.md
@@ -1,10 +1,49 @@
-# patina Launch Copy
+# patina Launch Copy and Playbook
 
-Use this file as the source of truth for public launch posts. The positioning is deliberately "auditable cleanup / editing tool", not detector bypass.
+Use this file as the source of truth for public launch posts. The positioning is deliberately **auditable cleanup / editing tool**, not detector bypass.
+
+## Launch sequence
+
+Run the launch in this order. Do not skip the Korean-first pass: it is the wedge that makes patina different from generic English humanizers.
+
+| Order | Surface | Primary angle | Launch state |
+|---:|---|---|---|
+| 1 | Korean communities: GeekNews, Velog, Clien | Korean AI tells plus auditable edits | Ready after final score pass |
+| 2 | Show HN | Local, auditable, benchmarked prose cleanup | Wait for playground URL |
+| 3 | Product Hunt | Visual demo plus “keep the meaning” | Wait for playground URL and share card |
+| 4 | Reddit / X / Threads / LinkedIn | Local/no-key angle or editing/voice angle | Reuse the channel drafts below |
+
+## Prerequisite checklist
+
+| Item | Status | Launch impact |
+|---|---|---|
+| npm package live (#203) | Done | Use `npx patina-cli` in posts. |
+| GitHub Action v1 (#204) | Done | Mention PR comments and README score badge. |
+| README score badge (#282) | Done | Use as adoption/social proof. |
+| Ethics framing (#164, [`docs/ETHICS.md`](../ETHICS.md)) | Done | Never imply detector evasion. |
+| Comparison page (#213, [`docs/COMPARISON.md`](../COMPARISON.md)) | Done | Cite only factual comparisons. |
+| Web playground (#208) | Blocker | Broad launch waits for the try-it-now URL. |
+| Shareable card generator (#283) | Helpful | Product Hunt and X work better with it. |
+| “Signs of AI writing” guide (#285) | Helpful | Use as top-of-funnel content. |
+
+## Non-negotiable rules
+
+- Score every final post before publishing. Target `<= 30`.
+- Attach the score screenshot or CLI output to the internal launch thread.
+- Lead with the writing problem. Mention the tool after the reader recognizes the problem.
+- Do not use “bypass,” “undetectable,” or “beats detectors.”
+- Avoid hype vocabulary, emoji-bullet stacks, and tidy three-item slogans.
+- Link the playground from every broad-launch post once #208 is live. Until then, link the repo.
+
+Score command:
+
+```bash
+node scripts/precommit-score.mjs docs/social/patina-launch-copy.md
+```
+
+Last local score check: 2026-05-21, `docs/social/patina-launch-copy.md` scored 14.3% (`node scripts/precommit-score.mjs docs/social/patina-launch-copy.md`).
 
 ## Positioning
-
-patina detects recurring AI-writing patterns, rewrites the affected passages, and checks whether the original claims were preserved.
 
 Short tagline:
 
@@ -14,38 +53,50 @@ Long tagline:
 
 > A pattern-based cleanup tool for AI-sounding text. It shows what changed, why it changed, and whether the original claims survived.
 
-## Before posting
+One-sentence description:
 
-- Run `npm run benchmark:report && npm test`.
-- Check the current benchmark: [`docs/benchmarks/latest.md`](../benchmarks/latest.md).
-- If comparing tools, link the factual comparison page: [`docs/COMPARISON.md`](../COMPARISON.md).
-- Use the launch social preview when the surface supports images: [`assets/social/patina-og.svg`](../../assets/social/patina-og.svg).
-- Keep claims to "editing signal" and "suspect-zone benchmark"; do not imply authorship proof.
-- Link issues for useful feedback: false positives, missing patterns, benchmark fixtures.
+> patina finds recurring AI-writing habits in Korean, English, Chinese, and Japanese, rewrites the affected passages, and keeps the edit auditable.
 
-## Avoid
+## Assets to attach
 
-Do not frame patina as:
+- Social preview: [`assets/social/patina-og.svg`](../../assets/social/patina-og.svg)
+- Before/after card: [`assets/social/patina-before-after.svg`](../../assets/social/patina-before-after.svg)
+- Static badge fallback: [`assets/brand/patina-badge.svg`](../../assets/brand/patina-badge.svg)
+- Benchmark report: [`docs/benchmarks/latest.md`](../benchmarks/latest.md)
+- Comparison page: [`docs/COMPARISON.md`](../COMPARISON.md)
 
-- an AI detector bypass tool
-- a way to fake authorship
-- proof that text is human-written
-- a universal paraphraser
+## Korean communities
 
-Use these instead:
+Title options:
 
-- auditable editing
-- pattern-based cleanup
-- meaning preservation
-- false-positive-aware scoring
-- diff/audit/score modes
+```text
+patina — 한국어·영어 AI 글의 “AI 티”를 찾아서 지워주는 오픈소스
+AI가 쓴 티 나는 문장, 패턴으로 잡아서 고쳐주는 도구를 만들었습니다
+```
+
+Post body:
+
+```text
+GPT한테 글을 맡기면 어딘가 티가 납니다. “~적인”, “~하고 있다”, 갑자기 늘어나는 한자어, 너무 반듯한 목록 같은 것들요.
+
+patina는 그런 패턴을 찾아서 고칩니다. 한국어, 영어, 중국어, 일본어를 지원하고, Claude Code / Codex / Cursor / OpenCode 스킬이나 Node CLI로 쓸 수 있습니다.
+
+핵심은 AI detector 우회가 아니라 편집입니다. 어떤 표현을 잡았는지, 왜 바꿨는지, 원래 주장과 의미가 보존됐는지를 audit / diff / score로 확인할 수 있게 만들었습니다.
+
+API 키 없이도 쓸 수 있습니다. codex, claude, gemini CLI 중 하나에 로그인돼 있으면 됩니다.
+
+레포:
+https://github.com/devswha/patina
+
+특히 한국어 오탐 사례가 필요합니다. 사람이 쓴 글인데 patina가 AI 티로 잡는 사례를 알려주시면 패턴을 다듬는 데 가장 도움이 됩니다.
+```
 
 ## Show HN
 
 Title:
 
 ```text
-Show HN: patina – Strip the AI packaging, keep the meaning
+Show HN: Patina – strip AI-writing tells from Korean/English/Chinese/Japanese text
 ```
 
 Post body:
@@ -53,141 +104,135 @@ Post body:
 ```text
 Hi HN,
 
-I built patina, a pattern-based cleanup tool for AI-sounding text.
+I built Patina because I kept editing the same LLM tells out of drafts: inflated adjectives, neat three-part lists, hedging on hedging, and in Korean, suffixes like “~적”, progressive “~고 있다”, and needless Sino-Korean phrasing.
 
-It detects recurring LLM writing habits, rewrites the affected passages, and checks whether the original claims were preserved. It supports Korean, English, Chinese, and Japanese, and runs as a skill for Claude Code, Codex CLI, Cursor, and OpenCode, or as a standalone Node.js CLI.
+Patina turns those habits into a pattern catalog for Korean, English, Chinese, and Japanese. It can rewrite the affected passages, but it is not a black-box paraphraser. It shows what changed, why it changed, and whether claims, numbers, polarity, causation, and negation survived the edit.
 
-The main difference from a generic paraphraser is auditability: patina can show what pattern it found, what it changed, and whether semantic anchors such as claims, polarity, causation, numbers, and negation survived the rewrite.
+It runs as a skill in Claude Code, Codex CLI, Cursor, and OpenCode, or as a standalone Node CLI:
 
-Example:
+npx patina-cli --lang en draft.md
 
-Before:
-"Coffee has emerged as a pivotal cultural phenomenon that has fundamentally transformed social interactions across the globe. This beloved beverage serves as a catalyst for community building, fosters meaningful connections, and facilitates cross-cultural dialogue."
+If you are already logged into codex, claude, or gemini CLI, you can use it without adding an API key.
 
-After:
-"Coffee has quietly changed how people meet. Sit across from someone long enough, and something like a real connection tends to form — even between people from very different cultures."
-
-This is not meant as an AI-detector bypass tool. Detectors are noisy. I treat the score as an editing signal, and the diff/audit output as the useful artifact.
+This is not meant as a detector-bypass tool. I treat the score as an editing signal, not proof of authorship. False positives are documented because the useful output is the audit and diff, not a verdict.
 
 Repo:
 https://github.com/devswha/patina
 
-I would especially like feedback on false positives, missing pattern families, and whether the MPS / diff / audit modes are useful for real writing workflows.
+The feedback I want most: human text that Patina wrongly flags, missing pattern families, and examples where the rewrite preserved the wrong thing.
 ```
 
-## Reddit / ClaudeAI Megathread
+## Product Hunt
+
+Tagline:
 
 ```text
-I built patina, a Claude Code skill / CLI for cleaning up AI-sounding text.
+Strip the AI packaging. Keep the meaning.
+```
 
-It detects recurring AI writing patterns, rewrites them, and checks that the original meaning is preserved. It supports Korean, English, Chinese, and Japanese, and also works with Codex CLI, Cursor, OpenCode, and standalone Node.js.
+Description:
 
-Quick before/after:
+```text
+Patina finds the habits that make text read as AI-written — in Korean, English, Chinese, and Japanese — and rewrites them out. It is not a black-box paraphraser: it shows what changed, why it changed, and whether your claims survived. Use it in Claude Code, Codex, Cursor, OpenCode, or as a Node CLI.
+```
 
-Before:
-“Coffee has emerged as a pivotal cultural phenomenon that has fundamentally transformed social interactions across the globe. This beloved beverage serves as a catalyst for community building, fosters meaningful connections, and facilitates cross-cultural dialogue.”
+Maker comment:
 
-After:
-“Coffee has quietly changed how people meet. Sit across from someone long enough, and something like a real connection tends to form, even between people from very different cultures.”
+```text
+I built Patina because I was tired of removing the same AI tells from drafts by hand. Two details matter to me: it works on Korean, where most English-first humanizers miss the obvious tells, and it is auditable. Every edit should have a reason and a meaning-preservation check.
+
+I do not want this framed as “make text undetectable.” Detectors are noisy. Patina is an editing pass: find the synthetic packaging, remove it, and keep the claim intact.
+
+Try it on something you wrote and tell me where it is wrong. False positives are the most useful reports.
+```
+
+## Reddit
+
+### r/LocalLLaMA
+
+```text
+I built Patina, a local-friendly tool for cleaning up AI-sounding prose.
+
+It runs through the CLI you already use. If you are logged into codex, claude, or gemini, you can run Patina without adding a separate API key. It also works as a Claude Code / Codex / Cursor / OpenCode skill.
+
+The tool finds recurring LLM writing habits, rewrites the affected text, and checks whether the original claims survived. It supports Korean, English, Chinese, and Japanese.
+
+This is not an “undetectable text” project. The score is an editing signal. The useful artifact is the audit: what pattern fired, what changed, and whether meaning drifted.
 
 Repo:
 https://github.com/devswha/patina
 
-I’d especially like feedback on false positives, missing AI-writing patterns, and whether the audit/score/diff modes make sense for real Claude output.
+I am looking for false positives and missing pattern families, especially outside English.
 ```
 
-## X launch thread
-
-### 1
+### r/writing or r/Korean
 
 ```text
-I built patina: a pattern-based cleanup tool for AI-sounding text.
+I built a tool that spots and rewrites AI-sounding patterns in writing, including Korean.
 
-It strips the AI packaging while keeping the meaning.
+The goal is not to hide authorship. It is to make AI-assisted drafts easier to edit. Patina points out habits like inflated phrasing, tidy generic structure, and Korean AI tells such as “~적인”, “~하고 있다”, and needless formal nouns.
 
-Claude Code / Codex CLI / Cursor / OpenCode / Node CLI
-KO / EN / ZH / JA
+It then rewrites the affected passages and checks that the original meaning survived. You can see the audit and diff instead of trusting a black-box paraphrase.
+
+Repo:
+https://github.com/devswha/patina
+
+If you have human-written text that gets flagged, I would love to see it. Those examples are the best way to reduce false positives.
+```
+
+## X / Threads
+
+### Korean thread
+
+```text
+1/ AI가 쓴 글은 티가 납니다. “~적인”, 너무 반듯한 목록, 갑자기 늘어나는 한자어 같은 것들요.
+
+patina는 그런 패턴을 찾아서 고칩니다. KO / EN / ZH / JA.
+```
+
+```text
+2/ 그냥 다시 써주는 도구는 많습니다.
+
+patina는 뭘 왜 바꿨는지, 원래 의미가 보존됐는지까지 보여주는 편집 도구에 가깝습니다.
+```
+
+```text
+3/ API 키 없이도 쓸 수 있습니다.
+
+codex / claude / gemini CLI 중 하나만 로그인돼 있으면 Node CLI나 에디터 스킬로 바로 돌릴 수 있습니다.
+```
+
+```text
+4/ 목표는 detector 우회가 아닙니다.
+
+점수는 편집 신호일 뿐이고, 중요한 건 audit / diff / meaning check입니다.
 
 https://github.com/devswha/patina
 ```
 
-### 2
+### English single post
 
 ```text
-The goal is not detector bypass.
+I built Patina: an AI-writing cleanup tool that works on Korean, shows its edits, and checks whether the meaning survived.
 
-AI detectors are noisy. patina treats the score as an editing signal, not proof of authorship.
+Not detector bypass. Just auditable editing for text that sounds too packaged.
 
-The useful parts are audit, diff, and meaning-preservation checks: what changed, why it changed, and whether the original claims survived.
-```
-
-### 3
-
-```text
-Example before:
-
-“Coffee has emerged as a pivotal cultural phenomenon that has fundamentally transformed social interactions across the globe...”
-
-This is the kind of AI packaging patina looks for: inflated stakes, vague abstraction, and generic benefit stacking.
-```
-
-### 4
-
-```text
-After:
-
-“Coffee has quietly changed how people meet. Sit across from someone long enough, and something like a real connection tends to form — even between people from very different cultures.”
-
-Same claims. Less model voice.
-```
-
-### 5
-
-```text
-Under the hood, patina tracks semantic anchors: claims, polarity, causation, numbers, and negation.
-
-If a rewrite drops or flips an anchor, it retries or rolls back the change.
-
-That is the part I care about most: editable output with a safety rail.
-```
-
-### 6
-
-```text
-Current calibration:
-
-- 146 pattern catalog
-- 91% Korean editing-hotspot recall [84.0-95.4%], n=100
-- 76% English HC3 editing-hotspot recall [66.7-83.3%], n=100
-- 13-25% human-prose false-positive point-estimate range across registers
-- Latest fixture benchmark: https://github.com/devswha/patina/blob/main/docs/benchmarks/latest.md
-
-False positives are documented because this should be used as an editor, not a judge.
-```
-
-### 7
-
-```text
-If you write with LLMs and hate the default polished-but-empty voice, try it and tell me where it fails.
-
-I’m especially looking for missing patterns, false positives, and better before/after examples.
-
+Claude Code / Codex / Cursor / OpenCode / Node CLI.
 https://github.com/devswha/patina
 ```
 
-## Short Korean community post
+## LinkedIn
 
 ```text
-patina라는 오픈소스 도구를 만들고 있습니다.
+Every team ships AI-assisted writing now: docs, release notes, support replies, launch posts. The problem is not that the writing is AI-assisted. The problem is that it often reads like it.
 
-AI가 쓴 글에서 자주 보이는 표현 패턴을 잡아서, 의미는 유지한 채 더 자연스럽게 고치는 도구입니다. Claude Code 스킬로 쓸 수 있고, Codex CLI / Cursor / OpenCode / Node CLI에서도 동작합니다. 한국어, 영어, 중국어, 일본어 패턴을 지원합니다.
+I built Patina for the editing pass after generation. It finds the habits that make prose feel machine-written, rewrites the affected passages, and checks whether the original claims survived.
 
-핵심은 “AI detector 우회”가 아니라 편집입니다. 어떤 패턴을 잡았는지, 왜 바꿨는지, 원래 주장과 의미가 보존됐는지를 audit / diff / score 모드로 확인할 수 있게 만드는 쪽에 집중했습니다.
+The important part for work is auditability. You can see what changed and why instead of trusting a black-box paraphrase.
 
-레포:
+It supports Korean, English, Chinese, and Japanese, and runs as an editor skill or Node CLI.
+
 https://github.com/devswha/patina
-
-특히 한국어 false positive, 빠진 AI 문체 패턴, before/after 예시 피드백을 받고 싶습니다.
 ```
 
 ## Maintainer reply templates
@@ -195,17 +240,17 @@ https://github.com/devswha/patina
 ### Detector-bypass concern
 
 ```text
-Fair concern. I do not think of patina as a detector-bypass tool. AI detectors are noisy anyway.
+Fair concern. I do not think of Patina as a detector-bypass tool. AI detectors are noisy anyway.
 
-The goal is editing: find repeated writing habits that make LLM output feel synthetic, rewrite those parts, and keep the meaning checkable through audit/diff/score modes.
+The goal is editing: find repeated writing habits that make LLM output feel synthetic, rewrite those parts, and keep the meaning checkable through audit, diff, and score modes.
 ```
 
 ### False positives
 
 ```text
-False positives are real. Human prose can trigger patina, especially encyclopedic, corporate, academic, or heavily edited writing.
+False positives are real. Human prose can trigger Patina, especially encyclopedic, corporate, academic, or heavily edited writing.
 
-That is why I treat the score as a rough editing signal, not a truth machine. The diff and the highlighted patterns matter more than the exact number.
+That is why I treat the score as a rough editing signal, not a truth machine. The diff and highlighted patterns matter more than the exact number.
 ```
 
 ### Install help
@@ -223,5 +268,12 @@ Then in Claude Code:
 
 Or as a standalone CLI:
 
-patina --lang en input.txt
+npx patina-cli --lang en input.txt
 ```
+
+## Post-launch triage
+
+- Collect false-positive reports under the `false-positive` label.
+- Turn repeated missing patterns into pattern issues with examples.
+- Add strong before/after examples to `docs/EXAMPLES.md` or `examples/`.
+- Re-score public copy after edits; keep the launch thread evidence attached.


### PR DESCRIPTION
## Summary
- turn `docs/social/patina-launch-copy.md` into the tracked launch playbook and channel-copy source
- add launch order, prerequisite/blocker table, score gate, assets, and post-launch triage rules
- sync README and roadmap after #282 closed; keep #286 open as the launch execution tracker because #208 is still the broad-launch blocker

## Verification
- `git diff --check`
- `npm run lint`
- `npm run dogfood`
- `node scripts/precommit-score.mjs docs/social/patina-launch-copy.md` → 14.3%, pass

Refs #286
