### PR TITLE
fix(playground): align formatting tells with the catalog

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@ const nodeGlobals = {
   clearTimeout: 'readonly',
   fetch: 'readonly',
   globalThis: 'readonly',
+  Intl: 'readonly',
   process: 'readonly',
   setTimeout: 'readonly',
 };

--- a/playground/analyzer.js
+++ b/playground/analyzer.js
@@ -16,12 +16,15 @@ export const DEFAULT_BURSTINESS_BANDS = { low: 0.30, high: 0.50 };
 export const DEFAULT_MIN_BURSTINESS_SENTENCES = 3;
 export const DEFAULT_MATTR_BANDS = { low: 0.55, high: 0.70 };
 export const DEFAULT_MATTR_WINDOW = 50;
-// Document-level formatting tells (mirror catalog patterns #13 em-dash, #14 boldface).
-// These are doc-level by design: 3 em-dashes spread one-per-paragraph must still fire,
-// so we count across the whole document and then flag the paragraphs that carry the token.
+// Formatting tells mirror catalog patterns #13/#14/#17.
+// Em dash is doc-level (3+ across the document). Bold fires at 5+ across the
+// document or 3+ within one paragraph. Emoji currently mirrors the catalog's
+// "any occurrence" contract for editorial/professional text.
 export const DEFAULT_FORMATTING_THRESHOLDS = {
   emDashDoc: 3, // U+2014 occurrences across the document
   boldDoc: 5, // **bold** spans across the document
+  boldParagraph: 3, // **bold** spans inside one paragraph
+  emojiDoc: 1, // any emoji occurrence in the document
 };
 export const DEFAULT_KO_DIAGNOSTIC_BANDS = {
   minSentences: 4,
@@ -388,12 +391,38 @@ export function detectThematicBreaks(text) {
   };
 }
 
-// Count formatting tells in a chunk of raw text (em-dash U+2014, markdown **bold** spans).
-export function countFormatting(text) {
+const EMOJI_BASE_RE = '\\p{Extended_Pictographic}(?:\\uFE0F|\\uFE0E)?(?:\\p{Emoji_Modifier})?';
+const EMOJI_CLUSTER_PATTERN = `(?:\\p{Regional_Indicator}{2}|[#*0-9]\\uFE0F?\\u20E3|${EMOJI_BASE_RE}(?:\\u200D${EMOJI_BASE_RE})*)`;
+const EMOJI_CLUSTER_RE = new RegExp(EMOJI_CLUSTER_PATTERN, 'u');
+const EMOJI_CLUSTER_RE_GLOBAL = new RegExp(EMOJI_CLUSTER_PATTERN, 'gu');
+
+function getGraphemeSegmenter() {
+  return typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
+    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    : null;
+}
+
+function countEmojiClusters(text, segmenter = getGraphemeSegmenter()) {
+  const str = String(text ?? '');
+  if (!str) return 0;
+  if (segmenter) {
+    let count = 0;
+    for (const { segment } of segmenter.segment(str)) {
+      if (EMOJI_CLUSTER_RE.test(segment)) count++;
+    }
+    return count;
+  }
+  return (str.match(EMOJI_CLUSTER_RE_GLOBAL) || []).length;
+}
+
+// Count formatting tells in a chunk of raw text (em-dash U+2014, markdown **bold**
+// spans, decorative emoji).
+export function countFormatting(text, opts = {}) {
   const str = String(text ?? '');
   const emDash = (str.match(/—/gu) || []).length;
   const bold = (str.match(/\*\*(?=\S)(?:[^*]|\*(?!\*))+?\*\*/gu) || []).length;
-  return { emDash, bold };
+  const emoji = countEmojiClusters(str, opts.segmenter);
+  return { emDash, bold, emoji };
 }
 
 function buildReasons({ cvBand, mattrBand, lexiconHot, lex, koDiagnostics, formatting, formattingThresholds, leakage, candor, thematicBreaks }) {
@@ -428,10 +457,20 @@ function buildReasons({ cvBand, mattrBand, lexiconHot, lex, koDiagnostics, forma
     });
   }
   if (formatting?.boldHot) {
+    const paragraphOnly = formatting.bold >= formattingThresholds.boldParagraph && formatting.docBold < formattingThresholds.boldDoc;
     reasons.push({
       code: 'bold-overuse',
       label: 'Boldface overuse',
-      detail: `${formatting.docBold} bold spans in the document (threshold ${formattingThresholds.boldDoc}); this paragraph carries ${formatting.bold}.`,
+      detail: paragraphOnly
+        ? `${formatting.bold} bold spans in this paragraph (threshold ${formattingThresholds.boldParagraph}).`
+        : `${formatting.docBold} bold spans in the document (threshold ${formattingThresholds.boldDoc}); this paragraph carries ${formatting.bold}.`,
+    });
+  }
+  if (formatting?.emojiHot) {
+    reasons.push({
+      code: 'emoji-overuse',
+      label: 'Emoji overuse',
+      detail: `${formatting.docEmoji} emoji in the document (catalog threshold: any occurrence); this paragraph carries ${formatting.emoji}.`,
     });
   }
   if (cvBand === 'low') {
@@ -484,6 +523,7 @@ export function analyzePlaygroundText(text, opts = {}) {
   const paraFormatting = paragraphs.map(countFormatting);
   const docEmDash = paraFormatting.reduce((sum, f) => sum + f.emDash, 0);
   const docBold = paraFormatting.reduce((sum, f) => sum + f.bold, 0);
+  const docEmoji = paraFormatting.reduce((sum, f) => sum + f.emoji, 0);
   // Fake-candor openers (#334): doc-level density gate, then attribute to the
   // paragraphs that carry an opener (same shape as the em-dash doc-level pass).
   const paraCandor = paragraphs.map(countFakeCandor);
@@ -513,8 +553,11 @@ export function analyzePlaygroundText(text, opts = {}) {
     });
     const counts = paraFormatting[idx];
     const emDashHot = docEmDash >= formattingThresholds.emDashDoc && counts.emDash >= 1;
-    const boldHot = docBold >= formattingThresholds.boldDoc && counts.bold >= 1;
-    const formatting = { ...counts, docEmDash, docBold, emDashHot, boldHot };
+    const boldHot =
+      (docBold >= formattingThresholds.boldDoc && counts.bold >= 1) ||
+      counts.bold >= formattingThresholds.boldParagraph;
+    const emojiHot = docEmoji >= formattingThresholds.emojiDoc && counts.emoji >= 1;
+    const formatting = { ...counts, docEmDash, docBold, docEmoji, emDashHot, boldHot, emojiHot };
     // Model-output leakage (#332): per-paragraph hit, fires on a single occurrence.
     const leakage = detectMarkupLeakage(paragraph);
     // Fake-candor (#334): this paragraph carries an opener AND the doc total >= gate.
@@ -527,6 +570,7 @@ export function analyzePlaygroundText(text, opts = {}) {
       Boolean(koSignals.koDiagnostics?.hot) ||
       emDashHot ||
       boldHot ||
+      emojiHot ||
       leakage.leaked ||
       candorHot ||
       thematicBreakHot;

--- a/tests/unit/playground.test.js
+++ b/tests/unit/playground.test.js
@@ -13,6 +13,7 @@ import {
   renderAuditDiff,
   SUPPORTED_LANGS,
   splitProseSentences,
+  countFormatting,
 } from '../../playground/analyzer.js';
 import { analyzeText } from '../../src/features/index.js';
 
@@ -160,6 +161,84 @@ test('playground excludes Markdown list blocks from prose rhythm samples', () =>
   assert.equal(residuePlayground.paragraphs[0].sentenceCount, residueNode.paragraphs[0].sentenceCount);
   assert.equal(residuePlayground.paragraphs[0].burstiness.band, residueNode.paragraphs[0].burstiness.band);
   assert.equal(residuePlayground.hotCount > 0, residueNode.hot);
+});
+
+test('playground flags a single emoji marker because pattern 17 is any-hit', () => {
+  const text = 'Status update 🙂 the deploy finished on time.';
+  const analysis = analyzePlaygroundText(text, { lang: 'en' });
+
+  assert.equal(analysis.hotCount, 1);
+  assert.equal(analysis.paragraphs[0].formatting.docEmoji, 1);
+  assert.ok(analysis.paragraphs[0].reasons.some((reason) => reason.code === 'emoji-overuse'));
+});
+
+test('playground counts joined emoji by visible glyph and still flags them once', () => {
+  const text = `Status update 👩‍💻 the deploy finished on time.
+
+Budget note 👨‍👩‍👧‍👦 the team stayed within plan.`;
+  const analysis = analyzePlaygroundText(text, { lang: 'en' });
+
+  assert.equal(analysis.paragraphs[0].formatting.docEmoji, 2);
+  assert.equal(analysis.hotCount, 2);
+  assert.ok(analysis.paragraphs.every((paragraph) => paragraph.reasons.some((reason) => reason.code === 'emoji-overuse')));
+
+  assert.deepEqual(countFormatting('👩‍💻 👨‍👩‍👧‍👦', { segmenter: null }), { emDash: 0, bold: 0, emoji: 2 });
+});
+
+test('playground marks repeated em dashes as a document-level formatting tell', () => {
+  const text = `Status update — the deploy finished on time.
+
+Budget note — the team stayed within plan.
+
+Support review — response time dropped this week.`;
+  const analysis = analyzePlaygroundText(text, { lang: 'en' });
+
+  assert.equal(analysis.hotCount, 3);
+  assert.ok(analysis.paragraphs.every((paragraph) => paragraph.formatting.docEmDash === 3));
+  assert.ok(analysis.paragraphs.every((paragraph) => paragraph.reasons.some((reason) => reason.code === 'em-dash-overuse')));
+});
+
+test('playground does not hot-classify em dashes below the threshold', () => {
+  const text = `Status update — the deploy finished on time.
+
+Budget note — the team stayed within plan.`;
+  const analysis = analyzePlaygroundText(text, { lang: 'en' });
+
+  assert.equal(analysis.hotCount, 0);
+  assert.ok(analysis.paragraphs.every((paragraph) => paragraph.reasons.every((reason) => reason.code !== 'em-dash-overuse')));
+});
+
+test('playground marks repeated bold spans as a document-level formatting tell', () => {
+  const text = `**Status** update for the deploy.
+
+**Budget** note for the team.
+
+**Support** review from this week.
+
+**Latency** trend from the dashboard.
+
+**Owner** list for the rollout.`;
+  const analysis = analyzePlaygroundText(text, { lang: 'en' });
+
+  assert.equal(analysis.hotCount, 5);
+  assert.ok(analysis.paragraphs.every((paragraph) => paragraph.formatting.docBold === 5));
+  assert.ok(analysis.paragraphs.every((paragraph) => paragraph.reasons.some((reason) => reason.code === 'bold-overuse')));
+});
+
+test('playground marks 3 bold spans in one paragraph even below the document threshold', () => {
+  const text = '**Status** update with a **Budget** note and a **Support** review.';
+  const analysis = analyzePlaygroundText(text, { lang: 'en' });
+
+  assert.equal(analysis.hotCount, 1);
+  assert.ok(analysis.paragraphs[0].reasons.some((reason) => reason.code === 'bold-overuse'));
+});
+
+test('playground does not hot-classify bold spans below both thresholds', () => {
+  const text = '**Status** update with a **Budget** note for the deploy.';
+  const analysis = analyzePlaygroundText(text, { lang: 'en' });
+
+  assert.equal(analysis.hotCount, 0);
+  assert.ok(analysis.paragraphs.every((paragraph) => paragraph.reasons.every((reason) => reason.code !== 'bold-overuse')));
 });
 
 test('playground keeps one Korean lexicon hit as an audit hint', () => {


### PR DESCRIPTION
## Summary
- finish issue #333 by extending the browser playground analyzer's formatting tells to cover emoji alongside the already-shipped em-dash and bold signals
- keep the shared document-level formatting pipeline, but preserve the catalog's actual thresholds:
  - em dash: 3+ per document
  - bold: 5+ per document or 3+ in one paragraph
  - emoji: any occurrence
- count joined emoji by visible glyph in both the `Intl.Segmenter` path and the fallback path
- add regressions for emoji, joined-emoji fallback counting, em-dash thresholds, and bold thresholds

Closes #333.

## Verification
- `npm run lint`
- `npm test` (420 pass, 0 fail)
- `npm run release:check`
- `npm run playground:data -- --check`

## Review
- Architect final review: CLEAR / APPROVE
