### PR TITLE
Trim CLI flags and expand backend listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ patina --lang <ko|en|zh|ja> [mode] [--profile <name>] input.txt
 | `--batch` | Treat positional args as a list of files (e.g. `--batch docs/*.md`) |
 | `--format json\|text\|markdown` | Select machine-readable JSON, plain text, or default Markdown output |
 | `--quiet` | Suppress status, warning, and progress logs on stderr |
-| `--json-logs` | Emit stderr logs as NDJSON with `level`, `event`, `model`, and `latency_ms` fields |
 
 `patina --help` for the full flag list. `patina doctor --json` checks Node/backend/tmux/API-key readiness without making an LLM call, and `patina init` writes a project `.patina.yaml`.
 
@@ -225,7 +224,7 @@ In rewrite mode, the model emits its self-audit notes inside `[SELF_AUDIT]`/`[/S
 
 ### Machine-readable output and exit codes
 
-`--format json` wraps every mode in a stable envelope with `overall`, `categories[]`, `tone`, `mps`, `gateResult`, and the cleaned `output` body. `--json-logs` keeps stderr machine-readable as NDJSON, while `--quiet` silences status/warning/progress logs for scripts that only want stdout. `--format markdown` is the default; `--format text` keeps the user-facing body without the YAML tone footer. Exit codes are standardized in [EXIT-CODES.md](docs/EXIT-CODES.md): `0` success, `1` runtime/backend, `2` input/usage, `3` score gate exceeded.
+`--format json` wraps every mode in a stable envelope with `overall`, `categories[]`, `tone`, `mps`, `gateResult`, and the cleaned `output` body. `--quiet` silences status, warning, and progress logs on stderr for scripts that only want stdout. `--format markdown` is the default; `--format text` keeps the user-facing body without the YAML tone footer. Exit codes are standardized in [EXIT-CODES.md](docs/EXIT-CODES.md): `0` success, `1` runtime/backend, `2` input/usage, `3` score gate exceeded.
 
 ### Score weight drift detection (v3.11)
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -188,7 +188,6 @@ patina --lang <ko|en|zh|ja> [モード] [--profile <名前>] input.txt
 | `--batch` | 位置引数をファイル一覧として処理（例：`--batch docs/*.md`） |
 | `--format json\|text\|markdown` | JSON、プレーンテキスト、デフォルト Markdown 出力を選択 |
 | `--quiet` | stderr の状態・警告・進捗ログを抑制 |
-| `--json-logs` | `level`、`event`、`model`、`latency_ms` を持つ NDJSON として stderr ログを出力 |
 
 全オプションは `patina --help`。`patina doctor --json` は LLM 呼び出しなしで Node/backend/tmux/API-key の準備状況を確認し、`patina init` はプロジェクト用 `.patina.yaml` を書きます。
 
@@ -210,7 +209,7 @@ rewrite モードでは、モデルは `[BODY]`/`[/BODY]` ブロックを囲む 
 
 ### Machine-readable output and exit codes
 
-`--format json` は、すべてのモードを `overall`、`categories[]`、`tone`、`mps`、`gateResult`、クリーンな `output` 本文を含む安定した envelope で包みます。`--json-logs` は stderr も NDJSON のまま保ち、`--quiet` は stdout だけ欲しいスクリプトのために状態・警告・進捗ログを隠します。`--format markdown` がデフォルトで、`--format text` は YAML tone footer なしのユーザー向け本文だけを保持します。終了コードは [EXIT-CODES.md](docs/EXIT-CODES.md) にまとまっています: `0` success、`1` runtime/backend、`2` input/usage、`3` score gate exceeded。
+`--format json` は、すべてのモードを `overall`、`categories[]`、`tone`、`mps`、`gateResult`、クリーンな `output` 本文を含む安定した envelope で包みます。`--quiet` は stdout だけ欲しいスクリプトのために状態・警告・進捗ログを隠します。`--format markdown` がデフォルトで、`--format text` は YAML tone footer なしのユーザー向け本文だけを保持します。終了コードは [EXIT-CODES.md](docs/EXIT-CODES.md) にまとまっています: `0` success、`1` runtime/backend、`2` input/usage、`3` score gate exceeded。
 
 ### スコア重みドリフト検出 (v3.11)
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -186,7 +186,6 @@ patina --lang <ko|en|zh|ja> [모드] [--profile <이름>] input.txt
 | `--batch` | 위치 인자를 파일 목록으로 처리 (예: `--batch docs/*.md`) |
 | `--format json\|text\|markdown` | JSON, 일반 텍스트, 기본 Markdown 출력 선택 |
 | `--quiet` | stderr의 상태, 경고, 진행 로그를 숨김 |
-| `--json-logs` | stderr 로그를 `level`, `event`, `model`, `latency_ms` 필드가 있는 NDJSON으로 출력 |
 
 전체 옵션은 `patina --help`. `patina doctor --json`은 LLM 호출 없이 Node/backend/tmux/API-key 준비 상태를 점검하고, `patina init`은 프로젝트용 `.patina.yaml`을 씁니다.
 
@@ -209,7 +208,7 @@ rewrite 모드에서 모델은 `[BODY]`/`[/BODY]` 블록을 감싸는 `[SELF_AUD
 
 ### 기계가 읽기 쉬운 출력과 종료 코드
 
-`--format json`은 모든 모드를 `overall`, `categories[]`, `tone`, `mps`, `gateResult`, 정리된 `output` 본문이 들어 있는 일관된 JSON 구조(envelope)로 감싸 반환합니다. `--json-logs`는 stderr 로그도 NDJSON으로 유지하고, `--quiet`는 stdout만 필요한 스크립트를 위해 상태·경고·진행 로그를 숨깁니다. `--format markdown`이 기본값이고, `--format text`는 YAML tone footer 없이 사용자가 보게 될 본문만 남깁니다. 종료 코드는 [EXIT-CODES.md](docs/EXIT-CODES.md)에 정리되어 있습니다: `0` 성공, `1` runtime/backend, `2` input/usage, `3` score gate 초과.
+`--format json`은 모든 모드를 `overall`, `categories[]`, `tone`, `mps`, `gateResult`, 정리된 `output` 본문이 들어 있는 일관된 JSON 구조(envelope)로 감싸 반환합니다. `--quiet`는 stdout만 필요한 스크립트를 위해 상태·경고·진행 로그를 숨깁니다. `--format markdown`이 기본값이고, `--format text`는 YAML tone footer 없이 사용자가 보게 될 본문만 남깁니다. 종료 코드는 [EXIT-CODES.md](docs/EXIT-CODES.md)에 정리되어 있습니다: `0` 성공, `1` runtime/backend, `2` input/usage, `3` score gate 초과.
 
 ### 점수 가중치 드리프트 감지 (v3.11)
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -188,7 +188,6 @@ patina --lang <ko|en|zh|ja> [模式] [--profile <名称>] input.txt
 | `--batch` | 把位置参数当作文件列表（例：`--batch docs/*.md`） |
 | `--format json\|text\|markdown` | 选择 JSON、纯文本或默认 Markdown 输出 |
 | `--quiet` | 隐藏 stderr 中的状态、警告和进度日志 |
-| `--json-logs` | 以 NDJSON 输出 stderr 日志，包含 `level`、`event`、`model`、`latency_ms` 字段 |
 
 完整选项请运行 `patina --help`。`patina doctor --json` 可在不调用 LLM 的情况下检查 Node/backend/tmux/API-key 状态，`patina init` 会写入项目 `.patina.yaml`。
 
@@ -210,7 +209,7 @@ Markdown-heavy 工程流程可使用开发者原生 profile shortcut：`code-com
 
 ### Machine-readable output and exit codes
 
-`--format json` 会把所有模式包进稳定 envelope，包含 `overall`、`categories[]`、`tone`、`mps`、`gateResult` 和清理后的 `output` 正文。`--json-logs` 会让 stderr 也保持 NDJSON 格式，`--quiet` 则为只需要 stdout 的脚本隐藏状态、警告和进度日志。`--format markdown` 是默认值；`--format text` 保留无 YAML tone footer 的用户可见正文。退出码见 [EXIT-CODES.md](docs/EXIT-CODES.md)：`0` 成功，`1` runtime/backend，`2` input/usage，`3` score gate 超限。
+`--format json` 会把所有模式包进稳定 envelope，包含 `overall`、`categories[]`、`tone`、`mps`、`gateResult` 和清理后的 `output` 正文。`--quiet` 则为只需要 stdout 的脚本隐藏状态、警告和进度日志。`--format markdown` 是默认值；`--format text` 保留无 YAML tone footer 的用户可见正文。退出码见 [EXIT-CODES.md](docs/EXIT-CODES.md)：`0` 成功，`1` runtime/backend，`2` input/usage，`3` score gate 超限。
 
 ### 分数权重漂移检测 (v3.11)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -196,7 +196,7 @@ still be genuinely human and we avoid claiming absolute proof.</p>
 <dd><p>Map a resolved named tone to its primary backbone profile.</p>
 </dd>
 <dt><a href="#createLogger">createLogger([options])</a> ⇒ <code>Object</code></dt>
-<dd><p>Create a small stderr logger with text, JSON, and progress modes.</p>
+<dd><p>Create a small stderr logger with text and progress modes.</p>
 </dd>
 <dt><a href="#runOuroboros">runOuroboros(options)</a> ⇒ <code>Promise.&lt;{finalText: string, finalScore: number, iterations: number, reason: string, log: Array.&lt;object&gt;}&gt;</code></dt>
 <dd><p>Run the iterative Ouroboros rewrite-and-score loop.</p>
@@ -884,7 +884,7 @@ const profile = toneToBackboneProfile('casual'); // blog
 <a name="createLogger"></a>
 
 ## createLogger([options]) ⇒ <code>Object</code>
-Create a small stderr logger with text, JSON, and progress modes.
+Create a small stderr logger with text and progress modes.
 
 **Kind**: global function
 **Returns**: <code>Object</code> - Logger facade.
@@ -898,12 +898,11 @@ Create a small stderr logger with text, JSON, and progress modes.
 | [options] | <code>object</code> |  | Logger options. |
 | [options.level] | <code>string</code> | <code>&quot;info&quot;</code> | Minimum log level. |
 | [options.quiet] | <code>boolean</code> | <code>false</code> | Suppress all log output. |
-| [options.json] | <code>boolean</code> | <code>false</code> | Emit structured JSON records. |
 | [options.stream] | <code>NodeJS.WritableStream</code> | <code>process.stderr</code> | Progress stream. |
 
 **Example**
 ```js
-const logger = createLogger({ json: true });
+const logger = createLogger();
 logger.info('event', { message: 'ready' });
 ```
 <a name="runOuroboros"></a>

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -19,7 +19,7 @@ patina runs through one of several backends. Pick whichever matches your existin
 patina auth status         # backend availability + auth state
 patina auth login          # per-backend login instructions
 patina auth login codex-cli # confirm, then run `codex login`
-patina --list-providers    # preset providers + key status
+patina --list-backends     # backend selectors + auth state
 ```
 
 Backend selection requires an explicit signal: pass `--backend <name>` directly, pass a comma-separated fallback chain such as `--backend claude-cli,codex-cli`, or use `--model <prefix>` (`codex-*`, `claude-*`, `gemini-*` route to the matching local CLI). With no flags and no API key, patina exits with an error rather than silently dispatching to a coding agent. See [issue #88](https://github.com/devswha/patina/issues/88) for the rationale.

--- a/docs/AUTHENTICATION_KR.md
+++ b/docs/AUTHENTICATION_KR.md
@@ -19,7 +19,7 @@ patina는 여러 backend 중 하나를 통해 실행됩니다. 이미 쓰고 있
 patina auth status         # backend availability + auth state
 patina auth login          # per-backend login instructions
 patina auth login codex-cli # confirm 후 `codex login` 실행
-patina --list-providers    # preset providers + key status
+patina --list-backends     # backend selector와 auth 상태
 ```
 
 Backend selection에는 명시적인 신호가 필요합니다. `--backend <name>`을 직접 넘기거나, `--backend claude-cli,codex-cli`처럼 comma-separated fallback chain을 넘기거나, `--model <prefix>`를 사용하세요. `codex-*`, `claude-*`, `gemini-*`는 각각 맞는 local CLI로 라우팅됩니다. flag도 API key도 없으면 patina는 coding agent로 조용히 보내지 않고 오류로 종료합니다. 이유는 [issue #88](https://github.com/devswha/patina/issues/88)를 참고하세요.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -53,8 +53,6 @@ Human-facing status, warnings, and progress indicators go to stderr so stdout
 stays reserved for the transformed text or JSON envelope.
 
 - `--quiet` suppresses stderr logs, including Ouroboros progress.
-- `--json-logs` emits newline-delimited JSON records with stable fields:
-  `ts`, `level`, `event`, `model`, `latency_ms`, and optional `message`.
 - Ouroboros reports per-iteration score movement and latency.
 
 

--- a/docs/FLAG-PARITY.md
+++ b/docs/FLAG-PARITY.md
@@ -11,9 +11,7 @@ Basis: local checkout plus `node bin/patina.js --help` and `SKILL.md` reviewed o
 | `--exit-on <n>` | ✓ | — | CLI score-gate spelling for CI. |
 | `--ouroboros` | ✓ | ✓ | Iterative rewrite / score convergence loop. |
 | `--format <markdown\|text\|json>` | ✓ | — | CLI output-envelope feature. |
-| `--json` | ✓ | — | CLI alias for `--format json`; `patina doctor --json` also exists. |
 | `--quiet` | ✓ | — | CLI stderr log suppression for scripts. |
-| `--json-logs` | ✓ | — | CLI structured stderr logs for automation. |
 | `--batch` | ✓ | ✓ | Multi-file CLI/skill rewrite flow. |
 | `--in-place` | ✓ | ✓ | Batch-only write mode. |
 | `--suffix <ext>` | ✓ | ✓ | Batch-only alternate output naming. |
@@ -26,9 +24,8 @@ Basis: local checkout plus `node bin/patina.js --help` and `SKILL.md` reviewed o
 | `--api-key-file <path>` | ✓ | — | CLI auth. |
 | `--base-url <url>` | ✓ | — | CLI provider/backend config. |
 | `--backend <name[,name]>` | ✓ | — | CLI backend selection and explicit fallback chains (`openai-http`, `codex-cli`, `claude-cli`, `gemini-cli`). |
-| `--list-backends` | ✓ | — | CLI diagnostics. |
+| `--list-backends` | ✓ | — | CLI diagnostics with selectors and auth state. |
 | `--provider <name>` | ✓ | — | CLI provider preset. |
-| `--list-providers` | ✓ | — | CLI diagnostics. |
 | `--config <path>` | ✓ | — | CLI config override. |
 | `--allow-insecure-base-url` | ✓ | — | CLI network safety override. |
 | `--allow-private-base-url` | ✓ | — | CLI SSRF/metadata-address safety override. |

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -36,14 +36,38 @@ const REGISTRY = {
   'gemini-cli': geminiCli,
 };
 
+const BACKEND_META = {
+  'openai-http': {
+    kind: 'http',
+    selectWith: 'default, --backend openai-http, --provider <name>',
+  },
+  'codex-cli': {
+    kind: 'local-cli',
+    selectWith: '--backend codex-cli, --model codex-*',
+  },
+  'claude-cli': {
+    kind: 'local-cli',
+    selectWith: '--backend claude-cli, --model claude-*',
+  },
+  'gemini-cli': {
+    kind: 'local-cli',
+    selectWith: '--backend gemini-cli, --model gemini-*',
+  },
+};
+
 export function listBackends() {
   return Object.keys(REGISTRY).map((key) => {
     const b = REGISTRY[key];
+    const meta = BACKEND_META[key] || { kind: 'unknown', selectWith: `--backend ${key}` };
     return {
       name: key,
+      kind: meta.kind,
+      selectWith: meta.selectWith,
       available: b.isAvailable(),
       authenticated: b.isAuthenticated(),
       authHint: b.authHint(),
+      loginCommand: b.loginCommand || null,
+      installHint: b.installHint || null,
     };
   });
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,7 +9,7 @@ import {
 } from './loader.js';
 import { buildPrompt } from './prompt-builder.js';
 import { invokeBackendChain, selectBackendChain, listBackends, listBackendNames, resolveBackend } from './backends/index.js';
-import { selectProvider, resolveProviderConfig, PROVIDERS } from './providers.js';
+import { selectProvider, resolveProviderConfig } from './providers.js';
 import { validateBaseURL, applyInsecureBaseURLOptIn, applyPrivateBaseURLOptIn } from './security.js';
 import { formatOutput, validateScoreWeights, buildDeterministicAuditBackstop } from './output.js';
 import { runOuroboros } from './ouroboros.js';
@@ -17,7 +17,7 @@ import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals } from
 import { runDoctor } from './commands/doctor.js';
 import { runInit } from './commands/init.js';
 import { PatinaCliError, inputError, runtimeError, renderCliError, getExitCode } from './errors.js';
-import { inspectHttpApiKeySource, providerHttpKeyEnvVars, resolveHttpApiKey } from './auth.js';
+import { providerHttpKeyEnvVars, resolveHttpApiKey } from './auth.js';
 import { createLogger } from './logger.js';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, basename, extname } from 'node:path';
@@ -53,7 +53,7 @@ export async function main(args) {
   }
 
   const parsed = parseArgs(args);
-  const logger = createLogger({ quiet: parsed.quiet, json: parsed.jsonLogs });
+  const logger = createLogger({ quiet: parsed.quiet });
 
   if (parsed.help) {
     printHelp();
@@ -76,11 +76,6 @@ export async function main(args) {
 
   if (parsed.listBackends) {
     printBackendStatus();
-    return;
-  }
-
-  if (parsed.listProviders) {
-    printProviderStatus();
     return;
   }
 
@@ -369,14 +364,8 @@ function parseArgs(args) {
         parsed.format = value;
         break;
       }
-      case '--json':
-        parsed.format = 'json';
-        break;
       case '--quiet':
         parsed.quiet = true;
-        break;
-      case '--json-logs':
-        parsed.jsonLogs = true;
         break;
       case '--exit-on': {
         const value = readOptionValue(args, i, arg, { allowFlagLike: true });
@@ -434,9 +423,6 @@ function parseArgs(args) {
       case '--provider':
         parsed.provider = readOptionValue(args, i, arg);
         i++;
-        break;
-      case '--list-providers':
-        parsed.listProviders = true;
         break;
       case '--allow-insecure-base-url':
         parsed.allowInsecureBaseURL = true;
@@ -730,9 +716,7 @@ MODES
 
 OUTPUT & BATCH
   --format <fmt>          Output format: markdown (default), text, json
-  --json                  Alias for --format json
   --quiet                 Suppress patina status/warning logs on stderr
-  --json-logs             Emit stderr logs as NDJSON objects
   --batch                 Process multiple files
   --in-place              Overwrite original files (with --batch)
   --suffix <ext>          Save as {name}{ext}{extname}
@@ -758,9 +742,8 @@ MODEL & AUTH
   --base-url <url>        API base URL (or PATINA_API_BASE env)
   --backend <name[,name]> Backend or explicit fallback chain:
                           ${backendChoices} (default: openai-http)
-  --list-backends         List available backends and their availability
+  --list-backends         List backends, selectors, and auth status
   --provider <name>       Provider preset: openai, gemini, groq, together
-  --list-providers        List provider presets and which keys are set
 ADVANCED
   --config <path>         Load config from <path> instead of .patina.default.yaml
   --allow-insecure-base-url  Permit plaintext http:// to non-localhost endpoints
@@ -865,62 +848,42 @@ function printBackendStatus() {
   const list = listBackends();
   const rows = list.map((b) => ({
     name: b.name,
+    kind: b.kind,
+    selectWith: b.selectWith,
     available: b.available ? 'yes' : 'no',
     authenticated: b.authenticated ? 'yes' : 'no',
-    note: b.authenticated ? '' : b.authHint,
+    note: backendStatusNote(b),
   }));
   const widths = {
     name: Math.max('Backend'.length, ...rows.map((r) => r.name.length)),
+    kind: Math.max('Kind'.length, ...rows.map((r) => r.kind.length)),
+    selectWith: Math.max('Select with'.length, ...rows.map((r) => r.selectWith.length)),
     available: Math.max('Available'.length, ...rows.map((r) => r.available.length)),
     authenticated: Math.max('Authenticated'.length, ...rows.map((r) => r.authenticated.length)),
   };
   const pad = (s, w) => s + ' '.repeat(Math.max(0, w - s.length));
   console.log(
-    `${pad('Backend', widths.name)}  ${pad('Available', widths.available)}  ${pad('Authenticated', widths.authenticated)}  Notes`
+    `${pad('Backend', widths.name)}  ${pad('Kind', widths.kind)}  ${pad('Select with', widths.selectWith)}  ${pad('Available', widths.available)}  ${pad('Authenticated', widths.authenticated)}  Notes`
   );
   console.log(
-    `${'-'.repeat(widths.name)}  ${'-'.repeat(widths.available)}  ${'-'.repeat(widths.authenticated)}  -----`
+    `${'-'.repeat(widths.name)}  ${'-'.repeat(widths.kind)}  ${'-'.repeat(widths.selectWith)}  ${'-'.repeat(widths.available)}  ${'-'.repeat(widths.authenticated)}  -----`
   );
   for (const r of rows) {
     console.log(
-      `${pad(r.name, widths.name)}  ${pad(r.available, widths.available)}  ${pad(r.authenticated, widths.authenticated)}  ${r.note}`
+      `${pad(r.name, widths.name)}  ${pad(r.kind, widths.kind)}  ${pad(r.selectWith, widths.selectWith)}  ${pad(r.available, widths.available)}  ${pad(r.authenticated, widths.authenticated)}  ${r.note}`
     );
   }
 }
 
-function printProviderStatus() {
-  const rows = Object.values(PROVIDERS).map((p) => ({
-    name: p.name,
-    free: p.freeTier ? 'yes' : 'no',
-    keySource: providerKeySource(p),
-    providerEnv: process.env[p.apiKeyEnv] ? 'set' : 'missing',
-    note: `${p.apiKeyEnv} → ${p.baseURL}`,
-  }));
-  const widths = {
-    name: Math.max('Provider'.length, ...rows.map((r) => r.name.length)),
-    free: Math.max('Free tier'.length, ...rows.map((r) => r.free.length)),
-    keySource: Math.max('Key source'.length, ...rows.map((r) => r.keySource.length)),
-    providerEnv: Math.max('Provider env'.length, ...rows.map((r) => r.providerEnv.length)),
-  };
-  const pad = (s, w) => s + ' '.repeat(Math.max(0, w - s.length));
-  console.log(
-    `${pad('Provider', widths.name)}  ${pad('Free tier', widths.free)}  ${pad('Key source', widths.keySource)}  ${pad('Provider env', widths.providerEnv)}  Notes`
-  );
-  console.log(
-    `${'-'.repeat(widths.name)}  ${'-'.repeat(widths.free)}  ${'-'.repeat(widths.keySource)}  ${'-'.repeat(widths.providerEnv)}  -----`
-  );
-  for (const r of rows) {
-    console.log(
-      `${pad(r.name, widths.name)}  ${pad(r.free, widths.free)}  ${pad(r.keySource, widths.keySource)}  ${pad(r.providerEnv, widths.providerEnv)}  ${r.note}`
-    );
+function backendStatusNote(backend) {
+  if (!backend.available) return backend.installHint || backend.authHint;
+  if (backend.name === 'openai-http') return backend.authHint;
+  if (backend.authenticated && backend.name === 'gemini-cli' && backend.authHint.startsWith('Authenticated via ')) {
+    return backend.authHint;
   }
-}
-
-function providerKeySource(provider) {
-  const source = inspectHttpApiKeySource({
-    envVars: providerHttpKeyEnvVars(provider.apiKeyEnv),
-  });
-  return source.ok ? source.source : 'missing';
+  if (backend.authenticated) return 'ready';
+  if (backend.loginCommand) return `${backend.authHint} Use \`patina auth login ${backend.name}\` for the guided flow.`;
+  return backend.authHint;
 }
 
 async function handleAuth(subArgs) {

--- a/src/logger.js
+++ b/src/logger.js
@@ -7,23 +7,21 @@ const LEVELS = {
 };
 
 /**
- * Create a small stderr logger with text, JSON, and progress modes.
+ * Create a small stderr logger with text and progress modes.
  *
  * @param {object} [options] Logger options.
  * @param {string} [options.level=info] Minimum log level.
  * @param {boolean} [options.quiet=false] Suppress all log output.
- * @param {boolean} [options.json=false] Emit structured JSON records.
  * @param {NodeJS.WritableStream} [options.stream=process.stderr] Progress stream.
  * @returns {{debug: Function, info: Function, warn: Function, error: Function, progress: Function, closeProgress: Function, child: Function}} Logger facade.
  * @throws {Error} Propagates stream write errors from the configured output stream.
  * @example
- * const logger = createLogger({ json: true });
+ * const logger = createLogger();
  * logger.info('event', { message: 'ready' });
  */
 export function createLogger({
   level = process.env.PATINA_LOG_LEVEL || 'info',
   quiet = false,
-  json = false,
   stream = process.stderr,
 } = {}) {
   const threshold = quiet ? LEVELS.silent : (LEVELS[String(level).toLowerCase()] ?? LEVELS.info);
@@ -32,19 +30,11 @@ export function createLogger({
   const emit = (levelName, event, fields = {}) => {
     if (LEVELS[levelName] < threshold) return;
     closeProgress();
-    if (json) {
-      console.error(JSON.stringify(record(levelName, event, fields)));
-      return;
-    }
     if (fields.message) console.error(fields.message);
   };
 
-  const progress = (event, fields = {}) => {
+  const progress = (_event, fields = {}) => {
     if (LEVELS.info < threshold) return;
-    if (json) {
-      console.error(JSON.stringify(record('info', event, fields)));
-      return;
-    }
     if (!fields.message || !stream?.write) return;
     stream.write(`\r${fields.message}`);
     progressOpen = true;
@@ -63,23 +53,11 @@ export function createLogger({
     progress,
     closeProgress,
     child(extra = {}) {
-      return createLogger({ level, quiet, json, stream, ...extra });
+      return createLogger({ level, quiet, stream, ...extra });
     },
   };
 }
 
-function record(level, event, fields = {}) {
-  const { message, model = null, latency_ms = null, ...rest } = fields;
-  return {
-    ts: new Date().toISOString(),
-    level,
-    event,
-    model,
-    latency_ms,
-    ...(message ? { message } : {}),
-    ...rest,
-  };
-}
 
 /**
  * Default stderr logger used by simple callers.

--- a/src/providers.js
+++ b/src/providers.js
@@ -63,7 +63,7 @@ export function selectProvider(name) {
     throw inputError(
       `Unknown provider: ${name}`,
       `Available providers are: ${Object.keys(PROVIDERS).join(', ')}.`,
-      'Run `patina --list-providers` to inspect provider presets.'
+      'Run `patina --help` to see provider presets.'
     );
   }
   return provider;

--- a/tests/e2e/cli-adoption.test.js
+++ b/tests/e2e/cli-adoption.test.js
@@ -96,29 +96,22 @@ describe('CLI adoption commands', () => {
     }
   });
 
-  it('patina --list-providers shows the effective shared key source', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'patina-provider-key-file-'));
-    const keyFile = join(dir, 'key.txt');
-    writeFileSync(keyFile, 'file-key\n');
-    try {
-      await withEnv({
-        PATINA_API_KEY: undefined,
-        OPENAI_API_KEY: 'env-key',
-        GEMINI_API_KEY: undefined,
-        GROQ_API_KEY: undefined,
-        TOGETHER_API_KEY: undefined,
-        PATINA_API_KEY_FILE: keyFile,
-      }, async () => {
-        const { logs } = await captureConsole(() => main(['--list-providers']));
-        const output = logs.join('\n');
-        assert.match(output, /Key source/);
-        assert.match(output, /Provider env/);
-        assert.match(output, /PATINA_API_KEY_FILE/);
-        assert.match(output, /OPENAI_API_KEY/);
-      });
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+  it('patina --list-backends shows selectors and setup guidance', async () => {
+    await withEnv({
+      PATINA_API_KEY: 'test-key',
+      PATINA_API_KEY_FILE: undefined,
+      OPENAI_API_KEY: undefined,
+      GEMINI_API_KEY: 'gemini-key',
+    }, async () => {
+      const { logs } = await captureConsole(() => main(['--list-backends']));
+      const output = logs.join('\n');
+      assert.match(output, /Kind/);
+      assert.match(output, /Select with/);
+      assert.match(output, /default, --backend openai-http, --provider <name>/);
+      assert.match(output, /--model codex-\*/);
+      assert.match(output, /--model gemini-\*/);
+      assert.match(output, /PATINA_API_KEY/);
+    });
   });
 
   it('patina init --defaults writes a parseable project config', async () => {
@@ -150,7 +143,7 @@ describe('CLI adoption commands', () => {
 
 describe('CLI adoption exit/error behavior', () => {
   it('unknown flags fail before stdin handling with a usage exit', () => {
-    for (const flag of ['--bogus', '--gate', '--variants', '--save-run', '--cache', '--cache-ttl', '--no-cache', '--suspected-generator', '--prompt-mode']) {
+    for (const flag of ['--bogus', '--gate', '--json', '--json-logs', '--list-providers', '--variants', '--save-run', '--cache', '--cache-ttl', '--no-cache', '--suspected-generator', '--prompt-mode']) {
       const result = spawnSync(process.execPath, [BIN, flag], {
         cwd: REPO_ROOT,
         input: '',

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -291,7 +291,9 @@ describe('CLI End-to-End with Mock API', () => {
     assert.ok(help.includes('--exit-on <n>'), 'help should document score gate');
     assert.ok(help.includes('--format <fmt>'), 'help should document output format');
     assert.ok(help.includes('--quiet'), 'help should document quiet logs');
-    assert.ok(help.includes('--json-logs'), 'help should document structured stderr logs');
+    assert.ok(!help.includes('--json-logs'), 'help should not document removed structured stderr logs');
+    assert.ok(!help.includes('--list-providers'), 'help should not document removed provider listing');
+    assert.ok(!/\n\s*--json\s+Alias for --format json/.test(help), 'help should not document removed json alias');
     assert.ok(help.includes('--no-color'), 'help should document diff color opt-out');
     assert.ok(
       help.includes('openai-http, codex-cli, claude-cli, gemini-cli'),
@@ -413,39 +415,6 @@ describe('CLI End-to-End with Mock API', () => {
     await startMockServer('This is the humanized result.');
   });
 
-  it('should emit stderr logs as NDJSON with stable fields', async () => {
-    callCount = 0;
-    lastRequestBody = null;
-    await stopMockServer();
-    await startMockServer('{ "overall": 42, "interpretation": "mixed" }');
-
-    const oldExitCode = process.exitCode;
-    process.exitCode = undefined;
-    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
-    try {
-      const { errors } = await captureConsole(() => main([
-        '--lang', 'en',
-        '--score',
-        '--exit-on', '30',
-        '--json-logs',
-        '--api-key-file', mockApiKeyPath,
-        '--base-url', `http://127.0.0.1:${mockPort}`,
-        testFile,
-      ]));
-
-      assert.strictEqual(process.exitCode, 3);
-      const records = errors.map((line) => JSON.parse(line));
-      const gate = records.find((record) => record.event === 'score.gate_failed');
-      assert.ok(gate);
-      assert.strictEqual(gate.level, 'warn');
-      assert.strictEqual(gate.model, null);
-      assert.strictEqual(gate.latency_ms, null);
-    } finally {
-      process.exitCode = oldExitCode;
-    }
-    await stopMockServer();
-    await startMockServer('This is the humanized result.');
-  });
 
   it('should accept --exit-on as the CI score gate', async () => {
     callCount = 0;

--- a/tests/unit/logger.test.js
+++ b/tests/unit/logger.test.js
@@ -31,21 +31,3 @@ test('logger respects quiet and PATINA_LOG_LEVEL', () => {
     else process.env.PATINA_LOG_LEVEL = previous;
   }
 });
-
-test('logger emits NDJSON records with stable fields', () => {
-  const lines = captureConsoleError(() => {
-    const logger = createLogger({ json: true });
-    logger.info('rewrite.complete', {
-      message: '[patina] rewrite complete',
-      model: 'claude',
-      latency_ms: 1234,
-    });
-  });
-
-  assert.equal(lines.length, 1);
-  const record = JSON.parse(lines[0]);
-  assert.equal(record.level, 'info');
-  assert.equal(record.event, 'rewrite.complete');
-  assert.equal(record.model, 'claude');
-  assert.equal(record.latency_ms, 1234);
-});


### PR DESCRIPTION
## Summary
- remove the main CLI `--json` alias, `--json-logs`, and `--list-providers`
- keep `--list-backends` and expand it with selector hints plus clearer auth/setup notes
- simplify the stderr logger to text/progress mode only and update docs/tests

## Verification
- node bin/patina.js --list-backends
- node bin/patina.js --help
- node bin/patina.js --json
- node bin/patina.js --json-logs
- node bin/patina.js --list-providers
- node scripts/precommit-score.mjs --score-threshold 30 README.md
- node scripts/badge-json.mjs --score-threshold 30 README.md
- npm run docs:api
- npm run lint
- npm test
- npm run release:check