### PR TITLE
docs: trim Show HN title to 77 chars for headroom

### DIFF
--- a/docs/social/patina-launch-copy.md
+++ b/docs/social/patina-launch-copy.md
@@ -108,7 +108,7 @@ https://github.com/devswha/patina/issues/new?template=false_positive.yml
 Title:
 
 ```text
-Show HN: Patina – rewrite AI text patterns in Korean, English, Chinese, Japanese
+Show HN: Patina – rewrite AI text patterns in Korean/English/Chinese/Japanese
 ```
 
 Post body:


### PR DESCRIPTION
Swaps the comma-separated language list for slashes so the rewrite-framing Show HN title drops from **80** (exactly at HN's 80-char limit) to **77**, leaving a small margin.

> `Show HN: Patina – rewrite AI text patterns in Korean/English/Chinese/Japanese`

Verification: 77 chars; `node scripts/precommit-score.mjs docs/social/patina-launch-copy.md` → 6.3% (gate ≤30).

Refs #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)