### PR TITLE
docs: sync README_ZH / README_JA Documentation sections with EN/KR

### DIFF
--- a/README_JA.md
+++ b/README_JA.md
@@ -293,25 +293,42 @@ max-models: [claude, gemini]
 
 ## ドキュメント
 
+- **[Cookbook](docs/COOKBOOK.md)** — 実用レシピ（Hugo バッチスコアリング、GitHub Actions、MAX モード比較、誤検出 triage、カスタム profile、pre-commit）
 - **[Glossary](docs/GLOSSARY.md)** — MPS、fidelity、burstiness、MATTR、モードなどの反復用語の短い定義
 - **[Demo](docs/DEMO.md)** — ターミナル transcript と複数ジャンルの before/after スナップショット
 - **[Patterns](docs/PATTERNS.md)** — 160 パターンカタログ
-- **[Authentication](docs/AUTHENTICATION.md)** — バックエンド、プロバイダ、無料ティア設定
-- **[CLI Contract](docs/CLI.md)** — score gate、終了コード、自動化に安全なインターフェイス
+- **[Authentication](docs/AUTHENTICATION.md)** ([한국어](docs/AUTHENTICATION_KR.md)) — バックエンド、プロバイダ、無料ティア設定
+- **[GitHub Action](docs/integrations/github-action.md)** — live model key なしで PR hotspot コメントと README score badge を生成
+- **[Pre-commit](docs/integrations/pre-commit.md)** — pre-commit、Husky、Lefthook の score-only レシピ
+- **[Static-site Stencils](docs/integrations/static-sites.md)** — Hugo、Astro、Next.js MDX のビルド時スコアリングレシピ
+- **[Docker](docs/integrations/docker.md)** — GHCR イメージの使い方と release tag
+- **[Release workflow](docs/integrations/release.md)** — npm provenance + GHCR 公開チェックリスト
+- **[CLI Contract](docs/CLI.md)** — score gate、JSON/text/Markdown 出力、自動化に安全なインターフェイス
+- **[API Reference](docs/API.md)** — プログラム的な import とスコアリング helper 向けの生成 JSDoc リファレンス
 - **[Flag Parity](docs/FLAG-PARITY.md)** — standalone CLI、`/patina`、`/patina-max` のオプション対応範囲
+- **[Exit Codes](docs/EXIT-CODES.md)** — CI とエディタ統合向けのプロセス終了コード契約
 - **[Ethics](docs/ETHICS.md)** — 正しい使用目的、禁止用途、disclosure 方針
-- **[FAQ](docs/FAQ.md)** — detector-bypass の懸念、MPS、誤検出、貢献の始め方
+- **[FAQ](docs/FAQ.md)** ([한국어](docs/FAQ_KR.md)) — detector-bypass の懸念、MPS、誤検出、貢献の始め方
+- **[False-positive Gallery](docs/FALSE-POSITIVES.md)** — 指摘ではなく編集ヒントとして扱うべき人間らしい文体の例
 - **[Comparison](docs/COMPARISON.md)** — 一般的な paraphraser/humanizer ツールとの事実ベース比較
 - **[Branding](docs/BRANDING.md)** — canonical logo/social assets と OG 設定メモ
 - **[Design](DESIGN.md)** — repo-native SVG と README surface の製品/ブランド基準
 - **[Roadmap](docs/ROADMAP.md)** — 品質、ベンチマーク、プロダクト、コミュニティ、ローンチ優先事項
+- **[Docs Platform RFC](docs/RESEARCH-DOCS-PLATFORM.md)** — Docusaurus、Astro Starlight、MkDocs、GitHub Pages の調査
+- **[Benchmark Reports](docs/benchmarks/README.md)** — チェックインされたベンチマーク成果物、更新コマンド、public-claim gate
 - **[Benchmark Report](docs/benchmarks/latest.md)** — 最新の再現可能な suspect-zone ベンチマーク要約
+- **[Detector Comparison Harness](docs/benchmarks/detector-comparison.md)** — サードパーティ detector のオフライン/手動比較プロトコル
 - **[AI/Human Metrics Research](docs/research/ai-human-metrics.md)** — AI-like writing signals 測定用ベンチマーク設計メモ
-- **[Launch Copy](docs/social/patina-launch-copy.md)** — Show HN、Reddit、X、韓国コミュニティ向け下書き
+- **[2026 Modern-model Rebaseline](docs/research/2026-rebaseline.md)** — 現在の日付スタンプ付き KO+EN catch/FP claim
+- **[2025+ Re-baseline Plan](docs/research/2025-rebaseline-plan.md)** — より広い model-era claim 向けのプロトコル
+- **[zh/ja Lexicon Calibration](docs/research/zh-ja-lexicon-calibration.md)** — starter lexicon gate と残りの corpus risk
+- **[Launch Copy](docs/social/patina-launch-copy.md)** — launch sequence、score gate、Show HN/Product Hunt/Reddit/X/韓国コミュニティ向け下書き
+- **[Signs of AI Writing](docs/social/signs-of-ai-writing.md)** ([한국어](docs/social/signs-of-ai-writing_KR.md)) — 引用例付きの共有用編集 checklist
+- **[Share Card SVGs](docs/social/share-card.md)** — score と MPS pill 付きの `--card` before/after social card
 - **[Stylometry](core/stylometry.md)** — burstiness + MATTR + AI 語彙アルゴリズム
 - **[Scoring](core/scoring.md)** — AI 類似度 + 忠実度 + MPS
 - **[Changelog](CHANGELOG.md)** — リリースノートと方法論
-- **[Contributing](CONTRIBUTING.md)** — パターン提出、誤検出 triage、ベンチマーク fixture、バージョン管理
+- **[Contributing](CONTRIBUTING.md)** ([한국어](CONTRIBUTING_KR.md)) — パターン提出、誤検出 triage、ベンチマーク fixture、バージョン管理
 - **[Governance](GOVERNANCE.md)** / **[Maintainers](MAINTAINERS.md)** — 軽量なプロジェクト意思決定ルール
 
 ## 着想元

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -293,25 +293,42 @@ max-models: [claude, gemini]
 
 ## 文档
 
+- **[Cookbook](docs/COOKBOOK.md)** — 实用配方（Hugo 批量打分、GitHub Actions、MAX 模式对比、误报 triage、自定义 profile、pre-commit）
 - **[Glossary](docs/GLOSSARY.md)** — MPS、fidelity、burstiness、MATTR、模式等常见术语的简短定义
 - **[Demo](docs/DEMO.md)** — 终端 transcript 与多种体裁的 before/after 快照
 - **[Patterns](docs/PATTERNS.md)** — 160 个模式目录
-- **[Authentication](docs/AUTHENTICATION.md)** — 后端、服务商、免费层设置
-- **[CLI Contract](docs/CLI.md)** — score gate、退出码，以及适合自动化的接口边界
+- **[Authentication](docs/AUTHENTICATION.md)** ([한국어](docs/AUTHENTICATION_KR.md)) — 后端、服务商、免费层设置
+- **[GitHub Action](docs/integrations/github-action.md)** — 无需 live model key 即可生成 PR hotspot 评论与 README score badge
+- **[Pre-commit](docs/integrations/pre-commit.md)** — pre-commit、Husky 与 Lefthook 的 score-only 配方
+- **[Static-site Stencils](docs/integrations/static-sites.md)** — Hugo、Astro 与 Next.js MDX 构建期打分配方
+- **[Docker](docs/integrations/docker.md)** — GHCR 镜像用法与 release tag
+- **[Release workflow](docs/integrations/release.md)** — npm provenance + GHCR 发布清单
+- **[CLI Contract](docs/CLI.md)** — score gate、JSON/text/Markdown 输出，以及适合自动化的接口边界
+- **[API Reference](docs/API.md)** — 用于编程式导入与打分 helper 的生成 JSDoc 参考
 - **[Flag Parity](docs/FLAG-PARITY.md)** — standalone CLI、`/patina`、`/patina-max` 的选项支持范围
+- **[Exit Codes](docs/EXIT-CODES.md)** — 面向 CI 与编辑器集成的进程退出码约定
 - **[Ethics](docs/ETHICS.md)** — 正确使用目的、禁止用途和披露立场
-- **[FAQ](docs/FAQ.md)** — detector-bypass 疑虑、MPS、误报、贡献起点
+- **[FAQ](docs/FAQ.md)** ([한국어](docs/FAQ_KR.md)) — detector-bypass 疑虑、MPS、误报、贡献起点
+- **[False-positive Gallery](docs/FALSE-POSITIVES.md)** — 应被视为编辑提示而非指控的人类文风示例
 - **[Comparison](docs/COMPARISON.md)** — 与常见 paraphraser/humanizer 工具的事实比较
 - **[Branding](docs/BRANDING.md)** — canonical logo/social assets 和 OG 设置说明
 - **[Design](DESIGN.md)** — repo-native SVG 与 README surface 的产品/品牌基准
 - **[Roadmap](docs/ROADMAP.md)** — 质量、基准、产品、社区和发布优先级
+- **[Docs Platform RFC](docs/RESEARCH-DOCS-PLATFORM.md)** — Docusaurus、Astro Starlight、MkDocs 与 GitHub Pages 调研
+- **[Benchmark Reports](docs/benchmarks/README.md)** — 已签入的基准产物、刷新命令与 public-claim gate
 - **[Benchmark Report](docs/benchmarks/latest.md)** — 最新可复现 suspect-zone 基准摘要
+- **[Detector Comparison Harness](docs/benchmarks/detector-comparison.md)** — 第三方 detector 的离线/手动对比协议
 - **[AI/Human Metrics Research](docs/research/ai-human-metrics.md)** — 用于测量 AI-like writing signals 的基准设计说明
-- **[Launch Copy](docs/social/patina-launch-copy.md)** — Show HN、Reddit、X、韩国社区草稿
+- **[2026 Modern-model Rebaseline](docs/research/2026-rebaseline.md)** — 带当前日期戳的 KO+EN catch/FP claim
+- **[2025+ Re-baseline Plan](docs/research/2025-rebaseline-plan.md)** — 面向更广 model-era claim 的协议
+- **[zh/ja Lexicon Calibration](docs/research/zh-ja-lexicon-calibration.md)** — starter lexicon gate 与剩余 corpus risk
+- **[Launch Copy](docs/social/patina-launch-copy.md)** — launch sequence、score gate 与 Show HN/Product Hunt/Reddit/X/韩国社区草稿
+- **[Signs of AI Writing](docs/social/signs-of-ai-writing.md)** ([한국어](docs/social/signs-of-ai-writing_KR.md)) — 附带引用示例的可分享编辑 checklist
+- **[Share Card SVGs](docs/social/share-card.md)** — 带 score 与 MPS pill 的 `--card` before/after social card
 - **[Stylometry](core/stylometry.md)** — burstiness + MATTR + AI 词汇算法
 - **[Scoring](core/scoring.md)** — AI 相似度 + 忠实度 + MPS
 - **[Changelog](CHANGELOG.md)** — 发布说明和方法论
-- **[Contributing](CONTRIBUTING.md)** — 模式提交、误报 triage、基准 fixture、版本管理
+- **[Contributing](CONTRIBUTING.md)** ([한국어](CONTRIBUTING_KR.md)) — 模式提交、误报 triage、基准 fixture、版本管理
 - **[Governance](GOVERNANCE.md)** / **[Maintainers](MAINTAINERS.md)** — 轻量级项目决策规则
 
 ## 致谢


### PR DESCRIPTION
## What

Backfills the missing entries in the **Documentation** sections of `README_ZH.md` and `README_JA.md` so each matches the canonical EN link set in `README.md`. Both localized READMEs previously carried only ~20 entries (vs the EN 37) and omitted the translated-counterpart cross-links.

After this change all four READMEs (EN / KR / ZH / JA) expose the same 37-entry Documentation index.

## Backfilled per language

Both ZH and JA gained the same 17 missing entries, in EN order:

- Cookbook, GitHub Action, Pre-commit, Static-site Stencils, Docker, Release workflow
- API Reference, Exit Codes, False-positive Gallery
- Docs Platform RFC, Benchmark Reports, Detector Comparison Harness
- 2026 Modern-model Rebaseline, 2025+ Re-baseline Plan, zh/ja Lexicon Calibration
- Signs of AI Writing, Share Card SVGs

Existing entries (Authentication, FAQ, Launch Copy, Contributing) were updated to:
- add the EN↔KR translated-counterpart cross-links (`([한국어](..._KR.md))`) for Authentication / FAQ / Signs of AI Writing / Contributing, matching the EN/KR convention;
- bring the Launch Copy / CLI Contract descriptions in line with the EN wording.

Link **labels/descriptions are translated** into Chinese (ZH) / Japanese (JA); the existing EN section ordering and grouping is preserved.

## URLs identical to EN

Every link URL/path is byte-identical to the EN version (verified with a diff of the extracted URL set):

```
EN vs ZH URL set+order: IDENTICAL
EN vs JA URL set+order: IDENTICAL
```

No links were invented. No EN link was skipped — every EN target exists on disk, so the full set was carried over (nothing dropped for a missing target). The KR-only `EXAMPLES` entry is intentionally **not** added, since it does not exist in the canonical EN set.

## Verification

```
npm ci            → 0 vulnerabilities
npm run lint      → Syntax OK (107 files); eslint clean; typecheck OK; cspell 0 issues  (exit 0)
```

All 37 newly-synced repo-relative link targets confirmed to exist on disk (`ALL TARGETS EXIST`). Entry counts: EN 37 / ZH 37 / JA 37. Diff scoped to the two README files only (Documentation section).

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)