### PR TITLE
feat(detect): density-gated discourse tells (fake-candor + thematic breaks) (#334)

### DIFF
--- a/playground/analyzer.js
+++ b/playground/analyzer.js
@@ -291,6 +291,30 @@ export function detectMarkupLeakage(text) {
   return { leaked: hits.length > 0, hits };
 }
 
+// Fake-candor / manufactured-intimacy openers (issue #334). Density-gated:
+// humans use these once; 2+ per document is an AI tell. Mirrors
+// src/features/discourse-tells.js (fake-candor half; thematic-break is CLI-side).
+const FAKE_CANDOR_RULES = [
+  /\bhere'?s the thing\b/gi,
+  /\bhere'?s the kicker\b/gi,
+  /\blet'?s be honest\b/gi,
+  /\blet'?s be real\b/gi,
+  /\bthe truth is\b/gi,
+  /\bi'?ll be honest(?: with you)?\b/gi,
+  /\breal talk\b/gi,
+];
+export const DEFAULT_FAKE_CANDOR_MIN = 2;
+
+export function countFakeCandor(text) {
+  const str = typeof text === 'string' ? text : '';
+  let count = 0;
+  for (const re of FAKE_CANDOR_RULES) {
+    const m = str.match(re);
+    if (m) count += m.length;
+  }
+  return count;
+}
+
 // Count formatting tells in a chunk of raw text (em-dash U+2014, markdown **bold** spans).
 export function countFormatting(text) {
   const str = String(text ?? '');
@@ -299,8 +323,15 @@ export function countFormatting(text) {
   return { emDash, bold };
 }
 
-function buildReasons({ cvBand, mattrBand, lexiconHot, lex, koDiagnostics, formatting, formattingThresholds, leakage }) {
+function buildReasons({ cvBand, mattrBand, lexiconHot, lex, koDiagnostics, formatting, formattingThresholds, leakage, candor }) {
   const reasons = [];
+  if (candor?.hot) {
+    reasons.push({
+      code: 'fake-candor',
+      label: 'Fake-candor opener',
+      detail: `Manufactured-intimacy opener ("here's the thing", "the truth is", …); ${candor.docCount} in the document (threshold ${DEFAULT_FAKE_CANDOR_MIN}).`,
+    });
+  }
   if (leakage?.leaked) {
     const labels = leakage.hits.map((h) => h.label).join(', ');
     reasons.push({
@@ -373,6 +404,10 @@ export function analyzePlaygroundText(text, opts = {}) {
   const paraFormatting = paragraphs.map(countFormatting);
   const docEmDash = paraFormatting.reduce((sum, f) => sum + f.emDash, 0);
   const docBold = paraFormatting.reduce((sum, f) => sum + f.bold, 0);
+  // Fake-candor openers (#334): doc-level density gate, then attribute to the
+  // paragraphs that carry an opener (same shape as the em-dash doc-level pass).
+  const paraCandor = paragraphs.map(countFakeCandor);
+  const docCandor = paraCandor.reduce((sum, n) => sum + n, 0);
 
   const analyzed = paragraphs.map((paragraph, idx) => {
     const sentences = splitSentences(paragraph);
@@ -398,6 +433,8 @@ export function analyzePlaygroundText(text, opts = {}) {
     const formatting = { ...counts, docEmDash, docBold, emDashHot, boldHot };
     // Model-output leakage (#332): per-paragraph hit, fires on a single occurrence.
     const leakage = detectMarkupLeakage(paragraph);
+    // Fake-candor (#334): this paragraph carries an opener AND the doc total >= gate.
+    const candorHot = docCandor >= DEFAULT_FAKE_CANDOR_MIN && paraCandor[idx] >= 1;
     const hot =
       cvBand === 'low' ||
       mattrBand === 'low' ||
@@ -405,7 +442,8 @@ export function analyzePlaygroundText(text, opts = {}) {
       Boolean(koSignals.koDiagnostics?.hot) ||
       emDashHot ||
       boldHot ||
-      leakage.leaked;
+      leakage.leaked ||
+      candorHot;
     const reasons = buildReasons({
       cvBand,
       mattrBand,
@@ -415,6 +453,7 @@ export function analyzePlaygroundText(text, opts = {}) {
       formatting,
       formattingThresholds,
       leakage,
+      candor: { hot: candorHot, docCount: docCandor },
     });
 
     return {

--- a/src/features/discourse-tells.js
+++ b/src/features/discourse-tells.js
@@ -1,0 +1,68 @@
+// Density-gated discourse tells (issue #334). Unlike markup-leakage (a single
+// near-proof-grade hit), these are constructions humans also use, so each fires
+// only past a density threshold to keep false positives low.
+//
+// 1. Fake-candor / manufactured-intimacy openers (English): AI overuses
+//    intimacy-signaling openers ("here's the thing", "let's be honest") that
+//    real writers use sparingly. Fires at >= 2 per document.
+// 2. Decorative thematic breaks: AI sprinkles `---` / `***` / `___` dividers,
+//    often before every heading. Fires at >= 3 per document.
+
+const FAKE_CANDOR_RULES = [
+  /\bhere'?s the thing\b/gi,
+  /\bhere'?s the kicker\b/gi,
+  /\blet'?s be honest\b/gi,
+  /\blet'?s be real\b/gi,
+  /\bthe truth is\b/gi,
+  /\bi'?ll be honest(?: with you)?\b/gi,
+  /\breal talk\b/gi,
+];
+
+const FAKE_CANDOR_MIN = 2;
+const THEMATIC_BREAK_MIN = 3;
+
+// A markdown thematic break: a line that is only ---, ***, or ___ (3+), optionally spaced.
+const THEMATIC_BREAK_LINE = /^[ \t]*(?:-[ \t]*){3,}$|^[ \t]*(?:\*[ \t]*){3,}$|^[ \t]*(?:_[ \t]*){3,}$/;
+const HEADING_LINE = /^[ \t]*#{1,6}[ \t]+\S/;
+
+export function detectFakeCandor(text) {
+  const str = typeof text === 'string' ? text : '';
+  const hits = [];
+  let count = 0;
+  for (const re of FAKE_CANDOR_RULES) {
+    const m = str.match(re);
+    if (m && m.length) {
+      count += m.length;
+      hits.push(...new Set(m.map((x) => x.trim().toLowerCase())));
+    }
+  }
+  return { count, hits: [...new Set(hits)].slice(0, 5), hot: count >= FAKE_CANDOR_MIN, threshold: FAKE_CANDOR_MIN };
+}
+
+export function detectThematicBreaks(text) {
+  const lines = (typeof text === 'string' ? text : '').split(/\r?\n/);
+  let count = 0;
+  let adjacentToHeading = 0;
+  for (let i = 0; i < lines.length; i++) {
+    if (!THEMATIC_BREAK_LINE.test(lines[i])) continue;
+    count++;
+    // "adjacent to a heading" = the next non-empty line is a heading.
+    for (let j = i + 1; j < lines.length; j++) {
+      if (lines[j].trim() === '') continue;
+      if (HEADING_LINE.test(lines[j])) adjacentToHeading++;
+      break;
+    }
+  }
+  return { count, adjacentToHeading, hot: count >= THEMATIC_BREAK_MIN, threshold: THEMATIC_BREAK_MIN };
+}
+
+/**
+ * @returns {{ fakeCandor: object, thematicBreaks: object, hot: boolean }}
+ */
+export function detectDiscourseTells(text) {
+  const fakeCandor = detectFakeCandor(text);
+  const thematicBreaks = detectThematicBreaks(text);
+  return { fakeCandor, thematicBreaks, hot: fakeCandor.hot || thematicBreaks.hot };
+}
+
+export { FAKE_CANDOR_MIN, THEMATIC_BREAK_MIN };

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -27,6 +27,7 @@ import {
   DEFAULT_LEXICON_MIN_HOT_MATCHES,
 } from './lexicon.js';
 import { detectMarkupLeakage } from './markup-leakage.js';
+import { detectDiscourseTells } from './discourse-tells.js';
 
 export function analyzeText(text, opts = {}) {
   const {
@@ -53,6 +54,9 @@ export function analyzeText(text, opts = {}) {
   // strong evidence of pasted model output, so it forces the document hot
   // regardless of the per-paragraph stylometry/lexicon signals.
   const markupLeakage = detectMarkupLeakage(normalized);
+  // Density-gated discourse tells (issue #334): fake-candor openers (>=2) and
+  // decorative thematic breaks (>=3). Document-level, weaker than leakage.
+  const discourseTells = detectDiscourseTells(normalized);
   const lexicon =
     providedLexicon ??
     (repoRoot ? loadLexicon(lang, repoRoot) : { strict: [], phrases: [] });
@@ -116,7 +120,8 @@ export function analyzeText(text, opts = {}) {
     skipReason,
     paragraphs: analyzed,
     markupLeakage,
-    hot: markupLeakage.leaked || analyzed.some((p) => p.hot),
+    discourseTells,
+    hot: markupLeakage.leaked || discourseTells.hot || analyzed.some((p) => p.hot),
   };
 }
 

--- a/tests/unit/discourse-tells.test.js
+++ b/tests/unit/discourse-tells.test.js
@@ -1,0 +1,77 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import {
+  detectFakeCandor,
+  detectThematicBreaks,
+  detectDiscourseTells,
+} from '../../src/features/discourse-tells.js';
+import { analyzeText } from '../../src/features/index.js';
+
+test('fake-candor fires at >= 2 openers, not at 1', () => {
+  assert.equal(detectFakeCandor("Here's the thing, it works.").hot, false);
+  const two = detectFakeCandor("Here's the thing. And the truth is, it also scales.");
+  assert.equal(two.hot, true);
+  assert.ok(two.count >= 2);
+});
+
+test('fake-candor matches the documented opener set', () => {
+  const text = "Let's be honest. Real talk. I'll be honest with you.";
+  const r = detectFakeCandor(text);
+  assert.ok(r.count >= 3);
+  assert.equal(r.hot, true);
+});
+
+test('fake-candor does not fire on ordinary prose', () => {
+  const clean = 'We shipped the feature on Tuesday. The team reviewed it and moved on.';
+  assert.equal(detectFakeCandor(clean).hot, false);
+  assert.equal(detectFakeCandor(clean).count, 0);
+});
+
+test('thematic breaks fire at >= 3 dividers, not at 2', () => {
+  const two = 'A para\n\n---\n\nB para\n\n***\n\nC para';
+  assert.equal(detectThematicBreaks(two).hot, false);
+  const three = 'A\n\n---\n\nB\n\n***\n\nC\n\n___\n\nD';
+  const r = detectThematicBreaks(three);
+  assert.equal(r.hot, true);
+  assert.ok(r.count >= 3);
+});
+
+test('thematic breaks count adjacency to headings', () => {
+  const md = '---\n# Title\n\nbody\n\n---\n## Section\n\nmore\n\n---\n### Sub\n';
+  const r = detectThematicBreaks(md);
+  assert.equal(r.count, 3);
+  assert.equal(r.adjacentToHeading, 3);
+  assert.equal(r.hot, true);
+});
+
+test('thematic break does not fire on normal markdown with one rule', () => {
+  const md = '# Title\n\nSome body text here.\n\n---\n\nA footer note.';
+  assert.equal(detectThematicBreaks(md).hot, false);
+});
+
+test('detectDiscourseTells aggregates both', () => {
+  const r = detectDiscourseTells("Here's the thing. The truth is, this works.\n\n---\n\nmore");
+  assert.equal(r.fakeCandor.hot, true);
+  assert.equal(r.thematicBreaks.hot, false);
+  assert.equal(r.hot, true);
+});
+
+test('analyzeText surfaces discourseTells and ORs into hot', () => {
+  const text =
+    "Here's the thing about this tool, it varies sentence length nicely here.\n\n" +
+    "And the truth is, a second plainly written human paragraph follows.\n\n" +
+    'A third paragraph clears the short-input skip threshold cleanly.';
+  const r = analyzeText(text, { lang: 'en' });
+  assert.equal(r.discourseTells.fakeCandor.hot, true);
+  assert.equal(r.hot, true);
+});
+
+test('analyzeText leaves discourseTells clean on ordinary prose', () => {
+  const text =
+    'A plainly written first paragraph with some natural variation in length.\n\n' +
+    'A second ordinary human paragraph, nothing unusual in here at all.\n\n' +
+    'A third one to clear the skip threshold, still just normal writing.';
+  const r = analyzeText(text, { lang: 'en' });
+  assert.equal(r.discourseTells.hot, false);
+});


### PR DESCRIPTION
Refs #334.

## What
Two deterministic, **density-gated** signals (humans use both, so each fires only past a threshold):
- **Fake-candor openers** (`here's the thing`, `the truth is`, `let's be honest`, `real talk`, `I'll be honest`, `here's the kicker`, `let's be real`): fires at **>=2 / doc**.
- **Decorative thematic breaks** (`---` / `***` / `___`): fires at **>=3 / doc**; also counts how many sit immediately before a heading.

## Where
- new `src/features/discourse-tells.js`
- `src/features/index.js` — `analyzeText` exposes `discourseTells`, ORs into `hot`
- `playground/analyzer.js` — mirrors **fake-candor** (doc-gated, per-paragraph attribution, `fake-candor` reason code). Thematic-break stays CLI-side for v1 (markdown dividers are a file concern more than a paste concern).
- `tests/unit/discourse-tells.test.js` — on/off density boundaries + clean-prose negatives

## Verification
- unit: **273/273 green** · benchmark 39 fixtures **100%** · eslint clean
- density gate confirmed: 1 candor opener does NOT fire, 2 does; 2 thematic breaks do NOT fire, 3 does
- No collision with #330 (touches `patterns/*`/`docs/*`, disjoint from `src/`)

## Scope / follow-ups (keep #334 open)
Playground thematic-break surface + CLI severity-scoring integration remain follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)