### PR TITLE
test(catalog): enforce worked-example coverage for every pattern

### DIFF
--- a/tests/unit/pattern-docs.test.js
+++ b/tests/unit/pattern-docs.test.js
@@ -286,16 +286,27 @@ test('mirrored docs keep fire conditions aligned for drift-prone numbered patter
   }
 });
 
-test('zh and ja rewrite patterns have success and failure examples', () => {
-  for (const lang of ['zh', 'ja']) {
-    for (let n = 1; n <= 28; n++) {
-      const id = String(n).padStart(2, '0');
+test('every rewrite pattern has success and failure examples in all four languages', () => {
+  // #322: the symmetric pack counts hid missing worked examples (e.g. #29 once
+  // had none). Derive the numbered pattern ids from the packs themselves so the
+  // guard tracks every rewrite pattern, in every language, and self-extends as
+  // patterns are added. Korean examples are unprefixed; en/zh/ja are prefixed.
+  for (const lang of LANGS) {
+    const sourceFiles = patternFiles().filter((file) => {
+      const { meta } = parsePatternFile(file);
+      return meta.language === lang && !meta.score_only;
+    });
+    const numbers = [...new Set(sourceFiles.flatMap((file) => patternHeadings(file).map((heading) => heading.number)))].sort((a, b) => a - b);
+    assert.ok(numbers.length > 0, `${lang} should expose numbered pattern headings`);
+    const prefix = lang === 'ko' ? '' : `${lang}-`;
+    for (const number of numbers) {
+      const id = String(number).padStart(2, '0');
       assert.ok(
-        existsSync(resolve(REPO_ROOT, `examples/${lang}-${id}-success-01.md`)),
+        existsSync(resolve(REPO_ROOT, `examples/${prefix}${id}-success-01.md`)),
         `${lang} pattern ${id} must have a success example`
       );
       assert.ok(
-        existsSync(resolve(REPO_ROOT, `examples/${lang}-${id}-failure-01.md`)),
+        existsSync(resolve(REPO_ROOT, `examples/${prefix}${id}-failure-01.md`)),
         `${lang} pattern ${id} must have a failure example`
       );
     }


### PR DESCRIPTION
## Summary
Closes the two completeness gaps in issue #322 and makes the fix durable.

Both concrete gaps were already resolved on current `main`:
1. **Pattern #29 examples** — `29-*` plus `en-/zh-/ja-29-*` success+failure files exist; in fact every numbered pattern 1–33 now has worked examples in all four languages.
2. **zh/ja lexicon parity** — frontmatter `entries` exactly match the parsed entry counts (zh=60, ja=60; en=88, ko=96), the entry format is already normalized (both parse as phrase lists), and the maturity tier is documented as `needs-external-calibration` in `docs/research/lexicon-freshness-audit.md`. Expanding zh/ja toward ko/en parity is research-gated (per `process/pattern-freshness.md`) and tracked separately.

This PR enforces gap #1 so it can't silently regress:
- replace the old `zh`/`ja`-only, hardcoded `n=1..28` example guard with a **pack-derived** guard
- for each language it collects the numbered rewrite-pattern ids from the packs and asserts `examples/<prefix><id>-success-01.md` and `-failure-01.md` exist (ko unprefixed, en/zh/ja prefixed)
- score-only viral-hook packs are excluded by design; the guard self-extends as patterns are added

Closes #322.

## Verification
- `npm run lint` (typecheck 6 files, clean)
- `npm test` (422 pass, 0 fail — includes the new guard)
- `npm run release:check`

## Review
- Architect review: CLEAR / APPROVE (one LOW maintainability note applied: exclude `score_only` packs).
