### PR TITLE
chore(types): add @ts-check coverage to core runtime modules

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { validateBaseURL } from './security.js';
 
 const DEFAULT_TIMEOUT = 120000;
@@ -185,8 +186,8 @@ export function createSemaphore(max) {
  * @param {object} options LLM request options.
  * @param {string} options.prompt User prompt sent as the single chat message.
  * @param {string} [options.apiKey] Bearer token for the provider.
- * @param {string} [options.baseURL=https://api.openai.com/v1] OpenAI-compatible API base URL.
- * @param {string} [options.model=gpt-4o] Model id to request.
+ * @param {string} [options.baseURL] OpenAI-compatible API base URL. Defaults to https://api.openai.com/v1.
+ * @param {string} [options.model] Model id to request. Defaults to gpt-4o.
  * @param {number} [options.temperature=DEFAULT_TEMPERATURE] Sampling temperature.
  * @param {number|string} [options.seed] Optional deterministic seed forwarded to the provider.
  * @param {number} [options.timeout=120000] Per-attempt timeout in milliseconds.
@@ -339,9 +340,12 @@ export async function callLLM({
     }
   }
 
-  const err = new Error(`LLM API failed after ${attemptsMade || 1} attempts: ${lastError?.message ?? 'unknown'}`);
+  const err = /** @type {Error & { status?: number }} */ (
+    new Error(`LLM API failed after ${attemptsMade || 1} attempts: ${lastError?.message ?? 'unknown'}`)
+  );
   if (lastError?.name === 'AbortError') err.name = 'AbortError';
-  if (typeof lastError?.status === 'number') err.status = lastError.status;
+  const lastStatus = /** @type {{ status?: unknown }} */ (lastError ?? {}).status;
+  if (typeof lastStatus === 'number') err.status = lastStatus;
   throw err;
 }
 
@@ -352,7 +356,7 @@ export async function callLLM({
  * @param {string} options.prompt Prompt to send to each model.
  * @param {string[]} options.models Ordered model ids to call.
  * @param {string} [options.apiKey] Provider API key.
- * @param {string} [options.baseURL=https://api.openai.com/v1] Provider base URL.
+ * @param {string} [options.baseURL] Provider base URL. Defaults to https://api.openai.com/v1.
  * @param {number} [options.temperature=DEFAULT_TEMPERATURE] Sampling temperature.
  * @param {number|string} [options.seed] Optional deterministic seed.
  * @param {number} [options.timeout] Per-call timeout in milliseconds.
@@ -365,6 +369,8 @@ export async function callLLM({
  * @param {Function} [options.onResponse] Called with response metadata.
  * @param {object} [options.cache] Response cache shared by calls.
  * @param {Function} [options.callLLM] Injectable single-model implementation.
+ * @param {Function} [options.sleep] Sleep helper for tests.
+ * @param {Function} [options.now] Clock returning epoch milliseconds.
  * @returns {Promise<Array<Object>>} Per-model results in input order.
  * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example

--- a/src/errors.js
+++ b/src/errors.js
@@ -79,7 +79,7 @@ export function renderCliError(err) {
  * const code = getExitCode(inputError('bad', 'why', 'fix')); // 2
  */
 export function getExitCode(err, fallback = 1) {
-  const n = Number(err?.exitCode);
+  const n = Number(/** @type {{ exitCode?: unknown }} */ (err ?? {}).exitCode);
   return Number.isInteger(n) && n >= 0 ? n : fallback;
 }
 

--- a/src/features/lexicon.js
+++ b/src/features/lexicon.js
@@ -96,6 +96,10 @@ export function computeDensity(paragraphText, tokens, lexicon) {
   return { matches: hits.length, density, hits };
 }
 
+/**
+ * @param {{ matches?: number, density?: number }} [lexiconStats]
+ * @param {{ lang?: string, densityThreshold?: number, minHotMatches?: (number|Record<string, number>) }} [options]
+ */
 export function classifyLexiconHot(
   lexiconStats,
   {

--- a/src/features/stylometry.js
+++ b/src/features/stylometry.js
@@ -172,6 +172,10 @@ export function koreanPosDiversityProxy(paragraph) {
   };
 }
 
+/**
+ * @param {{ sentenceCount?: number, spacing?: object, comma?: object, posDiversity?: object }} [features]
+ * @param {object} [bands]
+ */
 export function classifyKoreanDiagnostics({
   sentenceCount = 0,
   spacing,

--- a/src/output.js
+++ b/src/output.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { createLogger } from './logger.js';
 
 /**
@@ -70,7 +71,7 @@ function colorizeDiff(body, { parsed = {}, env = process.env, stdout = process.s
   }).join('\n');
 }
 
-function shouldColorDiff({ parsed = {}, env = process.env, stdout = process.stdout } = {}) {
+function shouldColorDiff(/** @type {{ parsed?: { noColor?: boolean }, env?: Record<string, string|undefined>, stdout?: { isTTY?: boolean } }} */ { parsed = {}, env = process.env, stdout = process.stdout } = {}) {
   return !parsed.noColor && env.NO_COLOR === undefined && stdout?.isTTY === true;
 }
 

--- a/src/prompt-builder.js
+++ b/src/prompt-builder.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Build the LLM prompt for rewrite, diff, audit, score, or ouroboros mode.
  *

--- a/src/providers.js
+++ b/src/providers.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Provider presets: shortcuts for common OpenAI-compatible endpoints.
 // Each provider maps to a base URL + a recommended default model + the env
 // variable users typically set to authenticate. Selecting a provider is

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { callLLM as defaultCallLLM } from './api.js';
 import { getRepoRoot } from './config.js';
 import { analyzeText } from './features/index.js';
@@ -51,7 +52,7 @@ async function callAndParseJson({
   temperature = 0.1,
   deadline,
   signal,
-  callLLM = defaultCallLLM,
+  callLLM = /** @type {Function} */ (defaultCallLLM),
   logger = createLogger(),
   now,
   sleep,
@@ -325,7 +326,7 @@ export function withShadowScore(parsed, { deterministicScore, config = {}, logge
  * @param {object|null} [options.deterministicScore] Deterministic score payload.
  * @param {object} [options.config={}] Effective config.
  * @param {object} [options.logger] Logger for warnings.
- * @returns {{overall: number|null, scorePreference: string|null}} Reconciled score and preference source.
+ * @returns {{overall: number|null, scorePreference: (object|null)}} Reconciled score and preference source.
  * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const result = reconcileScoreOverall({ llmOverall: 20, deterministicScore: { overall: 60 } });


### PR DESCRIPTION
## Summary
- resolve issue #320 item 2: opt the core runtime files into `// @ts-check` so `npm run typecheck` actually covers production code
  - `src/api.js`, `src/scoring.js`, `src/providers.js`, `src/output.js`, `src/prompt-builder.js`
- fix the 16 type errors this surfaced using **JSDoc annotations and inline `/** @type {...} */` casts only** — no runtime logic changed
  - touched transitively-checked deps `src/errors.js`, `src/features/lexicon.js`, `src/features/stylometry.js`
- `typecheck` now reports 6 files (was 1)

Item 1 of the issue (wire `tests/unit/test_composite.py` into CI) already shipped earlier via `.github/workflows/test.yml` (`python` job running `pytest tests/unit/test_composite.py`).

Closes #320.

## Verification
- `npm run lint` (includes `typecheck`, now 6 files, clean)
- `npm test` (420 pass, 0 fail)
- `npm run release:check`

## Review
- Architect review: CLEAR / APPROVE — confirmed type-annotation-only, zero runtime behavior change.
