### PR TITLE
ci: run test_composite.py in CI (was untested in automation)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,3 +84,20 @@ jobs:
 
       - name: Dogfood public docs
         run: npm run dogfood
+
+  python:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest
+        run: python -m pip install pytest
+
+      - name: Run composite.py tests
+        run: python -m pytest tests/unit/test_composite.py


### PR DESCRIPTION
## Gap

`tests/unit/test_composite.py` exercises `patina-max/composite.py` (4 tests covering `parse_metric`, `normalise_weights`, and the `main` winner-selection flow). It was invoked by **no npm script** (`npm test` only runs `node --test tests/unit/*.test.js tests/e2e/*.test.js`) and **no CI workflow job**. As a result, `composite.py` had zero automated coverage — a regression there would ship unnoticed.

## Change

Add a dedicated `python` job to `.github/workflows/test.yml`:

- `actions/setup-python@v5` with Python 3.12
- `python -m pip install pytest`
- `python -m pytest tests/unit/test_composite.py`

A separate job (rather than extending the Node-focused `quality` job) keeps the npm caching and Node setup clean and isolates the Python toolchain.

## Deferred

This PR addresses **only the pytest half of #320**. The `// @ts-check` half (adding `// @ts-check` to `src/*.js`) is intentionally deferred to a follow-up: enabling it surfaces many pre-existing type errors and deserves its own incremental PR. No `src/*.js` files are touched here. Uses `Refs #320` (not `Closes`) so the issue stays open for the `@ts-check` work.

## Verification

- `python3 -m pytest tests/unit/test_composite.py` → `4 passed in 0.03s`
- `npm ci` → clean, 0 vulnerabilities
- `npm test` → `# tests 383 # pass 383 # fail 0`
- `npm run lint` (lint:syntax + eslint + typecheck + spellcheck) → all clean
- `.github/workflows/test.yml` parses as valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)