### PR TITLE
ops: fix playground root route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ memory/
 # Generated benchmark artifacts (regenerated per `npm run benchmark`)
 tests/quality/results.json
 tests/e2e/temp-prompt.txt
+.vercel

--- a/playground/README.md
+++ b/playground/README.md
@@ -32,7 +32,7 @@ Commit both lexicon markdown changes and `playground/data/lexicons.js` together.
 
 ## Vercel wiring
 
-Deploy the repository root with the `vercel.json` in this repo. The root route rewrites `/` to `playground/index.html` and keeps `/assets/social/patina-og.svg` available for OG cards.
+Deploy the repository root with the `vercel.json` in this repo. The root route rewrites `/` to the clean `/playground` static entry and keeps `/assets/social/patina-og.svg` available for OG cards.
 
 Production domain:
 

--- a/tests/unit/playground.test.js
+++ b/tests/unit/playground.test.js
@@ -73,7 +73,7 @@ test('playground HTML points canonical and OG metadata at patina.vibetip.help', 
 
 test('Vercel config exposes the playground at the domain root', () => {
   const config = JSON.parse(readFileSync(resolve(REPO_ROOT, 'vercel.json'), 'utf8'));
-  assert.ok(config.rewrites.some((rule) => rule.source === '/' && rule.destination === '/playground/index.html'));
+  assert.ok(config.rewrites.some((rule) => rule.source === '/' && rule.destination === '/playground'));
   assert.ok(config.rewrites.some((rule) => rule.source === '/data/:path*' && rule.destination === '/playground/data/:path*'));
   assert.ok(config.headers[0].headers.some((header) => header.key === 'Content-Security-Policy'));
 });

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "rewrites": [
     {
       "source": "/",
-      "destination": "/playground/index.html"
+      "destination": "/playground"
     },
     {
       "source": "/app.js",


### PR DESCRIPTION
## Summary
- fix the Vercel root rewrite to target the clean /playground static entry
- keep local .vercel project metadata ignored after production deployment

Follow-up to #301 / #208 after live curl showed https://patina.vibetip.help/ returning Vercel 404 while /playground worked.

## Verification
- node --test tests/unit/playground.test.js
- npm run lint:syntax