### PR TITLE
chore(release): 3.12.0

### DIFF
--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "3.11.0"
+version: "3.12.0"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,15 @@ Semver rationale: patch | minor | major — explain whether this changes pattern
 
 ## Unreleased
 
-**Post-3.11.0 launch-prep and distribution polish (not yet versioned).**
+## 3.12.0 — 2026-06-02
 
-Semver rationale: patch — docs, packaging, and benchmark-evidence changes only; no pattern, schema, or CLI-behavior changes.
+Semver rationale: minor — adds new deterministic detection signals (new analyzer behavior); backward compatible.
+
+### Added
+
+- **Model-output leakage detection** (#332): a deterministic detector for pasted-LLM artifacts that never appear in human prose — OpenAI citation markup (`:contentReference` / `oaicite` / `oai_citation`), model tool tokens (`turn0search1`, `navlist`, `grok_card`), the U+FFFC object-replacement char, AI-tool tracking params (`utm_source=chatgpt.com`, …), and explicit self-identification (`as an AI language model`, …). A single hit is near-proof-grade, so it forces the document hot. New `src/features/markup-leakage.js`, mirrored in the playground.
+- **Em-dash and boldface overuse in the playground** (#333, partial): the browser analyzer now counts document-level em-dash (≥3) and markdown bold (≥5) overuse, mirroring catalog patterns #13/#14. Emoji / title-case / inline-header remain tracked in #333.
+- **Density-gated discourse tells** (#334): fake-candor / manufactured-intimacy openers (`here's the thing`, `the truth is`, …) fire at ≥2 per document; decorative thematic breaks (`---` / `***` / `___`) fire at ≥3. New `src/features/discourse-tells.js`; fake-candor mirrored in the playground.
 
 ### Changed
 
@@ -24,6 +30,7 @@ Semver rationale: patch — docs, packaging, and benchmark-evidence changes only
 - Reworked the README hero to be text-first and demoted the demo GIF below the static example; added per-language README demos.
 - Added a typewriter terminal animation for the README demo GIF.
 - Added a maintainer-owned launch-execution handoff packet (`docs/social/patina-launch-execution.md`).
+- One-click false-positive report button on the playground (#331).
 
 ### Evidence
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 3.11.0" src="https://img.shields.io/badge/version-3.11.0-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 3.12.0" src="https://img.shields.io/badge/version-3.12.0-blue"></a>
 </p>
 
 <p align="center">
@@ -304,7 +304,7 @@ If meaning drifts at any verification step, the change is retried or rolled back
 
 ```yaml
 # .patina.default.yaml
-version: "3.11.0"
+version: "3.12.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/README_JA.md
+++ b/README_JA.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#クイックスタート)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-3.11.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-3.12.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-en.gif" alt="patina が英語のAIっぽい文を整え、スコアを表示するターミナルデモGIF" width="780">
@@ -281,7 +281,7 @@ rewrite モードでは、モデルは `[BODY]`/`[/BODY]` ブロック（`--vari
 
 ```yaml
 # .patina.default.yaml
-version: "3.11.0"
+version: "3.12.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/README_KR.md
+++ b/README_KR.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#빠른-시작)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-3.11.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-3.12.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-ko.gif" alt="patina가 한국어 AI풍 문장을 다듬고 결과 점수를 보여주는 터미널 데모 GIF" width="780">
@@ -284,7 +284,7 @@ Standalone CLI MAX(`patina --models ...`)는 더 이상 HTTP-only가 아닙니�
 
 ```yaml
 # .patina.default.yaml
-version: "3.11.0"
+version: "3.12.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#快速开始)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-3.11.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-3.12.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-en.gif" alt="patina 将带有 AI 味的英文文案改写并显示评分的终端演示 GIF" width="780">
@@ -281,7 +281,7 @@ Markdown-heavy 工程流程可使用开发者原生 profile shortcut：`code-com
 
 ```yaml
 # .patina.default.yaml
-version: "3.11.0"
+version: "3.12.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/SKILL-MAX.md
+++ b/SKILL-MAX.md
@@ -1,6 +1,6 @@
 ---
 name: patina-max
-version: 3.11.0
+version: 3.12.0
 description: |
   Multi-model humanization. Runs the same humanization task on multiple
   local model CLIs, scores each result, and selects the best

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 3.11.0
+version: 3.12.0
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "3.11.0"
+    "patina-cli": "3.12.0"
   },
   "license": "MIT",
   "repository": {

--- a/patina-max/SKILL.md
+++ b/patina-max/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina-max
-version: 3.11.0
+version: 3.12.0
 description: Best-of-N humanizer. Runs the same text through multiple model CLIs (claude / codex / gemini) and auto-picks the lowest AI-score result that passes the meaning-preservation floor (MPS ≥ 70).
 allowed-tools:
   - Read


### PR DESCRIPTION
Version bump 3.11.0 → **3.12.0** (minor) for the new detection signals merged since the last release.

## Released in 3.12.0
- **#332** model-output leakage detection (citation markup, tool tokens, U+FFFC, `utm_source=chatgpt.com`, explicit `as an AI` self-id) — deterministic, single-hit
- **#333** (partial) playground em-dash + boldface overuse
- **#334** density-gated discourse tells (fake-candor openers ≥2, thematic breaks ≥3)
- **#331** one-click false-positive report button (already merged)

## Version sync (CLAUDE.md rule)
All in sync at 3.12.0: `package.json`, `.patina.default.yaml`, `SKILL.md`, `SKILL-MAX.md`, `patina-max/SKILL.md`, all 4 READMEs, and the `patina-humanizer` alias package (+ its `patina-cli` dep). CHANGELOG `Unreleased` → `3.12.0` with corrected semver (minor, not patch).

## Verification
- `npm run release:check`: **Release metadata OK for 3.12.0**
- `npm test`: **404/404**
- eslint(src/playground/tests/scripts) + typecheck + spellcheck: clean

## After merge (maintainer)
`npm publish` (runs `prepublishOnly`: release:check + test + benchmark:report + dogfood) and tag `v3.12.0` + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)