### PR TITLE
feat: add share-card SVG output

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ patina --lang <ko|en|zh|ja> [mode] [--profile <name>] input.txt
 | `--json-logs` | Emit stderr logs as NDJSON with `level`, `event`, `model`, and `latency_ms` fields |
 | `--prompt-mode strict\|minimal\|auto` | Choose full pattern-pack prompting, compressed prompting, or backend-aware auto |
 | `--variants <1-5>` | Generate multiple rewrite variants with the same facts and meaning anchors |
+| `--card <path>` | Write a 1200×630 SVG before/after card with AI score and MPS |
 
 `patina --help` for the full flag list. `patina doctor --json` checks Node/backend/tmux/API-key readiness without making an LLM call, and `patina init` writes a project `.patina.yaml`.
 
@@ -309,6 +310,7 @@ Pattern packs are auto-discovered by language prefix. `.patina.yaml` in the work
 - **[zh/ja Lexicon Calibration](docs/research/zh-ja-lexicon-calibration.md)** — starter lexicon gate and remaining corpus risk
 - **[Launch Copy](docs/social/patina-launch-copy.md)** — launch sequence, score gate, and Show HN/Product Hunt/Reddit/X/Korean drafts
 - **[Signs of AI Writing](docs/social/signs-of-ai-writing.md)** ([한국어](docs/social/signs-of-ai-writing_KR.md)) — shareable editing checklist with cited examples
+- **[Share Card SVGs](docs/social/share-card.md)** — `--card` before/after social cards with score and MPS pills
 - **[Stylometry](core/stylometry.md)** — burstiness + MATTR + AI-lexicon algorithm
 - **[Scoring](core/scoring.md)** — AI-likeness + fidelity + MPS
 - **[Changelog](CHANGELOG.md)** — release notes and methodology

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -250,13 +250,13 @@ Do not lead with “bypass AI detectors.” Lead with:
 
 ## 5. Immediate next actions
 
-Last triaged: 2026-05-21, after Launch Wave 1 score-badge/playbook work.
+Last triaged: 2026-05-21, after Launch Wave 2 share-card/educational-guide work.
 
 Current GitHub issue inventory:
 
-- 16 open issues; 132 closed issues; 148 tracked issues total.
+- 14 open issues; 134 closed issues; 148 tracked issues total.
 - Open PRs: 0.
-- Open priority split: 1 high, 5 medium, 10 low, and 0 without priority labels.
+- Open priority split: 1 high, 3 medium, 10 low, and 0 without priority labels.
 - Current high-priority issue: #286 launch tracking/playbook.
 
 Campaign state:
@@ -265,7 +265,8 @@ Campaign state:
 - Concurrent cleanup merged during the final gate: #294 closed #291.
 - Final review blocker cleanup: #295.
 - Launch Wave 1 badge work: #297 closed #282; companion patina-action#1 added `badge-json` / `badge-branch`.
-- #286 now has a checked-in launch playbook/copy source and remains open as the launch execution tracker until #208/#283/#285 are ready or explicitly waived.
+- Launch Wave 2 support work: #299 closed #285; share-card generator work closes #283.
+- #286 now has a checked-in launch playbook/copy source and remains open as the launch execution tracker until #208 is ready or explicitly waived.
 - Closed or verified during the campaign: #99, #165, #186, #191, #199, #209, #210.
 - Kept open with explicit blocker comments: #104, #155, #156, #157, #158, #159, #160, #206, #207, #208, #211, #212.
 - Legacy bot/harness notes were removed from the public repo; restart autonomous bot work only from a fresh, tracked design if it becomes necessary.
@@ -273,6 +274,6 @@ Campaign state:
 Next recommended order:
 
 1. Keep #286 as the launch execution tracker; do not broad-launch until #208 has a URL, or explicitly waive the playground dependency.
-2. Continue launch-support medium items (#283 share card generator, #285 educational guide), then research/process items (#104, #155, #160).
+2. Continue research/process medium items (#104, #155, #160) only when there is corpus, evaluator, or release bandwidth.
 3. Treat low-priority research/ecosystem items (#156-#159, #206-#208, #211, #212, #284) as parked until corpus, external repo, hosting, or governance prerequisites exist.
 4. Keep new campaign PRs short-lived: green checks, merged, or explicitly blocked with issue comments.

--- a/docs/social/share-card.md
+++ b/docs/social/share-card.md
@@ -1,0 +1,41 @@
+# Share-card SVGs
+
+`patina --card <path>` writes a 1200×630 SVG card with:
+
+- the original snippet (`Before`),
+- the cleaned rewrite (`After`),
+- AI-likeness score,
+- meaning-preservation score (MPS),
+- the transparent patina brand mark.
+
+Use it for launch posts, README demos, issue comments, and future playground share buttons.
+
+```bash
+printf 'AI 티 나는 문장입니다. 의미는 유지해야 합니다.' \
+  | patina --lang ko --card /tmp/patina-card.svg
+```
+
+For iterative runs, the card reuses the existing Ouroboros final score and MPS:
+
+```bash
+patina --lang en --ouroboros --card /tmp/patina-card.svg draft.md
+```
+
+For MAX runs, the card uses the winning candidate's `aiScore` and `mps`:
+
+```bash
+patina --lang en --models gpt-4o,claude --card /tmp/patina-card.svg draft.md
+```
+
+Plain rewrite mode does not otherwise expose a score object, so `--card` asks the existing AI-score and MPS evaluators after the rewrite to fill the two pills. That keeps the card honest without adding a second scoring implementation.
+
+## Privacy and text handling
+
+- Before/after snippets are truncated to roughly 280 code points and then line-wrapped.
+- XML-sensitive characters are escaped before rendering.
+- Long source text is not embedded in full in the SVG.
+- The font stack is system-only and includes CJK fallbacks; there is no webfont dependency.
+
+## Raster output
+
+PNG export is intentionally out of scope for v1 because it would require a renderer dependency such as `sharp`, `resvg`, or a browser runtime. Platforms that need PNG can rasterize the SVG externally, for example with their existing design pipeline or CI image tooling.

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "LICENSE",
     "CHANGELOG.md",
     "scripts/check-release-metadata.mjs",
+    "scripts/share-card.mjs",
     "scripts/prose-score.mjs",
     "scripts/badge-json.mjs",
     "scripts/precommit-score.mjs",

--- a/scripts/share-card.mjs
+++ b/scripts/share-card.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+const FONT_STACK = "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans CJK KR', 'Noto Sans CJK JP', 'Noto Sans CJK SC', 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif";
+const SNIPPET_LIMIT = 280;
+
+/**
+ * Escape text for safe SVG/XML text nodes and attributes.
+ *
+ * @param {string} value Untrusted user text.
+ * @returns {string} XML-safe text.
+ * @example
+ * escapeXml('<tag & value>');
+ */
+export function escapeXml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Normalize and truncate share-card snippets before rendering.
+ *
+ * @param {string} value Source or rewritten text.
+ * @param {number} [limit=280] Maximum visible code points.
+ * @returns {string} Truncated snippet with a single ellipsis when needed.
+ * @example
+ * truncateText('a'.repeat(300));
+ */
+export function truncateText(value, limit = SNIPPET_LIMIT) {
+  const normalized = String(value ?? '').replace(/\s+/gu, ' ').trim();
+  const chars = Array.from(normalized);
+  if (chars.length <= limit) return normalized;
+  return `${chars.slice(0, Math.max(0, limit - 1)).join('').trimEnd()}…`;
+}
+
+/**
+ * Render a 1200x630 SVG before/after social card.
+ *
+ * @param {object} input Card input.
+ * @param {string} input.before Source text snippet.
+ * @param {string} input.after Rewritten text snippet.
+ * @param {number|null} input.aiScore AI-likeness score, 0-100.
+ * @param {number|null} input.mps Meaning preservation score, 0-100.
+ * @param {string} [input.lang] Language code.
+ * @returns {string} SVG document string.
+ * @example
+ * renderShareCard({ before: 'AI-sounding text', after: 'Cleaner text', aiScore: 21, mps: 94, lang: 'en' });
+ */
+export function renderShareCard({ before, after, aiScore, mps, lang = 'ko' } = {}) {
+  const beforeLines = wrapSnippet(truncateText(before), { maxCharsPerLine: 34, maxLines: 6 });
+  const afterLines = wrapSnippet(truncateText(after), { maxCharsPerLine: 34, maxLines: 6 });
+  const aiLabel = formatScore(aiScore, '/100');
+  const mpsLabel = formatScore(mps);
+  const langLabel = String(lang || 'auto').toUpperCase();
+  const title = `patina before/after card — AI score ${aiLabel}, MPS ${mpsLabel}`;
+  const desc = `A patina share card comparing a ${langLabel} source snippet with its meaning-preserving rewrite.`;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" role="img" aria-labelledby="title desc">
+  <title id="title">${escapeXml(title)}</title>
+  <desc id="desc">${escapeXml(desc)}</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1020"/>
+      <stop offset="55%" stop-color="#111827"/>
+      <stop offset="100%" stop-color="#1f2937"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#000" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <g id="patina-brand-mark" transform="translate(72 39) scale(0.10546875)" aria-hidden="true">
+    <path d="M92 196C160 86 320 74 420 164L346 238C288 190 218 198 174 258Z" fill="#c46a2a"/>
+    <path d="M420 316C352 426 192 438 92 348L160 270C224 322 294 314 338 254Z" fill="#2dd4bf"/>
+    <circle cx="252" cy="248" r="54" fill="#ffe6a8" stroke="#020617" stroke-width="10"/>
+  </g>
+  <text x="142" y="78" fill="#f9fafb" font-family="${FONT_STACK}" font-size="46" font-weight="800" letter-spacing="-1.5">patina</text>
+  <text x="72" y="122" fill="#a7f3d0" font-family="${FONT_STACK}" font-size="24" font-weight="650">Strip the AI packaging. Keep the meaning.</text>
+
+  <g filter="url(#shadow)">
+    <rect x="72" y="158" width="500" height="330" rx="26" fill="#111827" stroke="#374151" stroke-width="2"/>
+    <text x="104" y="210" fill="#fca5a5" font-family="${FONT_STACK}" font-size="24" font-weight="800">Before</text>
+    <text x="104" y="258" fill="#e5e7eb" font-family="${FONT_STACK}" font-size="24">
+${renderTspans(beforeLines, 104, 0, 37)}
+    </text>
+  </g>
+
+  <text x="596" y="332" fill="#93c5fd" font-family="${FONT_STACK}" font-size="42" font-weight="800">→</text>
+
+  <g filter="url(#shadow)">
+    <rect x="628" y="158" width="500" height="330" rx="26" fill="#ecfdf5" stroke="#34d399" stroke-width="2"/>
+    <text x="660" y="210" fill="#047857" font-family="${FONT_STACK}" font-size="24" font-weight="800">After</text>
+    <text x="660" y="258" fill="#064e3b" font-family="${FONT_STACK}" font-size="24">
+${renderTspans(afterLines, 660, 0, 37)}
+    </text>
+  </g>
+
+  <g aria-label="score summary">
+    ${renderPill(72, 516, `AI score ${aiLabel}`, '#dbeafe', '#1d4ed8')}
+    ${renderPill(350, 516, `MPS ${mpsLabel}`, '#dcfce7', '#047857')}
+    ${renderPill(520, 516, `LANG ${langLabel}`, '#fef3c7', '#92400e')}
+  </g>
+
+  <text x="72" y="574" fill="#d1d5db" font-family="${FONT_STACK}" font-size="23">Pattern-based · auditable · KO/EN/ZH/JA · Claude Code · Codex CLI · Cursor · OpenCode · Node CLI</text>
+  <text x="72" y="606" fill="#93c5fd" font-family="${FONT_STACK}" font-size="22" font-weight="700">github.com/devswha/patina</text>
+</svg>
+`;
+}
+
+function wrapSnippet(text, { maxCharsPerLine, maxLines }) {
+  const words = tokenizeForWrapping(text);
+  const lines = [];
+  let current = '';
+
+  for (const word of words) {
+    if (!current) {
+      current = word;
+    } else if (visibleLength(`${current}${needsSpace(current, word) ? ' ' : ''}${word}`) <= maxCharsPerLine) {
+      current = `${current}${needsSpace(current, word) ? ' ' : ''}${word}`;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+
+    while (visibleLength(current) > maxCharsPerLine) {
+      lines.push(Array.from(current).slice(0, maxCharsPerLine).join(''));
+      current = Array.from(current).slice(maxCharsPerLine).join('');
+    }
+  }
+  if (current) lines.push(current);
+
+  if (lines.length <= maxLines) return lines.length > 0 ? lines : [''];
+
+  const kept = lines.slice(0, maxLines);
+  kept[maxLines - 1] = ensureTrailingEllipsis(kept[maxLines - 1], maxCharsPerLine);
+  return kept;
+}
+
+function tokenizeForWrapping(text) {
+  if (!text) return [''];
+  const parts = String(text).split(/(\s+)/u).filter((part) => part && !/^\s+$/u.test(part));
+  if (parts.length > 1) return parts;
+  return Array.from(String(text));
+}
+
+function needsSpace(left, right) {
+  if (!left || !right) return false;
+  return /[\p{L}\p{N})\].,!?;:'"%]$/u.test(left) && /^[\p{L}\p{N}([{]/u.test(right);
+}
+
+function visibleLength(text) {
+  return Array.from(String(text || '')).length;
+}
+
+function ensureTrailingEllipsis(text, maxChars) {
+  const chars = Array.from(String(text || '').replace(/…$/u, ''));
+  if (chars.length >= maxChars) return `${chars.slice(0, Math.max(0, maxChars - 1)).join('').trimEnd()}…`;
+  return `${chars.join('').trimEnd()}…`;
+}
+
+function renderTspans(lines, x, firstDy, lineHeight) {
+  return lines
+    .map((line, index) => `      <tspan x="${x}" dy="${index === 0 ? firstDy : lineHeight}">${escapeXml(line)}</tspan>`)
+    .join('\n');
+}
+
+function renderPill(x, y, label, bg, fg) {
+  const width = Math.max(132, 22 + visibleLength(label) * 13);
+  return `<g transform="translate(${x} ${y})"><rect width="${width}" height="38" rx="19" fill="${bg}"/><text x="18" y="25" fill="${fg}" font-family="${FONT_STACK}" font-size="18" font-weight="800">${escapeXml(label)}</text></g>`;
+}
+
+function formatScore(value, suffix = '') {
+  if (value === null || value === undefined || value === '') return 'n/a';
+  const n = Number(value);
+  if (!Number.isFinite(n)) return 'n/a';
+  const rounded = Math.round(n * 10) / 10;
+  return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}${suffix}`;
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,7 +14,8 @@ import { validateBaseURL, applyInsecureBaseURLOptIn, applyPrivateBaseURLOptIn } 
 import { formatOutput, validateScoreWeights } from './output.js';
 import { runMaxMode } from './max-mode.js';
 import { runOuroboros } from './ouroboros.js';
-import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals } from './scoring.js';
+import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals, scoreMPS, scoreText } from './scoring.js';
+import { renderShareCard } from '../scripts/share-card.mjs';
 import { callLLM, DEFAULT_TEMPERATURE } from './api.js';
 import { createResponseCache, DEFAULT_CACHE_TTL_SECONDS } from './cache.js';
 import { buildManifest, appendResult, writeManifest, hashSha256 } from './manifest.js';
@@ -24,7 +25,7 @@ import { PatinaCliError, inputError, runtimeError, renderCliError, getExitCode }
 import { inspectHttpApiKeySource, providerHttpKeyEnvVars, resolveHttpApiKey } from './auth.js';
 import { createLogger } from './logger.js';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { resolve, basename, extname } from 'node:path';
+import { resolve, basename, dirname, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createInterface } from 'node:readline/promises';
 
@@ -154,6 +155,20 @@ export async function main(args) {
     : parsed.score ? 'score'
     : parsed.ouroboros ? 'ouroboros'
     : 'rewrite';
+  if (parsed.card && mode !== 'rewrite' && mode !== 'ouroboros') {
+    throw inputError(
+      '--card can only be used with rewrite or --ouroboros',
+      'Share cards need before/after text, AI score, and meaning-preservation metadata.',
+      'Run `patina --card card.svg draft.md` or `patina --ouroboros --card card.svg draft.md`.'
+    );
+  }
+  if (parsed.card && parsed.batch) {
+    throw inputError(
+      '--card cannot be combined with --batch',
+      'One output path cannot safely represent multiple input files.',
+      'Run one input at a time, or omit --batch.'
+    );
+  }
   const voiceSamplePath = (mode === 'rewrite' || mode === 'ouroboros')
     ? (parsed.voiceSample ?? config['voice-sample'])
     : null;
@@ -167,6 +182,13 @@ export async function main(args) {
   }
 
   const inputTexts = await loadInputs(parsed, logger);
+  if (parsed.card && inputTexts.length !== 1) {
+    throw inputError(
+      '--card expects exactly one input',
+      `Received ${inputTexts.length} inputs.`,
+      'Run patina once per share card.'
+    );
+  }
   const cancellation = createCancellationController({ logger });
 
   cancellation.install();
@@ -207,6 +229,7 @@ export async function main(args) {
       });
 
       let result;
+      let shareCardCallLLM = trackedCallLLM;
 
       if (parsed.models) {
         result = await runMaxMode({
@@ -245,6 +268,19 @@ export async function main(args) {
           model: resolved.model,
         });
         const backend = backends[0];
+        shareCardCallLLM = (callArgs) => invokeBackendChain({
+          backends,
+          prompt: callArgs.prompt,
+          apiKey: callArgs.apiKey ?? resolved.apiKey,
+          baseURL: callArgs.baseURL ?? resolved.baseURL,
+          model: callArgs.model ?? resolved.model,
+          signal: callArgs.signal ?? cancellation.signal,
+          temperature: callArgs.temperature,
+          seed: manifestSeed,
+          onResponse: recordManifestCall,
+          cache: responseCache,
+          logger,
+        });
 
         if (autoSelected) {
           logger.info('backend.selected', {
@@ -331,6 +367,26 @@ export async function main(args) {
 
       if (result?.type === 'max-mode' && (result.allFailed || result.mpsFallback)) {
         process.exitCode = Math.max(Number(process.exitCode) || 0, 4);
+      }
+
+      if (parsed.card) {
+        const cardPayload = await buildShareCardPayload({
+          mode,
+          sourceText: text,
+          output,
+          result,
+          lang,
+          config,
+          patterns,
+          apiKey: resolved.apiKey,
+          baseURL: resolved.baseURL,
+          model: resolved.model,
+          callLLM: shareCardCallLLM,
+          signal: cancellation.signal,
+          logger,
+        });
+        const cardPath = writeShareCard(parsed.card, cardPayload);
+        logger.info('share_card.written', { message: `[patina] wrote share card to ${cardPath}` });
       }
 
       if (parsed.saveRun) {
@@ -473,6 +529,10 @@ function parseArgs(args) {
         break;
       case '--json-logs':
         parsed.jsonLogs = true;
+        break;
+      case '--card':
+        parsed.card = readOptionValue(args, i, arg);
+        i++;
         break;
       case '--gate': {
         const value = readOptionValue(args, i, arg, { allowFlagLike: true });
@@ -923,6 +983,122 @@ async function writeBatchOutput(parsed, inputPath, output) {
   console.log(`Written: ${outPath}`);
 }
 
+async function buildShareCardPayload({
+  mode,
+  sourceText,
+  output,
+  result,
+  lang,
+  config,
+  patterns,
+  apiKey,
+  baseURL,
+  model,
+  callLLM,
+  signal,
+  logger,
+}) {
+  const after = resolveShareCardAfterText({ mode, output, result, logger });
+  const metrics = existingShareCardMetrics({ mode, result, sourceText, after });
+
+  if (result?.type === 'max-mode' && !result.best) {
+    return { before: sourceText, after, aiScore: null, mps: null, lang };
+  }
+
+  if (metrics.aiScore !== null && metrics.mps !== null) {
+    return { before: sourceText, after, aiScore: metrics.aiScore, mps: metrics.mps, lang };
+  }
+
+  const [aiScoreResult, mpsResult] = await Promise.all([
+    metrics.aiScore === null
+      ? scoreText({
+        text: after,
+        config,
+        patterns,
+        apiKey,
+        baseURL,
+        model,
+        callLLM,
+        signal,
+        logger,
+      })
+      : Promise.resolve({ overall: metrics.aiScore }),
+    metrics.mps === null
+      ? scoreMPS({
+        original: sourceText,
+        rewritten: after,
+        apiKey,
+        baseURL,
+        model,
+        callLLM,
+        signal,
+        logger,
+      })
+      : Promise.resolve({ mps: metrics.mps }),
+  ]);
+
+  return {
+    before: sourceText,
+    after,
+    aiScore: toFiniteNumber(aiScoreResult?.overall),
+    mps: toFiniteNumber(mpsResult?.mps),
+    lang,
+  };
+}
+
+function resolveShareCardAfterText({ mode, output, result, logger }) {
+  if (result?.type === 'max-mode') {
+    return cleanShareCardText(result.best?.result || output);
+  }
+  if (mode === 'ouroboros') {
+    return cleanShareCardText(result?.finalText || output);
+  }
+  return cleanShareCardText(formatOutput(result, mode, { format: 'text' }, { logger }));
+}
+
+function existingShareCardMetrics({ mode, result, sourceText, after }) {
+  if (result?.type === 'max-mode') {
+    return {
+      aiScore: toFiniteNumber(result.best?.aiScore),
+      mps: toFiniteNumber(result.best?.mps),
+    };
+  }
+  if (mode === 'ouroboros') {
+    const aiScore = toFiniteNumber(result?.finalScore);
+    const mps = latestOuroborosMps(result?.log) ?? (sourceText.trim() === after.trim() ? 100 : null);
+    return { aiScore, mps };
+  }
+  return { aiScore: null, mps: null };
+}
+
+function latestOuroborosMps(log) {
+  if (!Array.isArray(log)) return null;
+  for (let i = log.length - 1; i >= 0; i--) {
+    const mps = toFiniteNumber(log[i]?.mps);
+    if (mps !== null) return mps;
+  }
+  return null;
+}
+
+function cleanShareCardText(output) {
+  return String(output || '')
+    .replace(/\n---\s*\ntone:[\s\S]*?\n---\s*$/u, '')
+    .trim();
+}
+
+function writeShareCard(cardPath, payload) {
+  const outPath = resolve(process.cwd(), cardPath);
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, renderShareCard(payload), 'utf8');
+  return outPath;
+}
+
+function toFiniteNumber(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const n = Number(String(value).replace(/[^\d.-]/g, ''));
+  return Number.isFinite(n) ? n : null;
+}
+
 function formatOuroborosOutput(result) {
   let output = '## Ouroboros Iteration Log\n\n';
   output += '| Iter | Before | After | Improvement | Reason |\n';
@@ -970,6 +1146,7 @@ OUTPUT & BATCH
   --json                  Alias for --format json
   --quiet                 Suppress patina status/warning logs on stderr
   --json-logs             Emit stderr logs as NDJSON objects
+  --card <path>           Write a 1200x630 SVG before/after + score share card
   --batch                 Process multiple files
   --in-place              Overwrite original files (with --batch)
   --suffix <ext>          Save as {name}{ext}{extname}

--- a/tests/e2e/cli-adoption.test.js
+++ b/tests/e2e/cli-adoption.test.js
@@ -165,6 +165,7 @@ describe('CLI adoption exit/error behavior', () => {
     const cases = [
       { args: ['--tone'], message: /--tone requires a value/ },
       { args: ['--models'], message: /--models requires a value/ },
+      { args: ['--card'], message: /--card requires a value/ },
       { args: ['--gate', 'nope'], message: /--gate expects a number/ },
       { args: ['--prompt-mode', 'wrong'], message: /--prompt-mode expects/ },
       { args: ['--api-key', '--base-url'], message: /--api-key requires a value/ },

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -267,6 +267,7 @@ describe('CLI End-to-End with Mock API', () => {
     assert.ok(help.includes('--format <fmt>'), 'help should document output format');
     assert.ok(help.includes('--quiet'), 'help should document quiet logs');
     assert.ok(help.includes('--json-logs'), 'help should document structured stderr logs');
+    assert.ok(help.includes('--card <path>'), 'help should document share-card SVG output');
     assert.ok(help.includes('--max-timeout <sec>'), 'help should document MAX wall-clock timeout');
     assert.ok(help.includes('--no-color'), 'help should document diff color opt-out');
     assert.ok(
@@ -457,6 +458,77 @@ describe('CLI End-to-End with Mock API', () => {
     assert.strictEqual(callCount, 1, 'Should make exactly one API call');
     assert.deepStrictEqual(errors, []);
     assert.match(logs.join('\n'), /This is the humanized result\./);
+  });
+
+  it('writes --card SVG for rewrite mode with AI score and MPS', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+    await stopMockServer();
+
+    mockServer = createServer((req, res) => {
+      callCount++;
+      let body = '';
+      req.on('data', (chunk) => { body += chunk; });
+      req.on('end', () => {
+        lastRequestBody = JSON.parse(body);
+        const prompt = lastRequestBody.messages[0].content;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+
+        if (prompt.includes('AI-likeness scoring engine')) {
+          res.end(JSON.stringify({
+            choices: [{ message: { content: '{ "overall": 18, "interpretation": "mostly human" }' } }],
+          }));
+          return;
+        }
+
+        if (prompt.includes('Meaning Preservation evaluator')) {
+          res.end(JSON.stringify({
+            choices: [{ message: { content: '{ "anchors": [], "pass_count": 1, "total_count": 1, "polarity_pass_count": 0, "polarity_total_count": 0, "mps": 94 }' } }],
+          }));
+          return;
+        }
+
+        res.end(JSON.stringify({
+          choices: [{
+            message: {
+              content: '[BODY]AI 포장을 덜어내고 뜻은 그대로 둔 문장입니다.[/BODY]\n[SELF_AUDIT]ok[/SELF_AUDIT]',
+            },
+          }],
+        }));
+      });
+    });
+
+    await new Promise((resolve) => {
+      mockServer.listen(0, '127.0.0.1', () => {
+        mockPort = mockServer.address().port;
+        resolve();
+      });
+    });
+
+    const dir = mkdtempSync(join(tmpdir(), 'patina-share-card-'));
+    const inputPath = resolve(dir, 'input.txt');
+    const cardPath = resolve(dir, 'card.svg');
+    writeFileSync(inputPath, 'AI 티 나는 문장입니다. 의미는 유지해야 합니다.', 'utf8');
+
+    await captureConsole(() => main([
+      '--lang', 'ko',
+      '--card', cardPath,
+      '--api-key', 'test-key',
+      '--base-url', `http://127.0.0.1:${mockPort}`,
+      inputPath,
+    ]));
+
+    const svg = readFileSync(cardPath, 'utf8');
+    assert.strictEqual(callCount, 3, 'rewrite + AI score + MPS calls should run');
+    assert.match(svg, /width="1200" height="630"/u);
+    assert.match(svg, /AI 티 나는 문장입니다/u);
+    assert.match(svg, /AI 포장을 덜어내고 뜻은 그대로 둔 문장입니다/u);
+    assert.match(svg, /AI score 18\/100/u);
+    assert.match(svg, /MPS 94/u);
+    assert.match(svg, /patina-brand-mark/u);
+
+    await stopMockServer();
+    await startMockServer('This is the humanized result.');
   });
 
   it('should set exit code 3 when --score gate fails', async () => {

--- a/tests/unit/share-card.test.js
+++ b/tests/unit/share-card.test.js
@@ -1,0 +1,75 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { renderShareCard, truncateText } from '../../scripts/share-card.mjs';
+
+describe('share-card renderer', () => {
+  it('renders a stable SVG skeleton with score, MPS, and brand mark', () => {
+    const svg = renderShareCard({
+      before: 'Coffee has emerged as a pivotal cultural phenomenon.',
+      after: 'Coffee changed how people meet.',
+      aiScore: 24,
+      mps: 93,
+      lang: 'en',
+    });
+
+    assert.match(svg, /<svg[^>]+width="1200" height="630"/u);
+    assert.match(svg, /<g id="patina-brand-mark"/u);
+    assert.match(svg, /AI score 24\/100/u);
+    assert.match(svg, /MPS 93/u);
+
+    const snapshot = [
+      svg.match(/<svg[^>]+>/u)?.[0],
+      svg.match(/<g id="patina-brand-mark"[\s\S]*?<\/g>/u)?.[0].replace(/\s+/gu, ' ').trim(),
+      svg.match(/>AI score [^<]+<\/text>/u)?.[0].replace(/^>|<\/text>$/gu, ''),
+      svg.match(/>MPS [^<]+<\/text>/u)?.[0].replace(/^>|<\/text>$/gu, ''),
+    ].join('\n');
+
+    assert.strictEqual(snapshot, [
+      '<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">',
+      '<g id="patina-brand-mark" transform="translate(72 39) scale(0.10546875)" aria-hidden="true"> <path d="M92 196C160 86 320 74 420 164L346 238C288 190 218 198 174 258Z" fill="#c46a2a"/> <path d="M420 316C352 426 192 438 92 348L160 270C224 322 294 314 338 254Z" fill="#2dd4bf"/> <circle cx="252" cy="248" r="54" fill="#ffe6a8" stroke="#020617" stroke-width="10"/> </g>',
+      'AI score 24/100',
+      'MPS 93',
+    ].join('\n'));
+  });
+
+  it('truncates long input and escapes XML without leaking the full source', () => {
+    const long = `<script data-x="1">${'가'.repeat(330)} & done</script>`;
+    const svg = renderShareCard({
+      before: long,
+      after: '괜찮게 다듬은 문장입니다.',
+      aiScore: 12.5,
+      mps: 91.4,
+      lang: 'ko',
+    });
+
+    assert.ok(!svg.includes(long), 'full input should not be embedded');
+    assert.ok(!svg.includes('<script'), 'raw XML-sensitive text should not appear');
+    assert.match(svg, /&lt;script/u);
+    assert.match(svg, /data-x=&quot;1&quot;&gt;/u);
+    assert.match(svg, /…/u);
+    assert.match(svg, /AI score 12\.5\/100/u);
+    assert.match(svg, /MPS 91\.4/u);
+  });
+
+  it('keeps CJK glyphs in visible text under the system font stack', () => {
+    const svg = renderShareCard({
+      before: '한국어 中文 日本語 문장을 한 카드에 넣습니다.',
+      after: '한국어·中文·日本語가 그대로 보입니다.',
+      aiScore: null,
+      mps: null,
+      lang: 'zh',
+    });
+
+    assert.match(svg, /한국어 中文 日本語/u);
+    assert.match(svg, /한국어·中文·日本語/u);
+    assert.match(svg, /Noto Sans CJK KR/u);
+    assert.match(svg, /AI score n\/a/u);
+    assert.match(svg, /MPS n\/a/u);
+  });
+
+  it('limits snippets to roughly 280 code points', () => {
+    const truncated = truncateText('나'.repeat(320));
+    assert.strictEqual(Array.from(truncated).length, 280);
+    assert.ok(truncated.endsWith('…'));
+  });
+});


### PR DESCRIPTION
## Summary
- add `scripts/share-card.mjs` with a dependency-free 1200×630 SVG renderer, XML escaping, CJK system-font stack, and long-text truncation
- wire `patina --card <path>` for rewrite/Ouroboros/MAX paths; Ouroboros/MAX reuse existing metrics, plain rewrite uses existing score/MPS evaluators only for the card
- document share-card usage/PNG out-of-scope and refresh the launch-support roadmap snapshot

Closes #283.

## Verification
- `npm test`
- `npm run lint`
- `npm run dogfood`
- `node scripts/precommit-score.mjs docs/social/share-card.md README.md docs/ROADMAP.md`
- `npm pack --dry-run --json` inclusion check
- share-card SVG smoke check
