### PR TITLE
chore: normalize .mailmap to email-only mappings

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,7 +1,7 @@
 # Canonical author mapping for git shortlog / GitHub UI display.
-# All listed identities below belong to the maintainer (devswha).
-# Format: <canonical-name> <canonical-email> <historical-name> <historical-email>
+# All historical identities below belong to the maintainer (devswha).
+# Mapped by historical email only, so display names are normalized to the
+# canonical identity without listing personal names here.
 
-devswha <devswha@gmail.com> Sangwoo Ha <devswha@gmail.com>
-devswha <devswha@gmail.com> Hako <devswha@gmail.com>
-devswha <devswha@gmail.com> Calvin Ha <calvin-ha_Noul@noul.kr>
+devswha <devswha@gmail.com> <devswha@gmail.com>
+devswha <devswha@gmail.com> <calvin-ha_Noul@noul.kr>


### PR DESCRIPTION
## Summary
Maps historical author identities by email only and removes the personal display names from `.mailmap`. The shortlog / GitHub contributor view still collapses every maintainer commit to the canonical `devswha` identity, but the names are no longer spelled out in the file.

Verified:
- `git shortlog -nse --all` → maintainer commits stay consolidated under one identity.
- No `Sangwoo`/`Hako`/`Calvin` names appear in any mailmap-resolved `git log` display.

## Note
This is a **cosmetic display change**. It does not rewrite history — raw commit metadata is unchanged, which is the deliberate choice (history rewrite was considered and declined). Removing identities from past commit objects would require a `git filter-repo` pass and a force-push.

## Test plan
- [ ] CI green
- [ ] `git shortlog -nse` shows the single consolidated maintainer identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)