### PR TITLE
Remove gate alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ patina --lang <ko|en|zh|ja> [mode] [--profile <name>] input.txt
 | *(default)* | Rewrite |
 | `--audit` | Detect AI patterns only |
 | `--score` | 0–100 AI-likeness score with category breakdown |
-| `--score --exit-on <n>` | Keep CI strict: exit code `3` when `overall > n` (`--gate` is kept as an alias) |
+| `--score --exit-on <n>` | Keep CI strict: exit code `3` when `overall > n` |
 | `--diff` | Show changes pattern by pattern |
 | `--ouroboros` | Iterate the rewrite until score converges (with MPS rollback) |
 | `--lang <ko\|en\|zh\|ja>` | Select language (default: `ko`) |

--- a/README_JA.md
+++ b/README_JA.md
@@ -179,7 +179,7 @@ patina --lang <ko|en|zh|ja> [モード] [--profile <名前>] input.txt
 | *(デフォルト)* | 書き換え |
 | `--audit` | AI パターン検出のみ |
 | `--score` | 0–100 AI 類似度スコア + カテゴリ別内訳 |
-| `--score --exit-on <n>` | CI を厳格に保つ: `overall > n` の場合は終了コード `3`（`--gate` は alias） |
+| `--score --exit-on <n>` | CI を厳格に保つ: `overall > n` の場合は終了コード `3` |
 | `--diff` | 変更箇所をパターンごとに表示 |
 | `--ouroboros` | スコア収束まで反復（MPS ロールバック付き） |
 | `--lang <ko\|en\|zh\|ja>` | 言語選択（デフォルト：`ko`） |

--- a/README_KR.md
+++ b/README_KR.md
@@ -177,7 +177,7 @@ patina --lang <ko|en|zh|ja> [모드] [--profile <이름>] input.txt
 | *(기본)* | 재작성 |
 | `--audit` | AI 패턴 탐지만 수행 |
 | `--score` | 0–100 AI 유사도 점수 + 카테고리별 분석 |
-| `--score --exit-on <n>` | CI를 엄격하게 유지: `overall > n`이면 종료 코드 `3` (`--gate`는 alias) |
+| `--score --exit-on <n>` | CI를 엄격하게 유지: `overall > n`이면 종료 코드 `3` |
 | `--diff` | 변경 사항을 패턴별로 표시 |
 | `--ouroboros` | 점수가 수렴할 때까지 반복 (MPS 롤백 포함) |
 | `--lang <ko\|en\|zh\|ja>` | 언어 선택 (기본값: `ko`) |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -179,7 +179,7 @@ patina --lang <ko|en|zh|ja> [模式] [--profile <名称>] input.txt
 | *(默认)* | 改写 |
 | `--audit` | 仅检测 AI 模式 |
 | `--score` | 0–100 AI 相似度评分 + 类别细分 |
-| `--score --exit-on <n>` | 保持 CI 严格：当 `overall > n` 时以退出码 `3` 结束（`--gate` 保留为 alias） |
+| `--score --exit-on <n>` | 保持 CI 严格：当 `overall > n` 时以退出码 `3` 结束 |
 | `--diff` | 按模式逐项展示改动 |
 | `--ouroboros` | 反复改写直到分数收敛（含 MPS 回滚） |
 | `--lang <ko\|en\|zh\|ja>` | 选择语言（默认：`ko`） |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -4,7 +4,7 @@ patina's CLI is optimized for interactive editing, but a few surfaces are stable
 
 ## Score gate
 
-Use `--score --exit-on <n>` (or the older `--gate <n>` alias) when CI should fail if a text still reads too AI-like.
+Use `--score --exit-on <n>` when CI should fail if a text still reads too AI-like.
 
 ```bash
 patina --lang en --score --exit-on 30 draft.md
@@ -21,7 +21,7 @@ patina --lang en --score --exit-on 30 draft.md
 | `0` | Command completed; for `--score --exit-on`, the score was at or below the gate. |
 | `1` | Runtime or backend error, including API/auth/backend failures. |
 | `2` | Input/usage error from no interactive input or empty stdin. |
-| `3` | `--score --exit-on` / `--score --gate` completed, but the score exceeded the configured gate. |
+| `3` | `--score --exit-on` completed, but the score exceeded the configured gate. |
 
 ## Output formats
 
@@ -43,7 +43,7 @@ patina --lang en --score --exit-on 30 draft.md
 - `overall` and `categories[]` are populated when patina can parse them from score JSON or score tables.
 - Score JSON may include `scores.llm`, `scores.deterministic`, and `scores.preference` when deterministic shadow scoring is available.
 - `mps` is populated when the underlying mode emits it.
-- `gateResult` is `null` unless `--exit-on` / `--gate` is used.
+- `gateResult` is `null` unless `--exit-on` is used.
 - `--voice-sample <path>` or config `voice-sample: <path>` injects the first 1–3 user-written paragraphs into rewrite/Ouroboros prompts as style-only examples of how this person writes. `--profile` / `--tone` still define the outer register; samples refine cadence and texture without importing facts.
 - `patina doctor --json` emits setup diagnostics for CI without making an LLM call.
 

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -20,7 +20,7 @@ patina --lang en --score --batch content/posts/*.md
 For a stricter sweep that flags anything above 30/100, fail the run instead of just printing:
 
 ```bash
-patina --lang en --score --gate 30 --batch content/posts/*.md
+patina --lang en --score --exit-on 30 --batch content/posts/*.md
 ```
 
 When any file's `overall` exceeds the gate, patina exits with code `3` ([`CLI.md`](CLI.md) §Exit codes), which is perfect for a pre-publish check.
@@ -53,13 +53,13 @@ jobs:
         run: |
           changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- '*.md')
           [ -z "$changed" ] && echo "no markdown changes" && exit 0
-          patina --lang en --score --gate 30 --batch $changed
+          patina --lang en --score --exit-on 30 --batch $changed
         env:
           # pick one backend that has a token in repo secrets
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 ```
 
-Drop `--gate` while you calibrate the threshold for your project. Swap `GEMINI_API_KEY` for whichever backend you have (`claude` / `codex` / `gemini`) — see [`AUTHENTICATION.md`](AUTHENTICATION.md) for the full list.
+Drop `--exit-on` while you calibrate the threshold for your project. Swap `GEMINI_API_KEY` for whichever backend you have (`claude` / `codex` / `gemini`) — see [`AUTHENTICATION.md`](AUTHENTICATION.md) for the full list.
 
 ---
 
@@ -145,10 +145,10 @@ Block commits that introduce too-AI-sounding markdown. Drop this into `.git/hook
 set -euo pipefail
 changed=$(git diff --cached --name-only --diff-filter=ACM -- '*.md')
 [ -z "$changed" ] && exit 0
-patina --lang en --score --gate 30 --batch $changed
+patina --lang en --score --exit-on 30 --batch $changed
 ```
 
-`--gate` returns exit code `3` when any file's `overall` exceeds the threshold, which the shell treats as failure and aborts the commit. To bypass once (e.g. you intentionally want hype copy), commit with `--no-verify`.
+`--exit-on` returns exit code `3` when any file's `overall` exceeds the threshold, which the shell treats as failure and aborts the commit. To bypass once (e.g. you intentionally want hype copy), commit with `--no-verify`.
 
 ---
 

--- a/docs/EXIT-CODES.md
+++ b/docs/EXIT-CODES.md
@@ -7,7 +7,7 @@ patina uses stable exit codes so CI and editor integrations can distinguish cont
 | `0` | Success. For `--score --exit-on <n>`, the parsed `overall` score was at or below the threshold. |
 | `1` | Runtime/backend failure: API/auth/backend errors, failed doctor blockers, invalid runtime setup, or unexpected exceptions. |
 | `2` | Input/usage failure: unknown flags, missing required option values, empty stdin, or `--no-interactive` with no input. |
-| `3` | Score gate exceeded. `--score --exit-on <n>` or `--score --gate <n>` completed, but `overall > n`. |
+| `3` | Score gate exceeded. `--score --exit-on <n>` completed, but `overall > n`. |
 
 ## Score gates
 
@@ -15,7 +15,7 @@ patina uses stable exit codes so CI and editor integrations can distinguish cont
 patina --lang en --score --exit-on 30 draft.md
 ```
 
-`--gate <n>` remains as a backward-compatible alias for the same behavior. The command still prints the score output; only the process exit code changes to `3` when the gate fails.
+`--exit-on <n>` prints the score output as usual; only the process exit code changes to `3` when the threshold fails.
 
 ## Empty input
 

--- a/docs/FLAG-PARITY.md
+++ b/docs/FLAG-PARITY.md
@@ -8,8 +8,7 @@ Basis: local checkout plus `node bin/patina.js --help` and `SKILL.md` reviewed o
 | `--diff` | ✓ | ✓ | Single-candidate pattern-by-pattern diff. |
 | `--audit` | ✓ | ✓ | Detection-only mode. |
 | `--score` | ✓ | ✓ | Score mode is available on both surfaces. |
-| `--gate <n>` | ✓ | — | CLI score-gate alias; automation-only. |
-| `--exit-on <n>` | ✓ | — | Preferred CLI score-gate spelling for CI. |
+| `--exit-on <n>` | ✓ | — | CLI score-gate spelling for CI. |
 | `--ouroboros` | ✓ | ✓ | Iterative rewrite / score convergence loop. |
 | `--format <markdown\|text\|json>` | ✓ | — | CLI output-envelope feature. |
 | `--json` | ✓ | — | CLI alias for `--format json`; `patina doctor --json` also exists. |

--- a/docs/integrations/pre-commit.md
+++ b/docs/integrations/pre-commit.md
@@ -13,7 +13,7 @@ repos:
     rev: main # replace with a release tag after v1 is cut
     hooks:
       - id: patina-score
-        args: [--gate, "30", --lang, auto]
+        args: [--score-threshold, "30", --lang, auto]
 ```
 
 Run it locally:
@@ -33,7 +33,7 @@ npx husky init
 // package.json
 {
   "lint-staged": {
-    "*.{md,mdx}": "patina-score --gate 30 --lang auto"
+    "*.{md,mdx}": "patina-score --score-threshold 30 --lang auto"
   }
 }
 ```
@@ -57,7 +57,7 @@ pre-commit:
   commands:
     patina-score:
       glob: "*.{md,mdx}"
-      run: npx patina-score --gate 30 --lang auto {staged_files}
+      run: npx patina-score --score-threshold 30 --lang auto {staged_files}
 ```
 
 A repo-local Lefthook command if this repository is vendored or checked out:
@@ -67,11 +67,11 @@ pre-commit:
   commands:
     patina-score:
       glob: "*.{md,mdx}"
-      run: node scripts/precommit-score.mjs --gate 30 --lang auto {staged_files}
+      run: node scripts/precommit-score.mjs --score-threshold 30 --lang auto {staged_files}
 ```
 
 ## Tuning
 
-- `--gate 30` means fail when more than 30% of prose paragraphs in a file trip a hot signal.
+- `--score-threshold 30` means fail when more than 30% of prose paragraphs in a file trip a hot signal.
 - `--lang auto` infers language from filename and Unicode ranges; pass `ko`, `en`, `zh`, or `ja` when a repo is single-language.
 - Use this as a discussion prompt, not as an accusation. See [ETHICS.md](../ETHICS.md).

--- a/scripts/badge-json.mjs
+++ b/scripts/badge-json.mjs
@@ -39,16 +39,17 @@ export function parseArgs(argv) {
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
-    if (arg === '--gate' || arg === '--score-threshold') opts.gate = Number(argv[++i]);
+    if (arg === '--score-threshold') opts.gate = Number(argv[++i]);
     else if (arg === '--lang') opts.lang = argv[++i] || 'auto';
     else if (arg === '--max-files') opts.maxFiles = Number(argv[++i]);
     else if (arg === '--label') opts.label = argv[++i] || 'patina';
-    else if (!arg.startsWith('-')) opts.files.push(arg);
+    else if (arg.startsWith('-')) throw new Error(`unknown option ${arg}`);
+    else opts.files.push(arg);
   }
 
   if (opts.files.length === 0) opts.files.push('README.md');
   if (!Number.isFinite(opts.gate) || opts.gate < 0 || opts.gate > 100) {
-    throw new Error(`--gate expects a number from 0 to 100, got ${opts.gate}`);
+    throw new Error(`--score-threshold expects a number from 0 to 100, got ${opts.gate}`);
   }
   if (!Number.isInteger(opts.maxFiles) || opts.maxFiles < 1) {
     throw new Error(`--max-files expects a positive integer, got ${opts.maxFiles}`);

--- a/scripts/precommit-score.mjs
+++ b/scripts/precommit-score.mjs
@@ -5,13 +5,14 @@ function parseArgs(argv) {
   const out = { files: [], gate: 30, lang: 'auto', maxFiles: 200 };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
-    if (arg === '--gate' || arg === '--score-threshold') out.gate = Number(argv[++i]);
+    if (arg === '--score-threshold') out.gate = Number(argv[++i]);
     else if (arg === '--lang') out.lang = argv[++i] || 'auto';
     else if (arg === '--max-files') out.maxFiles = Number(argv[++i]);
-    else if (!arg.startsWith('-')) out.files.push(arg);
+    else if (arg.startsWith('-')) throw new Error(`unknown option ${arg}`);
+    else out.files.push(arg);
   }
   if (!Number.isFinite(out.gate) || out.gate < 0 || out.gate > 100) {
-    throw new Error(`--gate expects a number from 0 to 100, got ${out.gate}`);
+    throw new Error(`--score-threshold expects a number from 0 to 100, got ${out.gate}`);
   }
   return out;
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -68,7 +68,7 @@ export async function main(args) {
 
   if (parsed.gate !== undefined && !parsed.score) {
     throw inputError(
-      `${parsed.gateOption || '--gate'} can only be used with --score`,
+      '--exit-on can only be used with --score',
       'Score gates need a parsed overall score.',
       'Run `patina --score --exit-on 30 <file>`.'
     );
@@ -378,21 +378,6 @@ function parseArgs(args) {
       case '--json-logs':
         parsed.jsonLogs = true;
         break;
-      case '--gate': {
-        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
-        i++;
-        const n = Number(value);
-        if (!Number.isFinite(n) || n < 0 || n > 100) {
-          throw inputError(
-            '--gate expects a number from 0 to 100',
-            `Received ${value === undefined ? 'no value' : `"${value}"`}.`,
-            'Use `patina --score --gate 30 <file>` for CI gates.'
-          );
-        }
-        parsed.gate = n;
-        parsed.gateOption = '--gate';
-        break;
-      }
       case '--exit-on': {
         const value = readOptionValue(args, i, arg, { allowFlagLike: true });
         i++;
@@ -405,7 +390,6 @@ function parseArgs(args) {
           );
         }
         parsed.gate = n;
-        parsed.gateOption = '--exit-on';
         break;
       }
       case '--ouroboros':
@@ -741,8 +725,7 @@ MODES
   --no-color              Disable ANSI colors in --diff output
   --audit                 Detect patterns only (no rewrite)
   --score                 Output AI-likeness score (0-100)
-  --gate <n>              With --score, exit 3 when overall score > n
-  --exit-on <n>           Alias for --gate, intended for CI scripts
+  --exit-on <n>           With --score, exit 3 when overall score > n
   --ouroboros             Iterative self-improvement loop
 
 OUTPUT & BATCH
@@ -831,7 +814,7 @@ function withDeterministicScore(rawResult, { text, config, repoRoot, logger }) {
 function applyScoreGate(result, output, gate, logger = createLogger()) {
   const overall = extractScoreOverall(result, output);
   if (overall === null) {
-    throw new Error('--gate could not find a numeric `overall` value in --score output.');
+    throw new Error('score gate could not find a numeric `overall` value in --score output.');
   }
   if (overall > gate) {
     logger.warn('score.gate_failed', { message: `[patina] score gate failed: overall ${overall} > ${gate}` });

--- a/tests/e2e/cli-adoption.test.js
+++ b/tests/e2e/cli-adoption.test.js
@@ -150,7 +150,7 @@ describe('CLI adoption commands', () => {
 
 describe('CLI adoption exit/error behavior', () => {
   it('unknown flags fail before stdin handling with a usage exit', () => {
-    for (const flag of ['--bogus', '--variants', '--save-run', '--cache', '--cache-ttl', '--no-cache', '--suspected-generator', '--prompt-mode']) {
+    for (const flag of ['--bogus', '--gate', '--variants', '--save-run', '--cache', '--cache-ttl', '--no-cache', '--suspected-generator', '--prompt-mode']) {
       const result = spawnSync(process.execPath, [BIN, flag], {
         cwd: REPO_ROOT,
         input: '',
@@ -175,7 +175,7 @@ describe('CLI adoption exit/error behavior', () => {
   it('value-taking usage errors use the standardized input exit code', () => {
     const cases = [
       { args: ['--tone'], message: /--tone requires a value/ },
-      { args: ['--gate', 'nope'], message: /--gate expects a number/ },
+      { args: ['--exit-on', 'nope'], message: /--exit-on expects a number/ },
       { args: ['--api-key-file'], message: /--api-key-file requires a value/ },
     ];
 

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -288,7 +288,7 @@ describe('CLI End-to-End with Mock API', () => {
     assert.ok(help.includes('MODEL & AUTH'), 'help should group backend options');
     assert.ok(help.includes('ADVANCED'), 'help should group advanced options');
     assert.ok(help.includes('EXAMPLES'), 'help should include examples');
-    assert.ok(help.includes('--gate <n>'), 'help should document score gate');
+    assert.ok(help.includes('--exit-on <n>'), 'help should document score gate');
     assert.ok(help.includes('--format <fmt>'), 'help should document output format');
     assert.ok(help.includes('--quiet'), 'help should document quiet logs');
     assert.ok(help.includes('--json-logs'), 'help should document structured stderr logs');
@@ -398,7 +398,7 @@ describe('CLI End-to-End with Mock API', () => {
       const { errors } = await captureConsole(() => main([
         '--lang', 'en',
         '--score',
-        '--gate', '30',
+        '--exit-on', '30',
         '--api-key-file', mockApiKeyPath,
         '--base-url', `http://127.0.0.1:${mockPort}`,
         testFile,
@@ -426,7 +426,7 @@ describe('CLI End-to-End with Mock API', () => {
       const { errors } = await captureConsole(() => main([
         '--lang', 'en',
         '--score',
-        '--gate', '30',
+        '--exit-on', '30',
         '--json-logs',
         '--api-key-file', mockApiKeyPath,
         '--base-url', `http://127.0.0.1:${mockPort}`,
@@ -447,7 +447,7 @@ describe('CLI End-to-End with Mock API', () => {
     await startMockServer('This is the humanized result.');
   });
 
-  it('should accept --exit-on as the CI score gate alias', async () => {
+  it('should accept --exit-on as the CI score gate', async () => {
     callCount = 0;
     lastRequestBody = null;
     await stopMockServer();
@@ -474,17 +474,17 @@ describe('CLI End-to-End with Mock API', () => {
     await startMockServer('This is the humanized result.');
   });
 
-  it('should reject --gate outside score mode', async () => {
+  it('should reject --exit-on outside score mode', async () => {
     const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
 
     await assert.rejects(
       () => main([
-        '--gate', '30',
+        '--exit-on', '30',
         '--api-key-file', mockApiKeyPath,
         '--base-url', `http://127.0.0.1:${mockPort}`,
         testFile,
       ]),
-      /--gate can only be used with --score/
+      /--exit-on can only be used with --score/
     );
   });
 

--- a/tests/e2e/precommit-score.test.js
+++ b/tests/e2e/precommit-score.test.js
@@ -16,10 +16,22 @@ test('precommit score exits non-zero when a Markdown file exceeds the gate', () 
   );
   const result = spawnSync(
     process.execPath,
-    [resolve(REPO_ROOT, 'scripts/precommit-score.mjs'), '--gate', '0', 'hot.md'],
+    [resolve(REPO_ROOT, 'scripts/precommit-score.mjs'), '--score-threshold', '0', 'hot.md'],
     { cwd: dir, encoding: 'utf8' }
   );
   assert.equal(result.status, 1, result.stdout + result.stderr);
   assert.match(result.stdout, /hot\.md/);
   assert.match(result.stderr, /exceeded gate 0/);
+});
+
+test('precommit score rejects removed --gate alias', () => {
+  const dir = mkdtempSync(resolve(tmpdir(), 'patina-precommit-'));
+  writeFileSync(resolve(dir, 'hot.md'), 'This innovative solution is pivotal.');
+  const result = spawnSync(
+    process.execPath,
+    [resolve(REPO_ROOT, 'scripts/precommit-score.mjs'), '--gate', '30', 'hot.md'],
+    { cwd: dir, encoding: 'utf8' }
+  );
+  assert.equal(result.status, 2, result.stdout + result.stderr);
+  assert.match(result.stderr, /unknown option --gate/);
 });

--- a/tests/unit/badge-json.test.js
+++ b/tests/unit/badge-json.test.js
@@ -33,9 +33,10 @@ test('toShieldsEndpoint formats a valid Shields endpoint payload', () => {
   assert.equal(formatBadgeScore(18.6), '19%');
 });
 
-test('parseArgs defaults to README and validates numeric options', () => {
+test('parseArgs defaults to README and validates options', () => {
   assert.deepEqual(parseArgs([]).files, ['README.md']);
-  assert.throws(() => parseArgs(['--gate', '101']), /--gate expects/);
+  assert.throws(() => parseArgs(['--score-threshold', '101']), /--score-threshold expects/);
+  assert.throws(() => parseArgs(['--gate', '30']), /unknown option --gate/);
   assert.throws(() => parseArgs(['--max-files', '0']), /--max-files expects/);
 });
 


### PR DESCRIPTION
## Summary
- remove the `--gate` alias from the main CLI and keep `--exit-on` as the only score-gate spelling
- remove the `--gate` alias from auxiliary scripts and keep `--score-threshold` there
- update docs, integrations, and tests to match the reduced surface

## Verification
- node bin/patina.js --help
- node bin/patina.js --gate
- node scripts/precommit-score.mjs --gate 30 README.md
- node scripts/badge-json.mjs --gate 30 README.md
- npm run lint
- npm test
- npm run release:check