### PR TITLE
Remove rewrite variants option

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ patina --lang <ko|en|zh|ja> [mode] [--profile <name>] input.txt
 | `--quiet` | Suppress status, warning, and progress logs on stderr |
 | `--json-logs` | Emit stderr logs as NDJSON with `level`, `event`, `model`, and `latency_ms` fields |
 | `--prompt-mode strict\|minimal\|auto` | Choose full pattern-pack prompting, compressed prompting, or backend-aware auto |
-| `--variants <1-5>` | Generate multiple rewrite variants with the same facts and meaning anchors |
 
 `patina --help` for the full flag list. `patina doctor --json` checks Node/backend/tmux/API-key readiness without making an LLM call, and `patina init` writes a project `.patina.yaml`.
 
@@ -221,17 +220,13 @@ They appear in score and audit output so the benchmark matches human intuition f
 
 `--prompt-mode strict|minimal|auto` lets you trade off between the full pattern packs (~34KB structured prompt) and a compressed casual instruction (~3KB). `auto` picks per backend — Gemini does better on minimal (it gets over-constrained by long structured prompts), while Claude leverages the full packs and Codex is roughly insensitive. case-05 documents the A/B.
 
-### Multiple stylistic variants (v3.11)
-
-`--variants <1-5>` asks for several tone variants in one call (e.g., V1 casual, V2 direct, V3 measured) — facts, numbers, and causation stay identical across variants. Each comes back as `## Variant N` so you can pick the voice you want.
-
 ### Short-text scoring boost (v3.11)
 
 For inputs ≤200 chars or ≤3 paragraphs, register-sensitive categories (`language`, `style`, `viral-hook`) get a 1.5× severity multiplier so single-paragraph voice shifts surface in the score. case-04 found these were undercounted by the long-text formula.
 
 ### Self-audit isolation (v3.11)
 
-In rewrite mode, the model emits its self-audit notes inside `[SELF_AUDIT]`/`[/SELF_AUDIT]` tags wrapped around a `[BODY]`/`[/BODY]` block (or `[VARIANT n]` blocks when `--variants > 1`). patina strips the audit before showing the user, so raw output is clean — earlier versions sometimes leaked phrases like "남아 있는 AI 티" or "Phase 3" preambles into the user-facing text.
+In rewrite mode, the model emits its self-audit notes inside `[SELF_AUDIT]`/`[/SELF_AUDIT]` tags wrapped around a `[BODY]`/`[/BODY]` block. patina strips the audit before showing the user, so raw output is clean — earlier versions sometimes leaked phrases like "남아 있는 AI 티" or "Phase 3" preambles into the user-facing text.
 
 ### Machine-readable output and exit codes
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -190,7 +190,6 @@ patina --lang <ko|en|zh|ja> [モード] [--profile <名前>] input.txt
 | `--quiet` | stderr の状態・警告・進捗ログを抑制 |
 | `--json-logs` | `level`、`event`、`model`、`latency_ms` を持つ NDJSON として stderr ログを出力 |
 | `--prompt-mode strict\|minimal\|auto` | 完全なパターンパック、圧縮プロンプト、またはバックエンド別 auto を選択 |
-| `--variants <1-5>` | 同じ事実と意味アンカーを保った複数の rewrite バリアントを生成 |
 
 全オプションは `patina --help`。`patina doctor --json` は LLM 呼び出しなしで Node/backend/tmux/API-key の準備状況を確認し、`patina init` はプロジェクト用 `.patina.yaml` を書きます。
 
@@ -206,17 +205,13 @@ Markdown 中心の開発ワークフローには、開発者向け profile short
 
 `--prompt-mode strict|minimal|auto` では、完全なパターンパック（約34KBの構造化プロンプト）と圧縮されたカジュアル指示（約3KB）のどちらを使うかを調整できます。`auto` はバックエンドごとに選択します — Gemini は minimal の方が良く（長い構造化プロンプトで過度に制約されるため）、Claude は完全なパックを活用し、Codex はおおむね影響を受けません。case-05 が A/B を記録しています。
 
-### 複数の文体バリアント (v3.11)
-
-`--variants <1-5>` は、1回の呼び出しで複数のトーン変体を求めます（例: V1 casual、V2 direct、V3 measured）。事実、数値、因果関係はすべてのバリアントで同一に保たれます。各結果は `## Variant N` として返るため、必要な声色を選べます。
-
 ### 短文スコアリング補正 (v3.11)
 
 入力が200文字以下、または3段落以下の場合、register に敏感なカテゴリ（`language`、`style`、`viral-hook`）へ 1.5 倍の severity multiplier を適用し、単一段落の声色変化もスコアに反映されるようにします。case-04 では、長文向けの式がこれらを過小評価していたことが確認されました。
 
 ### セルフ監査の分離 (v3.11)
 
-rewrite モードでは、モデルは `[BODY]`/`[/BODY]` ブロック（`--variants > 1` の場合は `[VARIANT n]` ブロック）を囲む `[SELF_AUDIT]`/`[/SELF_AUDIT]` タグの中にセルフ監査メモを出力します。patina はユーザーに表示する前に監査部分を取り除くため、出力はクリーンです — 以前のバージョンでは "남아 있는 AI 티" や "Phase 3" のような前置きがユーザー向けテキストに漏れることがありました。
+rewrite モードでは、モデルは `[BODY]`/`[/BODY]` ブロックを囲む `[SELF_AUDIT]`/`[/SELF_AUDIT]` タグの中にセルフ監査メモを出力します。patina はユーザーに表示する前に監査部分を取り除くため、出力はクリーンです — 以前のバージョンでは "남아 있는 AI 티" や "Phase 3" のような前置きがユーザー向けテキストに漏れることがありました。
 
 ### Machine-readable output and exit codes
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -188,7 +188,6 @@ patina --lang <ko|en|zh|ja> [모드] [--profile <이름>] input.txt
 | `--quiet` | stderr의 상태, 경고, 진행 로그를 숨김 |
 | `--json-logs` | stderr 로그를 `level`, `event`, `model`, `latency_ms` 필드가 있는 NDJSON으로 출력 |
 | `--prompt-mode strict\|minimal\|auto` | 전체 패턴 팩 프롬프트, 압축 프롬프트, 백엔드별 자동 선택 |
-| `--variants <1-5>` | 사실과 의미 앵커를 유지한 여러 rewrite 변형 생성 |
 
 전체 옵션은 `patina --help`. `patina doctor --json`은 LLM 호출 없이 Node/backend/tmux/API-key 준비 상태를 점검하고, `patina init`은 프로젝트용 `.patina.yaml`을 씁니다.
 
@@ -205,17 +204,13 @@ Markdown 중심의 개발 워크플로우에는 개발자용 프로필 단축키
 
 `--prompt-mode strict|minimal|auto` 는 전체 패턴 팩(약 34KB 구조화 프롬프트)과 압축된 캐주얼 지시문(약 3KB) 사이의 균형을 선택합니다. `auto` 는 백엔드별로 선택합니다 — Gemini는 minimal에서 더 잘 동작하고(너무 긴 구조화 프롬프트에는 얽매이는 경향이 있음), Claude는 전체 팩을 활용하며, Codex는 대체로 차이가 작습니다. case-05가 A/B 결과를 문서화합니다.
 
-### 여러 스타일 변형 (v3.11)
-
-`--variants <1-5>` 는 한 번의 호출로 텍스트 톤을 여러 버전으로 나누어 요청합니다(예: V1 캐주얼, V2 직설적, V3 절제됨). 사실, 수치, 인과관계는 모든 변형에서 동일하게 유지됩니다. 각 결과는 `## Variant N` 형식으로 돌아오므로 원하는 보이스를 고를 수 있습니다.
-
 ### 짧은 텍스트 점수 보정 (v3.11)
 
 입력이 200자 이하이거나 3문단 이하이면 문장 스타일에 민감한 카테고리(`language`, `style`, `viral-hook`)에 1.5배 가중치를 주어, 짧은 단락의 미세한 어조 변화도 점수에 반영되게 합니다. case-04에서 긴 글 기준 공식이 이런 신호를 과소계산한다는 점을 확인했습니다.
 
 ### 자기검수 분리 (v3.11)
 
-rewrite 모드에서 모델은 `[BODY]`/`[/BODY]` 블록(또는 `--variants > 1`일 때 `[VARIANT n]` 블록)을 감싸는 `[SELF_AUDIT]`/`[/SELF_AUDIT]` 태그 안에 자기검수 메모를 냅니다. patina는 사용자에게 보여주기 전에 audit을 제거하므로 원시 출력이 깔끔합니다 — 이전 버전에서는 "남아 있는 AI 티"나 "Phase 3" 같은 프리앰블이 사용자-facing 텍스트에 새어 나오는 경우가 있었습니다.
+rewrite 모드에서 모델은 `[BODY]`/`[/BODY]` 블록을 감싸는 `[SELF_AUDIT]`/`[/SELF_AUDIT]` 태그 안에 자기검수 메모를 냅니다. patina는 사용자에게 보여주기 전에 audit을 제거하므로 원시 출력이 깔끔합니다 — 이전 버전에서는 "남아 있는 AI 티"나 "Phase 3" 같은 프리앰블이 사용자-facing 텍스트에 새어 나오는 경우가 있었습니다.
 
 ### 기계가 읽기 쉬운 출력과 종료 코드
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -190,7 +190,6 @@ patina --lang <ko|en|zh|ja> [模式] [--profile <名称>] input.txt
 | `--quiet` | 隐藏 stderr 中的状态、警告和进度日志 |
 | `--json-logs` | 以 NDJSON 输出 stderr 日志，包含 `level`、`event`、`model`、`latency_ms` 字段 |
 | `--prompt-mode strict\|minimal\|auto` | 选择完整模式包提示、压缩提示，或按后端自动选择 |
-| `--variants <1-5>` | 生成多个改写变体，同时保留相同事实和意义锚点 |
 
 完整选项请运行 `patina --help`。`patina doctor --json` 可在不调用 LLM 的情况下检查 Node/backend/tmux/API-key 状态，`patina init` 会写入项目 `.patina.yaml`。
 
@@ -206,17 +205,13 @@ Markdown-heavy 工程流程可使用开发者原生 profile shortcut：`code-com
 
 `--prompt-mode strict|minimal|auto` 可在完整模式包（约 34KB 结构化提示）和压缩的轻量指令（约 3KB）之间取舍。`auto` 会按后端选择 — Gemini 在 minimal 下表现更好（长结构化提示会让它过度受限），Claude 能利用完整模式包，Codex 大致不敏感。case-05 记录了 A/B 结果。
 
-### 多个风格变体 (v3.11)
-
-`--variants <1-5>` 会在一次调用中请求多个文本语气变体（例如 V1 casual、V2 direct、V3 measured）— 事实、数字和因果关系在所有变体中保持一致。每个结果会以 `## Variant N` 返回，方便你选择需要的语气。
-
 ### 短文本评分增强 (v3.11)
 
 当输入不超过 200 个字符或不超过 3 个段落时，对 register 敏感的类别（`language`、`style`、`viral-hook`）会获得 1.5 倍 severity multiplier，让单段文本里的声音变化也能体现在分数中。case-04 发现这些信号会被长文本公式低估。
 
 ### 自审隔离 (v3.11)
 
-在 rewrite 模式中，模型会把自审笔记放在 `[SELF_AUDIT]`/`[/SELF_AUDIT]` 标签内，并包裹一个 `[BODY]`/`[/BODY]` 块（当 `--variants > 1` 时则是 `[VARIANT n]` 块）。patina 会在展示给用户前移除审计内容，因此原始输出保持干净 — 早期版本有时会把 “남아 있는 AI 티” 或 “Phase 3” 之类的前言泄漏到用户可见文本中。
+在 rewrite 模式中，模型会把自审笔记放在 `[SELF_AUDIT]`/`[/SELF_AUDIT]` 标签内，并包裹一个 `[BODY]`/`[/BODY]` 块。patina 会在展示给用户前移除审计内容，因此原始输出保持干净 — 早期版本有时会把 “남아 있는 AI 티” 或 “Phase 3” 之类的前言泄漏到用户可见文本中。
 
 ### Machine-readable output and exit codes
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -43,7 +43,6 @@ Glob .patina.default.yaml → Read
 - `--lang <code>`: 처리 언어 변경 (ko, en, zh, ja). 설정 파일의 `language` 값을 오버라이드한다.
 - `--tone <name>`: 톤 카테고리 지정. 유효값: `casual | professional | academic | narrative | marketing | instructional | auto`. 알 수 없는 값이면 즉시 오류: "Unknown tone '<name>'. Valid tones: casual, professional, academic, narrative, marketing, instructional, auto"
 - `--prompt-mode <strict|minimal|auto>`: 패턴 팩 전체를 쓰는 strict 모드와 압축 지시문 minimal 모드 중 선택한다. `auto`는 백엔드/문맥별로 선택하되, 불확실하면 strict를 사용한다.
-- `--variants <1-5>`: rewrite 모드에서 같은 의미 앵커를 보존한 N개의 문체 변형을 요청한다. `--audit`, `--score`, `--diff`에는 적용하지 않는다.
 - `--batch <files>`: 여러 파일을 한꺼번에 처리 (glob 또는 명시적 경로 목록).
   - `--in-place`: 원본 파일을 교정된 텍스트로 덮어쓴다.
   - `--suffix <ext>`: 결과를 `{원본명}{ext}` 파일로 저장한다 (예: `--suffix .humanized`).
@@ -581,14 +580,6 @@ tone_confidence: low | medium | high
 5. YAML footer (위 공통 규칙 적용)
 
 > **주의 (A7):** rewrite 최종본 본문에 tone 정보를 언급하거나 삽입하지 않는다. "이 텍스트는 casual 톤으로 재작성되었습니다" 같은 내러티브 인터젝션 금지.
-
-#### 변형 출력 (`--variants`)
-
-`--variants N`이 주어지면 최종본을 하나로 고정하지 말고 `## Variant 1` … `## Variant N` 형식으로 반환한다. 각 변형은 같은 의미 앵커(주장, 수치, 인과관계, 고유명사, 극성)를 보존해야 하며, 문체 축만 달라져야 한다.
-
-- Variant 1: 기본 프로필/톤을 가장 충실히 따른다.
-- Variant 2+: 더 직설적, 더 캐주얼, 더 절제된 식으로 리듬과 레지스터를 바꾼다.
-- 각 variant마다 `[SELF_AUDIT]` 메모는 내부 검수용으로만 사용하고 사용자-facing 본문에는 남기지 않는다.
 
 ### diff 모드 (`--diff`)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -251,9 +251,6 @@ still be genuinely human and we avoid claiming absolute proof.</p>
 </dd>
 <dt><a href="#shouldColorDiff">shouldColorDiff([options])</a></dt>
 <dd></dd>
-<dt><a href="#extractVariants">extractVariants(body)</a> ⇒ <code>Array.&lt;{id: number, text: string}&gt;</code></dt>
-<dd><p>Extract tagged [VARIANT n] blocks from a model response.</p>
-</dd>
 <dt><a href="#validateScoreWeights">validateScoreWeights(output, configWeights)</a> ⇒ <code>Array.&lt;string&gt;</code></dt>
 <dd><p>Validate that a model-emitted score table used configured category weights.</p>
 </dd>
@@ -1345,26 +1342,6 @@ const output = formatOutput('[BODY]Hi[/BODY]', 'rewrite');
 | [options.stdout] | <code>object</code> |
 | [options.stdout.isTTY] | <code>boolean</code> |
 
-<a name="extractVariants"></a>
-
-## extractVariants(body) ⇒ <code>Array.&lt;{id: number, text: string}&gt;</code>
-Extract tagged [VARIANT n] blocks from a model response.
-
-**Kind**: global function
-**Returns**: <code>Array.&lt;{id: number, text: string}&gt;</code> - Variants sorted by numeric id.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
-
-| Param | Type | Description |
-| --- | --- | --- |
-| body | <code>string</code> | Raw model response. |
-
-**Example**
-```js
-const variants = extractVariants('[VARIANT 1]\nHello\n[/VARIANT]');
-```
 <a name="validateScoreWeights"></a>
 
 ## validateScoreWeights(output, configWeights) ⇒ <code>Array.&lt;string&gt;</code>
@@ -1456,7 +1433,6 @@ Build the LLM prompt for rewrite, diff, audit, score, or ouroboros mode.
 | [options.mode] | <code>string</code> | <code>&quot;rewrite&quot;</code> | Output mode. |
 | [options.tone] | <code>object</code> \| <code>null</code> | <code></code> | Tone resolution metadata. |
 | [options.promptMode] | <code>string</code> | <code>&quot;strict&quot;</code> | Prompt mode: strict or minimal. |
-| [options.variants] | <code>number</code> | <code>1</code> | Number of rewrite variants. |
 
 **Example**
 ```js

--- a/docs/FLAG-PARITY.md
+++ b/docs/FLAG-PARITY.md
@@ -33,7 +33,6 @@ Basis: local checkout plus `node bin/patina.js --help` and `SKILL.md` reviewed o
 | `--list-providers` | ✓ | — | CLI diagnostics. |
 | `--config <path>` | ✓ | — | CLI config override. |
 | `--prompt-mode <strict\|minimal\|auto>` | ✓ | ✓ | User-visible prompt loading control. |
-| `--variants <n>` | ✓ | ✓ | User-visible rewrite variants. |
 | `--allow-insecure-base-url` | ✓ | — | CLI network safety override. |
 | `--allow-private-base-url` | ✓ | — | CLI SSRF/metadata-address safety override. |
 | `-h`, `--help` | ✓ | — | CLI help. |
@@ -44,5 +43,5 @@ Basis: local checkout plus `node bin/patina.js --help` and `SKILL.md` reviewed o
 
 ## Audit notes
 
-- `--prompt-mode` and `--variants` remain the main user-facing omissions that must stay visible in `SKILL.md` as well as the CLI.
+- `--prompt-mode` is the main user-facing prompt-loading control that must stay visible in `SKILL.md` as well as the CLI.
 - `--save-run`, auth/provider/base-url flags, and `doctor`/`auth` commands are CLI automation or transport controls; they do not map cleanly to prompt-only skills.

--- a/src/cli.js
+++ b/src/cli.js
@@ -200,7 +200,6 @@ export async function main(args) {
           }),
           { backend: parsed.backend ?? config.backend, model: resolved.model }
         ),
-        variants: parsed.variants || 1,
       });
 
       let result;
@@ -595,20 +594,6 @@ function parseArgs(args) {
         parsed.promptMode = m;
         break;
       }
-      case '--variants': {
-        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
-        i++;
-        const n = Number(value);
-        if (!Number.isInteger(n) || n < 1 || n > 5) {
-          throw inputError(
-            '--variants expects an integer from 1 to 5',
-            `Received ${value === undefined ? 'no value' : `"${value}"`}.`,
-            'Use `--variants 2` for alternate rewrite drafts.'
-          );
-        }
-        parsed.variants = n;
-        break;
-      }
       case '--no-interactive':
         parsed.noInteractive = true;
         break;
@@ -965,7 +950,6 @@ MODEL & AUTH
   --provider <name>       Provider preset: openai, gemini, groq, together
   --list-providers        List provider presets and which keys are set
 ADVANCED
-  --variants <n>          Generate N rewrite variants (1-5; rewrite mode only)
   --config <path>         Load config from <path> instead of .patina.default.yaml
   --prompt-mode <m>       strict | minimal | auto. auto picks per backend.
   --allow-insecure-base-url  Permit plaintext http:// to non-localhost endpoints

--- a/src/output.js
+++ b/src/output.js
@@ -42,11 +42,10 @@ export function formatOutput(result, mode, parsed = {}, opts = {}) {
 
 function renderFormattedBody(result, mode, parsed = {}, opts = {}) {
   let body = renderBody(result);
-  // Only rewrite and ouroboros emit [BODY]/[VARIANT n] tags; diff/audit/score
+  // Only rewrite and ouroboros emit [BODY] tags; diff/audit/score
   // emit tables and don't need the extraction step.
   if (mode === 'rewrite' || mode === 'ouroboros') {
-    const variants = extractVariants(body);
-    body = variants.length > 0 ? formatVariants(variants, body) : stripSelfAudit(body, { logger: opts.logger });
+    body = stripSelfAudit(body, { logger: opts.logger });
   }
   if (mode === 'diff') {
     body = colorizeDiff(body, { parsed, env: opts.env, stdout: opts.stdout });
@@ -90,44 +89,6 @@ function shouldColorDiff({ parsed = {}, env = process.env, stdout = process.stdo
   return !parsed.noColor && env.NO_COLOR === undefined && stdout?.isTTY === true;
 }
 
-// v3.11 Phase 3.1: extract [VARIANT n]...[/VARIANT] blocks from a model
-// response. Returns an array of { id, text } sorted by id, empty if no
-// variant tags are present.
-/**
- * Extract tagged [VARIANT n] blocks from a model response.
- *
- * @param {string} body Raw model response.
- * @returns {Array<{id: number, text: string}>} Variants sorted by numeric id.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
- * @example
- * const variants = extractVariants('[VARIANT 1]\nHello\n[/VARIANT]');
- */
-export function extractVariants(body) {
-  if (!body) return [];
-  const re = /\[VARIANT\s*(\d+)\]\s*\n([\s\S]*?)\n\s*\[\/VARIANT\]/g;
-  const out = [];
-  let m;
-  while ((m = re.exec(body)) !== null) {
-    const id = parseInt(m[1], 10);
-    const text = m[2].trim();
-    if (text) out.push({ id, text });
-  }
-  out.sort((a, b) => a.id - b.id);
-  return out;
-}
-
-function formatVariants(variants, raw) {
-  // Surface each variant with a labeled header so users can copy whichever
-  // voice they want. Strip [SELF_AUDIT] and any tail metadata that follows
-  // the last [/VARIANT] block, but preserve the YAML footer if present.
-  const lastClose = raw.lastIndexOf('[/VARIANT]');
-  const tail = lastClose >= 0
-    ? raw.slice(lastClose + '[/VARIANT]'.length).replace(/\[SELF_AUDIT\][\s\S]*?\[\/SELF_AUDIT\]/g, '').trim()
-    : '';
-  const blocks = variants.map(({ id, text }) => `## Variant ${id}\n\n${text}`);
-  const merged = blocks.join('\n\n');
-  return tail ? `${merged}\n\n${tail}` : merged;
-}
 
 // v3.11 Phase 1.3: parse the model's score table and check that the Weight
 // column matches the config-supplied category-weights. case-02 found that

--- a/src/prompt-builder.js
+++ b/src/prompt-builder.js
@@ -13,7 +13,6 @@
  * @param {string} [options.mode=rewrite] Output mode.
  * @param {object|null} [options.tone=null] Tone resolution metadata.
  * @param {string} [options.promptMode=strict] Prompt mode: strict or minimal.
- * @param {number} [options.variants=1] Number of rewrite variants.
  * @returns {string} Complete prompt text.
  * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
@@ -30,7 +29,6 @@ export function buildPrompt({
   mode = 'rewrite',
   tone = null,
   promptMode = 'strict',
-  variants = 1,
 }) {
   // v3.11+ prompt-mode dispatch (case-04 hypothesis test). minimal prompt
   // strips pattern definitions/examples and uses a casual instruction; only
@@ -38,7 +36,7 @@ export function buildPrompt({
   // still passed through (Round 2 found Gemini ignored casual-conversation
   // when the profile was dropped).
   if (promptMode === 'minimal' && mode === 'rewrite') {
-    return buildMinimalPrompt({ config, patterns, profile, voiceSample, text, tone, variants });
+    return buildMinimalPrompt({ config, patterns, profile, voiceSample, text, tone });
   }
 
   const lang = config.language || 'ko';
@@ -121,7 +119,7 @@ export function buildPrompt({
   prompt += `Process the following text according to the output mode "${mode}".\n\n`;
 
   if (mode === 'rewrite') {
-    prompt += buildRewriteInstructions(structurePacks, lexicalPacks, { variants });
+    prompt += buildRewriteInstructions(structurePacks, lexicalPacks);
   } else if (mode === 'diff') {
     prompt += buildDiffInstructions();
   } else if (mode === 'audit') {
@@ -138,7 +136,7 @@ export function buildPrompt({
   return prompt;
 }
 
-function buildRewriteInstructions(structurePacks, lexicalPacks, { includeSelfAudit = true, variants = 1 } = {}) {
+function buildRewriteInstructions(structurePacks, lexicalPacks, { includeSelfAudit = true } = {}) {
   const phaseCount = includeSelfAudit ? 3 : 2;
   let inst = `Follow the ${phaseCount}-Phase pipeline:\n\n`;
 
@@ -174,7 +172,7 @@ function buildRewriteInstructions(structurePacks, lexicalPacks, { includeSelfAud
     inst += `3. Ensure Phase 1 corrections were not reverted in Phase 2\n`;
     inst += `4. Final check: meaning preserved?\n\n`;
 
-    inst += buildOutputFormatBlock({ variants });
+    inst += buildOutputFormatBlock();
   } else {
     // Self-audit suppressed: external evaluators (scoreText, scoreMPS,
     // scoreFidelity) handle AI-tell detection, polarity, and meaning checks
@@ -186,45 +184,22 @@ function buildRewriteInstructions(structurePacks, lexicalPacks, { includeSelfAud
   return inst;
 }
 
-// v3.11: emit the strict-mode output-format block. Single-variant uses
-// [BODY]/[/BODY]; --variants > 1 uses [VARIANT n]/[/VARIANT] blocks.
-function buildOutputFormatBlock({ variants = 1 } = {}) {
-  const isVariants = variants > 1;
-  const tag = isVariants ? '[VARIANT n]/[/VARIANT]' : '[BODY]/[/BODY]';
-  const itemDesc = isVariants
-    ? `Produce ${variants} stylistic VARIANTS of the rewrite, each wrapped in ` +
-      `\`[VARIANT n]\`/\`[/VARIANT]\` tags where n is 1..${variants}. Each ` +
-      `variant must preserve all facts, numbers, and causation, but differ in ` +
-      `voice (e.g., V1 casual conversational, V2 direct/punchy, V3 measured/` +
-      `professional). No headings, no preamble inside the tags.`
-    : `The rewritten text wrapped in \`[BODY]\`/\`[/BODY]\` tags. The body ` +
-      `block must contain ONLY the user-facing rewrite — no headings, no ` +
-      `Phase labels, no preamble like "잔여 AI 티" or "최종 결과물".`;
-  const auditDesc = isVariants
-    ? `(brief: what differs across variants, residual AI signals, applied patterns)`
-    : `(brief: what still looks AI-written, which patterns were applied). ` +
-      `This block is for downstream review — patina strips it before showing the user`;
-
-  let exampleBody = '';
-  if (isVariants) {
-    for (let i = 1; i <= variants; i++) {
-      exampleBody += `[VARIANT ${i}]\n<rewritten text — voice ${i}>\n[/VARIANT]\n\n`;
-    }
-  } else {
-    exampleBody = `[BODY]\n<rewritten text>\n[/BODY]\n\n`;
-  }
-
+function buildOutputFormatBlock() {
   return (
     `### Output format (STRICT — v3.11)\n\n` +
     `Produce output in this exact order, with no other text outside the tagged blocks:\n\n` +
-    `1. ${itemDesc}\n` +
-    `2. Self-audit notes wrapped in \`[SELF_AUDIT]\`/\`[/SELF_AUDIT]\` tags ${auditDesc}.\n` +
+    `1. The rewritten text wrapped in \`[BODY]\`/\`[/BODY]\` tags. The body ` +
+      `block must contain ONLY the user-facing rewrite — no headings, no ` +
+      `Phase labels, no preamble like "잔여 AI 티" or "최종 결과물".\n` +
+    `2. Self-audit notes wrapped in \`[SELF_AUDIT]\`/\`[/SELF_AUDIT]\` tags ` +
+      `(brief: what still looks AI-written, which patterns were applied). ` +
+      `This block is for downstream review — patina strips it before showing the user.\n` +
     `3. The Phase 6 YAML footer if tone resolution requires it.\n\n` +
-    `Example shape (uses ${tag}):\n\n` +
+    `Example shape (uses [BODY]/[/BODY]):\n\n` +
     '```\n' +
-    exampleBody +
-    `[SELF_AUDIT]\n- ${isVariants ? 'voice axis' : 'residual signals'}: ...\n` +
-    `- ${isVariants ? 'residual signals' : 'patterns applied'}: ...\n[/SELF_AUDIT]\n\n` +
+    `[BODY]\n<rewritten text>\n[/BODY]\n\n` +
+    `[SELF_AUDIT]\n- residual signals: ...\n` +
+    `- patterns applied: ...\n[/SELF_AUDIT]\n\n` +
     `---\ntone: ...\ntone_source: ...\ntone_evidence: [...]\ntone_confidence: ...\n---\n` +
     '```\n'
   );
@@ -314,7 +289,7 @@ export function isShortText(text) {
 // model's natural voice prior isn't overridden by analytical framing. Only
 // invoked for rewrite mode; score/audit/diff/ouroboros stay on the strict
 // path because they need precise pattern references.
-function buildMinimalPrompt({ config, patterns, profile, voiceSample, text, tone, variants = 1 }) {
+function buildMinimalPrompt({ config, patterns, profile, voiceSample, text, tone }) {
   const lang = config.language || 'ko';
   const activePatterns = patterns.filter((p) => !p.isScoreOnly);
 
@@ -358,16 +333,9 @@ function buildMinimalPrompt({ config, patterns, profile, voiceSample, text, tone
   }
 
   prompt += lang === 'ko' ? `## 출력 형식\n\n` : `## Output format\n\n`;
-  if (variants > 1) {
-    prompt += `1. ${variants}개 voice variant를 각각 \`[VARIANT 1]\` ~ \`[VARIANT ${variants}]\` ` +
-      `태그 안에. 사실·숫자·인과관계는 동일하되 voice만 다르게 (예: V1 캐주얼 대화체, V2 직설·짧은 문장, V3 정중·차분).\n`;
-    prompt += `2. \`[SELF_AUDIT]\` ... \`[/SELF_AUDIT]\` 안에 짧게: variant별 voice 차이, 남은 AI 신호.\n`;
-    prompt += `3. 톤 정보가 있으면 마지막에 YAML 푸터.\n\n`;
-  } else {
-    prompt += `1. 다듬은 본문을 \`[BODY]\` ... \`[/BODY]\` 안에. 본문만, 머리말·메타·"최종 결과물" 같은 라벨 없이.\n`;
-    prompt += `2. \`[SELF_AUDIT]\` ... \`[/SELF_AUDIT]\` 안에 짧게: 어떤 부분 손봤는지, 남은 AI 신호 있는지.\n`;
-    prompt += `3. 톤 정보가 있으면 마지막에 YAML 푸터: \`---\\ntone: ...\\ntone_source: ...\\ntone_evidence: [...]\\ntone_confidence: ...\\n---\`\n\n`;
-  }
+  prompt += `1. 다듬은 본문을 \`[BODY]\` ... \`[/BODY]\` 안에. 본문만, 머리말·메타·"최종 결과물" 같은 라벨 없이.\n`;
+  prompt += `2. \`[SELF_AUDIT]\` ... \`[/SELF_AUDIT]\` 안에 짧게: 어떤 부분 손봤는지, 남은 AI 신호 있는지.\n`;
+  prompt += `3. 톤 정보가 있으면 마지막에 YAML 푸터: \`---\\ntone: ...\\ntone_source: ...\\ntone_evidence: [...]\\ntone_confidence: ...\\n---\`\n\n`;
 
   prompt += lang === 'ko' ? `## 입력\n\n${text}\n\n` : `## Input\n\n${text}\n\n`;
   prompt += lang === 'ko' ? `## 출력\n\n` : `## Output\n\n`;

--- a/tests/e2e/cli-adoption.test.js
+++ b/tests/e2e/cli-adoption.test.js
@@ -150,13 +150,15 @@ describe('CLI adoption commands', () => {
 
 describe('CLI adoption exit/error behavior', () => {
   it('unknown flags fail before stdin handling with a usage exit', () => {
-    const result = spawnSync(process.execPath, [BIN, '--bogus'], {
-      cwd: REPO_ROOT,
-      input: '',
-      encoding: 'utf8',
-    });
-    assert.strictEqual(result.status, 2);
-    assert.match(result.stderr, /\[patina\] Error: unknown option --bogus/);
+    for (const flag of ['--bogus', '--variants']) {
+      const result = spawnSync(process.execPath, [BIN, flag], {
+        cwd: REPO_ROOT,
+        input: '',
+        encoding: 'utf8',
+      });
+      assert.strictEqual(result.status, 2);
+      assert.match(result.stderr, new RegExp(`\\[patina\\] Error: unknown option ${flag}`));
+    }
   });
 
   it('empty stdin uses the three-line patina error format and exits 2', () => {

--- a/tests/unit/tone.test.js
+++ b/tests/unit/tone.test.js
@@ -372,39 +372,6 @@ test('validateScoreWeights: empty config → no-op', () => {
   assert.deepEqual(validateScoreWeights('', { content: 0.18 }), []);
 });
 
-// --- variants (v3.11 Phase 3.1) ---
-
-import { extractVariants } from '../../src/output.js';
-
-test('extractVariants: parses [VARIANT n] blocks in order', () => {
-  const raw = '[VARIANT 1]\nfirst\n[/VARIANT]\n\n[VARIANT 2]\nsecond\n[/VARIANT]';
-  const out = extractVariants(raw);
-  assert.equal(out.length, 2);
-  assert.deepEqual(out[0], { id: 1, text: 'first' });
-  assert.deepEqual(out[1], { id: 2, text: 'second' });
-});
-
-test('extractVariants: returns empty when no tags', () => {
-  assert.deepEqual(extractVariants('plain rewrite'), []);
-  assert.deepEqual(extractVariants('[BODY]\nsingle\n[/BODY]'), []);
-});
-
-test('extractVariants: sorts by id even if emitted out of order', () => {
-  const raw = '[VARIANT 3]\nthird\n[/VARIANT]\n[VARIANT 1]\nfirst\n[/VARIANT]\n[VARIANT 2]\nsecond\n[/VARIANT]';
-  const out = extractVariants(raw);
-  assert.deepEqual(out.map((v) => v.id), [1, 2, 3]);
-});
-
-test('formatOutput: renders variants as labeled headings', () => {
-  const raw = '[VARIANT 1]\nfirst voice\n[/VARIANT]\n\n[VARIANT 2]\nsecond voice\n[/VARIANT]\n\n[SELF_AUDIT]\nstuff\n[/SELF_AUDIT]';
-  const out = formatOutput(raw, 'rewrite', {});
-  assert.match(out, /## Variant 1/);
-  assert.match(out, /first voice/);
-  assert.match(out, /## Variant 2/);
-  assert.match(out, /second voice/);
-  assert.ok(!out.includes('[VARIANT'));
-  assert.ok(!out.includes('SELF_AUDIT'));
-});
 
 // --- isShortText (v3.11 Phase 3.2) ---
 


### PR DESCRIPTION
## Summary
- remove the `--variants` CLI flag and prompt fan-out path
- remove tagged `[VARIANT n]` output parsing/formatting and related tests
- update SKILL, API docs, flag parity, and translated READMEs

## Verification
- npm run docs:api
- node bin/patina.js --help
- node bin/patina.js --variants (exits 2 as unknown option)
- npm run lint
- npm test