### PR TITLE
Hide prompt mode from user-facing CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ patina --lang <ko|en|zh|ja> [mode] [--profile <name>] input.txt
 | `--format json\|text\|markdown` | Select machine-readable JSON, plain text, or default Markdown output |
 | `--quiet` | Suppress status, warning, and progress logs on stderr |
 | `--json-logs` | Emit stderr logs as NDJSON with `level`, `event`, `model`, and `latency_ms` fields |
-| `--prompt-mode strict\|minimal\|auto` | Choose full pattern-pack prompting, compressed prompting, or backend-aware auto |
 
 `patina --help` for the full flag list. `patina doctor --json` checks Node/backend/tmux/API-key readiness without making an LLM call, and `patina init` writes a project `.patina.yaml`.
 
@@ -215,10 +214,6 @@ Dev-native profile shortcuts are available for Markdown-heavy engineering workfl
 `--score` and `--audit` measure a slightly broader set of signals than `--rewrite` does. The viral-hook packs (`ko/en/zh/ja-viral-hook`, 9 patterns each: shock-number hooks, clickbait closings, source-skipping authority claims, breath-optimized short-sentence stacking, hyperbolic engagement lexicon, fake-stat citations, stacked credentials, future-self/parasocial promises, aphoristic punchlines) are **detection-only**.
 
 They appear in score and audit output so the benchmark matches human intuition for SNS-style marketing copy across all four languages. `--rewrite`/`--diff`/`--ouroboros` skip them because those signals are often intentional rhetoric. Real-world demos: [`examples/viral-hook/`](examples/viral-hook/).
-
-### Prompt-mode tuning (v3.11)
-
-`--prompt-mode strict|minimal|auto` lets you trade off between the full pattern packs (~34KB structured prompt) and a compressed casual instruction (~3KB). `auto` picks per backend — Gemini does better on minimal (it gets over-constrained by long structured prompts), while Claude leverages the full packs and Codex is roughly insensitive. case-05 documents the A/B.
 
 ### Short-text scoring boost (v3.11)
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -189,7 +189,6 @@ patina --lang <ko|en|zh|ja> [モード] [--profile <名前>] input.txt
 | `--format json\|text\|markdown` | JSON、プレーンテキスト、デフォルト Markdown 出力を選択 |
 | `--quiet` | stderr の状態・警告・進捗ログを抑制 |
 | `--json-logs` | `level`、`event`、`model`、`latency_ms` を持つ NDJSON として stderr ログを出力 |
-| `--prompt-mode strict\|minimal\|auto` | 完全なパターンパック、圧縮プロンプト、またはバックエンド別 auto を選択 |
 
 全オプションは `patina --help`。`patina doctor --json` は LLM 呼び出しなしで Node/backend/tmux/API-key の準備状況を確認し、`patina init` はプロジェクト用 `.patina.yaml` を書きます。
 
@@ -200,10 +199,6 @@ Markdown 中心の開発ワークフローには、開発者向け profile short
 `--score`と`--audit`は`--rewrite`より少し広い範囲のシグナルを測定します。viral-hook パック（`ko/en/zh/ja-viral-hook`、各9パターン: 数字ショックフック、クリックベイト末尾、出典を飛ばした権威主張、息継ぎに最適化された短文の積み重ね、誇張されたエンゲージメント語彙、偽統計引用、肩書き積み上げ、未来の自分への約束、警句的パンチライン）は**検出専用**です。
 
 これらのシグナルはスコアと監査にだけ現れ、4言語のSNSマーケティングコピーに対するユーザーの直感とベンチマークを揃えるために使います。`--rewrite`/`--diff`/`--ouroboros` は、意図的な修辞であることが多いので対象外です。実例: [`examples/viral-hook/`](examples/viral-hook/).
-
-### プロンプトモード調整 (v3.11)
-
-`--prompt-mode strict|minimal|auto` では、完全なパターンパック（約34KBの構造化プロンプト）と圧縮されたカジュアル指示（約3KB）のどちらを使うかを調整できます。`auto` はバックエンドごとに選択します — Gemini は minimal の方が良く（長い構造化プロンプトで過度に制約されるため）、Claude は完全なパックを活用し、Codex はおおむね影響を受けません。case-05 が A/B を記録しています。
 
 ### 短文スコアリング補正 (v3.11)
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -187,7 +187,6 @@ patina --lang <ko|en|zh|ja> [모드] [--profile <이름>] input.txt
 | `--format json\|text\|markdown` | JSON, 일반 텍스트, 기본 Markdown 출력 선택 |
 | `--quiet` | stderr의 상태, 경고, 진행 로그를 숨김 |
 | `--json-logs` | stderr 로그를 `level`, `event`, `model`, `latency_ms` 필드가 있는 NDJSON으로 출력 |
-| `--prompt-mode strict\|minimal\|auto` | 전체 패턴 팩 프롬프트, 압축 프롬프트, 백엔드별 자동 선택 |
 
 전체 옵션은 `patina --help`. `patina doctor --json`은 LLM 호출 없이 Node/backend/tmux/API-key 준비 상태를 점검하고, `patina init`은 프로젝트용 `.patina.yaml`을 씁니다.
 
@@ -199,10 +198,6 @@ Markdown 중심의 개발 워크플로우에는 개발자용 프로필 단축키
 `--score`와 `--audit`는 `--rewrite`보다 약간 더 넓은 신호를 측정합니다. viral-hook 팩(`ko/en/zh/ja-viral-hook`, 각 9개 패턴: 숫자 충격 훅, 클릭베이트 종결, 출처 회피 권위 주장, 호흡 최적화 단문 배열, 과장된 참여 유도 어휘, 가짜 통계 인용, 권위 타이틀 쌓기, 미래의 나/친밀한 2인칭 약속, 경구형 펀치라인)은 **탐지 전용**입니다.
 
 이 신호들은 score와 audit에만 나타나 네 언어의 SNS 마케팅 카피에 대한 사용자 직관과 벤치마크를 맞춥니다. `--rewrite`/`--diff`/`--ouroboros`는 이런 표현이 의도된 수사일 수 있어 건너뜁니다. 실제 데모: [`examples/viral-hook/`](examples/viral-hook/).
-
-### 프롬프트 모드 튜닝 (v3.11)
-
-`--prompt-mode strict|minimal|auto` 는 전체 패턴 팩(약 34KB 구조화 프롬프트)과 압축된 캐주얼 지시문(약 3KB) 사이의 균형을 선택합니다. `auto` 는 백엔드별로 선택합니다 — Gemini는 minimal에서 더 잘 동작하고(너무 긴 구조화 프롬프트에는 얽매이는 경향이 있음), Claude는 전체 팩을 활용하며, Codex는 대체로 차이가 작습니다. case-05가 A/B 결과를 문서화합니다.
 
 ### 짧은 텍스트 점수 보정 (v3.11)
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -189,7 +189,6 @@ patina --lang <ko|en|zh|ja> [模式] [--profile <名称>] input.txt
 | `--format json\|text\|markdown` | 选择 JSON、纯文本或默认 Markdown 输出 |
 | `--quiet` | 隐藏 stderr 中的状态、警告和进度日志 |
 | `--json-logs` | 以 NDJSON 输出 stderr 日志，包含 `level`、`event`、`model`、`latency_ms` 字段 |
-| `--prompt-mode strict\|minimal\|auto` | 选择完整模式包提示、压缩提示，或按后端自动选择 |
 
 完整选项请运行 `patina --help`。`patina doctor --json` 可在不调用 LLM 的情况下检查 Node/backend/tmux/API-key 状态，`patina init` 会写入项目 `.patina.yaml`。
 
@@ -200,10 +199,6 @@ Markdown-heavy 工程流程可使用开发者原生 profile shortcut：`code-com
 `--score` 和 `--audit` 测量的信号范围比 `--rewrite` 略广。viral-hook 包（`ko/en/zh/ja-viral-hook`，每种语言 9 个模式：数字震撼钩子、标题党收尾、跳过来源的权威断言、适合呼吸节奏的短句堆叠、夸张互动词汇、伪统计引用、头衔堆叠、未来自我承诺、格言式收束句）为**仅检测**模式。
 
 这些信号只会出现在评分和审计中，用来让基准更贴近用户对四种语言 SNS 营销文案的直觉。`--rewrite`/`--diff`/`--ouroboros` 会跳过它们，因为这些信号往往是有意的修辞。实例: [`examples/viral-hook/`](examples/viral-hook/).
-
-### 提示模式调优 (v3.11)
-
-`--prompt-mode strict|minimal|auto` 可在完整模式包（约 34KB 结构化提示）和压缩的轻量指令（约 3KB）之间取舍。`auto` 会按后端选择 — Gemini 在 minimal 下表现更好（长结构化提示会让它过度受限），Claude 能利用完整模式包，Codex 大致不敏感。case-05 记录了 A/B 结果。
 
 ### 短文本评分增强 (v3.11)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -32,7 +32,6 @@ Glob .patina.default.yaml → Read
 - `output`: 출력 모드 (`rewrite` | `diff` | `audit` | `score`)
 - `blocklist`: 추가 감지 어휘
 - `allowlist`: 감지 제외 어휘
-- `prompt-mode`: 프롬프트 로딩 방식 (`strict` | `minimal` | `auto`, 기본: `strict`)
 
 `$ARGUMENTS`에서 옵션을 파싱하여 설정을 오버라이드:
 - `--profile <name>`: 프로필 변경
@@ -42,7 +41,6 @@ Glob .patina.default.yaml → Read
 - `--ouroboros`: ouroboros 모드 (반복 교정 + 점수 수렴)
 - `--lang <code>`: 처리 언어 변경 (ko, en, zh, ja). 설정 파일의 `language` 값을 오버라이드한다.
 - `--tone <name>`: 톤 카테고리 지정. 유효값: `casual | professional | academic | narrative | marketing | instructional | auto`. 알 수 없는 값이면 즉시 오류: "Unknown tone '<name>'. Valid tones: casual, professional, academic, narrative, marketing, instructional, auto"
-- `--prompt-mode <strict|minimal|auto>`: 패턴 팩 전체를 쓰는 strict 모드와 압축 지시문 minimal 모드 중 선택한다. `auto`는 백엔드/문맥별로 선택하되, 불확실하면 strict를 사용한다.
 - `--batch <files>`: 여러 파일을 한꺼번에 처리 (glob 또는 명시적 경로 목록).
   - `--in-place`: 원본 파일을 교정된 텍스트로 덮어쓴다.
   - `--suffix <ext>`: 결과를 `{원본명}{ext}` 파일로 저장한다 (예: `--suffix .humanized`).

--- a/docs/API.md
+++ b/docs/API.md
@@ -147,14 +147,8 @@ still be genuinely human and we avoid claiming absolute proof.</p>
 <dt><a href="#createCancellationController">createCancellationController([options])</a> ⇒ <code>Object</code></dt>
 <dd><p>Create a SIGINT-aware cancellation controller for long-running CLI operations.</p>
 </dd>
-<dt><a href="#resolvePromptMode">resolvePromptMode(mode, context)</a> ⇒ <code>string</code></dt>
-<dd><p>Resolve the effective prompt style for backend/model auto mode.</p>
-</dd>
 <dt><a href="#resolveProfileForLanguage">resolveProfileForLanguage(profileName, lang, [logger])</a> ⇒ <code>string</code></dt>
 <dd><p>Resolve a profile name against language-specific profile limits.</p>
-</dd>
-<dt><a href="#resolveConfiguredPromptMode">resolveConfiguredPromptMode([options])</a> ⇒ <code>string</code></dt>
-<dd><p>Choose the configured prompt mode before backend/model auto-resolution.</p>
 </dd>
 <dt><a href="#loadConfig">loadConfig([path])</a> ⇒ <code>object</code></dt>
 <dd><p>Load default config and merge global/project .patina.yaml overrides.</p>
@@ -558,29 +552,6 @@ Create a SIGINT-aware cancellation controller for long-running CLI operations.
 const cancellation = createCancellationController();
 cancellation.install();
 ```
-<a name="resolvePromptMode"></a>
-
-## resolvePromptMode(mode, context) ⇒ <code>string</code>
-Resolve the effective prompt style for backend/model auto mode.
-
-**Kind**: global function
-**Returns**: <code>string</code> - Resolved prompt mode.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
-
-| Param | Type | Description |
-| --- | --- | --- |
-| mode | <code>string</code> | Requested prompt mode: auto, strict, or minimal. |
-| context | <code>object</code> | Backend selection context. |
-| [context.backend] | <code>string</code> | Backend name. |
-| [context.model] | <code>string</code> | Model id. |
-
-**Example**
-```js
-const mode = resolvePromptMode('auto', { model: 'gemini-2.5-flash' });
-```
 <a name="resolveProfileForLanguage"></a>
 
 ## resolveProfileForLanguage(profileName, lang, [logger]) ⇒ <code>string</code>
@@ -602,28 +573,6 @@ Resolve a profile name against language-specific profile limits.
 **Example**
 ```js
 resolveProfileForLanguage('namuwiki', 'en') // 'default'
-```
-<a name="resolveConfiguredPromptMode"></a>
-
-## resolveConfiguredPromptMode([options]) ⇒ <code>string</code>
-Choose the configured prompt mode before backend/model auto-resolution.
-
-**Kind**: global function
-**Returns**: <code>string</code> - Requested prompt mode.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
-
-| Param | Type | Description |
-| --- | --- | --- |
-| [options] | <code>object</code> | Prompt-mode sources. |
-| [options.cliPromptMode] | <code>string</code> | CLI --prompt-mode value. |
-| [options.configPromptMode] | <code>string</code> | Config prompt-mode value. |
-
-**Example**
-```js
-const requested = resolveConfiguredPromptMode();
 ```
 <a name="loadConfig"></a>
 
@@ -1124,7 +1073,6 @@ Build the LLM prompt for rewrite, diff, audit, score, or ouroboros mode.
 | options.text | <code>string</code> |  | Input text. |
 | [options.mode] | <code>string</code> | <code>&quot;rewrite&quot;</code> | Output mode. |
 | [options.tone] | <code>object</code> \| <code>null</code> | <code></code> | Tone resolution metadata. |
-| [options.promptMode] | <code>string</code> | <code>&quot;strict&quot;</code> | Prompt mode: strict or minimal. |
 
 **Example**
 ```js

--- a/docs/FLAG-PARITY.md
+++ b/docs/FLAG-PARITY.md
@@ -31,7 +31,6 @@ Basis: local checkout plus `node bin/patina.js --help` and `SKILL.md` reviewed o
 | `--provider <name>` | ✓ | — | CLI provider preset. |
 | `--list-providers` | ✓ | — | CLI diagnostics. |
 | `--config <path>` | ✓ | — | CLI config override. |
-| `--prompt-mode <strict\|minimal\|auto>` | ✓ | ✓ | User-visible prompt loading control. |
 | `--allow-insecure-base-url` | ✓ | — | CLI network safety override. |
 | `--allow-private-base-url` | ✓ | — | CLI SSRF/metadata-address safety override. |
 | `-h`, `--help` | ✓ | — | CLI help. |
@@ -42,5 +41,4 @@ Basis: local checkout plus `node bin/patina.js --help` and `SKILL.md` reviewed o
 
 ## Audit notes
 
-- `--prompt-mode` is the main user-facing prompt-loading control that must stay visible in `SKILL.md` as well as the CLI.
 - Auth/provider/base-url flags and `doctor`/`auth` commands are CLI automation or transport controls; they do not map cleanly to prompt-only skills.

--- a/src/cli.js
+++ b/src/cli.js
@@ -171,13 +171,7 @@ export async function main(args) {
         text,
         mode,
         tone: toneResolution,
-        promptMode: resolvePromptMode(
-          resolveConfiguredPromptMode({
-            cliPromptMode: parsed.promptMode,
-            configPromptMode: config['prompt-mode'],
-          }),
-          { backend: parsed.backend ?? config.backend, model: resolved.model }
-        ),
+        promptMode: resolvePromptMode({ backend: parsed.backend ?? config.backend, model: resolved.model }),
       });
 
       let result;
@@ -467,19 +461,6 @@ function parseArgs(args) {
         parsed.config = readOptionValue(args, i, arg);
         i++;
         break;
-      case '--prompt-mode': {
-        const m = readOptionValue(args, i, arg);
-        i++;
-        if (!m || !['strict', 'minimal', 'auto'].includes(m)) {
-          throw inputError(
-            '--prompt-mode expects strict, minimal, or auto',
-            `Received ${m === undefined ? 'no value' : `"${m}"`}.`,
-            'Use `--prompt-mode auto` unless you need a specific prompt style.'
-          );
-        }
-        parsed.promptMode = m;
-        break;
-      }
       case '--no-interactive':
         parsed.noInteractive = true;
         break;
@@ -588,30 +569,12 @@ function readOptionValue(args, index, option, { allowFlagLike = false } = {}) {
   return value;
 }
 
-// v3.11: case-05 found that prompt-mode preference is per-backend.
-// auto resolves to strict for codex-cli/claude (instruction-rich) and
-// minimal for gemini (voice-rich, over-constrained by long prompts).
-// Explicit strict/minimal pass through unchanged.
-/**
- * Resolve the effective prompt style for backend/model auto mode.
- *
- * @param {string} mode Requested prompt mode: auto, strict, or minimal.
- * @param {object} context Backend selection context.
- * @param {string} [context.backend] Backend name.
- * @param {string} [context.model] Model id.
- * @returns {string} Resolved prompt mode.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
- * @example
- * const mode = resolvePromptMode('auto', { model: 'gemini-2.5-flash' });
- */
-export function resolvePromptMode(mode, { backend, model }) {
-  if (mode !== 'auto') return mode;
+// Internal prompt style is selected per backend/model. Gemini gets the compact
+// rewrite prompt; everything else keeps the full pattern-pack prompt.
+function resolvePromptMode({ backend, model }) {
   const backendStr = (backend || '').toLowerCase();
   const modelStr = (model || '').toLowerCase();
   if (backendStr.includes('gemini') || modelStr.includes('gemini')) return 'minimal';
-  if (modelStr.includes('claude')) return 'strict';
-  // Default for codex-cli, openai-http with gpt-* models, and anything we
-  // can't classify — strict is the conservative choice (full pattern packs).
   return 'strict';
 }
 
@@ -637,20 +600,6 @@ export function resolveProfileForLanguage(profileName, lang, logger = null) {
   return effective;
 }
 
-/**
- * Choose the configured prompt mode before backend/model auto-resolution.
- *
- * @param {object} [options] Prompt-mode sources.
- * @param {string} [options.cliPromptMode] CLI --prompt-mode value.
- * @param {string} [options.configPromptMode] Config prompt-mode value.
- * @returns {string} Requested prompt mode.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
- * @example
- * const requested = resolveConfiguredPromptMode();
- */
-export function resolveConfiguredPromptMode({ cliPromptMode, configPromptMode } = {}) {
-  return cliPromptMode || configPromptMode || 'strict';
-}
 
 // Resolve the API key from file or environment. Precedence: --api-key-file >
 // PATINA_API_KEY_FILE > provider/default env vars.
@@ -831,7 +780,6 @@ MODEL & AUTH
   --list-providers        List provider presets and which keys are set
 ADVANCED
   --config <path>         Load config from <path> instead of .patina.default.yaml
-  --prompt-mode <m>       strict | minimal | auto. auto picks per backend.
   --allow-insecure-base-url  Permit plaintext http:// to non-localhost endpoints
   --allow-private-base-url   Permit private/IMDS base URLs
   -h, --help              Show this help message

--- a/src/output.js
+++ b/src/output.js
@@ -232,7 +232,7 @@ export function stripSelfAudit(body, { logger = createLogger() } = {}) {
     const stripped = removeSelfAuditBlocks(body).trim();
     if (stripped !== body.trim()) {
       logger.warn('output.missing_body_tags', {
-        message: `[patina] warning: model output omitted [BODY] tags (${body.length} chars); stripped [SELF_AUDIT]. Re-run with --prompt-mode strict if the output looks wrong.`,
+        message: `[patina] warning: model output omitted [BODY] tags (${body.length} chars); stripped [SELF_AUDIT]. Try a different backend if the output looks wrong.`,
       });
       return stripped;
     }

--- a/src/prompt-builder.js
+++ b/src/prompt-builder.js
@@ -12,29 +12,28 @@
  * @param {string} options.text Input text.
  * @param {string} [options.mode=rewrite] Output mode.
  * @param {object|null} [options.tone=null] Tone resolution metadata.
- * @param {string} [options.promptMode=strict] Prompt mode: strict or minimal.
  * @returns {string} Complete prompt text.
  * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const prompt = buildPrompt({ config, patterns, profile, voice, scoring, text: 'Draft' });
  */
-export function buildPrompt({
-  config,
-  patterns,
-  profile,
-  voice,
-  voiceSample,
-  scoring,
-  text,
-  mode = 'rewrite',
-  tone = null,
-  promptMode = 'strict',
-}) {
-  // v3.11+ prompt-mode dispatch (case-04 hypothesis test). minimal prompt
-  // strips pattern definitions/examples and uses a casual instruction; only
-  // applies to rewrite mode where voice prior matters most. Profile body is
-  // still passed through (Round 2 found Gemini ignored casual-conversation
-  // when the profile was dropped).
+export function buildPrompt(options) {
+  const {
+    config,
+    patterns,
+    profile,
+    voice,
+    voiceSample,
+    scoring,
+    text,
+    mode = 'rewrite',
+    tone = null,
+  } = options;
+  const promptMode = /** @type {any} */ (options).promptMode || 'strict';
+  // v3.11+ internal backend prompt-style dispatch. The compact prompt strips
+  // pattern definitions/examples and uses a casual instruction; it only applies
+  // to rewrite mode where voice prior matters most. Profile body is still passed
+  // through (Round 2 found Gemini ignored casual-conversation when omitted).
   if (promptMode === 'minimal' && mode === 'rewrite') {
     return buildMinimalPrompt({ config, patterns, profile, voiceSample, text, tone });
   }

--- a/tests/e2e/cli-adoption.test.js
+++ b/tests/e2e/cli-adoption.test.js
@@ -150,7 +150,7 @@ describe('CLI adoption commands', () => {
 
 describe('CLI adoption exit/error behavior', () => {
   it('unknown flags fail before stdin handling with a usage exit', () => {
-    for (const flag of ['--bogus', '--variants', '--save-run', '--cache', '--cache-ttl', '--no-cache', '--suspected-generator']) {
+    for (const flag of ['--bogus', '--variants', '--save-run', '--cache', '--cache-ttl', '--no-cache', '--suspected-generator', '--prompt-mode']) {
       const result = spawnSync(process.execPath, [BIN, flag], {
         cwd: REPO_ROOT,
         input: '',
@@ -176,7 +176,6 @@ describe('CLI adoption exit/error behavior', () => {
     const cases = [
       { args: ['--tone'], message: /--tone requires a value/ },
       { args: ['--gate', 'nope'], message: /--gate expects a number/ },
-      { args: ['--prompt-mode', 'wrong'], message: /--prompt-mode expects/ },
       { args: ['--api-key-file'], message: /--api-key-file requires a value/ },
     ];
 

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -113,6 +113,26 @@ describe('CLI End-to-End with Mock API', () => {
     assert.ok(lastRequestBody.messages[0].content.includes('Input Text'));
   });
 
+  it('uses the compact rewrite prompt internally for gemini models', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+
+    await main([
+      '--lang', 'en',
+      '--backend', 'openai-http',
+      '--api-key-file', mockApiKeyPath,
+      '--base-url', `http://127.0.0.1:${mockPort}`,
+      '--model', 'gemini-3-flash-preview',
+      testFile,
+    ]);
+
+    const prompt = lastRequestBody.messages[0].content;
+    assert.ok(prompt.includes('AI signal words (reference)'));
+    assert.ok(!prompt.includes('Follow the 3-Phase pipeline'));
+  });
+
   it('should pass correct temperature', async () => {
     callCount = 0;
     lastRequestBody = null;

--- a/tests/unit/tone.test.js
+++ b/tests/unit/tone.test.js
@@ -232,7 +232,7 @@ test('stripSelfAudit: missing [BODY] strips audit and warns', () => {
   }
   assert.equal(logs.length, 1);
   assert.match(logs[0], /omitted \[BODY\] tags/);
-  assert.match(logs[0], /--prompt-mode strict/);
+  assert.match(logs[0], /Try a different backend/);
 });
 
 test('stripSelfAudit: only applied to rewrite/ouroboros modes', () => {
@@ -243,45 +243,8 @@ test('stripSelfAudit: only applied to rewrite/ouroboros modes', () => {
   assert.ok(audit.includes('[SELF_AUDIT]'));
 });
 
-// --- resolvePromptMode (v3.11 Phase 3.3) ---
-
-import { resolveConfiguredPromptMode, resolvePromptMode } from '../../src/cli.js';
-import { validateScoreWeights } from '../../src/output.js';
-
-test('resolvePromptMode: strict passes through unchanged', () => {
-  assert.equal(resolvePromptMode('strict', { backend: 'codex-cli' }), 'strict');
-  assert.equal(resolvePromptMode('strict', { backend: 'gemini' }), 'strict');
-});
-
-test('resolvePromptMode: minimal passes through unchanged', () => {
-  assert.equal(resolvePromptMode('minimal', { backend: 'codex-cli' }), 'minimal');
-});
-
-test('resolvePromptMode: auto + gemini backend → minimal', () => {
-  assert.equal(resolvePromptMode('auto', { backend: 'gemini' }), 'minimal');
-  assert.equal(resolvePromptMode('auto', { backend: '', model: 'gemini-3-flash-preview' }), 'minimal');
-});
-
-test('resolvePromptMode: auto + claude model → strict', () => {
-  assert.equal(resolvePromptMode('auto', { backend: '', model: 'claude-sonnet-4-6' }), 'strict');
-});
-
-test('resolvePromptMode: auto + codex-cli → strict (default)', () => {
-  assert.equal(resolvePromptMode('auto', { backend: 'codex-cli' }), 'strict');
-});
-
-test('resolvePromptMode: auto + unknown → strict (conservative)', () => {
-  assert.equal(resolvePromptMode('auto', { backend: 'openai-http', model: 'gpt-5.5' }), 'strict');
-  assert.equal(resolvePromptMode('auto', {}), 'strict');
-});
-
-test('resolveConfiguredPromptMode defaults to strict unless overridden', () => {
-  assert.equal(resolveConfiguredPromptMode({}), 'strict');
-  assert.equal(resolveConfiguredPromptMode({ configPromptMode: 'strict' }), 'strict');
-  assert.equal(resolveConfiguredPromptMode({ cliPromptMode: 'auto', configPromptMode: 'strict' }), 'auto');
-});
-
 // --- validateScoreWeights (v3.11 Phase 1.3) ---
+import { validateScoreWeights } from '../../src/output.js';
 
 test('validateScoreWeights: matches → no warnings', () => {
   const output = `| Category | Weight | Detected | Raw | Weighted |


### PR DESCRIPTION
## Summary
- remove `--prompt-mode` from CLI parsing/help and docs
- keep prompt style as an internal backend/model decision, using compact rewrite prompts for Gemini
- update generated API docs, SKILL guidance, and tests

## Verification
- npm run docs:api
- node bin/patina.js --help
- node bin/patina.js --prompt-mode (unknown option, exit 2)
- npm run test:e2e
- npm run lint
- npm test
- npm run release:check