### PR TITLE
docs(readme): text-first hero; demote demo GIF below the static example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,7 @@
 </p>
 
 <p align="center">
-  <img src="assets/demo/patina-demo-en.gif" alt="Animated terminal demo showing patina rewriting English AI-sounding copy and scoring the cleaned result" width="780">
-</p>
-
-<p align="center">
-  <a href="https://patina.vibetip.help/"><b>Try it now on your own text — no install</b></a>
+  <a href="https://patina.vibetip.help/"><b>▶ Try it now on your own text — no install</b></a>
 </p>
 
 patina looks for AI-sounding patterns in Korean, English, Chinese, and Japanese, then rewrites them without changing the claim, numbers, polarity, or causation. Use it as a skill for [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), [Cursor](https://cursor.sh), and OpenCode, or run it as a standalone Node.js CLI.
@@ -52,6 +48,12 @@ It is not a black-box rewriting tool or an AI-detector bypass tool. patina is **
 | Korean marketing | “혁신적인 솔루션”, “새로운 패러다임” | 30 Notion templates, workflow fit, copy-and-edit usage |
 | Academic | “획기적인 성과”, broad significance claims | 60 GitHub projects, 72h→10m setup time, p<0.01, limits noted |
 | Technical | “핵심적인 역할”, future-standard hype | GPU management, one-command provisioning, 5× result caveat |
+
+**See it run** *(English)*:
+
+<p align="center">
+  <img src="assets/demo/patina-demo-en.gif" alt="Animated terminal demo showing patina rewriting English AI-sounding copy and scoring the cleaned result" width="780">
+</p>
 
 ## Try it in your browser — no install
 


### PR DESCRIPTION
## Summary
- Lead the hero with the **playground "Try it now" CTA + copyable static before/after** (text-first), instead of a 4.5MB autoplay GIF.
- **Demote** the English demo GIF into a "See it run" slot inside the Demo section. Nothing removed — the GIF is kept, just no longer the first hero visual.

## Why
A Claude + Codex + Gemini consensus review of "should the README hero feature a demo GIF?" agreed: for patina (a **text** tool with an **anti-slop** brand), a heavy autoplaying GIF as the primary hero is self-contradictory — text-as-image (not selectable/searchable/screen-reader-friendly), doesn't adapt to dark/light theme, and must be re-recorded across 4 language READMEs (we just hit the KO-GIF-in-EN mismatch, #308). An interactive playground + copyable text converts better for a tool and fits the sober brand. Demo-in-first-screenful (the star driver) is preserved via the static before/after + playground link.

## Test plan
- [x] `npm run dogfood` — README.md scores **17.0 / 30** (pass)
- [x] `npm run lint` — pass
- [ ] CI: lint + test (18.0.0/20/22) + quality

## Notes
- English `README.md` only. **README_KR/ZH/JA should mirror this hero order** — not changed here (KR is maintainer/Codex territory; I don't edit `*_KR.md`).
- Follow-up to #306 / #308 (demo GIF). This is a *placement* refinement, not a revert.