### PR TITLE
Korean Register Stability (RSS) — JS port of the MAX composite metric

### DIFF
--- a/src/features/index.js
+++ b/src/features/index.js
@@ -28,6 +28,7 @@ import {
 } from './lexicon.js';
 import { detectMarkupLeakage } from './markup-leakage.js';
 import { detectDiscourseTells } from './discourse-tells.js';
+import { registerStability, endingDistribution, dominantRegister } from './register-stability.js';
 
 export function analyzeText(text, opts = {}) {
   const {
@@ -140,6 +141,9 @@ export {
   koreanSpacingFeatures,
   loadLexicon,
   computeDensity,
+  registerStability,
+  endingDistribution,
+  dominantRegister,
 };
 
 function buildKoreanSignals(paragraph, sentenceCount, { enabled, bands }) {

--- a/src/features/register-stability.js
+++ b/src/features/register-stability.js
@@ -11,7 +11,7 @@ import { splitProseSentences } from './segment.js';
 // Sentence-final ending vocabulary. Order matters — longer/more-specific forms
 // first so e.g. 합니다 matches 합쇼체 before 다 falls through to 해라체.
 // Mirrors patina-max/composite.py _ENDING_PATTERNS.
-const ENDING_PATTERNS = [
+const ENDING_PATTERNS = /** @type {Array<[string, RegExp]>} */ ([
   // 합쇼체 (deferential formal): ~ㅂ니다 / ~습니다 / ~ㅂ니까 / ~십시오
   ['hapsho', /(?:[가-힣]니다|[가-힣]니까|[가-힣]시오|십시오|십시요)$/],
   // 해요체 (polite informal)
@@ -20,7 +20,7 @@ const ENDING_PATTERNS = [
   ['haera', /(?:[가-힣]는다|한다|[가-힣]다|하라|마라|보라|들라|[가-힣]아라|[가-힣]어라|[가-힣]라)$/],
   // 해체 (casual / 반말)
   ['hae', /(?:해|야|아|어|네|군|지)$/],
-];
+]);
 
 const TRAILING_PUNCT = /[\s.,!?;:。、]+$/;
 
@@ -34,7 +34,7 @@ function stripFences(text) {
  * @returns {Record<string, number>} e.g. { hapsho: 3, haera: 1 }
  */
 export function endingDistribution(text) {
-  const dist = {};
+  const dist = /** @type {Record<string, number>} */ ({});
   for (const sentence of splitProseSentences(stripFences(text))) {
     const tail = sentence.replace(TRAILING_PUNCT, '');
     if (!tail) continue;

--- a/src/features/register-stability.js
+++ b/src/features/register-stability.js
@@ -1,0 +1,91 @@
+// Korean Register Stability (RSS) — a deterministic measure of how much the
+// sentence-final REGISTER (politeness/formality level) drifts between two texts.
+// This is the JS port of patina-max/composite.py's `register_stability`, so the
+// Node engine can guard register the same way MAX mode does (e.g. a rewrite that
+// keeps the claim but flips 평어체→존댓말 is a register-stability regression).
+//
+// It is a PAIRWISE metric (baseline vs candidate), not a single-text hot signal,
+// so it is exported as a utility rather than folded into analyzeText.
+import { splitProseSentences } from './segment.js';
+
+// Sentence-final ending vocabulary. Order matters — longer/more-specific forms
+// first so e.g. 합니다 matches 합쇼체 before 다 falls through to 해라체.
+// Mirrors patina-max/composite.py _ENDING_PATTERNS.
+const ENDING_PATTERNS = [
+  // 합쇼체 (deferential formal): ~ㅂ니다 / ~습니다 / ~ㅂ니까 / ~십시오
+  ['hapsho', /(?:[가-힣]니다|[가-힣]니까|[가-힣]시오|십시오|십시요)$/],
+  // 해요체 (polite informal)
+  ['haeyo', /(?:세요|예요|이에요|에요|해요|어요|아요|네요|군요|지요|죠|[가-힣]요)$/],
+  // 해라체 (plain declarative / imperative)
+  ['haera', /(?:[가-힣]는다|한다|[가-힣]다|하라|마라|보라|들라|[가-힣]아라|[가-힣]어라|[가-힣]라)$/],
+  // 해체 (casual / 반말)
+  ['hae', /(?:해|야|아|어|네|군|지)$/],
+];
+
+const TRAILING_PUNCT = /[\s.,!?;:。、]+$/;
+
+function stripFences(text) {
+  return String(text ?? '').replace(/```[\s\S]*?```/g, '');
+}
+
+/**
+ * Count sentence-final register buckets across a text.
+ * @param {string} text
+ * @returns {Record<string, number>} e.g. { hapsho: 3, haera: 1 }
+ */
+export function endingDistribution(text) {
+  const dist = {};
+  for (const sentence of splitProseSentences(stripFences(text))) {
+    const tail = sentence.replace(TRAILING_PUNCT, '');
+    if (!tail) continue;
+    let bucket = 'other';
+    for (const [name, re] of ENDING_PATTERNS) {
+      if (re.test(tail)) {
+        bucket = name;
+        break;
+      }
+    }
+    dist[bucket] = (dist[bucket] || 0) + 1;
+  }
+  return dist;
+}
+
+/** Cosine similarity of two bucket-count maps (0..1). */
+export function cosineSimilarity(a, b) {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (const k of keys) dot += (a[k] || 0) * (b[k] || 0);
+  for (const v of Object.values(a)) na += v * v;
+  for (const v of Object.values(b)) nb += v * v;
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+/**
+ * RSS: cosine similarity of the two register distributions, scaled to 0-100.
+ * 100 = identical register mix; lower = the candidate drifted register.
+ * @param {string} baseline
+ * @param {string} candidate
+ * @returns {number}
+ */
+export function registerStability(baseline, candidate) {
+  return cosineSimilarity(endingDistribution(baseline), endingDistribution(candidate)) * 100;
+}
+
+/** The dominant (most frequent) non-"other" register bucket, or 'other'. */
+export function dominantRegister(text) {
+  const dist = endingDistribution(text);
+  let best = 'other';
+  let n = -1;
+  for (const [k, v] of Object.entries(dist)) {
+    if (k !== 'other' && v > n) {
+      best = k;
+      n = v;
+    }
+  }
+  return best;
+}
+
+export { ENDING_PATTERNS };

--- a/tests/unit/register-stability.test.js
+++ b/tests/unit/register-stability.test.js
@@ -1,0 +1,50 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import {
+  endingDistribution,
+  cosineSimilarity,
+  registerStability,
+  dominantRegister,
+} from '../../src/features/register-stability.js';
+
+test('endingDistribution classifies 합쇼체 / 평어체 / 해요체', () => {
+  assert.deepEqual(endingDistribution('설치합니다. 호출합니다.'), { hapsho: 2 });
+  assert.deepEqual(endingDistribution('끝까지 끌고 간다. 가둘 수 없다.'), { haera: 2 });
+  assert.deepEqual(endingDistribution('이렇게 하면 돼요. 참 좋네요.'), { haeyo: 2 });
+});
+
+test('identical register mix scores RSS 100', () => {
+  const t = '설치합니다. 호출합니다. 검증합니다.';
+  assert.equal(registerStability(t, t), 100);
+});
+
+test('switching 평어체 -> 존댓말 drops RSS toward 0', () => {
+  const plain = '끝까지 끌고 간다. 모델에 묶이지 않는다. 알아서 돈다.';
+  const polite = '끝까지 끌고 갑니다. 모델에 묶이지 않습니다. 알아서 돕니다.';
+  const rss = registerStability(plain, polite);
+  assert.equal(rss, 0, `expected full switch -> 0, got ${rss}`);
+});
+
+test('a partial register switch yields a known intermediate RSS', () => {
+  // baseline {haera:2}; candidate {haera:1, hapsho:1} -> cosine 2/(2*sqrt2)=0.7071
+  const baseline = '간다. 없다.';
+  const candidate = '간다. 없습니다.';
+  const rss = registerStability(baseline, candidate);
+  assert.ok(Math.abs(rss - 70.71) < 0.5, `expected ~70.71, got ${rss}`);
+});
+
+test('dominantRegister returns the most frequent bucket', () => {
+  assert.equal(dominantRegister('합니다. 합니다. 간다.'), 'hapsho');
+  assert.equal(dominantRegister('간다. 없다. 합니다.'), 'haera');
+});
+
+test('cosineSimilarity is 0 when a distribution is empty', () => {
+  assert.equal(cosineSimilarity({}, { haera: 1 }), 0);
+});
+
+test('known limitation: "아니다" classifies as 합쇼체 (~니다), inherited from RSS regex', () => {
+  // "아니다" ends in 니다 so the 합쇼체 pattern matches first. This is the same
+  // ambiguity patina-max/composite.py has; documented so it is not a surprise.
+  assert.deepEqual(endingDistribution('그것은 사실이 아니다.'), { hapsho: 1 });
+});


### PR DESCRIPTION
Register Stability existed only in `patina-max/composite.py` (Python). Porting it to `src/features/register-stability.js` lets the Node engine guard register the same way MAX mode does: a rewrite that preserves the claim but flips 평어체↔존댓말 is a register-stability regression the rewrite/ouroboros flow can now catch in JS.

- `endingDistribution` / `cosineSimilarity` / `registerStability` / `dominantRegister`, mirroring composite.py `_ENDING_PATTERNS` and cosine-of-distributions RSS. Re-exported from `features/index`.
- Pairwise metric (baseline vs candidate), exported as a utility (not folded into `analyzeText`).
- Tests incl. the documented "아니다 → 합쇼체" regex ambiguity (identical to the Python).

**Verification:** `node --test tests/unit/register-stability.test.js` → 7/7 pass; eslint clean.