### PR TITLE
Deterministic audit backstop for 번역투 (model-independent)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -356,24 +356,21 @@ export async function main(args) {
         });
       }
 
+      const auditBackstop =
+        mode === 'audit' && (parsed.format ?? 'markdown') !== 'json' && !parsed.batch
+          ? buildDeterministicAuditBackstop(text, { lang, repoRoot })
+          : '';
       let output;
       let scoreValidationOutput = null;
       if (parsed.ouroboros) {
         const ouroborosBody = formatOuroborosOutput(result);
-        output = formatOutput(ouroborosBody, mode, parsed, { tone: toneResolution, logger });
+        output = formatOutput(ouroborosBody, mode, parsed, { tone: toneResolution, logger, auditBackstop });
         scoreValidationOutput = ouroborosBody;
       } else {
-        output = formatOutput(result, mode, parsed, { tone: toneResolution, logger });
+        output = formatOutput(result, mode, parsed, { tone: toneResolution, logger, auditBackstop });
         if (mode === 'score') {
           scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' }, { logger });
         }
-      }
-
-      // Deterministic backstop for audit (issue: weak LLM backends drop 번역투).
-      // Appended so calques/leakage/discourse tells appear regardless of model.
-      // Skip json (structured) and batch (per-file) outputs.
-      if (mode === 'audit' && (parsed.format ?? 'markdown') !== 'json' && !parsed.batch) {
-        output += buildDeterministicAuditBackstop(text, { lang, repoRoot });
       }
 
       // v3.11 Phase 1.3: surface weight drift between config and the score

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,7 +11,7 @@ import { buildPrompt } from './prompt-builder.js';
 import { invokeBackendChain, selectBackendChain, listBackends, listBackendNames, resolveBackend } from './backends/index.js';
 import { selectProvider, resolveProviderConfig, PROVIDERS } from './providers.js';
 import { validateBaseURL, applyInsecureBaseURLOptIn, applyPrivateBaseURLOptIn } from './security.js';
-import { formatOutput, validateScoreWeights } from './output.js';
+import { formatOutput, validateScoreWeights, buildDeterministicAuditBackstop } from './output.js';
 import { runMaxMode } from './max-mode.js';
 import { runOuroboros } from './ouroboros.js';
 import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals, scoreMPS, scoreText } from './scoring.js';
@@ -367,6 +367,13 @@ export async function main(args) {
         if (mode === 'score') {
           scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' }, { logger });
         }
+      }
+
+      // Deterministic backstop for audit (issue: weak LLM backends drop 번역투).
+      // Appended so calques/leakage/discourse tells appear regardless of model.
+      // Skip json (structured) and batch (per-file) outputs.
+      if (mode === 'audit' && (parsed.format ?? 'markdown') !== 'json' && !parsed.batch) {
+        output += buildDeterministicAuditBackstop(text, { lang, repoRoot });
       }
 
       // v3.11 Phase 1.3: surface weight drift between config and the score

--- a/src/output.js
+++ b/src/output.js
@@ -1,5 +1,7 @@
 // @ts-check
 import { createLogger } from './logger.js';
+import { analyzeText } from './features/index.js';
+import { TRANSLATIONESE_RULES } from './features/translationese.js';
 
 /**
  * Format a raw backend result for CLI output mode and requested format.
@@ -524,4 +526,54 @@ function formatMaxModeOutput(result) {
   }
 
   return output;
+}
+/**
+ * Build a deterministic "backstop" section for audit mode. The LLM audit is
+ * model-dependent (a weak model silently drops 번역투/calques); these signals are
+ * computed deterministically so they appear regardless of which model ran. ko
+ * translationese rules are listed even below the hot-density gate, because audit
+ * is a hint surface, not a verdict.
+ *
+ * @param {string} text Source text.
+ * @param {{ lang?: string, repoRoot?: string }} [opts]
+ * @returns {string} Markdown section (empty string when nothing fired).
+ */
+export function buildDeterministicAuditBackstop(text, opts = {}) {
+  const lang = opts.lang ?? 'ko';
+  const str = typeof text === 'string' ? text : '';
+  /** @type {{signal:string,label:string,severity:string,location:string}[]} */
+  const rows = [];
+
+  // ko translationese — per-rule, with matched samples (model-independent).
+  if (lang === 'ko' && str) {
+    for (const rule of TRANSLATIONESE_RULES) {
+      const matches = str.match(rule.re());
+      if (matches && matches.length) {
+        const samples = [...new Set(matches.map((m) => m.trim()).filter(Boolean))].slice(0, 4);
+        rows.push({ signal: `번역투: ${rule.id}`, label: rule.label, severity: rule.strong ? 'MEDIUM' : 'LOW', location: samples.join(', ') });
+      }
+    }
+  }
+
+  // markup leakage (near-proof) + density-gated discourse tells — language-agnostic.
+  const a = analyzeText(str, { lang, repoRoot: opts.repoRoot });
+  for (const h of a.markupLeakage?.hits ?? []) {
+    rows.push({ signal: 'markup-leakage', label: h.label, severity: 'HIGH', location: (h.samples ?? []).join(', ') });
+  }
+  if (a.discourseTells?.fakeCandor?.hot) {
+    rows.push({ signal: 'discourse: fake-candor', label: '친근함 위장 도입부', severity: 'MEDIUM', location: (a.discourseTells.fakeCandor.hits ?? []).join(', ') });
+  }
+  if (a.discourseTells?.thematicBreaks?.hot) {
+    rows.push({ signal: 'discourse: thematic-breaks', label: '장식용 구분선 남용', severity: 'LOW', location: `${a.discourseTells.thematicBreaks.count}개` });
+  }
+
+  if (rows.length === 0) return '';
+  const lines = [
+    '## 결정적 신호 (deterministic backstop — 모델과 무관하게 항상 검사)',
+    '',
+    '| 신호 | 설명 | 심각도 | 위치 |',
+    '|------|------|--------|------|',
+    ...rows.map((r) => `| ${r.signal} | ${r.label} | ${r.severity} | ${r.location} |`),
+  ];
+  return `\n\n${lines.join('\n')}`;
 }

--- a/src/output.js
+++ b/src/output.js
@@ -14,6 +14,7 @@ import { TRANSLATIONESE_RULES } from './features/translationese.js';
  * @param {object} [opts.logger] Logger for output warnings.
  * @param {object} [opts.env] Environment map for color decisions.
  * @param {object} [opts.stdout] Stdout-like stream for color decisions.
+ * @param {string} [opts.auditBackstop] Deterministic audit-mode section to append before the tone footer.
  * @returns {string} User-facing formatted output.
  * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
@@ -22,7 +23,11 @@ import { TRANSLATIONESE_RULES } from './features/translationese.js';
 export function formatOutput(result, mode, parsed = {}, opts = {}) {
   const tone = opts.tone || null;
   const format = parsed.format || 'markdown';
-  const body = renderFormattedBody(result, mode, parsed, opts);
+  let body = renderFormattedBody(result, mode, parsed, opts);
+
+  if (mode === 'audit' && format !== 'json' && opts.auditBackstop) {
+    body += opts.auditBackstop;
+  }
 
   if (format === 'json') {
     return formatJsonOutput({ result, mode, body, tone, gate: parsed.gate });

--- a/tests/unit/audit-backstop.test.js
+++ b/tests/unit/audit-backstop.test.js
@@ -1,0 +1,33 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import { buildDeterministicAuditBackstop } from '../../src/output.js';
+
+const CALQUE = '이것은 강력한 도구입니다. 다양한 기능을 제공합니다. 이 작업은 에이전트에 의해 처리됩니다. 당신은 이것을 매우 쉽게 사용할 수 있습니다.';
+
+test('audit backstop surfaces ko translationese even when an LLM would miss it', () => {
+  const md = buildDeterministicAuditBackstop(CALQUE, { lang: 'ko' });
+  assert.ok(md.includes('deterministic backstop'), 'has backstop header');
+  assert.ok(md.includes('번역투: passive-e-uihae'), '~에 의해 passive');
+  assert.ok(md.includes('번역투: direct-address-you'), '당신');
+  assert.ok(md.includes('번역투: dummy-subject'), '이것은');
+  assert.ok(md.includes('번역투: provides'), '제공합니다');
+  // matched location should show the actual offending substring
+  assert.ok(md.includes('에 의해'));
+});
+
+test('audit backstop is empty for clean native ko (no false positives)', () => {
+  const clean = '어제는 비가 많이 왔다. 그래서 집에 있었다. 라면 먹고 영화 봤다. 나쁘지 않았다.';
+  assert.equal(buildDeterministicAuditBackstop(clean, { lang: 'ko' }), '');
+});
+
+test('audit backstop catches markup leakage regardless of language', () => {
+  const leaked = 'This is fine text :contentReference[oaicite:1]{index=1} and more.';
+  const md = buildDeterministicAuditBackstop(leaked, { lang: 'en' });
+  assert.ok(md.includes('markup-leakage'), 'flags pasted model-output markup');
+});
+
+test('audit backstop skips ko translationese rows for non-ko languages', () => {
+  const md = buildDeterministicAuditBackstop('You can use this. It is provided by the agent.', { lang: 'en' });
+  assert.equal(md.includes('번역투:'), false);
+});


### PR DESCRIPTION
The `--audit` table is produced by the LLM, so a weak backend (e.g. gemini-2.5-flash) silently drops calques that a strong one (codex/claude) catches via pattern 26/27. This appends a **deterministic backstop** to audit output so 번역투 / markup-leakage / discourse tells appear regardless of model.

- `output.js` `buildDeterministicAuditBackstop()` — ko translationese rules (with matched substrings, listed below the hot-density gate since audit is a hint surface) + markup-leakage + discourse tells.
- `cli.js` appends it for audit mode (skips json/batch).

Live proof: `patina --lang ko --audit --provider gemini` now lists 이것은 / ~에 의해 / 당신 / 제공합니다 that the model's own pass missed.

**Stacked on #353** (the translationese detector). 367/367 unit tests pass; lint clean.

Note: framed as robustness (weak-model safety net), not a bug — patina is fine with capable models.