### PR TITLE
Update Gemini default model

### DIFF
--- a/src/providers.js
+++ b/src/providers.js
@@ -24,7 +24,7 @@ export const PROVIDERS = {
     name: 'gemini',
     baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai',
     apiKeyEnv: 'GEMINI_API_KEY',
-    defaultModel: 'gemini-1.5-flash',
+    defaultModel: 'gemini-2.5-flash',
     freeTier: true,
     note: 'Free tier available. Get a key at https://aistudio.google.com/app/apikey',
   },

--- a/tests/e2e/providers.test.js
+++ b/tests/e2e/providers.test.js
@@ -73,7 +73,7 @@ describe('Provider Config Resolution', () => {
       assert.strictEqual(r.apiKey, 'gemini-env');
       assert.strictEqual(r.apiKeySource, 'env:GEMINI_API_KEY');
       assert.match(r.baseURL, /generativelanguage/);
-      assert.strictEqual(r.model, 'gemini-1.5-flash');
+      assert.strictEqual(r.model, 'gemini-2.5-flash');
     });
   });
 


### PR DESCRIPTION
## Summary
- update the Gemini provider default model to gemini-2.5-flash`n- update the provider config e2e assertion for the new default

## Issue
Fixes #318

## Verification
- node --test tests/e2e/providers.test.js
- node --check src/providers.js
- node --check tests/e2e/providers.test.js