### PR TITLE
feat(detect): deterministic model-output leakage detection (#332 core)

### DIFF
--- a/playground/analyzer.js
+++ b/playground/analyzer.js
@@ -267,6 +267,30 @@ function fmt(value, digits = 2) {
   return value == null ? 'n/a' : Number(value).toFixed(digits);
 }
 
+// Model-output leakage artifacts (issue #332): tokens LLM tooling injects that
+// never appear in human prose. A single hit is near-proof-grade, so it forces
+// the document hot. Mirrors src/features/markup-leakage.js.
+const MARKUP_LEAKAGE_RULES = [
+  { id: 'oai-citation-markup', label: 'OpenAI citation markup', build: () => /:contentReference|oaicite|oai_citation/gi },
+  { id: 'model-tool-token', label: 'Model tool token', build: () => /\bturn\d+(?:search|view|news|image|forecast|finance|fetch)\d*\b|\bnavlist\b|\bgrok_card\b/gi },
+  { id: 'object-replacement-char', label: 'Object-replacement character (￼)', build: () => /￼/g },
+  { id: 'ai-tracking-param', label: 'AI-tool tracking parameter in URL', build: () => /utm_source=(?:chatgpt\.com|openai\.com|perplexity\.ai|claude\.ai|gemini\.google\.com)|[?&](?:ref|utm_source)=chatgpt/gi },
+  { id: 'explicit-self-identification', label: 'Explicit AI self-identification', build: () => /\bas an? (?:AI|artificial intelligence) language model\b|\bas a large language model\b|\bas a language model\b|\bas an AI assistant\b|\bI am an AI\b|\bI'?m an AI\b/gi },
+];
+
+export function detectMarkupLeakage(text) {
+  const str = typeof text === 'string' ? text : '';
+  const hits = [];
+  if (!str) return { leaked: false, hits };
+  for (const rule of MARKUP_LEAKAGE_RULES) {
+    const m = str.match(rule.build());
+    if (m && m.length > 0) {
+      hits.push({ id: rule.id, label: rule.label, count: m.length, samples: [...new Set(m.map((x) => x.trim()).filter(Boolean))].slice(0, 3) });
+    }
+  }
+  return { leaked: hits.length > 0, hits };
+}
+
 // Count formatting tells in a chunk of raw text (em-dash U+2014, markdown **bold** spans).
 export function countFormatting(text) {
   const str = String(text ?? '');
@@ -275,8 +299,16 @@ export function countFormatting(text) {
   return { emDash, bold };
 }
 
-function buildReasons({ cvBand, mattrBand, lexiconHot, lex, koDiagnostics, formatting, formattingThresholds }) {
+function buildReasons({ cvBand, mattrBand, lexiconHot, lex, koDiagnostics, formatting, formattingThresholds, leakage }) {
   const reasons = [];
+  if (leakage?.leaked) {
+    const labels = leakage.hits.map((h) => h.label).join(', ');
+    reasons.push({
+      code: 'model-output-leakage',
+      label: 'Model-output leakage',
+      detail: `Pasted-LLM artifact present (${labels}). A single hit is near-proof-grade.`,
+    });
+  }
   if (formatting?.emDashHot) {
     reasons.push({
       code: 'em-dash-overuse',
@@ -364,13 +396,16 @@ export function analyzePlaygroundText(text, opts = {}) {
     const emDashHot = docEmDash >= formattingThresholds.emDashDoc && counts.emDash >= 1;
     const boldHot = docBold >= formattingThresholds.boldDoc && counts.bold >= 1;
     const formatting = { ...counts, docEmDash, docBold, emDashHot, boldHot };
+    // Model-output leakage (#332): per-paragraph hit, fires on a single occurrence.
+    const leakage = detectMarkupLeakage(paragraph);
     const hot =
       cvBand === 'low' ||
       mattrBand === 'low' ||
       lexiconHot ||
       Boolean(koSignals.koDiagnostics?.hot) ||
       emDashHot ||
-      boldHot;
+      boldHot ||
+      leakage.leaked;
     const reasons = buildReasons({
       cvBand,
       mattrBand,
@@ -379,6 +414,7 @@ export function analyzePlaygroundText(text, opts = {}) {
       koDiagnostics: koSignals.koDiagnostics,
       formatting,
       formattingThresholds,
+      leakage,
     });
 
     return {
@@ -391,6 +427,7 @@ export function analyzePlaygroundText(text, opts = {}) {
       mattr: { value: mattrValue, band: mattrBand },
       lexicon: { ...lex, hot: lexiconHot },
       formatting,
+      leakage,
       ...koSignals,
       hot,
       reasons,
@@ -407,6 +444,7 @@ export function analyzePlaygroundText(text, opts = {}) {
     paragraphCount: paragraphs.length,
     hotCount,
     totalTokens: analyzed.reduce((sum, p) => sum + p.tokenCount, 0),
+    markupLeakage: detectMarkupLeakage(text),
     paragraphs: analyzed,
     auditItems: analyzed.filter((p) => p.hot || p.lexicon.matches > 0),
     note: 'Audit-only deterministic score. It marks editing hotspots, not authorship or intent.',

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -26,6 +26,7 @@ import {
   DEFAULT_LEXICON_DENSITY_THRESHOLD,
   DEFAULT_LEXICON_MIN_HOT_MATCHES,
 } from './lexicon.js';
+import { detectMarkupLeakage } from './markup-leakage.js';
 
 export function analyzeText(text, opts = {}) {
   const {
@@ -47,6 +48,11 @@ export function analyzeText(text, opts = {}) {
   // vs decomposed) would otherwise yield different MATTR/lexicon hits.
   const normalized = text ? text.normalize('NFC') : '';
   const paragraphs = splitParagraphs(normalized);
+
+  // Document-level leakage scan (issue #332). Near-proof-grade: a single hit is
+  // strong evidence of pasted model output, so it forces the document hot
+  // regardless of the per-paragraph stylometry/lexicon signals.
+  const markupLeakage = detectMarkupLeakage(normalized);
   const lexicon =
     providedLexicon ??
     (repoRoot ? loadLexicon(lang, repoRoot) : { strict: [], phrases: [] });
@@ -109,7 +115,8 @@ export function analyzeText(text, opts = {}) {
     skipped: Boolean(skipReason),
     skipReason,
     paragraphs: analyzed,
-    hot: analyzed.some((p) => p.hot),
+    markupLeakage,
+    hot: markupLeakage.leaked || analyzed.some((p) => p.hot),
   };
 }
 

--- a/src/features/markup-leakage.js
+++ b/src/features/markup-leakage.js
@@ -1,0 +1,69 @@
+// Deterministic detection of model-output *leakage* artifacts: tokens that LLM
+// web-search / tooling inject and that essentially never appear in human-written
+// prose. Unlike the stylometry/lexicon signals (which are probabilistic and
+// fire on clusters), a single hit here is near-proof-grade evidence of pasted
+// model output, so it fires hard at the document level. See issue #332.
+//
+// Language-agnostic literal token set — applies to ko/en/zh/ja alike.
+//
+// Self-scan caveat: patina's own docs, fixtures, and issues that *discuss* these
+// tokens will match. That is correct behavior (the text genuinely contains
+// them); callers scanning the repo's own meta-content should expect hits.
+
+const OBJECT_REPLACEMENT_CHAR = '￼';
+
+// Each entry: { id, label, build() => fresh RegExp }. We build a fresh regex per
+// scan so the shared module is reentrant (no leaking lastIndex across calls).
+const MARKUP_RULES = [
+  {
+    id: 'oai-citation-markup',
+    label: 'OpenAI citation markup',
+    build: () => /:contentReference|oaicite|oai_citation/gi,
+  },
+  {
+    id: 'model-tool-token',
+    label: 'Model tool token',
+    build: () => /\bturn\d+(?:search|view|news|image|forecast|finance|fetch)\d*\b|\bnavlist\b|\bgrok_card\b/gi,
+  },
+  {
+    id: 'object-replacement-char',
+    label: 'Object-replacement character (￼)',
+    build: () => new RegExp(OBJECT_REPLACEMENT_CHAR, 'g'),
+  },
+  {
+    id: 'ai-tracking-param',
+    label: 'AI-tool tracking parameter in URL',
+    build: () => /utm_source=(?:chatgpt\.com|openai\.com|perplexity\.ai|claude\.ai|gemini\.google\.com)|[?&](?:ref|utm_source)=chatgpt/gi,
+  },
+  {
+    id: 'explicit-self-identification',
+    label: 'Explicit AI self-identification',
+    build: () => /\bas an? (?:AI|artificial intelligence) language model\b|\bas a large language model\b|\bas a language model\b|\bas an AI assistant\b|\bI am an AI\b|\bI'?m an AI\b/gi,
+  },
+];
+
+/**
+ * Scan raw text for model-output leakage artifacts.
+ * @param {string} text
+ * @returns {{ leaked: boolean, hits: Array<{id:string,label:string,count:number,samples:string[]}> }}
+ */
+export function detectMarkupLeakage(text) {
+  const str = typeof text === 'string' ? text : '';
+  const hits = [];
+  if (!str) return { leaked: false, hits };
+
+  for (const rule of MARKUP_RULES) {
+    const matches = str.match(rule.build());
+    if (matches && matches.length > 0) {
+      hits.push({
+        id: rule.id,
+        label: rule.label,
+        count: matches.length,
+        samples: [...new Set(matches.map((m) => m.trim()).filter(Boolean))].slice(0, 3),
+      });
+    }
+  }
+  return { leaked: hits.length > 0, hits };
+}
+
+export { MARKUP_RULES, OBJECT_REPLACEMENT_CHAR };

--- a/tests/unit/markup-leakage.test.js
+++ b/tests/unit/markup-leakage.test.js
@@ -1,0 +1,62 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import { detectMarkupLeakage } from '../../src/features/markup-leakage.js';
+import { analyzeText } from '../../src/features/index.js';
+
+test('detects OpenAI citation markup', () => {
+  const r = detectMarkupLeakage('The study found X :contentReference[oaicite:0]{index=0} and more.');
+  assert.equal(r.leaked, true);
+  assert.ok(r.hits.some((h) => h.id === 'oai-citation-markup'));
+});
+
+test('detects model tool tokens (turn0search, navlist, grok_card)', () => {
+  for (const s of ['see turn0search1 for', 'rendered navlist here', 'a grok_card block']) {
+    assert.equal(detectMarkupLeakage(s).leaked, true, s);
+  }
+});
+
+test('detects object-replacement character', () => {
+  assert.equal(detectMarkupLeakage('a line with ￼ in it').leaked, true);
+});
+
+test('detects AI tracking params in URLs', () => {
+  assert.equal(detectMarkupLeakage('source: https://example.com/x?utm_source=chatgpt.com').leaked, true);
+});
+
+test('detects explicit AI self-identification', () => {
+  for (const s of ['As an AI language model, I cannot', "I'm an AI, so", 'as a large language model']) {
+    assert.equal(detectMarkupLeakage(s).leaked, true, s);
+  }
+});
+
+test('does NOT fire on clean human prose', () => {
+  const clean =
+    'We cut the onboarding doc from 1,400 words to 600. People actually read it now. ' +
+    'The team shipped it on a Tuesday and moved on.';
+  assert.equal(detectMarkupLeakage(clean).leaked, false);
+});
+
+test('does NOT fire on ordinary use of "AI" or "model"', () => {
+  assert.equal(detectMarkupLeakage('I built an AI tool. The model is small.').leaked, false);
+  assert.equal(detectMarkupLeakage('as an engineer, I think the model works').leaked, false);
+});
+
+test('analyzeText forces hot=true when leakage present', () => {
+  const text =
+    'This is a perfectly ordinary paragraph with varied rhythm and no tells at all.\n\n' +
+    'Another normal paragraph here, written plainly by a person.\n\n' +
+    'A third one, just to clear the skip threshold, with a citation :contentReference[oaicite:1]{index=1}.';
+  const r = analyzeText(text, { lang: 'en' });
+  assert.equal(r.markupLeakage.leaked, true);
+  assert.equal(r.hot, true);
+});
+
+test('analyzeText leaves markupLeakage clean on normal text', () => {
+  const text =
+    'A plainly written first paragraph that varies its sentence length a little.\n\n' +
+    'A second human paragraph, nothing odd here, just prose.\n\n' +
+    'And a third to clear the short-input skip, still ordinary writing.';
+  const r = analyzeText(text, { lang: 'en' });
+  assert.equal(r.markupLeakage.leaked, false);
+});


### PR DESCRIPTION
Refs #332 (does not auto-close — CLI scoring integration + optional prose pattern remain).

## What
Deterministic detector for pasted-LLM artifacts that essentially never appear in human prose. A single hit is near-proof-grade, so it forces the document hot at the **document level** (unlike the probabilistic stylometry/lexicon signals).

Detected token classes (language-agnostic):
- OpenAI citation markup: `:contentReference`, `oaicite`, `oai_citation`
- Model tool tokens: `turn0search1`, `navlist`, `grok_card`
- U+FFFC object-replacement char (￼)
- AI-tool tracking params: `utm_source=chatgpt.com` (+ openai/perplexity/claude.ai/gemini)
- Explicit self-identification: `as an AI language model`, `as a large language model`, `I'm an AI` …

## Where
- new `src/features/markup-leakage.js` — fixed token set, reentrant regex builders
- `src/features/index.js` — `analyzeText` exposes `markupLeakage` + ORs it into `hot`
- `playground/analyzer.js` — mirrored, surfaces a `model-output-leakage` reason code in the audit
- `tests/unit/markup-leakage.test.js` — positives + clean-prose negatives (ordinary "AI"/"model" usage does NOT fire)

## Verification
- `tests/unit/*`: **264/264 green**
- `npm run benchmark`: 39 fixtures **100%**, no regression
- `eslint`: clean
- No collision with PR #330 (touches `patterns/*`, `docs/*`, `core/scoring.md`, tests — disjoint from `src/`)

## Scope / follow-ups (keep #332 open)
This is the deterministic core. Not in this PR: wiring leakage into the CLI LLM severity score (`src/scoring.js` / `core/scoring.md`), and an optional prose pattern-pack entry. The self-scan caveat (patina's own meta-docs that quote these tokens will match) is documented in the module header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)