### PR TITLE
ko translationese (번역투/calque) detector

### DIFF
--- a/docs/TRANSLATIONESE-KO.md
+++ b/docs/TRANSLATIONESE-KO.md
@@ -1,0 +1,51 @@
+# Korean translationese (번역투 / calque) detection
+
+`src/features/translationese.js` adds a deterministic, auditable signal for
+Korean **calques** — grammatical Korean that reads as translated-from-English.
+The stylometry + AI-lexicon signals catch *structure* and *AI vocabulary*; they
+do **not** catch lexical translationese (e.g. "커맨드 기둥" for "command pillars",
+"~에 의해" passives, "당신" for "you"). This catalog fills that gap.
+
+## Design notes
+
+- **Precision first.** Most of these constructions also appear in good native
+  Korean (formal/technical prose especially). So the signal is **density-gated**:
+  it only reports `hot` when both an absolute floor (≥4 hits) **and** a
+  per-prose-sentence density (≥0.5) are met. A single "~에 의해" means nothing.
+- **Advisory, not a verdict.** `analyzeText` surfaces it as `translationese`
+  but deliberately keeps it **out of the document `hot` decision**, so it cannot
+  regress benchmark false positives. The SKILL / callers act on it (e.g. the
+  rewrite loop), and the audit surface can display it.
+- **ko-only** for now (calques are language-specific).
+- Each rule ships a `before → after` example (enforced by a unit test).
+
+## Catalog (before → after)
+
+| id | tell | before | after |
+| --- | --- | --- | --- |
+| `noun-calque` | 직역 명사구 (pillar/layer 류) | 세 가지 **커맨드 기둥**을 설치합니다. | 핵심 커맨드 세 가지를 설치합니다. |
+| `dummy-subject` | 가주어 "그것은/이것은" (it is) | **그것은** 매우 중요하다. | 매우 중요하다. |
+| `direct-address-you` | "당신" 직접 호칭 (you) | **당신은** 이것을 설정할 수 있습니다. | 이건 설정할 수 있다. |
+| `passive-e-uihae` | "~에 의해" 피동 (by-passive) | 작업은 에이전트**에 의해** 처리됩니다. | 에이전트가 작업을 처리합니다. |
+| `have-overuse` | "~을 가지고 있다" (have) | 이 도구는 유연성을 **가지고 있습니다**. | 이 도구는 유연합니다. |
+| `one-of` | "~중 하나" (one of the) | 가장 빠른 도구 **중 하나입니다**. | 손꼽히게 빠릅니다. |
+| `provides` | "~을 제공합니다" (provides) | 다양한 기능을 **제공합니다**. | 여러 기능을 쓸 수 있다. |
+| `as-follows` | "다음과 같습니다" (as follows) | 사용법은 **다음과 같습니다**. | 사용법은 이렇다. |
+| `make-easy` | "~하게 만들어 준다" (make it ~) | 설치를 쉽게 **만들어 줍니다**. | 설치가 쉬워진다. |
+
+## Output shape
+
+```js
+analyzeText(text, { lang: 'ko' }).translationese
+// → { count, density, sentences, byRule:[{id,label,strong,count,example}],
+//     hits:[...], hot, thresholds:{count,density} }
+```
+
+## Limitations / next
+
+- Calques are **lexical**; the structural stylometric classifier cannot learn
+  them (proven separately). This is a rule catalog, like patina's pattern packs.
+- The catalog is intentionally small and conservative; expand with corpus
+  evidence and keep the density gate to protect precision.
+- Not wired into `hot` yet — promote only after validating no FP regression on
+  the benchmark / a diverse human ko control set.

--- a/src/cli.js
+++ b/src/cli.js
@@ -356,24 +356,21 @@ export async function main(args) {
         });
       }
 
+      const auditBackstop =
+        mode === 'audit' && (parsed.format ?? 'markdown') !== 'json' && !parsed.batch
+          ? buildDeterministicAuditBackstop(text, { lang, repoRoot })
+          : '';
       let output;
       let scoreValidationOutput = null;
       if (parsed.ouroboros) {
         const ouroborosBody = formatOuroborosOutput(result);
-        output = formatOutput(ouroborosBody, mode, parsed, { tone: toneResolution, logger });
+        output = formatOutput(ouroborosBody, mode, parsed, { tone: toneResolution, logger, auditBackstop });
         scoreValidationOutput = ouroborosBody;
       } else {
-        output = formatOutput(result, mode, parsed, { tone: toneResolution, logger });
+        output = formatOutput(result, mode, parsed, { tone: toneResolution, logger, auditBackstop });
         if (mode === 'score') {
           scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' }, { logger });
         }
-      }
-
-      // Deterministic backstop for audit (issue: weak LLM backends drop 번역투).
-      // Appended so calques/leakage/discourse tells appear regardless of model.
-      // Skip json (structured) and batch (per-file) outputs.
-      if (mode === 'audit' && (parsed.format ?? 'markdown') !== 'json' && !parsed.batch) {
-        output += buildDeterministicAuditBackstop(text, { lang, repoRoot });
       }
 
       // v3.11 Phase 1.3: surface weight drift between config and the score

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,7 +11,7 @@ import { buildPrompt } from './prompt-builder.js';
 import { invokeBackendChain, selectBackendChain, listBackends, listBackendNames, resolveBackend } from './backends/index.js';
 import { selectProvider, resolveProviderConfig, PROVIDERS } from './providers.js';
 import { validateBaseURL, applyInsecureBaseURLOptIn, applyPrivateBaseURLOptIn } from './security.js';
-import { formatOutput, validateScoreWeights } from './output.js';
+import { formatOutput, validateScoreWeights, buildDeterministicAuditBackstop } from './output.js';
 import { runMaxMode } from './max-mode.js';
 import { runOuroboros } from './ouroboros.js';
 import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals, scoreMPS, scoreText } from './scoring.js';
@@ -367,6 +367,13 @@ export async function main(args) {
         if (mode === 'score') {
           scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' }, { logger });
         }
+      }
+
+      // Deterministic backstop for audit (issue: weak LLM backends drop 번역투).
+      // Appended so calques/leakage/discourse tells appear regardless of model.
+      // Skip json (structured) and batch (per-file) outputs.
+      if (mode === 'audit' && (parsed.format ?? 'markdown') !== 'json' && !parsed.batch) {
+        output += buildDeterministicAuditBackstop(text, { lang, repoRoot });
       }
 
       // v3.11 Phase 1.3: surface weight drift between config and the score

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -28,6 +28,7 @@ import {
 } from './lexicon.js';
 import { detectMarkupLeakage } from './markup-leakage.js';
 import { detectDiscourseTells } from './discourse-tells.js';
+import { detectTranslationese } from './translationese.js';
 
 export function analyzeText(text, opts = {}) {
   const {
@@ -57,6 +58,10 @@ export function analyzeText(text, opts = {}) {
   // Density-gated discourse tells (issue #334): fake-candor openers (>=2) and
   // decorative thematic breaks (>=3). Document-level, weaker than leakage.
   const discourseTells = detectDiscourseTells(normalized);
+  // ko translationese (번역투/calque) — lexical, NOT structural. Advisory signal:
+  // surfaced for callers/SKILL but deliberately NOT folded into `hot` (these
+  // constructions appear in good Korean too; gating hot would regress FP).
+  const translationese = detectTranslationese(normalized, { lang });
   const lexicon =
     providedLexicon ??
     (repoRoot ? loadLexicon(lang, repoRoot) : { strict: [], phrases: [] });
@@ -121,6 +126,7 @@ export function analyzeText(text, opts = {}) {
     paragraphs: analyzed,
     markupLeakage,
     discourseTells,
+    translationese,
     hot: markupLeakage.leaked || discourseTells.hot || analyzed.some((p) => p.hot),
   };
 }

--- a/src/features/translationese.js
+++ b/src/features/translationese.js
@@ -1,0 +1,127 @@
+// Korean translationese (번역투 / calque) detector. The stylometry + lexicon
+// signals catch STRUCTURE (sentence rhythm, AI lexicon); they do NOT catch
+// lexical calques — phrasings that are grammatical Korean but read as
+// translated-from-English ("커맨드 기둥" for "command pillars", "~에 의해" passives,
+// "당신" for "you"). This deterministic, auditable detector fills that gap.
+//
+// IMPORTANT — precision first. Most of these constructions ALSO appear in good
+// native Korean (formal/technical prose especially). So this is a DENSITY-GATED
+// SUSPICION signal, not proof: a single "~에 의해" means nothing. It is surfaced
+// as its own `translationese` signal and does NOT flip the document `hot`
+// verdict (so it cannot regress benchmark false positives); the SKILL / callers
+// decide what to do with it. Each rule ships a before→after example.
+//
+// ko-only for now (calques are language-specific).
+import { splitProseSentences } from './segment.js';
+
+// strong: rarer in good Korean, weighted higher. weak: common, advisory only.
+// Each rule: { id, label, strong, re() -> fresh global RegExp, example:{before,after} }
+const RULES = [
+  {
+    id: 'noun-calque',
+    label: '직역 명사구 (pillar/layer 류 calque)',
+    strong: true,
+    re: () => /커맨드 기둥|명령(?:어)? 기둥|기둥 커맨드|[가-힣]+ 레이어로서/g,
+    example: { before: '세 가지 커맨드 기둥을 설치합니다.', after: '핵심 커맨드 세 가지를 설치합니다.' },
+  },
+  {
+    id: 'dummy-subject',
+    label: '가주어 "그것은/이것은" (English "it is")',
+    strong: true,
+    re: () => /(?:^|[.!?。]\s+|\n)\s*(?:그것은|이것은|그것이|이것이)\s/g,
+    example: { before: '그것은 매우 중요하다.', after: '매우 중요하다.' },
+  },
+  {
+    id: 'direct-address-you',
+    label: '"당신" 직접 호칭 (English "you")',
+    strong: true,
+    re: () => /당신(?:은|이|의|에게|을|를|께서|께)?/g,
+    example: { before: '당신은 이것을 설정할 수 있습니다.', after: '이건 설정할 수 있다.' },
+  },
+  {
+    id: 'passive-e-uihae',
+    label: '"~에 의해" 피동 (English by-passive)',
+    strong: false,
+    re: () => /에 의해/g,
+    example: { before: '작업은 에이전트에 의해 처리됩니다.', after: '에이전트가 작업을 처리합니다.' },
+  },
+  {
+    id: 'have-overuse',
+    label: '"~을 가지고 있다" (English "have")',
+    strong: false,
+    re: () => /(?:을|를)\s*가지(?:고 있|고 있습니다|고 있다)/g,
+    example: { before: '이 도구는 유연성을 가지고 있습니다.', after: '이 도구는 유연합니다.' },
+  },
+  {
+    id: 'one-of',
+    label: '"~중 하나" (English "one of the")',
+    strong: false,
+    re: () => /중\s*하나(?:이다|입니다|인|로|다|예요)?/g,
+    example: { before: '가장 빠른 도구 중 하나입니다.', after: '손꼽히게 빠릅니다.' },
+  },
+  {
+    id: 'provides',
+    label: '"~을 제공합니다" (English "provides")',
+    strong: false,
+    re: () => /(?:을|를)\s*제공(?:합니다|한다|해 줍니다|해준다)/g,
+    example: { before: '다양한 기능을 제공합니다.', after: '여러 기능을 쓸 수 있다.' },
+  },
+  {
+    id: 'as-follows',
+    label: '"다음과 같습니다" (English "as follows")',
+    strong: false,
+    re: () => /다음과\s*같(?:습니다|다|은|이)/g,
+    example: { before: '사용법은 다음과 같습니다.', after: '사용법은 이렇다.' },
+  },
+  {
+    id: 'make-easy',
+    label: '"~하게 만들어 준다" (English "make it ~")',
+    strong: false,
+    re: () => /(?:쉽게|가능하게|간단하게|편하게)\s*(?:만들어\s*(?:줍니다|준다|줘)|만듭니다|만든다)/g,
+    example: { before: '설치를 쉽게 만들어 줍니다.', after: '설치가 쉬워진다.' },
+  },
+];
+
+const ABS_MIN = 4;      // need at least this many total calque hits, and
+const DENSITY_MIN = 0.5; // at least this many hits per prose sentence, to call it hot.
+
+/**
+ * Scan ko text for translationese (calque) markers.
+ * @param {string} text
+ * @param {{lang?: string}} [opts]
+ * @returns {{count:number, density:number, sentences:number, byRule:Array, hits:string[], hot:boolean, thresholds:{count:number,density:number}}}
+ */
+export function detectTranslationese(text, opts = {}) {
+  const lang = opts.lang ?? 'ko';
+  const str = typeof text === 'string' ? text : '';
+  if (lang !== 'ko' || !str) {
+    return { count: 0, density: 0, sentences: 0, byRule: [], hits: [], hot: false, thresholds: { count: ABS_MIN, density: DENSITY_MIN } };
+  }
+  const byRule = [];
+  const hits = [];
+  let count = 0;
+  for (const rule of RULES) {
+    const matches = str.match(rule.re());
+    if (matches && matches.length) {
+      count += matches.length;
+      byRule.push({ id: rule.id, label: rule.label, strong: rule.strong, count: matches.length, example: rule.example });
+      hits.push(...new Set(matches.map((m) => m.trim()).filter(Boolean)));
+    }
+  }
+  const sentences = Math.max(1, splitProseSentences(str).length);
+  const density = count / sentences;
+  // Conservative: needs both an absolute floor AND a per-sentence density, so
+  // long legit docs with a few calques never trip it.
+  const hot = count >= ABS_MIN && density >= DENSITY_MIN;
+  return {
+    count,
+    density: Number(density.toFixed(3)),
+    sentences,
+    byRule: byRule.sort((a, b) => b.count - a.count),
+    hits: [...new Set(hits)].slice(0, 8),
+    hot,
+    thresholds: { count: ABS_MIN, density: DENSITY_MIN },
+  };
+}
+
+export { RULES as TRANSLATIONESE_RULES, ABS_MIN, DENSITY_MIN };

--- a/src/output.js
+++ b/src/output.js
@@ -1,5 +1,7 @@
 // @ts-check
 import { createLogger } from './logger.js';
+import { analyzeText } from './features/index.js';
+import { TRANSLATIONESE_RULES } from './features/translationese.js';
 
 /**
  * Format a raw backend result for CLI output mode and requested format.
@@ -524,4 +526,54 @@ function formatMaxModeOutput(result) {
   }
 
   return output;
+}
+/**
+ * Build a deterministic "backstop" section for audit mode. The LLM audit is
+ * model-dependent (a weak model silently drops 번역투/calques); these signals are
+ * computed deterministically so they appear regardless of which model ran. ko
+ * translationese rules are listed even below the hot-density gate, because audit
+ * is a hint surface, not a verdict.
+ *
+ * @param {string} text Source text.
+ * @param {{ lang?: string, repoRoot?: string }} [opts]
+ * @returns {string} Markdown section (empty string when nothing fired).
+ */
+export function buildDeterministicAuditBackstop(text, opts = {}) {
+  const lang = opts.lang ?? 'ko';
+  const str = typeof text === 'string' ? text : '';
+  /** @type {{signal:string,label:string,severity:string,location:string}[]} */
+  const rows = [];
+
+  // ko translationese — per-rule, with matched samples (model-independent).
+  if (lang === 'ko' && str) {
+    for (const rule of TRANSLATIONESE_RULES) {
+      const matches = str.match(rule.re());
+      if (matches && matches.length) {
+        const samples = [...new Set(matches.map((m) => m.trim()).filter(Boolean))].slice(0, 4);
+        rows.push({ signal: `번역투: ${rule.id}`, label: rule.label, severity: rule.strong ? 'MEDIUM' : 'LOW', location: samples.join(', ') });
+      }
+    }
+  }
+
+  // markup leakage (near-proof) + density-gated discourse tells — language-agnostic.
+  const a = analyzeText(str, { lang, repoRoot: opts.repoRoot });
+  for (const h of a.markupLeakage?.hits ?? []) {
+    rows.push({ signal: 'markup-leakage', label: h.label, severity: 'HIGH', location: (h.samples ?? []).join(', ') });
+  }
+  if (a.discourseTells?.fakeCandor?.hot) {
+    rows.push({ signal: 'discourse: fake-candor', label: '친근함 위장 도입부', severity: 'MEDIUM', location: (a.discourseTells.fakeCandor.hits ?? []).join(', ') });
+  }
+  if (a.discourseTells?.thematicBreaks?.hot) {
+    rows.push({ signal: 'discourse: thematic-breaks', label: '장식용 구분선 남용', severity: 'LOW', location: `${a.discourseTells.thematicBreaks.count}개` });
+  }
+
+  if (rows.length === 0) return '';
+  const lines = [
+    '## 결정적 신호 (deterministic backstop — 모델과 무관하게 항상 검사)',
+    '',
+    '| 신호 | 설명 | 심각도 | 위치 |',
+    '|------|------|--------|------|',
+    ...rows.map((r) => `| ${r.signal} | ${r.label} | ${r.severity} | ${r.location} |`),
+  ];
+  return `\n\n${lines.join('\n')}`;
 }

--- a/src/output.js
+++ b/src/output.js
@@ -14,6 +14,7 @@ import { TRANSLATIONESE_RULES } from './features/translationese.js';
  * @param {object} [opts.logger] Logger for output warnings.
  * @param {object} [opts.env] Environment map for color decisions.
  * @param {object} [opts.stdout] Stdout-like stream for color decisions.
+ * @param {string} [opts.auditBackstop] Deterministic audit-mode section to append before the tone footer.
  * @returns {string} User-facing formatted output.
  * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
@@ -22,7 +23,11 @@ import { TRANSLATIONESE_RULES } from './features/translationese.js';
 export function formatOutput(result, mode, parsed = {}, opts = {}) {
   const tone = opts.tone || null;
   const format = parsed.format || 'markdown';
-  const body = renderFormattedBody(result, mode, parsed, opts);
+  let body = renderFormattedBody(result, mode, parsed, opts);
+
+  if (mode === 'audit' && format !== 'json' && opts.auditBackstop) {
+    body += opts.auditBackstop;
+  }
 
   if (format === 'json') {
     return formatJsonOutput({ result, mode, body, tone, gate: parsed.gate });

--- a/tests/unit/audit-backstop.test.js
+++ b/tests/unit/audit-backstop.test.js
@@ -1,0 +1,33 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import { buildDeterministicAuditBackstop } from '../../src/output.js';
+
+const CALQUE = '이것은 강력한 도구입니다. 다양한 기능을 제공합니다. 이 작업은 에이전트에 의해 처리됩니다. 당신은 이것을 매우 쉽게 사용할 수 있습니다.';
+
+test('audit backstop surfaces ko translationese even when an LLM would miss it', () => {
+  const md = buildDeterministicAuditBackstop(CALQUE, { lang: 'ko' });
+  assert.ok(md.includes('deterministic backstop'), 'has backstop header');
+  assert.ok(md.includes('번역투: passive-e-uihae'), '~에 의해 passive');
+  assert.ok(md.includes('번역투: direct-address-you'), '당신');
+  assert.ok(md.includes('번역투: dummy-subject'), '이것은');
+  assert.ok(md.includes('번역투: provides'), '제공합니다');
+  // matched location should show the actual offending substring
+  assert.ok(md.includes('에 의해'));
+});
+
+test('audit backstop is empty for clean native ko (no false positives)', () => {
+  const clean = '어제는 비가 많이 왔다. 그래서 집에 있었다. 라면 먹고 영화 봤다. 나쁘지 않았다.';
+  assert.equal(buildDeterministicAuditBackstop(clean, { lang: 'ko' }), '');
+});
+
+test('audit backstop catches markup leakage regardless of language', () => {
+  const leaked = 'This is fine text :contentReference[oaicite:1]{index=1} and more.';
+  const md = buildDeterministicAuditBackstop(leaked, { lang: 'en' });
+  assert.ok(md.includes('markup-leakage'), 'flags pasted model-output markup');
+});
+
+test('audit backstop skips ko translationese rows for non-ko languages', () => {
+  const md = buildDeterministicAuditBackstop('You can use this. It is provided by the agent.', { lang: 'en' });
+  assert.equal(md.includes('번역투:'), false);
+});

--- a/tests/unit/translationese.test.js
+++ b/tests/unit/translationese.test.js
@@ -1,0 +1,75 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import { detectTranslationese, TRANSLATIONESE_RULES } from '../../src/features/translationese.js';
+import { analyzeText } from '../../src/features/index.js';
+
+test('calque-dense ko fires (count + density gate met)', () => {
+  const text = '당신은 이 도구를 사용할 수 있습니다. 그것은 다양한 기능을 제공합니다. 이 작업은 에이전트에 의해 처리됩니다. 사용법은 다음과 같습니다.';
+  const r = detectTranslationese(text, { lang: 'ko' });
+  assert.equal(r.hot, true);
+  assert.ok(r.count >= 4, `count ${r.count}`);
+  assert.ok(r.density >= 0.5, `density ${r.density}`);
+  const ids = r.byRule.map((x) => x.id);
+  assert.ok(ids.includes('direct-address-you'));
+  assert.ok(ids.includes('dummy-subject'));
+  assert.ok(ids.includes('provides'));
+});
+
+test('a single calque in long clean prose does NOT fire (density gate)', () => {
+  const text = '오늘 점심은 김치찌개를 먹었다. 비가 와서 우산을 챙겼다. 이 작업은 에이전트에 의해 처리되었다. 친구랑 영화를 봤는데 생각보다 재밌었다. 날씨가 좋아서 좀 걸었다.';
+  const r = detectTranslationese(text, { lang: 'ko' });
+  assert.equal(r.hot, false);
+  assert.ok(r.count < 4);
+});
+
+test('clean native ko has zero calque hits (no false positive)', () => {
+  const text = '어제는 비가 많이 왔다. 그래서 집에만 있었다. 라면 끓여 먹고 영화 한 편 봤다. 나쁘지 않은 하루였다.';
+  const r = detectTranslationese(text, { lang: 'ko' });
+  assert.equal(r.count, 0);
+  assert.equal(r.hot, false);
+});
+
+test('noun-calque catches "커맨드 기둥" style direct calques', () => {
+  const r = detectTranslationese('세 가지 커맨드 기둥을 설치합니다. 기둥 커맨드는 그 다음에 호출합니다.', { lang: 'ko' });
+  assert.ok(r.byRule.some((x) => x.id === 'noun-calque'));
+  assert.ok(r.hits.some((h) => h.includes('기둥')));
+});
+
+test('non-ko languages are skipped (calques are ko-specific here)', () => {
+  const r = detectTranslationese('You can use this. It is provided by the agent.', { lang: 'en' });
+  assert.equal(r.count, 0);
+  assert.equal(r.hot, false);
+});
+
+test('every rule ships a before/after example', () => {
+  for (const rule of TRANSLATIONESE_RULES) {
+    assert.ok(rule.example && rule.example.before && rule.example.after, `rule ${rule.id} missing example`);
+    // the rule must actually match its own "before" example
+    assert.ok(rule.re().test(rule.example.before), `rule ${rule.id} does not match its before example`);
+  }
+});
+
+test('analyzeText surfaces translationese as an advisory signal', () => {
+  const text =
+    '당신은 이 도구를 사용할 수 있습니다. 그것은 다양한 기능을 제공합니다.\n\n' +
+    '이 작업은 에이전트에 의해 처리됩니다. 사용법은 다음과 같습니다.\n\n' +
+    '설치는 한 줄로 끝납니다. 전역 설치는 필요 없습니다.';
+  const r = analyzeText(text, { lang: 'ko' });
+  assert.ok(r.translationese, 'translationese field present');
+  assert.equal(r.translationese.hot, true);
+  assert.ok(Array.isArray(r.translationese.byRule));
+});
+
+test('analyzeText keeps translationese OUT of the hot verdict (advisory only)', () => {
+  // Clean, structurally-human ko prose with a couple of calques but below the
+  // gate: translationese must not be hot, and must not be in the hot formula.
+  const text =
+    '어제는 비가 많이 왔다. 그래서 그냥 집에 있었다.\n\n' +
+    '라면을 끓여 먹고 영화를 한 편 봤다. 꽤 괜찮았다.\n\n' +
+    '저녁엔 동네를 좀 걸었다. 바람이 시원했다.';
+  const r = analyzeText(text, { lang: 'ko' });
+  assert.equal(r.translationese.hot, false);
+  // hot is driven only by leakage / discourse / paragraph stylometry
+  assert.equal(r.hot, r.markupLeakage.leaked || r.discourseTells.hot || r.paragraphs.some((p) => p.hot));
+});


### PR DESCRIPTION
Adds a deterministic, auditable detector for Korean **calques** — grammatical Korean that reads as translated-from-English (e.g. "커맨드 기둥" for "command pillars", "~에 의해" passives, "당신" for "you"). The stylometry + AI-lexicon signals catch structure and AI vocabulary but miss lexical translationese; this fills that gap.

- `src/features/translationese.js`: 9-rule calque catalog, each with a before→after example. **Density-gated** (>=4 hits AND >=0.5/sentence) so constructions that also appear in good Korean do not trip it.
- `analyzeText` surfaces `translationese` but deliberately keeps it **out of the `hot` verdict** (advisory only — gating hot would regress false positives; promote later after benchmark validation).
- Tests + `docs/TRANSLATIONESE-KO.md`.

**Verification:** `node --test tests/unit/*.test.js` → 363/363 pass; `npm run lint` clean (syntax/eslint/typecheck/spellcheck). Precision-safe: clean native ko → zero hits; a single calque in long prose does not fire. ko-only for now.