### PR TITLE
docs(faq): add a privacy / data-flow entry

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -50,6 +50,12 @@ Yes, if you already have the Codex CLI installed and logged in. The installer ca
 
 Other providers can be configured through the documented backend and provider settings.
 
+## Does patina send my text anywhere?
+
+The web playground runs entirely in your browser. It makes no network calls and loads no analytics or trackers, so text you paste into it never leaves the page.
+
+The CLI runs its deterministic analysis (the audit and the score) locally. The only step that sends text off your machine is the rewrite, and it goes to the backend you choose: a CLI you are already logged into, such as Codex, Claude, or Gemini, under your own account, or an OpenAI-compatible API using your own key and base URL (the default is the official OpenAI endpoint, but you can point it at a local or self-hosted model). patina runs no server of its own, ships no telemetry, and never sends your text to a patina-owned endpoint.
+
 ## Does it only work in Claude Code?
 
 No. patina runs as a skill for Claude Code, Codex CLI, Cursor, and OpenCode, and it also works as a standalone Node.js CLI.


### PR DESCRIPTION
## Summary
Adds a "Does patina send my text anywhere?" entry to `docs/FAQ.md` — a real user question that wasn't answered anywhere public. (Salvaged from the now-closed launch-prep PR #314; this is the one genuinely user-facing piece.)

The answer, verified against the code:
- **Playground** is fully client-side — no network calls, no analytics/trackers (confirmed in `playground/` + `vercel.json`).
- **CLI** analysis (audit/score) is local; only the **rewrite** leaves the machine, going to the backend the user picks — a logged-in CLI (Codex/Claude/Gemini) or their own OpenAI-compatible endpoint + key (default OpenAI, overridable to a local model).
- patina runs **no server of its own** and ships **no telemetry**. The only network call in `src/` is the user-configured LLM request in `src/api.js`.

## Verification
- Dogfood gate scores `docs/FAQ.md`; updated file is **0.0% hot (0/24), PASS (≤30)**.
- Claims cross-checked against `playground/`, `vercel.json`, and `src/api.js`.

Refs #286

## Test plan
- [ ] CI green (lint / test / quality / dogfood)

🤖 Generated with [Claude Code](https://claude.com/claude-code)