### PR TITLE
fix: use a current Gemini default model + warn when --model is ignored

### DIFF
--- a/src/backends/claude-cli.js
+++ b/src/backends/claude-cli.js
@@ -38,11 +38,23 @@ export function login(options = {}) {
   });
 }
 
-export async function invoke({ prompt, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS } = {}) {
+export async function invoke({ prompt, model, modelSource, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS, logger } = {}) {
   if (!prompt || typeof prompt !== 'string') {
     throw new Error('claude-cli backend: prompt must be a non-empty string');
   }
   throwIfAborted(signal);
+
+  // The claude-cli backend runs `claude -p`, which uses whatever model the
+  // logged-in Claude Code session is configured with; it does not accept a
+  // model override here. Warn (don't fail) when the user explicitly asked for
+  // a model so a `--model X` is not a silent no-op. Forwarding the model to the
+  // CLI is left as future work. Only fires for explicit models, not the
+  // default/undefined path (modelSource 'default' or unset).
+  if (model && modelSource && modelSource !== 'default') {
+    logger?.warn?.('backend.model.ignored', {
+      message: `[patina] claude-cli backend ignores --model (${model}); it uses your logged-in Claude Code model. Use --backend gemini-cli or the HTTP provider path to choose a model.`,
+    });
+  }
 
   // Spawn from a fresh temp directory so a prompt-injection in user text
   // cannot read or write inside the caller's repo. claude -p prints to

--- a/src/backends/codex-cli.js
+++ b/src/backends/codex-cli.js
@@ -35,11 +35,23 @@ export function login(options = {}) {
   });
 }
 
-export async function invoke({ prompt, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS } = {}) {
+export async function invoke({ prompt, model, modelSource, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS, logger } = {}) {
   if (!prompt || typeof prompt !== 'string') {
     throw new Error('codex-cli backend: prompt must be a non-empty string');
   }
   throwIfAborted(signal);
+
+  // The codex-cli backend runs `codex exec`, which uses the model configured in
+  // the logged-in codex session; it does not accept a model override here. Warn
+  // (don't fail) when the user explicitly asked for a model so a `--model X` is
+  // not a silent no-op. Forwarding the model to the CLI is left as future work.
+  // Only fires for explicit models, not the default/undefined path
+  // (modelSource 'default' or unset).
+  if (model && modelSource && modelSource !== 'default') {
+    logger?.warn?.('backend.model.ignored', {
+      message: `[patina] codex-cli backend ignores --model (${model}); it uses your logged-in codex model. Use --backend gemini-cli or the HTTP provider path to choose a model.`,
+    });
+  }
 
   // Run codex from a fresh temp directory with the read-only sandbox so that
   // a prompt-injection in user text cannot read the caller's repo or write

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -110,6 +110,7 @@ export async function invokeBackendChain({
   apiKey,
   baseURL,
   model,
+  modelSource,
   signal,
   timeout = DEFAULT_BACKEND_TIMEOUT_MS,
   temperature,
@@ -130,7 +131,7 @@ export async function invokeBackendChain({
   for (let attemptIndex = 0; attemptIndex < backends.length; attemptIndex++) {
     const backend = backends[attemptIndex];
     try {
-      return await backend.invoke({ prompt, apiKey, baseURL, model, signal, timeout, temperature, seed, onResponse, cache });
+      return await backend.invoke({ prompt, apiKey, baseURL, model, modelSource, signal, timeout, temperature, seed, onResponse, cache, logger });
     } catch (err) {
       lastError = err;
       const next = backends[attemptIndex + 1];

--- a/src/cli.js
+++ b/src/cli.js
@@ -868,7 +868,7 @@ function readOptionValue(args, index, option, { allowFlagLike = false } = {}) {
  * @returns {string} Resolved prompt mode.
  * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
- * const mode = resolvePromptMode('auto', { model: 'gemini-1.5-flash' });
+ * const mode = resolvePromptMode('auto', { model: 'gemini-2.5-flash' });
  */
 export function resolvePromptMode(mode, { backend, model }) {
   if (mode !== 'auto') return mode;

--- a/src/cli.js
+++ b/src/cli.js
@@ -336,6 +336,7 @@ export async function main(args) {
           apiKey: resolved.apiKey,
           baseURL: resolved.baseURL,
           model: resolved.model,
+          modelSource: resolved.modelSource,
           signal: cancellation.signal,
           temperature: manifestTemperature,
           seed: manifestSeed,
@@ -1223,7 +1224,9 @@ LANGUAGE & PROFILE
   --voice-sample <path>   Use 1-3 user paragraphs as style-only voice anchors
 
 MODEL & AUTH
-  --model <id>            Single model ID (default: gpt-4o)
+  --model <id>            Single model ID (default: gpt-4o). Only affects
+                          gemini-cli and the HTTP provider path; claude-cli
+                          and codex-cli use their logged-in session model.
   --api-key <key>         API key (DEPRECATED: leaks via ps/shell history; prefer
                           PATINA_API_KEY env or --api-key-file)
   --api-key-file <path>   Read API key from file (recommended)

--- a/src/providers.js
+++ b/src/providers.js
@@ -24,7 +24,7 @@ export const PROVIDERS = {
     name: 'gemini',
     baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai',
     apiKeyEnv: 'GEMINI_API_KEY',
-    defaultModel: 'gemini-1.5-flash',
+    defaultModel: 'gemini-2.5-flash',
     freeTier: true,
     note: 'Free tier available. Get a key at https://aistudio.google.com/app/apikey',
   },

--- a/tests/e2e/providers.test.js
+++ b/tests/e2e/providers.test.js
@@ -73,7 +73,7 @@ describe('Provider Config Resolution', () => {
       assert.strictEqual(r.apiKey, 'gemini-env');
       assert.strictEqual(r.apiKeySource, 'env:GEMINI_API_KEY');
       assert.match(r.baseURL, /generativelanguage/);
-      assert.strictEqual(r.model, 'gemini-1.5-flash');
+      assert.strictEqual(r.model, 'gemini-2.5-flash');
     });
   });
 


### PR DESCRIPTION
## Summary

Two related model-handling fixes.

### Fix A (#318): Gemini default pointed at a retired model
`src/providers.js:27` had `defaultModel: 'gemini-1.5-flash'`, which is retired. Changed it to `gemini-2.5-flash`, a current Gemini flash model (matching the value already chosen on the local bot/live-quality-regression-workflow branch). Updated the matching assertion in `tests/e2e/providers.test.js:76`.

### Fix B (#319): claude-cli and codex-cli silently ignored --model
Previously, passing `--model X` with the `claude-cli` or `codex-cli` backend was a silent no-op — those backends run `claude -p` / `codex exec`, which use the logged-in session's model and never received the resolved model.

Now each backend emits a single `logger.warn(...)` when an explicit model is provided, telling the user the model is ignored and pointing at the backends that honor it:
- `src/backends/claude-cli.js` (in `invoke`)
- `src/backends/codex-cli.js` (in `invoke`)

The warn is guarded so it only fires for an explicitly-set model, never the default/undefined path: the resolved `modelSource` is threaded from `src/cli.js:339` through `invokeBackendChain` (`src/backends/index.js`) to `backend.invoke`, and the warn fires only when `model && modelSource && modelSource !== 'default'`. MAX mode (`src/max-mode.js`) calls `invoke` without a model, so it never warns.

Also added a one-line note in `printHelp()` (`src/cli.js`) that `--model` only affects `gemini-cli` and the HTTP provider path.

**Deliberately left as follow-up:** actually forwarding the resolved model to the `claude`/`codex` CLIs. That is a larger, riskier change (CLI flag surface, model-name mapping) and is out of scope here — the goal of this PR is to remove the silent no-op, not to add forwarding.

## Verification

```
npm ci      # clean, 0 vulnerabilities
npm test    # tests 383, pass 383, fail 0
npm run lint # syntax OK, eslint OK, typecheck OK, spellcheck OK
```

Also sanity-checked the guard directly: explicit `modelSource: 'flag'` warns once per backend; `modelSource: 'default'` and the undefined path produce zero warns.

Closes #318
Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)