### PR TITLE
docs(demo): typewriter terminal animation for the README demo GIF

### DIFF
--- a/scripts/render-demo-gif.py
+++ b/scripts/render-demo-gif.py
@@ -2,10 +2,15 @@
 """Render a small README demo GIF from checked-in text fixtures.
 
 This is an optional asset-generation helper. It keeps README hero demos
-reproducible without adding a runtime dependency to the Node package.
-Requires Pillow in the local environment:
+reproducible without adding a runtime dependency to the Node package, and
+without needing a live model call (the rewrite is read from a checked-in
+fixture). Requires Pillow in the local environment:
 
     python3 -m pip install pillow
+
+The animation mimics a real terminal: prompts are typed out character by
+character with a blinking block cursor, command output appears line by line,
+and a trailing prompt blinks at rest.
 """
 
 from __future__ import annotations
@@ -24,21 +29,31 @@ except ImportError as exc:  # pragma: no cover - only used by humans
 
 
 WIDTH = 820
-HEIGHT = 620
+HEIGHT = 600
 PADDING_X = 34
-PADDING_TOP = 70
-LINE_GAP = 7
+PADDING_TOP = 72
+LINE_GAP = 8
+CURSOR = "█"  # full block
+
+# Typing/animation pacing (ms).
+TYPE_MS = 42
+CURSOR_BLINK_MS = 430
+LINE_REVEAL_MS = 150
+HOLD_MS = 2400
+CHARS_PER_FRAME = 2
 
 COLORS = {
     "page": "#080b16",
-    "terminal": "#111827",
-    "bar": "#1f2937",
+    "terminal": "#0d1320",
+    "bar": "#1b2334",
     "text": "#e5e7eb",
-    "muted": "#94a3b8",
-    "command": "#a7f3d0",
+    "muted": "#8b98ad",
+    "prompt": "#34d399",
+    "command": "#d6f5e3",
     "before": "#fca5a5",
     "after": "#bfdbfe",
     "pass": "#86efac",
+    "cursor": "#a7f3d0",
     "dot_red": "#f87171",
     "dot_yellow": "#fbbf24",
     "dot_green": "#34d399",
@@ -48,13 +63,19 @@ COLORS = {
 def find_font(size: int, lang: str) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
     latin_candidates = [
         "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+        "/usr/share/fonts/truetype/ubuntu/UbuntuMono-R.ttf",
         "/System/Library/Fonts/Menlo.ttc",
     ]
     cjk_candidates = [
         "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/truetype/nanum/NanumGothicCoding.ttf",
         "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc",
     ]
-    candidates = cjk_candidates + latin_candidates if lang in {"ko", "zh", "ja"} else latin_candidates + cjk_candidates
+    candidates = (
+        cjk_candidates + latin_candidates
+        if lang in {"ko", "zh", "ja"}
+        else latin_candidates + cjk_candidates
+    )
     for path in candidates:
         if Path(path).exists():
             return ImageFont.truetype(path, size=size)
@@ -100,30 +121,34 @@ def wrap_text(
     return out
 
 
-def build_lines(args: argparse.Namespace, draw: ImageDraw.ImageDraw, font: ImageFont.ImageFont) -> list[tuple[str, str]]:
+def build_segments(
+    args: argparse.Namespace,
+    draw: ImageDraw.ImageDraw,
+    font: ImageFont.ImageFont,
+) -> list[dict]:
+    """Ordered timeline segments: typed commands and revealed output lines."""
+
     source = Path(args.source).read_text(encoding="utf-8").strip()
     rewrite = Path(args.rewrite).read_text(encoding="utf-8").strip()
     max_width = WIDTH - (PADDING_X * 2)
+    src_name = Path(args.source).name
+    cmd = f"patina --lang {args.lang} --tone marketing {src_name}"
 
-    def add_wrapped(rows: list[tuple[str, str]], text: str, style: str) -> None:
-        for index, line in enumerate(wrap_text(draw, text, font, max_width)):
-            rows.append((line if index == 0 else f"  {line}", style))
-
-    rows: list[tuple[str, str]] = []
-    add_wrapped(rows, f"$ cat {args.source}", "command")
-    rows.extend((line, "before") for line in wrap_text(draw, source, font, max_width))
-    rows.append(("", "muted"))
-    add_wrapped(rows, f"$ patina --lang {args.lang} --tone marketing {args.source}", "command")
-    rows.extend((line, "after") for line in wrap_text(draw, rewrite, font, max_width))
-    rows.append(("", "muted"))
-    add_wrapped(rows, f"$ node scripts/precommit-score.mjs {args.rewrite}", "command")
-    rows.append((args.score_line, "pass"))
-    return rows
+    segments: list[dict] = []
+    segments.append({"kind": "cmd", "text": f"cat {src_name}"})
+    for line in wrap_text(draw, source, font, max_width):
+        segments.append({"kind": "line", "text": line, "style": "before"})
+    segments.append({"kind": "gap"})
+    segments.append({"kind": "cmd", "text": cmd})
+    for line in wrap_text(draw, rewrite, font, max_width):
+        segments.append({"kind": "line", "text": line, "style": "after"})
+    segments.append({"kind": "gap"})
+    segments.append({"kind": "line", "text": args.score_line, "style": "pass"})
+    return segments
 
 
 def draw_frame(
     rows: list[tuple[str, str]],
-    visible_rows: int,
     *,
     title: str,
     font: ImageFont.ImageFont,
@@ -132,13 +157,11 @@ def draw_frame(
     image = Image.new("RGB", (WIDTH, HEIGHT), COLORS["page"])
     draw = ImageDraw.Draw(image)
 
-    # Terminal body.
     left, top, right, bottom = 18, 18, WIDTH - 18, HEIGHT - 18
     draw.rounded_rectangle((left, top, right, bottom), radius=18, fill=COLORS["terminal"])
     draw.rounded_rectangle((left, top, right, top + 42), radius=18, fill=COLORS["bar"])
     draw.rectangle((left, top + 24, right, top + 42), fill=COLORS["bar"])
 
-    # Window controls.
     x = left + 22
     for name in ("dot_red", "dot_yellow", "dot_green"):
         draw.ellipse((x, top + 15, x + 12, top + 27), fill=COLORS[name])
@@ -146,43 +169,63 @@ def draw_frame(
 
     draw.text((left + 95, top + 12), title, fill=COLORS["muted"], font=title_font)
 
-    line_height = font.size + LINE_GAP if hasattr(font, "size") else 20
+    prompt_w = text_width(draw, "$ ", font)
+    line_height = (font.size + LINE_GAP) if hasattr(font, "size") else 24
     y = PADDING_TOP
-    for text, style in rows[:visible_rows]:
-        if text:
+    for text, style in rows:
+        if not text and style not in {"rest", "cursor_at"}:
+            y += line_height
+            continue
+        if style in {"command", "cursor_at"}:
+            draw.text((PADDING_X, y), "$ ", fill=COLORS["prompt"], font=font)
+            draw.text((PADDING_X + prompt_w, y), text, fill=COLORS["command"], font=font)
+            if style == "cursor_at":
+                cur_x = PADDING_X + prompt_w + text_width(draw, text, font)
+                draw.text((cur_x, y), CURSOR, fill=COLORS["cursor"], font=font)
+        elif style == "rest":
+            draw.text((PADDING_X, y), "$ ", fill=COLORS["prompt"], font=font)
+            if text:
+                draw.text((PADDING_X + prompt_w, y), text, fill=COLORS["cursor"], font=font)
+        else:
             draw.text((PADDING_X, y), text, fill=COLORS[style], font=font)
         y += line_height
-
     return image
-
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--lang", required=True, help="Demo language code, e.g. en or ko.")
-    parser.add_argument("--source", required=True, help="Source fixture path.")
-    parser.add_argument("--rewrite", required=True, help="Expected rewrite fixture path.")
-    parser.add_argument("--output", required=True, help="GIF output path.")
-    parser.add_argument("--title", default="patina demo", help="Terminal title text.")
-    parser.add_argument(
-        "--score-line",
-        default="PASS · score under 30% · MPS: meaning preserved",
-        help="Final verification line to render.",
-    )
-    return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
     font = find_font(17, args.lang)
     title_font = find_font(15, args.lang)
-    scratch = Image.new("RGB", (WIDTH, HEIGHT))
-    rows = build_lines(args, ImageDraw.Draw(scratch), font)
+    scratch = ImageDraw.Draw(Image.new("RGB", (WIDTH, HEIGHT)))
+    segments = build_segments(args, scratch, font)
 
     frames: list[Image.Image] = []
     durations: list[int] = []
-    for visible in range(1, len(rows) + 1):
-        frames.append(draw_frame(rows, visible, title=args.title, font=font, title_font=title_font))
-        durations.append(220 if visible < len(rows) else 1800)
+    completed: list[tuple[str, str]] = []
+
+    def emit(extra: tuple[str, str] | None, dur: int) -> None:
+        rows = completed + ([extra] if extra is not None else [])
+        frames.append(draw_frame(rows, title=args.title, font=font, title_font=title_font))
+        durations.append(dur)
+
+    for seg in segments:
+        kind = seg["kind"]
+        if kind == "gap":
+            completed.append(("", "muted"))
+        elif kind == "line":
+            completed.append((seg["text"], seg["style"]))
+            emit(None, LINE_REVEAL_MS)
+        elif kind == "cmd":
+            text = seg["text"]
+            for i in range(1, len(text) + 1, CHARS_PER_FRAME):
+                emit((text[:i], "cursor_at"), TYPE_MS)
+            for blink in range(2):
+                emit((text, "cursor_at" if blink % 2 == 0 else "command"), CURSOR_BLINK_MS)
+            completed.append((text, "command"))
+
+    for blink in range(4):
+        emit((CURSOR if blink % 2 == 0 else "", "rest"), CURSOR_BLINK_MS)
+    durations[-1] = HOLD_MS
 
     output = Path(args.output)
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -195,10 +238,26 @@ def main() -> int:
         optimize=True,
     )
     size = output.stat().st_size
-    print(f"wrote {output} ({size / 1024 / 1024:.1f} MB)")
+    print(f"wrote {output} ({size / 1024 / 1024:.1f} MB, {len(frames)} frames)")
     if size > 10 * 1024 * 1024:
         print("warning: GIF is over the 10 MB README target", file=sys.stderr)
+        return 1
     return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lang", required=True, help="Demo language code, e.g. en or ko.")
+    parser.add_argument("--source", required=True, help="Source fixture path.")
+    parser.add_argument("--rewrite", required=True, help="Expected rewrite fixture path.")
+    parser.add_argument("--output", required=True, help="GIF output path.")
+    parser.add_argument("--title", default="patina demo", help="Terminal title text.")
+    parser.add_argument(
+        "--score-line",
+        default="✓ score 0%  ·  MPS: meaning preserved",
+        help="Final verification line to render.",
+    )
+    return parser.parse_args()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Upgrade the README hero demo from a 14-frame line-by-line reveal to a **real-terminal feel**:
- prompts are **typed out character-by-character** with a **blinking block cursor**
- green `$` prompt, single-line command basenames (no wrapped long paths)
- output reveals per line; a trailing prompt blinks at rest
- cleaner score line (`✓ score 0% · MPS: meaning preserved`)

Regenerated **`assets/demo/patina-demo-en.gif`** → 59 frames, **4.6 MB** (under the 10 MB cap).

## Review note (visual)
Please eyeball the animated GIF in the **Files changed** tab (or the Vercel preview) — this is a subjective design change, so I'm leaving the merge to you.

## KO/ZH/JA
Not regenerated here: this environment has **no CJK font**, so the Korean demo would render tofu. Re-run the same script with a Korean-capable font to give `patina-demo-ko.gif` the same treatment:
```
python3 scripts/render-demo-gif.py --lang ko \
  --source examples/short/marketing-launch.md \
  --rewrite examples/short/marketing-launch-rewritten.md \
  --output assets/demo/patina-demo-ko.gif --title "patina demo — 한국어"
```

## Test plan
- [x] renders under 10 MB (4.6 MB), 59 frames, 820×600
- [x] verified two frames look like a real terminal (typing + before/after + score)
- [ ] CI: lint + test + quality (JS — unaffected by this Python/asset change)