### PR TITLE
docs: CHANGELOG Unreleased section + clear two launch-copy blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
+## Unreleased
+
+**Post-3.11.0 launch-prep and distribution polish (not yet versioned).**
+
+Semver rationale: patch — docs, packaging, and benchmark-evidence changes only; no pattern, schema, or CLI-behavior changes.
+
+### Changed
+
+- Trimmed the npm tarball from ~10MB to 627KB by excluding non-runtime assets.
+- Reworked the README hero to be text-first and demoted the demo GIF below the static example; added per-language README demos.
+- Added a typewriter terminal animation for the README demo GIF.
+- Added a maintainer-owned launch-execution handoff packet (`docs/social/patina-launch-execution.md`).
+
+### Evidence
+
+- Refreshed modern-model and English/Korean lexicon-lift benchmark evidence; widened Korean false-positive register coverage with positive-side calibration.
+- Aligned the issue-wave map and backlog docs with live GitHub state.
+
 ## 3.11.0 — 2026-05-20
 
 **Launch-readiness polish for trust, benchmarks, and distribution.**

--- a/docs/social/patina-launch-copy.md
+++ b/docs/social/patina-launch-copy.md
@@ -108,7 +108,7 @@ https://github.com/devswha/patina/issues/new?template=false_positive.yml
 Title:
 
 ```text
-Show HN: Patina – strip AI-writing tells, Korean-first, with an audit trail
+Show HN: Patina – rewrite AI text patterns in Korean, English, Chinese, Japanese
 ```
 
 Post body:

--- a/docs/social/patina-launch-copy.md
+++ b/docs/social/patina-launch-copy.md
@@ -108,7 +108,7 @@ https://github.com/devswha/patina/issues/new?template=false_positive.yml
 Title:
 
 ```text
-Show HN: Patina – strip AI-writing tells from Korean/English/Chinese/Japanese text
+Show HN: Patina – strip AI-writing tells, Korean-first, with an audit trail
 ```
 
 Post body:
@@ -277,19 +277,19 @@ That is why I treat the score as a rough editing signal, not a truth machine. Th
 ### Install help
 
 ```text
-Install:
+Install (standalone CLI, nothing to trust beyond npm):
 
-curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
+npx patina-cli --lang en input.txt
 
-Then in Claude Code:
+Or inside Claude Code:
 
 /patina --lang en
 
 [paste text]
 
-Or as a standalone CLI:
+Prefer a one-line installer? Review the script first, then:
 
-npx patina-cli --lang en input.txt
+curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
 ```
 
 ## Post-launch triage


### PR DESCRIPTION
## Why

Two small doc-drift / launch-prep fixes surfaced by a launch-readiness audit (issue #286).

### CHANGELOG drift

The top entry was `3.11.0 — 2026-05-20`, but several docs/packaging commits landed afterward (npm tarball trim 10MB→627KB, README hero rewrite + demo GIF, launch-execution handoff packet, rebaseline evidence) with no changelog line. Added an **Unreleased** section so the changelog reflects the tip of `main`.

### Launch-copy blockers (flagged in #286 editorial review, never applied)

1. **Show HN title was 82 chars** — HN hard-limits titles at 80, so it would be rejected/truncated. Per maintainer decision, switched to the **"rewrite" framing**:
   > `Show HN: Patina – rewrite AI text patterns in Korean, English, Chinese, Japanese`

   Rationale: "rewrite" reads as an editing tool rather than an AI detector, which fits HN's audience (often hostile to detector-style tools) and patina's auditable-editing positioning. **Length: 80 chars — exactly at HN's 80-char limit** (valid, but zero margin; trim a word if you want headroom).

2. **Install reply led with `curl … | bash`** — the first thing security-minded HN/Reddit readers criticize. Now leads with `npx patina-cli` and keeps the one-liner as a "review the script first" secondary option.

## Verification

- HN title now **80 chars** (≤80).
- `node scripts/precommit-score.mjs docs/social/patina-launch-copy.md` → **6.3%** (gate ≤30, still pass).
- `node --test tests/e2e/providers.test.js` → pass.

Refs #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
