### PR TITLE
fix(playground): align lint ignores and discourse-tell parity

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ export default [
   {
     ignores: [
       '.git/**',
+      '.omc/**',
       '.omx/**',
       'node_modules/**',
       'docs/benchmarks/*.json',

--- a/playground/analyzer.js
+++ b/playground/analyzer.js
@@ -291,9 +291,8 @@ export function detectMarkupLeakage(text) {
   return { leaked: hits.length > 0, hits };
 }
 
-// Fake-candor / manufactured-intimacy openers (issue #334). Density-gated:
-// humans use these once; 2+ per document is an AI tell. Mirrors
-// src/features/discourse-tells.js (fake-candor half; thematic-break is CLI-side).
+// Density-gated discourse tells (issue #334): fake-candor / manufactured-intimacy
+// openers and decorative thematic breaks. Mirrors src/features/discourse-tells.js.
 const FAKE_CANDOR_RULES = [
   /\bhere'?s the thing\b/gi,
   /\bhere'?s the kicker\b/gi,
@@ -304,15 +303,47 @@ const FAKE_CANDOR_RULES = [
   /\breal talk\b/gi,
 ];
 export const DEFAULT_FAKE_CANDOR_MIN = 2;
+export const DEFAULT_THEMATIC_BREAK_MIN = 3;
+const THEMATIC_BREAK_LINE = /^[ \t]*(?:-[ \t]*){3,}$|^[ \t]*(?:\*[ \t]*){3,}$|^[ \t]*(?:_[ \t]*){3,}$/;
+const HEADING_LINE = /^[ \t]*#{1,6}[ \t]+\S/;
 
-export function countFakeCandor(text) {
+export function detectFakeCandor(text) {
   const str = typeof text === 'string' ? text : '';
+  const hits = [];
   let count = 0;
   for (const re of FAKE_CANDOR_RULES) {
     const m = str.match(re);
-    if (m) count += m.length;
+    if (m && m.length) {
+      count += m.length;
+      hits.push(...new Set(m.map((x) => x.trim().toLowerCase())));
+    }
   }
-  return count;
+  return { count, hits: [...new Set(hits)].slice(0, 5), hot: count >= DEFAULT_FAKE_CANDOR_MIN, threshold: DEFAULT_FAKE_CANDOR_MIN };
+}
+
+export function countFakeCandor(text) {
+  return detectFakeCandor(text).count;
+}
+
+export function detectThematicBreaks(text) {
+  const lines = (typeof text === 'string' ? text : '').split(/\r?\n/);
+  let count = 0;
+  let adjacentToHeading = 0;
+  for (let i = 0; i < lines.length; i++) {
+    if (!THEMATIC_BREAK_LINE.test(lines[i])) continue;
+    count++;
+    for (let j = i + 1; j < lines.length; j++) {
+      if (lines[j].trim() === '') continue;
+      if (HEADING_LINE.test(lines[j])) adjacentToHeading++;
+      break;
+    }
+  }
+  return {
+    count,
+    adjacentToHeading,
+    hot: count >= DEFAULT_THEMATIC_BREAK_MIN,
+    threshold: DEFAULT_THEMATIC_BREAK_MIN,
+  };
 }
 
 // Count formatting tells in a chunk of raw text (em-dash U+2014, markdown **bold** spans).
@@ -323,13 +354,20 @@ export function countFormatting(text) {
   return { emDash, bold };
 }
 
-function buildReasons({ cvBand, mattrBand, lexiconHot, lex, koDiagnostics, formatting, formattingThresholds, leakage, candor }) {
+function buildReasons({ cvBand, mattrBand, lexiconHot, lex, koDiagnostics, formatting, formattingThresholds, leakage, candor, thematicBreaks }) {
   const reasons = [];
   if (candor?.hot) {
     reasons.push({
       code: 'fake-candor',
       label: 'Fake-candor opener',
       detail: `Manufactured-intimacy opener ("here's the thing", "the truth is", …); ${candor.docCount} in the document (threshold ${DEFAULT_FAKE_CANDOR_MIN}).`,
+    });
+  }
+  if (thematicBreaks?.hot) {
+    reasons.push({
+      code: 'thematic-break',
+      label: 'Decorative thematic break',
+      detail: `${thematicBreaks.docCount} markdown dividers in the document (threshold ${DEFAULT_THEMATIC_BREAK_MIN}); this paragraph carries ${thematicBreaks.count}.`,
     });
   }
   if (leakage?.leaked) {
@@ -407,7 +445,11 @@ export function analyzePlaygroundText(text, opts = {}) {
   // Fake-candor openers (#334): doc-level density gate, then attribute to the
   // paragraphs that carry an opener (same shape as the em-dash doc-level pass).
   const paraCandor = paragraphs.map(countFakeCandor);
-  const docCandor = paraCandor.reduce((sum, n) => sum + n, 0);
+  const docFakeCandor = detectFakeCandor(text);
+  const docCandor = docFakeCandor.count;
+
+  const paraThematicBreaks = paragraphs.map(detectThematicBreaks);
+  const docThematicBreaks = detectThematicBreaks(text);
 
   const analyzed = paragraphs.map((paragraph, idx) => {
     const sentences = splitSentences(paragraph);
@@ -435,6 +477,7 @@ export function analyzePlaygroundText(text, opts = {}) {
     const leakage = detectMarkupLeakage(paragraph);
     // Fake-candor (#334): this paragraph carries an opener AND the doc total >= gate.
     const candorHot = docCandor >= DEFAULT_FAKE_CANDOR_MIN && paraCandor[idx] >= 1;
+    const thematicBreakHot = docThematicBreaks.hot && paraThematicBreaks[idx].count >= 1;
     const hot =
       cvBand === 'low' ||
       mattrBand === 'low' ||
@@ -443,7 +486,14 @@ export function analyzePlaygroundText(text, opts = {}) {
       emDashHot ||
       boldHot ||
       leakage.leaked ||
-      candorHot;
+      candorHot ||
+      thematicBreakHot;
+    const thematicBreaks = {
+      ...paraThematicBreaks[idx],
+      docCount: docThematicBreaks.count,
+      docAdjacentToHeading: docThematicBreaks.adjacentToHeading,
+      hot: thematicBreakHot,
+    };
     const reasons = buildReasons({
       cvBand,
       mattrBand,
@@ -454,6 +504,7 @@ export function analyzePlaygroundText(text, opts = {}) {
       formattingThresholds,
       leakage,
       candor: { hot: candorHot, docCount: docCandor },
+      thematicBreaks,
     });
 
     return {
@@ -468,6 +519,7 @@ export function analyzePlaygroundText(text, opts = {}) {
       formatting,
       leakage,
       ...koSignals,
+      thematicBreaks,
       hot,
       reasons,
     };
@@ -484,6 +536,11 @@ export function analyzePlaygroundText(text, opts = {}) {
     hotCount,
     totalTokens: analyzed.reduce((sum, p) => sum + p.tokenCount, 0),
     markupLeakage: detectMarkupLeakage(text),
+    discourseTells: {
+      fakeCandor: docFakeCandor,
+      thematicBreaks: docThematicBreaks,
+      hot: docCandor >= DEFAULT_FAKE_CANDOR_MIN || docThematicBreaks.hot,
+    },
     paragraphs: analyzed,
     auditItems: analyzed.filter((p) => p.hot || p.lexicon.matches > 0),
     note: 'Audit-only deterministic score. It marks editing hotspots, not authorship or intent.',

--- a/tests/unit/playground.test.js
+++ b/tests/unit/playground.test.js
@@ -13,6 +13,7 @@ import {
   renderAuditDiff,
   SUPPORTED_LANGS,
 } from '../../playground/analyzer.js';
+import { analyzeText } from '../../src/features/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../..');
@@ -23,6 +24,10 @@ const SAMPLES = {
   zh: '总而言之，这一方案能够全面提升用户体验，并为未来发展提供新的可能。',
   ja: 'まとめると、この仕組みはユーザー体験を向上させ、より良い未来につながります。',
 };
+
+function analyzeNodeText(text, lang) {
+  return analyzeText(text, { lang, repoRoot: REPO_ROOT });
+}
 
 test('playground lexicons are generated for every supported language', () => {
   assert.deepEqual(Object.keys(PLAYGROUND_LEXICONS).sort(), [...SUPPORTED_LANGS].sort());
@@ -47,6 +52,87 @@ test('playground analyzer returns score, audit items, and diff HTML for ko/en/zh
     assert.match(html, /diff-card/);
     assert.match(html, /<mark>/);
   }
+});
+
+test('playground and node analyzers agree on shared deterministic signals', () => {
+  for (const lang of SUPPORTED_LANGS) {
+    const nodeAnalysis = analyzeNodeText(SAMPLES[lang], lang);
+    const playgroundAnalysis = analyzePlaygroundText(SAMPLES[lang], { lang });
+    assert.equal(
+      playgroundAnalysis.paragraphs[0].lexicon.matches > 0,
+      nodeAnalysis.paragraphs[0].lexicon.matches > 0,
+      `${lang} lexicon-hit presence should match node analyzer`,
+    );
+  }
+
+  const cases = [
+    {
+      name: 'model-output leakage',
+      text: 'This paragraph contains turn0search0 from copied model output.',
+      lang: 'en',
+      nodeHot: (analysis) => analysis.markupLeakage.leaked,
+      playgroundHot: (analysis) => analysis.markupLeakage.leaked,
+    },
+    {
+      name: 'fake-candor opener density',
+      text: "Here's the thing. Let's be honest. The rollout still needs one owner and one deadline.",
+      lang: 'en',
+      nodeHot: (analysis) => analysis.discourseTells.fakeCandor.hot,
+      playgroundHot: (analysis) => analysis.discourseTells.fakeCandor.hot,
+    },
+    {
+      name: 'short non-hot control',
+      text: 'I changed one parser branch and wrote down the reason.',
+      lang: 'en',
+      nodeHot: (analysis) => analysis.hot,
+      playgroundHot: (analysis) => analysis.hotCount > 0,
+    },
+  ];
+
+  for (const sample of cases) {
+    const nodeAnalysis = analyzeNodeText(sample.text, sample.lang);
+    const playgroundAnalysis = analyzePlaygroundText(sample.text, { lang: sample.lang });
+    assert.equal(
+      sample.playgroundHot(playgroundAnalysis),
+      sample.nodeHot(nodeAnalysis),
+      `${sample.name} verdict should match node analyzer`,
+    );
+  }
+});
+
+test('playground ports thematic-break discourse tells from the node analyzer', () => {
+  const text = [
+    '---',
+    '# First section',
+    'This practical note uses a plain sentence with uneven length.',
+    '',
+    '***',
+    '# Second section',
+    'The middle paragraph records the concrete tradeoff before the recommendation.',
+    '',
+    '___',
+    '# Third section',
+    'The final paragraph names the owner and the next review window.',
+  ].join('\n');
+
+  const nodeAnalysis = analyzeNodeText(text, 'en');
+  const playgroundAnalysis = analyzePlaygroundText(text, { lang: 'en' });
+
+  assert.equal(nodeAnalysis.discourseTells.thematicBreaks.hot, true);
+  assert.equal(
+    playgroundAnalysis.discourseTells.thematicBreaks.count,
+    nodeAnalysis.discourseTells.thematicBreaks.count,
+  );
+  assert.equal(
+    playgroundAnalysis.discourseTells.thematicBreaks.adjacentToHeading,
+    nodeAnalysis.discourseTells.thematicBreaks.adjacentToHeading,
+  );
+  assert.equal(
+    playgroundAnalysis.discourseTells.thematicBreaks.hot,
+    nodeAnalysis.discourseTells.thematicBreaks.hot,
+  );
+  assert.ok(playgroundAnalysis.paragraphs.some((paragraph) => paragraph.thematicBreaks.hot));
+  assert.ok(playgroundAnalysis.paragraphs.some((paragraph) => paragraph.reasons.some((reason) => reason.code === 'thematic-break')));
 });
 
 test('playground keeps one Korean lexicon hit as an audit hint', () => {


### PR DESCRIPTION
## Summary
- Fix local lint failures by ignoring the actual `.omc/**` scratch directory in ESLint while preserving `.omx/**`.
- Port thematic-break discourse tell detection to the static playground analyzer.
- Add browser-vs-node analyzer parity coverage for shared deterministic signals and thematic-break count/heading-adjacency/hot behavior.

Closes #342.
Closes #343.

## Verification
- `node --check playground/analyzer.js && node --test tests/unit/playground.test.js`
- `npm run lint`
- `npm test` (406 pass, 0 fail)
- `npm run release:check`

## Review
- Architect review lane: CLEAR / APPROVE, no findings.
