### PR TITLE
Polish localized README copy

### DIFF
--- a/README_JA.md
+++ b/README_JA.md
@@ -16,50 +16,50 @@
   <a href="https://patina.vibetip.help/"><b>自分の文章で試す — インストール不要</b></a>
 </p>
 
-> **AI の装飾だけを剥がし、意味はそのまま。**
+> **AIっぽさだけを落として、意味はそのまま。**
 
-patina は、韓国語・英語・中国語・日本語の文章から AI っぽさの強いパターンを見つけ、意味を変えずに書き換えます。[Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex CLI](https://github.com/openai/codex)、[Cursor](https://cursor.sh)、OpenCode 向けのスキルとして使うことも、スタンドアロン Node.js CLI として実行することもできます。
+patina は、日本語・韓国語・英語・中国語の文章から AI っぽく見える表現を見つけ、主張・数値・極性・因果関係を変えずに整えます。[Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex CLI](https://github.com/openai/codex)、[Cursor](https://cursor.sh)、OpenCode 向けのスキルとして使うことも、単体の Node.js CLI として実行することもできます。
 
-中身の見えないブラックボックス型の書き換えツールでも、AI 検出器を回避するためのツールでもありません。patina は **明確なパターンベースで監査可能**で、何をなぜ変更したか、原文の主張が保たれているかを示します。`codex`、`claude`、`gemini` CLI のいずれかにログイン済みなら、API キーなしでも使えます。
+中身の見えない言い換えツールでも、AI 検出器を避けるためのツールでもありません。patina は **明確なパターンベースで監査可能**です。何をなぜ変更したか、原文の主張が保たれているかを示します。`codex`、`claude`、`gemini` CLI のいずれかにログイン済みなら、API キーなしでも使えます。
 
 ## デモ
 
-**修正前** *(AI 風の文章；現在の GIF が使う英語 fixture)*：
+**修正前** *(AI 風の文章；現在の GIF はこの英語サンプルを使用)*：
 > The newly released Notion template pack is an **innovative solution** designed to **transform productivity** for modern teams. It offers 30 templates optimized for diverse workflows, with a user-friendly design that enables anyone to leverage them effortlessly. This product introduces a **new paradigm** for maximizing work efficiency.
 
-**修正後** *(`/patina --lang en --tone marketing` — 同じ事実、AI 装飾のみ除去)*：
+**修正後** *(`/patina --lang en --tone marketing` — 事実はそのまま、AIっぽさだけを除去)*：
 > If Notion still starts as a blank page for your team, open this pack first. It includes 30 templates for common workflows. Duplicate one, adjust the fields you need, and use it for a team project or your own planning without starting from scratch.
 
-> **Score = 0.0%** · 30 個のテンプレート ✓ · workflow fit ✓ · コピー後に調整して使えること ✓
+> **Score = 0.0%** · 30 個のテンプレート ✓ · ワークフローに合う ✓ · コピー後に調整して使える ✓
 
-**その他のデモ片**
+**ほかの例**
 
-| 入力タイプ | 取り除く AI 装飾 | 保つ意味 |
+| 入力タイプ | 落とす AI っぽさ | 保つ内容 |
 |---|---|---|
-| 韓国語マーケティング | “혁신적인 솔루션”, “새로운 패러다임” | Notion テンプレート 30 個、workflow fit、コピー後に編集して使うこと |
+| 韓国語マーケティング | “혁신적인 솔루션”, “새로운 패러다임” | Notion テンプレート 30 個、ワークフローに合う、コピー後に編集して使える |
 | 学術文体 | “획기적인 성과”, 広すぎる意義づけ | GitHub プロジェクト 60 個、72h→10m のセットアップ時間、p<0.01、限界の明記 |
-| 技術文書 | “핵심적인 역할”, 未来標準 hype | GPU 管理、one-command provisioning、5× 結果の caveat |
+| 技術文書 | “핵심적인 역할”, 未来標準のような誇張 | GPU 管理、1 コマンドでの準備、5× 結果の注意点 |
 
 ## ブラウザで試す — インストール不要
 
-**[patina.vibetip.help](https://patina.vibetip.help/)** で、KO / EN / ZH / JA 段落の AI ライティングパターンをブラウザ内で確認できます。
+**[patina.vibetip.help](https://patina.vibetip.help/)** で、KO / EN / ZH / JA 段落の AI っぽい書き方のサインをブラウザ内で確認できます。
 
-> **検出専用です。** playground は、決定的な文体統計分析だけをユーザーのブラウザ内で実行します。テキストを書き換えず、外部 LLM を呼び出さず、API キーをサーバーへ送信しません。実際に rewrite したい場合は、下の CLI または skill を使ってください。
+> **検出専用です。** playground は、決定的な文体統計分析だけをユーザーのブラウザ内で実行します。テキストを書き換えず、外部 LLM を呼び出さず、API キーをサーバーへ送りません。実際に書き換えたい場合は、下の CLI または skill を使ってください。
 
-完全な rewrite の流れは [30 秒ターミナルデモ](docs/DEMO.md) で確認できます。その他の例は [Before/After Gallery](docs/EXAMPLES.md)（[한국어](docs/EXAMPLES_KR.md)）にあります。
+書き換えの流れは [30 秒ターミナルデモ](docs/DEMO.md) で確認できます。その他の例は [Before/After Gallery](docs/EXAMPLES.md)（[한국어](docs/EXAMPLES_KR.md)）にあります。
 ブランドリソース: [logo](assets/brand/patina-logo.svg)、[mark](assets/brand/patina-mark.svg)、[icon](assets/brand/patina-icon.svg)、[social preview](assets/social/patina-og.svg)、[before/after card](assets/social/patina-before-after.svg)。利用ガイドラインは [BRANDING.md](docs/BRANDING.md) を参照してください。
 
 ## 概要
 
 |  |  |
 |---|---|
-| **168 パターン** | 各言語 33 個の rewrite-capable パターン + 9 個のスコア専用 viral-hook（KO/EN/ZH/JA 各 42 個） — [PATTERNS.md](docs/PATTERNS.md) |
-| **編集ホットスポット再現率** | 2026-05-22 modern-model rebaseline: GPT-5.5 / Claude Sonnet 4.6 / Gemini 2.5 Pro で全体 catch 67.3% [63.5–71.0%]（n=600、韓国語+英語） |
+| **168 パターン** | 各言語 33 個の書き換え可能パターン + 9 個のスコア専用 viral-hook（KO/EN/ZH/JA 各 42 個） — [PATTERNS.md](docs/PATTERNS.md) |
+| **編集ホットスポット再現率** | 2026-05-22 modern-model rebaseline: GPT-5.5 / Claude Sonnet 4.6 / Gemini 2.5 Pro で全体の検出率 67.3% [63.5–71.0%]（n=600、韓国語+英語） |
 | **ベンチマークレポート** | 再現可能な ko/en/zh/ja suspect-zone benchmark: [overview](docs/benchmarks/README.md) · [latest.md](docs/benchmarks/latest.md) · [latest.json](docs/benchmarks/latest.json) · [2026 rebaseline](docs/benchmarks/rebaseline-latest.md) · [detector comparison](docs/benchmarks/detector-comparison.md) |
-| **誤検出率** | 2026-05-22 KO+EN human controls で 16.0% [11.6–21.7%]（n=200）。レジスター別の境界は [stylometry.md](core/stylometry.md) に記録 — [誤検出を報告](https://github.com/devswha/patina/issues/new?template=false_positive.yml) |
+| **誤検出率** | 2026-05-22 KO+EN の人間文章コントロールで 16.0% [11.6–21.7%]（n=200）。レジスター別の境界は [stylometry.md](core/stylometry.md) に記録 — [誤検出を報告](https://github.com/devswha/patina/issues/new?template=false_positive.yml) |
 | **モード** | rewrite · audit · score · diff · ouroboros |
-| **無料利用** | 可能 — ログイン済みの `codex`、`claude`、`gemini` CLI 経由 (API キー不要) |
-| **決定性** | スコアリング式は決定的、LLM の severity 判定段階に ±8–10pt の変動 ([scoring.md §8](core/scoring.md)) |
+| **無料利用** | ログイン済みの `codex`、`claude`、`gemini` CLI 経由で利用可能 (API キー不要) |
+| **決定性** | スコアリング式は決定的。LLM の severity 判定段階には ±8–10pt の変動があります ([scoring.md §8](core/scoring.md)) |
 | **ライセンス** | MIT |
 
 ## クイックスタート
@@ -70,7 +70,7 @@ patina は、韓国語・英語・中国語・日本語の文章から AI っぽ
 curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
 ```
 
-インストーラは Claude Code、[Codex CLI](https://github.com/openai/codex)、Cursor、OpenCode に一括で接続します。checkout 前に repository HEAD を具体的な commit に解決します。完全に固定したインストールが必要な場合は `PATINA_REF=<tag-or-full-sha>` を設定してください。続いて：
+インストーラは Claude Code、[Codex CLI](https://github.com/openai/codex)、Cursor、OpenCode に patina をまとめて接続します。インストール時に remote HEAD を具体的な commit に固定します。特定のバージョンに固定したい場合は `PATINA_REF=<tag-or-full-sha>` を設定してください。続いて：
 
 ```
 /patina --lang ja
@@ -86,7 +86,7 @@ curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | ba
 [ここにエッセイの下書きを貼り付け]
 ```
 
-最適なトーンを自動検出：
+適したトーンを自動選択：
 
 ```
 /patina --tone auto --lang en
@@ -94,7 +94,7 @@ curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | ba
 [ここにテキストを貼り付け]
 ```
 
-> 注意：v1 では `--tone`（`auto` 含む）は ko/en のみ対応。zh/ja では警告を出して profile-only モードにフォールバックします。
+> 注意：v1 では `--tone`（`auto` 含む）は ko/en のみ対応。zh/ja では警告を出し、profile-only モードにフォールバックします。
 
 ### スタンドアロン CLI として
 
@@ -105,7 +105,7 @@ npx patina-cli doctor
 npx patina-cli --lang ja input.txt
 ```
 
-リポジトリを直接触って試す場合：
+リポジトリを手元で編集しながら試す場合：
 
 ```bash
 git clone https://github.com/devswha/patina.git
@@ -113,18 +113,18 @@ cd patina && npm install && npm link
 patina --lang ja input.txt
 ```
 
-link 後に stdin でも試せます:
+`npm link` 後に stdin でも試せます:
 
 ```bash
 printf '%s\n' 'コーヒーは、世界中の社会的交流を根本的に変えた重要な文化現象として浮上しました。' \
   | patina --lang ja --backend codex-cli
 ```
 
-> 🆓 **API キー不要** — [`codex`](https://github.com/openai/codex)、[`claude`](https://docs.anthropic.com/en/docs/claude-code)、[`gemini`](https://github.com/google-gemini/gemini-cli) のいずれか CLI にログイン済みであれば OK。`--backend codex-cli | claude-cli | gemini-cli` で直接選ぶか、`--backend claude-cli,codex-cli` のように明示的な fallback chain を指定するか、モデル名ヒューリスティックに任せることもできます（`--model claude-*` → claude-cli など）。`--model` を省略すると、backend ごとの最上位デフォルトモデル（`gpt-5.5`、`claude-sonnet-4-6`、`gemini-2.5-pro`）を渡します。全バックエンドは [AUTHENTICATION.md](docs/AUTHENTICATION.md) を参照。
+> 🆓 **API キー不要** — [`codex`](https://github.com/openai/codex)、[`claude`](https://docs.anthropic.com/en/docs/claude-code)、[`gemini`](https://github.com/google-gemini/gemini-cli) のいずれか CLI にログイン済みであれば使えます。`--backend codex-cli | claude-cli | gemini-cli` で直接選ぶか、`--backend claude-cli,codex-cli` のように明示的なフォールバック順を指定できます。モデル名で自動ルーティングすることもできます（`--model claude-*` → claude-cli など）。`--model` を省略すると、backend ごとのデフォルトモデル（`gpt-5.5`、`claude-sonnet-4-6`、`gemini-2.5-pro`）を渡します。全バックエンドは [AUTHENTICATION.md](docs/AUTHENTICATION.md) を参照してください。
 
 ### CI 連携
 
-Patina には、live model key なしで使える deterministic な prose review CI チェックもあります:
+Patina には、live model key なしで使える決定的な CI 文書チェックもあります:
 
 ```yaml
 # .github/workflows/patina.yml
@@ -165,7 +165,7 @@ Pre-commit、Husky、Lefthook、Docker、release workflow のメモは [docs/int
 
 ## 正しい使用目的
 
-Patina は、著者が AI 支援で下書きを作ってよい場面で、その下書きを編集し、どこをなぜ変えたかを確認しながら、文体をより自然に整えるためのツールです。テキストが「もともと人間によって書かれた」ことを保証するものではなく、学業上の honor-code 回避、出版社 disclosure の迂回、盗用の洗浄、detector-bypass 主張に使うべきではありません。スコアは誤検出と見逃しを含む編集シグナルであり、著者判定の根拠ではありません。[ETHICS.md](docs/ETHICS.md) を参照してください。
+Patina は、著者が AI 支援で下書きを作ってよい場面で、その下書きを整えるためのツールです。どこをなぜ変えたかを確認しながら、意味を保ったまま文体を自然にします。テキストが「もともと人間によって書かれた」ことを保証するものではなく、学業上の honor code 回避、出版社 disclosure の迂回、盗用の洗浄、detector-bypass 主張に使うべきではありません。スコアは誤検出と見逃しを含む編集シグナルであり、著者判定の根拠ではありません。[ETHICS.md](docs/ETHICS.md) を参照してください。
 
 ## モード
 
@@ -188,33 +188,33 @@ patina --lang <ko|en|zh|ja> [モード] [--profile <名前>] input.txt
 | `--format json\|text\|markdown` | JSON、プレーンテキスト、デフォルト Markdown 出力を選択 |
 | `--quiet` | stderr の状態・警告・進捗ログを抑制 |
 
-全オプションは `patina --help` を参照してください。`patina doctor --json` は LLM 呼び出しなしで Node/backend/tmux/API-key の準備状況を確認します。プロジェクト設定は任意なので、単発実行ではフラグを使い、固定のデフォルトが必要な場合だけ `.patina.yaml` を追加してください。
+全オプションは `patina --help` を参照してください。`patina doctor --json` は LLM 呼び出しなしで Node/backend/tmux/API-key の準備状況を確認します。プロジェクト設定は任意です。単発実行ではフラグを使い、固定のデフォルトが必要な場合だけ `.patina.yaml` を追加してください。
 
-Markdown 中心の開発ワークフローには、開発者向け profile shortcut もあります。`code-comment` は inline comments/docstrings を締め、`commit-message` は Git 履歴テキストを意図と検証中心に整え、`release-notes` は changelog bullets をユーザー影響と移行リスクが見えるリリースノートに変えます。`namuwiki` は韓国語専用の wiki 風 profile で、NamuWiki の記事本文をコピーしない license-safe なオリジナルガイドだけを含みます。
+Markdown 中心の開発ワークフローには、開発者向け profile もあります。`code-comment` は inline comments/docstrings を引き締め、`commit-message` は Git 履歴テキストを意図と検証が伝わる形に整えます。`release-notes` は changelog bullets をユーザー影響と移行リスクが見えるリリースノートに変えます。`namuwiki` は韓国語専用の wiki 風 profile で、NamuWiki の記事本文をコピーしない license-safe なオリジナルガイドだけを含みます。
 
 ### スコア専用パターン
 
-`--score`と`--audit`は`--rewrite`より少し広い範囲のシグナルを測定します。viral-hook パック（`ko/en/zh/ja-viral-hook`、各9パターン: 数字ショックフック、クリックベイト末尾、出典を飛ばした権威主張、息継ぎに最適化された短文の積み重ね、誇張されたエンゲージメント語彙、偽統計引用、肩書き積み上げ、未来の自分への約束、警句的パンチライン）は**検出専用**です。
+`--score` と `--audit` は、`--rewrite` より少し広い範囲のシグナルを測定します。viral-hook パック（`ko/en/zh/ja-viral-hook`、各9パターン: 数字ショックフック、クリックベイト末尾、出典を飛ばした権威主張、息継ぎに最適化された短文の積み重ね、誇張されたエンゲージメント語彙、偽統計引用、肩書き積み上げ、未来の自分への約束、警句的パンチライン）は**検出専用**です。
 
-これらのシグナルはスコアと監査にだけ現れ、4言語のSNSマーケティングコピーに対するユーザーの直感とベンチマークを揃えるために使います。`--rewrite`/`--diff`/`--ouroboros` は、意図的な修辞であることが多いので対象外です。実例: [`examples/viral-hook/`](examples/viral-hook/).
+これらのシグナルはスコアと監査にだけ現れ、4言語の SNS マーケティングコピーに対するユーザーの直感とベンチマークを揃えるために使います。`--rewrite`/`--diff`/`--ouroboros` は、意図的な修辞であることが多いので対象外です。実例: [`examples/viral-hook/`](examples/viral-hook/)。
 
 ### 短文スコアリング補正 (v3.11)
 
-入力が200文字以下、または3段落以下の場合、register に敏感なカテゴリ（`language`、`style`、`viral-hook`）へ 1.5 倍の severity multiplier を適用し、単一段落の声色変化もスコアに反映されるようにします。case-04 では、長文向けの式がこれらを過小評価していたことが確認されました。
+入力が200文字以下、または3段落以下の場合、文体に敏感なカテゴリ（`language`、`style`、`viral-hook`）へ 1.5 倍の重みを適用し、単一段落の声色変化もスコアに反映されるようにします。case-04 では、長文向けの式がこれらを過小評価していたことが確認されました。
 
 ### セルフ監査の分離 (v3.11)
 
-rewrite モードでは、モデルは `[BODY]`/`[/BODY]` ブロックを囲む `[SELF_AUDIT]`/`[/SELF_AUDIT]` タグの中にセルフ監査メモを出力します。patina はユーザーに表示する前に監査部分を取り除くため、出力はクリーンです — 以前のバージョンでは "남아 있는 AI 티" や "Phase 3" のような前置きがユーザー向けテキストに漏れることがありました。
+rewrite モードでは、モデルは `[BODY]`/`[/BODY]` ブロックを囲む `[SELF_AUDIT]`/`[/SELF_AUDIT]` タグの中にセルフ監査メモを出力します。patina はユーザーに表示する前に監査部分を取り除くため、出力はクリーンです。以前のバージョンでは "남아 있는 AI 티" や "Phase 3" のような前置きがユーザー向けテキストに漏れることがありました。
 
-### Machine-readable output and exit codes
+### 機械可読出力と終了コード
 
-`--format json` は、すべてのモードを `overall`、`categories[]`、`tone`、`mps`、`gateResult`、クリーンな `output` 本文を含む安定した envelope で包みます。`--quiet` は stdout だけ欲しいスクリプトのために状態・警告・進捗ログを隠します。`--format markdown` がデフォルトで、`--format text` は YAML tone footer なしのユーザー向け本文だけを保持します。終了コードは [EXIT-CODES.md](docs/EXIT-CODES.md) にまとまっています: `0` success、`1` runtime/backend、`2` input/usage、`3` score gate exceeded。
+`--format json` は、すべてのモードを `overall`、`categories[]`、`tone`、`mps`、`gateResult`、クリーンな `output` 本文を含む安定した JSON envelope で包みます。`--quiet` は stdout だけ欲しいスクリプトのために状態・警告・進捗ログを隠します。`--format markdown` がデフォルトで、`--format text` は YAML tone footer なしのユーザー向け本文だけを残します。終了コードは [EXIT-CODES.md](docs/EXIT-CODES.md) にまとまっています: `0` success、`1` runtime/backend、`2` input/usage、`3` score gate exceeded。
 
 ### スコア重みドリフト検出 (v3.11)
 
-`--score` 実行時は、モデルが出力した Weight 列を設定の `category-weights` と照合します。モデルが存在しないカテゴリ（例: `discord`）を作ったり、別の数値に置き換えたりした場合、stderr に `[patina]` 警告が出ます — これは観測用であり、weight check 自体はスコアを変更しません。`src/features/*` からの deterministic shadow score も記録され、LLM スコアと 20 点以上ずれた場合は警告し、gate には悲観的な方の値を使います。
+`--score` 実行時は、モデルが出力した Weight 列を設定の `category-weights` と照合します。モデルが存在しないカテゴリ（例: `discord`）を作ったり、別の数値に置き換えたりした場合、stderr に `[patina]` 警告が出ます。これは観測用であり、weight check 自体はスコアを変更しません。`src/features/*` からの deterministic shadow score も記録され、LLM スコアと 20 点以上ずれた場合は警告し、gate には保守的な方の値を使います。
 
-`--voice-sample <path>` または config の `voice-sample: <path>` を使うと、自分が書いた 1〜3 段落を rewrite のアンカーにできます。Profile と tone は引き続き目標 register を決め、sample は cadence、specificity、POV、sentence texture だけを教えます。prompt は sample facts の取り込みを明示的に禁止します。
+`--voice-sample <path>` または config の `voice-sample: <path>` を使うと、自分が書いた 1〜3 段落を rewrite のアンカーにできます。Profile と tone は引き続き目標 register を決め、sample はリズム、具体性、視点、文の質感だけを参照します。prompt は sample facts の取り込みを明示的に禁止します。
 
 ## トーン
 
@@ -229,7 +229,7 @@ rewrite モードでは、モデルは `[BODY]`/`[/BODY]` ブロックを囲む 
 | `marketing` | 広告コピー、ランディングページ、製品告知 | 短くインパクトのある文、説得力、CTA 親和 |
 | `instructional` | チュートリアル、ハウツー、技術ドキュメント | 命令形動詞、番号付き構造、推測表現を抑制 |
 
-`--tone auto` はヒューリスティック（語彙 + 構造シグナル）で最適なトーンを自動選択します。zh/ja では `auto` を含む全トーン指定時に警告を出して profile-only モードにフォールバックします — Phase 4.5b ヒューリスティックは ko/en のみ対応のためです。
+`--tone auto` はヒューリスティック（語彙 + 構造シグナル）で最適なトーンを自動選択します。zh/ja では `auto` を含む全トーン指定時に警告を出して profile-only モードにフォールバックします。Phase 4.5b ヒューリスティックは ko/en のみ対応のためです。
 
 ## 仕組み
 
@@ -246,9 +246,9 @@ rewrite モードでは、モデルは `[BODY]`/`[/BODY]` ブロックを囲む 
 自然なテキスト（意味検証済み）
 ```
 
-各検証ステップで意味が損なわれた場合、変更は再試行またはロールバックされます。
+各検証ステップで意味のずれが見つかった場合、patina は再試行またはロールバックします。
 
-**キャリブレーション** *(2026-05-22 modern-model rebaseline；方法論は [2026-rebaseline.md](docs/research/2026-rebaseline.md))*：GPT-5.5、Claude Sonnet 4.6、Gemini 2.5 Pro CLI サンプルで、決定的な編集ホットスポット catch は 67.3% [63.5–71.0%]（n=600、韓国語+英語）。人間文章コントロールの誤検出は 16.0% [11.6–21.7%]（n=200）。言語×モデル別の結果は [rebaseline-latest.md](docs/benchmarks/rebaseline-latest.md) に記載しています。これは編集シグナルであり、作者判定や検出回避の約束ではありません。
+**キャリブレーション** *(2026-05-22 modern-model rebaseline；方法論は [2026-rebaseline.md](docs/research/2026-rebaseline.md))*：GPT-5.5、Claude Sonnet 4.6、Gemini 2.5 Pro CLI サンプルで、決定的な編集ホットスポット catch は 67.3% [63.5–71.0%]（n=600、韓国語+英語）。人間文章コントロールの誤検出は 16.0% [11.6–21.7%]（n=200）。言語×モデル別の結果は [rebaseline-latest.md](docs/benchmarks/rebaseline-latest.md) に記載しています。これは編集シグナルであり、作者判定でも検出回避の約束でもありません。
 
 ## 設定
 
@@ -261,7 +261,7 @@ output: rewrite           # rewrite | diff | audit | score
 tone:                     # casual | professional | academic | narrative | marketing | instructional | auto
 ```
 
-パターンパックは言語プレフィックスで自動検出されます。作業ディレクトリの `.patina.yaml` がデフォルトを上書きします。検出を拡張するリストキー（`blocklist`、`allowlist`、`skip-patterns`）は default/global/project 設定の間で追加的にマージされ、その他の配列キーは意図した値をそのまま選べるように置き換えられます。
+パターンパックは言語プレフィックスで自動検出されます。作業ディレクトリの `.patina.yaml` がデフォルトを上書きします。検出を拡張するリストキー（`blocklist`、`allowlist`、`skip-patterns`）は default/global/project 設定の間で追加マージされ、その他の配列キーは指定した値で置き換えられます。
 
 ## ドキュメント
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -18,13 +18,13 @@
 
 > **AI 포장만 벗기고, 의미는 그대로.**
 
-patina는 한국어·영어·중국어·일본어 글에서 AI 냄새가 나는 패턴을 찾아, 원래 주장·수치·극성·인과관계를 건드리지 않고 다듬습니다. [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), [Cursor](https://cursor.sh), OpenCode 용 스킬로 쓰거나 독립형 Node.js CLI 로 실행할 수 있습니다.
+patina는 한국어·영어·중국어·일본어 글에서 AI가 쓴 듯한 표현을 찾아냅니다. 원래의 주장·수치·극성·인과관계는 유지한 채 문장만 다듬습니다. [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), [Cursor](https://cursor.sh), OpenCode 스킬로 쓰거나 독립형 Node.js CLI로 실행할 수 있습니다.
 
-블랙박스형 재작성 도구도, AI 탐지기 우회 도구도 아닙니다. patina는 **명확한 패턴 기반**으로 작동하며, 무엇을 왜 바꿨는지와 원문의 주장이 보존됐는지를 투명하게 보여줍니다. `codex`, `claude`, `gemini` CLI 중 하나가 로그인되어 있으면 API 키 없이도 쓸 수 있습니다.
+막연히 말을 바꾸는 블랙박스형 도구도, AI 탐지기를 우회하기 위한 도구도 아닙니다. patina는 **명확한 패턴 기반**으로 작동하며, 무엇을 왜 바꿨는지와 원문의 주장이 보존됐는지를 보여줍니다. `codex`, `claude`, `gemini` CLI 중 하나에 로그인되어 있으면 API 키 없이도 쓸 수 있습니다.
 
 ## 데모
 
-**수정 전** *(AI스러운 글; GIF가 쓰는 동일 fixture)*:
+**수정 전** *(AI스러운 글; GIF와 같은 예시)*:
 > 새롭게 출시된 노션 템플릿 팩은 생산성 향상을 위한 **혁신적인 솔루션**입니다. 다양한 워크플로우에 최적화된 30개의 템플릿을 제공하며, 사용자 친화적인 디자인으로 누구나 손쉽게 활용 가능합니다. 본 제품은 업무 효율성을 극대화하는 **새로운 패러다임**을 제시합니다.
 
 **수정 후** *(`/patina --lang ko --tone marketing` — 같은 내용, AI 포장만 제거)*:
@@ -32,34 +32,34 @@ patina는 한국어·영어·중국어·일본어 글에서 AI 냄새가 나는 
 
 > **Score = 0.0%** · 템플릿 30개 ✓ · 워크플로우 적합성 ✓ · 복제 후 수정 사용 ✓
 
-**더 많은 데모 조각**
+**다른 예시**
 
 | 입력 유형 | 제거되는 AI 포장 | 보존되는 의미 |
 |---|---|---|
-| 한국어 마케팅 | “혁신적인 솔루션”, “새로운 패러다임” | 노션 템플릿 30개, workflow fit, 복사 후 수정 사용 |
+| 한국어 마케팅 | “혁신적인 솔루션”, “새로운 패러다임” | 노션 템플릿 30개, 업무 흐름에 맞음, 복제 후 수정해서 사용 |
 | 학술 문체 | “획기적인 성과”, 넓은 의의 주장 | GitHub 프로젝트 60개, 72h→10m 설정 시간, p<0.01, 한계 명시 |
-| 기술 문서 | “핵심적인 역할”, 미래 표준 hype | GPU 관리, one-command provisioning, 5× 결과 caveat |
+| 기술 문서 | “핵심적인 역할”, 미래 표준식 과장 | GPU 관리, 명령 한 번으로 준비, 5× 결과의 주의점 |
 
 ## 브라우저에서 바로 보기 — 설치 없음
 
-**[patina.vibetip.help](https://patina.vibetip.help/)** 에서 KO / EN / ZH / JA 문단의 AI 글쓰기 패턴을 브라우저 안에서 바로 점검할 수 있습니다.
+**[patina.vibetip.help](https://patina.vibetip.help/)** 에서 KO / EN / ZH / JA 문단의 AI스러운 글쓰기 패턴을 브라우저 안에서 바로 점검할 수 있습니다.
 
-> **탐지 전용입니다.** playground는 정해진 문체 통계 분석만 사용자 브라우저 안에서 실행합니다. 텍스트를 재작성하지 않고, 외부 LLM을 호출하지 않으며, API 키를 서버로 보내지 않습니다. 실제 rewrite가 필요하면 아래 CLI나 스킬을 사용하세요.
+> **탐지 전용입니다.** playground는 정해진 문체 통계 분석만 사용자 브라우저에서 실행합니다. 텍스트를 다시 쓰지 않고, 외부 LLM을 호출하지 않으며, API 키를 서버로 보내지 않습니다. 실제 재작성이 필요하면 아래 CLI나 스킬을 사용하세요.
 
-전체 rewrite 흐름은 [30초 터미널 데모](docs/DEMO.md)에서 볼 수 있습니다. 더 많은 예시는 [Before/After Gallery](docs/EXAMPLES_KR.md) ([English](docs/EXAMPLES.md))에 있습니다.
+전체 재작성 흐름은 [30초 터미널 데모](docs/DEMO.md)에서 볼 수 있습니다. 더 많은 예시는 [Before/After Gallery](docs/EXAMPLES_KR.md) ([English](docs/EXAMPLES.md))에 있습니다.
 브랜드 리소스: [로고](assets/brand/patina-logo.svg), [마크](assets/brand/patina-mark.svg), [아이콘](assets/brand/patina-icon.svg), [소셜 프리뷰](assets/social/patina-og.svg), [before/after 카드](assets/social/patina-before-after.svg). 사용 가이드라인은 [BRANDING.md](docs/BRANDING.md)를 참고하세요.
 
 ## 한눈에 보기
 
 |  |  |
 |---|---|
-| **168개 패턴** | 언어별 33개 rewrite 가능 패턴 + 9개 스코어 전용 viral-hook (KO/EN/ZH/JA 각각 42개) — [PATTERNS.md](docs/PATTERNS.md) |
-| **편집 핫스팟 재현율** | 2026-05-22 최신 모델 리베이스라인: GPT-5.5 / Claude Sonnet 4.6 / Gemini 2.5 Pro 기준 전체 catch 67.3% [63.5–71.0%] (n=600, KO+EN) |
+| **168개 패턴** | 언어별 33개 재작성 패턴 + 9개 스코어 전용 바이럴 훅 패턴(KO/EN/ZH/JA 각각 42개) — [PATTERNS.md](docs/PATTERNS.md) |
+| **편집 핫스팟 재현율** | 2026-05-22 최신 모델 리베이스라인: GPT-5.5 / Claude Sonnet 4.6 / Gemini 2.5 Pro 기준 전체 탐지율 67.3% [63.5–71.0%] (n=600, KO+EN) |
 | **벤치마크 리포트** | 재현 가능한 ko/en/zh/ja 의심 구간 벤치마크: [overview](docs/benchmarks/README.md) · [latest.md](docs/benchmarks/latest.md) · [latest.json](docs/benchmarks/latest.json) · [2026 rebaseline](docs/benchmarks/rebaseline-latest.md) · [detector comparison](docs/benchmarks/detector-comparison.md) |
-| **오탐율** | 2026-05-22 KO+EN 사람 글 컨트롤에서 16.0% [11.6–21.7%] (n=200); register별 경계는 [stylometry.md](core/stylometry.md)에 문서화 — [오탐 제보](https://github.com/devswha/patina/issues/new?template=false_positive.yml) |
-| **모드** | rewrite · audit · score · diff · ouroboros |
-| **무료 사용** | 가능 — 로그인된 `codex`, `claude`, `gemini` CLI 중 하나로 API 키 없이 실행 |
-| **결정성** | 스코어링 공식은 결정적이지만 LLM severity 부여 단계는 ±8–10pt 변동 ([scoring.md §8](core/scoring.md)) |
+| **오탐율** | 2026-05-22 KO+EN 사람 글 컨트롤에서 16.0% [11.6–21.7%] (n=200). 문체별 경계는 [stylometry.md](core/stylometry.md)에 문서화되어 있습니다 — [오탐 제보](https://github.com/devswha/patina/issues/new?template=false_positive.yml) |
+| **모드** | 재작성 · 탐지 · 점수 · diff · ouroboros |
+| **무료 사용** | 로그인된 `codex`, `claude`, `gemini` CLI 중 하나로 API 키 없이 실행 |
+| **결정성** | 스코어링 공식은 결정적이지만 LLM severity 판정 단계에는 ±8–10pt 변동이 있습니다 ([scoring.md §8](core/scoring.md)) |
 | **라이선스** | MIT |
 
 ## 빠른 시작
@@ -70,7 +70,7 @@ patina는 한국어·영어·중국어·일본어 글에서 AI 냄새가 나는 
 curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
 ```
 
-설치 스크립트가 Claude Code, [Codex CLI](https://github.com/openai/codex), Cursor, OpenCode 에 한 번에 연결합니다. 설치 시점의 최신 커밋(HEAD)을 고정해서 설치하므로, 완전히 고정된 설치가 필요하면 `PATINA_REF=<tag-or-full-sha>`를 설정하세요. 그런 다음:
+설치 스크립트가 Claude Code, [Codex CLI](https://github.com/openai/codex), Cursor, OpenCode에 patina를 한 번에 연결합니다. 설치할 때 원격 HEAD를 실제 커밋으로 고정하므로, 특정 버전만 쓰고 싶다면 `PATINA_REF=<tag-or-full-sha>`를 지정하세요. 그런 다음:
 
 ```
 /patina --lang ko
@@ -94,16 +94,16 @@ curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | ba
 [텍스트를 여기에 붙여넣기]
 ```
 
-### 독립형 CLI 로
+### 독립형 CLI로
 
-Node.js ≥ 18 필요. npm 패키지가 공개되어 있으므로 바로 실행할 수 있습니다:
+Node.js 18 이상이 필요합니다. npm 패키지가 공개되어 있어 바로 실행할 수 있습니다:
 
 ```bash
 npx patina-cli doctor
 npx patina-cli --lang ko input.txt
 ```
 
-저장소를 직접 고치며 시험하려면:
+저장소를 직접 받아 고쳐 보려면:
 
 ```bash
 git clone https://github.com/devswha/patina.git
@@ -111,14 +111,14 @@ cd patina && npm install && npm link
 patina --lang ko input.txt
 ```
 
-link 후 stdin으로도 시험할 수 있습니다:
+`npm link` 후에는 stdin으로도 시험할 수 있습니다:
 
 ```bash
 printf '%s\n' '커피는 전 세계의 사회적 상호작용을 근본적으로 바꾼 중요한 문화 현상으로 부상했다.' \
   | patina --lang ko --backend codex-cli
 ```
 
-> 🆓 **API 키 없이 무료 사용 가능** — [`codex`](https://github.com/openai/codex), [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`gemini`](https://github.com/google-gemini/gemini-cli) CLI 중 하나만 로그인되어 있으면 됩니다. `--backend codex-cli | claude-cli | gemini-cli` 로 직접 선택하거나, `--backend claude-cli,codex-cli` 처럼 백업 순서를 지정하거나, `--model claude-*` / `--model gemini-*` 처럼 모델명으로 라우팅할 수 있습니다. `--model`을 생략하면 backend별 최상위 기본 모델(`gpt-5.5`, `claude-sonnet-4-6`, `gemini-2.5-pro`)을 넘깁니다. 전체 백엔드는 [AUTHENTICATION.md](docs/AUTHENTICATION.md) 참조.
+> 🆓 **API 키 없이 무료 사용 가능** — [`codex`](https://github.com/openai/codex), [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`gemini`](https://github.com/google-gemini/gemini-cli) CLI 중 하나에 로그인되어 있으면 됩니다. `--backend codex-cli | claude-cli | gemini-cli`로 직접 고르거나, `--backend claude-cli,codex-cli`처럼 백업 순서를 지정할 수 있습니다. `--model claude-*` / `--model gemini-*`처럼 모델명으로 라우팅하는 것도 가능합니다. `--model`을 생략하면 backend별 기본 모델(`gpt-5.5`, `claude-sonnet-4-6`, `gemini-2.5-pro`)을 넘깁니다. 전체 백엔드는 [AUTHENTICATION.md](docs/AUTHENTICATION.md)를 참고하세요.
 
 ### CI 연동
 
@@ -163,7 +163,7 @@ Pre-commit, Husky, Lefthook, Docker, 릴리스 워크플로우 메모는 [docs/i
 
 ## 올바른 사용 목적
 
-Patina는 글쓴이가 AI 도움을 써도 되는 상황에서 초안을 편집하고, 어떤 부분을 왜 바꿨는지 확인하며 문체를 자연스럽게 다듬도록 돕는 도구입니다. 텍스트가 "원래 사람이 쓴 것"이라는 보증은 아니며, 학업 윤리 규정 회피, 출판사 고지 의무 우회, 표절 세탁, 탐지기 우회 주장에 사용해서는 안 됩니다. 점수는 글을 고치기 위한 참고 신호일 뿐, 작성자가 AI인지 사람인지 판정하는 근거가 아닙니다. [ETHICS.md](docs/ETHICS.md)를 참고하세요.
+Patina는 AI 도움을 받아도 되는 상황에서 초안을 다듬기 위한 도구입니다. 어떤 부분을 왜 바꿨는지 확인하고, 원문의 의미를 유지한 채 문체만 자연스럽게 고치는 데 초점을 둡니다. 텍스트가 "원래 사람이 쓴 것"이라는 보증은 아니며, 학업 윤리 규정 회피, 출판사 고지 의무 우회, 표절 세탁, 탐지기 우회 주장에 사용해서는 안 됩니다. 점수는 글을 고치기 위한 참고 신호일 뿐, 작성자가 AI인지 사람인지 판정하는 근거가 아닙니다. [ETHICS.md](docs/ETHICS.md)를 참고하세요.
 
 ## 모드
 
@@ -188,36 +188,36 @@ patina --lang <ko|en|zh|ja> [모드] [--profile <이름>] input.txt
 
 전체 옵션은 `patina --help`를 참고하세요. `patina doctor --json`은 LLM 호출 없이 Node/backend/tmux/API-key 준비 상태를 점검합니다. 프로젝트 설정은 선택 사항이며, 일회성 실행은 플래그를 쓰고 고정 기본값이 필요할 때만 `.patina.yaml`을 추가하세요.
 
-Markdown 중심의 개발 워크플로우에는 개발자용 프로필 단축키가 있습니다:
-`code-comment`는 인라인 주석과 docstring을 줄이고, `commit-message`는 의도와 검증 중심의 커밋 메시지로 다듬으며, `release-notes`는 변경 로그 항목을 사용자 영향과 마이그레이션 위험이 보이는 릴리스 노트로 바꿉니다. `namuwiki`는 한국어 전용 위키풍 프로필이며, 실제 나무위키 문서 텍스트를 복사하지 않는 license-safe 가이드만 포함합니다.
+Markdown 중심 개발 흐름에는 개발자용 프로필도 있습니다.
+`code-comment`는 인라인 주석과 docstring을 줄이고, `commit-message`는 의도와 검증이 드러나는 커밋 메시지로 다듬습니다. `release-notes`는 변경 로그 항목을 사용자 영향과 마이그레이션 위험이 보이는 릴리스 노트로 바꿉니다. `namuwiki`는 한국어 전용 위키풍 프로필이며, 실제 나무위키 문서 텍스트를 복사하지 않는 license-safe 가이드만 포함합니다.
 
 ### 스코어 전용 패턴
 
-`--score`와 `--audit`는 `--rewrite`보다 약간 더 넓은 신호를 측정합니다. viral-hook 팩(`ko/en/zh/ja-viral-hook`, 각 9개 패턴: 숫자 충격 훅, 클릭베이트 종결, 출처 회피 권위 주장, 호흡 최적화 단문 배열, 과장된 참여 유도 어휘, 가짜 통계 인용, 권위 타이틀 쌓기, 미래의 나/친밀한 2인칭 약속, 경구형 펀치라인)은 **탐지 전용**입니다.
+`--score`와 `--audit`는 `--rewrite`보다 조금 더 넓은 신호를 봅니다. 바이럴 훅 팩(`ko/en/zh/ja-viral-hook`, 각 9개 패턴: 숫자 충격 훅, 클릭베이트 종결, 출처 회피 권위 주장, 호흡 최적화 단문 배열, 과장된 참여 유도 어휘, 가짜 통계 인용, 권위 타이틀 쌓기, 미래의 나/친밀한 2인칭 약속, 경구형 펀치라인)은 **탐지 전용**입니다.
 
-이 신호들은 score와 audit에만 나타나 네 언어의 SNS 마케팅 카피에 대한 사용자 직관과 벤치마크를 맞춥니다. `--rewrite`/`--diff`/`--ouroboros`는 이런 표현이 의도된 수사일 수 있어 건너뜁니다. 실제 데모: [`examples/viral-hook/`](examples/viral-hook/).
+이 신호들은 score와 audit에만 나타납니다. 네 언어의 SNS 마케팅 카피를 평가할 때 사용자 직관과 벤치마크를 맞추기 위한 장치입니다. `--rewrite`/`--diff`/`--ouroboros`는 이런 표현이 의도된 수사일 수 있어 건너뜁니다. 실제 데모: [`examples/viral-hook/`](examples/viral-hook/).
 
 ### 짧은 텍스트 점수 보정 (v3.11)
 
-입력이 200자 이하이거나 3문단 이하이면 문장 스타일에 민감한 카테고리(`language`, `style`, `viral-hook`)에 1.5배 가중치를 주어, 짧은 단락의 미세한 어조 변화도 점수에 반영되게 합니다. case-04에서 긴 글 기준 공식이 이런 신호를 과소계산한다는 점을 확인했습니다.
+입력이 200자 이하이거나 3문단 이하이면 문장 스타일에 민감한 카테고리(`language`, `style`, `viral-hook`)에 1.5배 가중치를 줍니다. 짧은 단락의 미세한 어조 변화도 점수에 반영하기 위해서입니다. case-04에서 긴 글 기준 공식이 이런 신호를 과소계산한다는 점을 확인했습니다.
 
 ### 자기검수 분리 (v3.11)
 
-rewrite 모드에서 모델은 `[BODY]`/`[/BODY]` 블록을 감싸는 `[SELF_AUDIT]`/`[/SELF_AUDIT]` 태그 안에 자기검수 메모를 냅니다. patina는 사용자에게 보여주기 전에 audit을 제거하므로 원시 출력이 깔끔합니다 — 이전 버전에서는 "남아 있는 AI 티"나 "Phase 3" 같은 프리앰블이 사용자-facing 텍스트에 새어 나오는 경우가 있었습니다.
+rewrite 모드에서 모델은 `[BODY]`/`[/BODY]` 블록을 감싸는 `[SELF_AUDIT]`/`[/SELF_AUDIT]` 태그 안에 자기검수 메모를 냅니다. patina는 사용자에게 보여주기 전에 audit을 제거하므로 원시 출력이 깔끔합니다. 이전 버전에서는 "남아 있는 AI 티"나 "Phase 3" 같은 프리앰블이 사용자에게 보이는 텍스트에 새어 나오는 경우가 있었습니다.
 
 ### 기계가 읽기 쉬운 출력과 종료 코드
 
-`--format json`은 모든 모드를 `overall`, `categories[]`, `tone`, `mps`, `gateResult`, 정리된 `output` 본문이 들어 있는 일관된 JSON 구조(envelope)로 감싸 반환합니다. `--quiet`는 stdout만 필요한 스크립트를 위해 상태·경고·진행 로그를 숨깁니다. `--format markdown`이 기본값이고, `--format text`는 YAML tone footer 없이 사용자가 보게 될 본문만 남깁니다. 종료 코드는 [EXIT-CODES.md](docs/EXIT-CODES.md)에 정리되어 있습니다: `0` 성공, `1` runtime/backend, `2` input/usage, `3` score gate 초과.
+`--format json`은 모든 모드를 `overall`, `categories[]`, `tone`, `mps`, `gateResult`, 정리된 `output` 본문이 들어 있는 일관된 JSON envelope로 감싸 반환합니다. `--quiet`는 stdout만 필요한 스크립트를 위해 상태·경고·진행 로그를 숨깁니다. `--format markdown`이 기본값이고, `--format text`는 YAML tone footer 없이 사용자가 보게 될 본문만 남깁니다. 종료 코드는 [EXIT-CODES.md](docs/EXIT-CODES.md)에 정리되어 있습니다: `0` 성공, `1` runtime/backend, `2` input/usage, `3` score gate 초과.
 
 ### 점수 가중치 드리프트 감지 (v3.11)
 
-`--score` 실행은 모델이 출력한 Weight 열을 설정의 `category-weights`와 교차 확인합니다. 모델이 존재하지 않는 카테고리(예: `discord`)를 만들거나 다른 숫자로 바꾸면 `[patina]` 경고가 stderr에 출력됩니다 — 관측용일 뿐 weight check 자체가 점수를 바꾸지는 않습니다. `src/features/*`의 결정론적 shadow score도 함께 기록되며, LLM 점수와 20점 넘게 벌어지면 patina가 경고를 내고 gate에는 더 보수적인 값을 사용합니다.
+`--score` 실행은 모델이 출력한 Weight 열을 설정의 `category-weights`와 대조합니다. 모델이 존재하지 않는 카테고리(예: `discord`)를 만들거나 다른 숫자로 바꾸면 stderr에 `[patina]` 경고가 나옵니다. 관측용 검사라서 weight check 자체가 점수를 바꾸지는 않습니다. `src/features/*`의 결정론적 shadow score도 함께 기록되며, LLM 점수와 20점 넘게 벌어지면 patina가 경고를 내고 gate에는 더 보수적인 값을 사용합니다.
 
-`--voice-sample <path>` 또는 설정의 `voice-sample: <path>`로 본인이 쓴 1~3문단을 rewrite 기준으로 줄 수 있습니다. profile과 tone은 여전히 register를 정하고, sample은 cadence, 구체성, POV, sentence texture만 가르칩니다. prompt는 sample의 사실을 가져오지 말라고 명시합니다.
+`--voice-sample <path>` 또는 설정의 `voice-sample: <path>`로 본인이 쓴 1~3문단을 rewrite 기준으로 줄 수 있습니다. profile과 tone은 여전히 register를 정하고, sample은 문장 리듬, 구체성, 시점, 문장 질감만 참고합니다. prompt는 sample의 사실을 가져오지 말라고 명시합니다.
 
 ## 톤
 
-`--tone` 은 패턴 기반 재작성과 함께 적용할 수 있는 톤(어조) 프리셋입니다. 우선순위: `--tone` CLI > `tone:` 설정 > `profile:` 설정.
+`--tone`은 패턴 기반 재작성과 함께 적용할 수 있는 톤(어조) 프리셋입니다. 우선순위: `--tone` CLI > `tone:` 설정 > `profile:` 설정.
 
 | 톤 | 용도 | 주요 특성 |
 |----|------|-----------|
@@ -228,7 +228,7 @@ rewrite 모드에서 모델은 `[BODY]`/`[/BODY]` 블록을 감싸는 `[SELF_AUD
 | `marketing` | 광고 카피, 랜딩 페이지, 제품 알림 | 짧고 강한 문장, 설득력, CTA 친화 |
 | `instructional` | 튜토리얼, 하우투, 기술 문서 | 명령형 동사, 번호 매김 구조, 추측 표현 억제 |
 
-`--tone auto` 는 휴리스틱(어휘 + 구조 신호)으로 가장 적합한 톤을 자동 선택합니다. zh/ja 에서는 `auto` 포함 모든 톤 지정 시 경고를 내고 프로필 전용 모드로 폴백합니다 — Phase 4.5b 휴리스틱이 ko/en만 지원하기 때문입니다.
+`--tone auto`는 휴리스틱(어휘 + 구조 신호)으로 가장 적합한 톤을 자동 선택합니다. zh/ja에서는 `auto`를 포함한 모든 톤 지정 시 경고를 내고 프로필 전용 모드로 폴백합니다. Phase 4.5b 휴리스틱이 ko/en만 지원하기 때문입니다.
 
 ## 동작 원리
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -16,50 +16,50 @@
   <a href="https://patina.vibetip.help/"><b>用你自己的文本试用 — 无需安装</b></a>
 </p>
 
-> **只剥掉 AI 包装，保留原意。**
+> **去掉 AI 味，保留原意。**
 
-patina 会在中文、韩文、英文和日文里找出 AI 味比较重的写作模式，并在不改动原意的前提下重写。它可以作为 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex CLI](https://github.com/openai/codex)、[Cursor](https://cursor.sh)、OpenCode 的技能使用，也可以作为独立的 Node.js CLI 运行。
+patina 会在中文、韩文、英文和日文中找出 AI 味较重的表达，并在不改变主张、数字、立场和因果关系的前提下改写。你可以把它装成 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex CLI](https://github.com/openai/codex)、[Cursor](https://cursor.sh)、OpenCode 的 agent skill，也可以直接运行独立的 Node.js CLI。
 
-它不是黑盒式改写工具，也不是 AI 检测器规避工具。patina **基于清晰的模式规则且可审计**：会说明改了什么、为什么改，以及原文的主张是否保留下来。只要 `codex`、`claude`、`gemini` 任一 CLI 已登录，就可以不填 API 密钥使用。
+它不是黑盒式改写器，也不是用来绕过 AI 检测器的工具。patina **基于清晰的模式规则，并且可审计**：会说明改了什么、为什么改，以及原文的主张是否保留下来。只要 `codex`、`claude`、`gemini` 任一 CLI 已登录，就可以不填 API 密钥使用。
 
 ## 效果展示
 
-**修改前** *(AI 风格；当前 GIF 使用的英文 fixture)*：
+**修改前** *(AI 风格；当前 GIF 使用的是英文示例)*：
 > The newly released Notion template pack is an **innovative solution** designed to **transform productivity** for modern teams. It offers 30 templates optimized for diverse workflows, with a user-friendly design that enables anyone to leverage them effortlessly. This product introduces a **new paradigm** for maximizing work efficiency.
 
-**修改后** *(`/patina --lang en --tone marketing` — 同样事实，仅去除 AI 包装)*：
+**修改后** *(`/patina --lang en --tone marketing` — 事实不变，只去掉 AI 味)*：
 > If Notion still starts as a blank page for your team, open this pack first. It includes 30 templates for common workflows. Duplicate one, adjust the fields you need, and use it for a team project or your own planning without starting from scratch.
 
-> **Score = 0.0%** · 30 个模板 ✓ · 工作流适配 ✓ · 复制后调整使用 ✓
+> **Score = 0.0%** · 30 个模板 ✓ · 适配工作流 ✓ · 复制后可调整使用 ✓
 
-**更多示例片段**
+**更多例子**
 
-| 输入类型 | 去掉的 AI 包装 | 保留的含义 |
+| 输入类型 | 去掉的 AI 味 | 保留的含义 |
 |---|---|---|
-| 韩文营销文案 | “혁신적인 솔루션”, “새로운 패러다임” | 30 个 Notion 模板、适配工作流、复制后可自行修改 |
+| 韩语营销文案 | “혁신적인 솔루션”, “새로운 패러다임” | 30 个 Notion 模板、适配工作流、复制后可自行修改 |
 | 学术文本 | “획기적인 성과”, 宽泛的意义宣称 | 60 个 GitHub 项目、72h→10m 设置时间、p<0.01、限制说明 |
-| 技术文档 | “핵심적인 역할”, 未来标准式 hype | GPU 管理、一条命令 provisioning、5× 结果 caveat |
+| 技术文档 | “핵심적인 역할”, 未来标准式夸张 | GPU 管理、一条命令完成配置、5× 结果的注意事项 |
 
 ## 浏览器直接体验 — 无需安装
 
-**[patina.vibetip.help](https://patina.vibetip.help/)** 可以在浏览器里直接检查 KO / EN / ZH / JA 段落中的 AI 写作模式。
+**[patina.vibetip.help](https://patina.vibetip.help/)** 可以在浏览器里直接检查 KO / EN / ZH / JA 段落中的 AI 写作信号。
 
-> **仅检测。** playground 只在你的浏览器内运行确定性的文体统计分析。它不会改写文本，不会调用外部 LLM，也不会把 API key 发送到服务器。需要实际 rewrite 时，请使用下面的 CLI 或 skill。
+> **仅检测。** playground 只在你的浏览器内运行确定性的文体统计分析。它不会改写文本，不会调用外部 LLM，也不会把 API key 发到服务器。需要实际改写时，请使用下面的 CLI 或 skill。
 
-完整 rewrite 流程见 [30 秒终端演示](docs/DEMO.md)。更多例子见 [Before/After Gallery](docs/EXAMPLES.md)（[한국어](docs/EXAMPLES_KR.md)）。
+完整改写流程见 [30 秒终端演示](docs/DEMO.md)。更多例子见 [Before/After Gallery](docs/EXAMPLES.md)（[한국어](docs/EXAMPLES_KR.md)）。
 品牌资源：[logo](assets/brand/patina-logo.svg)、[mark](assets/brand/patina-mark.svg)、[icon](assets/brand/patina-icon.svg)、[social preview](assets/social/patina-og.svg)、[before/after card](assets/social/patina-before-after.svg)。使用指南见 [BRANDING.md](docs/BRANDING.md)。
 
 ## 一览
 
 |  |  |
 |---|---|
-| **168 个模式** | 每种语言 33 个可 rewrite 模式 + 9 个仅评分 viral-hook（KO/EN/ZH/JA 各 42 个） — [PATTERNS.md](docs/PATTERNS.md) |
-| **编辑热点召回率** | 2026-05-22 现代模型重基线：GPT-5.5 / Claude Sonnet 4.6 / Gemini 2.5 Pro 的总体 catch 为 67.3% [63.5–71.0%]（n=600，韩文+英文） |
+| **168 条模式** | 每种语言 33 条可改写模式 + 9 条仅评分的病毒式钩子模式（KO/EN/ZH/JA 各 42 条） — [PATTERNS.md](docs/PATTERNS.md) |
+| **编辑热点召回率** | 2026-05-22 现代模型重基线：GPT-5.5 / Claude Sonnet 4.6 / Gemini 2.5 Pro 的总体命中率为 67.3% [63.5–71.0%]（n=600，韩文+英文） |
 | **基准报告** | 可复现的 ko/en/zh/ja 可疑区间基准：[overview](docs/benchmarks/README.md) · [latest.md](docs/benchmarks/latest.md) · [latest.json](docs/benchmarks/latest.json) · [2026 rebaseline](docs/benchmarks/rebaseline-latest.md) · [detector comparison](docs/benchmarks/detector-comparison.md) |
-| **误检率** | 2026-05-22 KO+EN 人类对照为 16.0% [11.6–21.7%]（n=200）；不同文体边界见 [stylometry.md](core/stylometry.md) — [报告误检](https://github.com/devswha/patina/issues/new?template=false_positive.yml) |
+| **误检率** | 2026-05-22 KO+EN 人类对照为 16.0% [11.6–21.7%]（n=200）；不同文体的边界见 [stylometry.md](core/stylometry.md) — [报告误检](https://github.com/devswha/patina/issues/new?template=false_positive.yml) |
 | **模式** | rewrite · audit · score · diff · ouroboros |
-| **免费层** | 支持 — 通过已登录的 `codex`、`claude` 或 `gemini` CLI（无需 API 密钥） |
-| **确定性** | 评分公式是确定性的；LLM 严重度判定阶段 ±8–10pt 波动（[scoring.md §8](core/scoring.md)） |
+| **免费使用** | 已登录的 `codex`、`claude` 或 `gemini` CLI 可直接运行，无需 API 密钥 |
+| **确定性** | 评分公式是确定性的；LLM 严重度判定阶段会有 ±8–10pt 波动（[scoring.md §8](core/scoring.md)） |
 | **许可证** | MIT |
 
 ## 快速开始
@@ -70,7 +70,7 @@ patina 会在中文、韩文、英文和日文里找出 AI 味比较重的写作
 curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
 ```
 
-安装脚本会把 patina 一次性接入 Claude Code、[Codex CLI](https://github.com/openai/codex)、Cursor、OpenCode。它会在 checkout 前把 repository HEAD 解析到具体 commit；如果需要完全固定安装，请设置 `PATINA_REF=<tag-or-full-sha>`。然后：
+安装脚本会把 patina 一次接入 Claude Code、[Codex CLI](https://github.com/openai/codex)、Cursor 和 OpenCode。安装时会先把远程 HEAD 固定到具体 commit；如果想固定到某个版本，请设置 `PATINA_REF=<tag-or-full-sha>`。然后：
 
 ```
 /patina --lang zh
@@ -78,7 +78,7 @@ curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | ba
 [在此粘贴你的文本]
 ```
 
-以特定语调改写：
+按指定语气改写：
 
 ```
 /patina --tone narrative
@@ -86,7 +86,7 @@ curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | ba
 [在此粘贴你的随笔草稿]
 ```
 
-自动检测最适合的语调：
+自动选择合适的语气：
 
 ```
 /patina --tone auto --lang en
@@ -94,7 +94,7 @@ curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | ba
 [在此粘贴你的文本]
 ```
 
-> 注意：`--tone`（含 `auto`）在 v1 仅对 ko/en 生效。zh/ja 使用任何语调均会触发警告并回退到 profile-only 模式。
+> 注意：`--tone`（含 `auto`）在 v1 仅对 ko/en 生效。zh/ja 使用任何语气都会触发警告，并回退到 profile-only 模式。
 
 ### 作为独立 CLI
 
@@ -105,7 +105,7 @@ npx patina-cli doctor
 npx patina-cli --lang zh input.txt
 ```
 
-如果想直接修改仓库再试：
+如果想拉下仓库本地修改再试：
 
 ```bash
 git clone https://github.com/devswha/patina.git
@@ -113,18 +113,18 @@ cd patina && npm install && npm link
 patina --lang zh input.txt
 ```
 
-link 后也可以通过 stdin 试用：
+`npm link` 后也可以通过 stdin 试用：
 
 ```bash
 printf '%s\n' '咖啡已成为一种关键文化现象，从根本上改变了全球各地的社会互动。' \
   | patina --lang zh --backend codex-cli
 ```
 
-> 🆓 **无需 API 密钥** — 只要 [`codex`](https://github.com/openai/codex)、[`claude`](https://docs.anthropic.com/en/docs/claude-code)、[`gemini`](https://github.com/google-gemini/gemini-cli) 任一 CLI 已登录即可。可通过 `--backend codex-cli | claude-cli | gemini-cli` 直接选择，也可以声明显式 fallback 链，如 `--backend claude-cli,codex-cli`，或让模型名启发式自动路由（`--model claude-*` → claude-cli 等）。未传 `--model` 时，patina 会按 backend 传入最强文档默认模型：`gpt-5.5`、`claude-sonnet-4-6` 或 `gemini-2.5-pro`。完整后端列表见 [AUTHENTICATION.md](docs/AUTHENTICATION.md)。
+> 🆓 **无需 API 密钥** — 只要 [`codex`](https://github.com/openai/codex)、[`claude`](https://docs.anthropic.com/en/docs/claude-code)、[`gemini`](https://github.com/google-gemini/gemini-cli) 任一 CLI 已登录即可。可以用 `--backend codex-cli | claude-cli | gemini-cli` 直接选择，也可以用 `--backend claude-cli,codex-cli` 指定后备顺序；还可以交给模型名自动路由（如 `--model claude-*` → claude-cli）。未传 `--model` 时，patina 会按 backend 传入默认模型：`gpt-5.5`、`claude-sonnet-4-6` 或 `gemini-2.5-pro`。完整后端列表见 [AUTHENTICATION.md](docs/AUTHENTICATION.md)。
 
 ### CI 集成
 
-Patina 提供不需要 live model key 的确定性 CI prose review：
+Patina 提供确定性的 CI 文档检查，不需要 live model key：
 
 ```yaml
 # .github/workflows/patina.yml
@@ -165,7 +165,7 @@ Pre-commit、Husky、Lefthook、Docker 和 release workflow 说明见 [docs/inte
 
 ## 正确使用目的
 
-Patina 适合在作者可以使用 AI 辅助起草的场景中，用来编辑草稿、看清改了哪里和为什么改，并让语气读起来更自然。它不保证文本“原本由人类写成”，也不应被用于规避学术 honor-code、绕过出版方 disclosure、洗白抄袭，或声称 detector-bypass。分数只是带有误报和漏报的编辑信号，不是作者身份的证明。见 [ETHICS.md](docs/ETHICS.md)。
+Patina 适合在作者可以使用 AI 辅助起草的场景中，用来编辑草稿、看清改了哪里和为什么改，并让文字读起来更自然。它不保证文本“原本由人类写成”，也不应被用于规避学术 honor code、绕过出版方 disclosure、洗白抄袭，或声称可以 bypass detector。分数只是有误报和漏报的编辑信号，不是作者身份的证明。见 [ETHICS.md](docs/ETHICS.md)。
 
 ## 模式
 
@@ -188,37 +188,37 @@ patina --lang <ko|en|zh|ja> [模式] [--profile <名称>] input.txt
 | `--format json\|text\|markdown` | 选择 JSON、纯文本或默认 Markdown 输出 |
 | `--quiet` | 隐藏 stderr 中的状态、警告和进度日志 |
 
-完整选项请运行 `patina --help`。`patina doctor --json` 可在不调用 LLM 的情况下检查 Node/backend/tmux/API-key 状态。项目配置是可选项；一次性运行请用 flags，只有需要固定默认值时再添加 `.patina.yaml`。
+完整选项请运行 `patina --help`。`patina doctor --json` 可在不调用 LLM 的情况下检查 Node/backend/tmux/API-key 状态。项目配置是可选的；一次性运行请用 flags，只有需要固定默认值时再添加 `.patina.yaml`。
 
-Markdown-heavy 工程流程可使用开发者原生 profile shortcut：`code-comment` 收紧 inline comments/docstrings，`commit-message` 围绕意图和验证改写 Git 历史文本，`release-notes` 把 changelog bullets 改成面向用户影响的发布说明，并保留迁移风险。`namuwiki` 是仅适用于韩文的 wiki 风格 profile，只包含原创的 license-safe 指南，不复制 NamuWiki 文章文本。
+Markdown 较多的工程流程可以使用开发者 profile：`code-comment` 会收紧 inline comments/docstrings，`commit-message` 会把 Git 历史文本改成更强调意图和验证，`release-notes` 会把 changelog bullets 改成面向用户影响的发布说明，并保留迁移风险。`namuwiki` 是仅适用于韩文的 wiki 风格 profile，只包含原创的 license-safe 指南，不复制 NamuWiki 文章文本。
 
 ### 仅评分模式
 
 `--score` 和 `--audit` 测量的信号范围比 `--rewrite` 略广。viral-hook 包（`ko/en/zh/ja-viral-hook`，每种语言 9 个模式：数字震撼钩子、标题党收尾、跳过来源的权威断言、适合呼吸节奏的短句堆叠、夸张互动词汇、伪统计引用、头衔堆叠、未来自我承诺、格言式收束句）为**仅检测**模式。
 
-这些信号只会出现在评分和审计中，用来让基准更贴近用户对四种语言 SNS 营销文案的直觉。`--rewrite`/`--diff`/`--ouroboros` 会跳过它们，因为这些信号往往是有意的修辞。实例: [`examples/viral-hook/`](examples/viral-hook/).
+这些信号只会出现在评分和审计中，用来让基准更贴近用户对四种语言 SNS 营销文案的直觉。`--rewrite`/`--diff`/`--ouroboros` 会跳过它们，因为这些表达往往是有意的修辞。实例：[`examples/viral-hook/`](examples/viral-hook/)。
 
 ### 短文本评分增强 (v3.11)
 
-当输入不超过 200 个字符或不超过 3 个段落时，对 register 敏感的类别（`language`、`style`、`viral-hook`）会获得 1.5 倍 severity multiplier，让单段文本里的声音变化也能体现在分数中。case-04 发现这些信号会被长文本公式低估。
+当输入不超过 200 个字符或不超过 3 个段落时，对语气更敏感的类别（`language`、`style`、`viral-hook`）会获得 1.5 倍权重，让单段文本里的声音变化也能体现在分数中。case-04 发现这些信号会被长文本公式低估。
 
 ### 自审隔离 (v3.11)
 
-在 rewrite 模式中，模型会把自审笔记放在 `[SELF_AUDIT]`/`[/SELF_AUDIT]` 标签内，并包裹一个 `[BODY]`/`[/BODY]` 块。patina 会在展示给用户前移除审计内容，因此原始输出保持干净 — 早期版本有时会把 “남아 있는 AI 티” 或 “Phase 3” 之类的前言泄漏到用户可见文本中。
+在 rewrite 模式中，模型会把自审笔记放在 `[SELF_AUDIT]`/`[/SELF_AUDIT]` 标签内，并包裹一个 `[BODY]`/`[/BODY]` 块。patina 会在展示给用户前移除审计内容，因此原始输出保持干净。早期版本有时会把 “남아 있는 AI 티” 或 “Phase 3” 之类的前言泄漏到用户可见文本中。
 
-### Machine-readable output and exit codes
+### 机器可读输出和退出码
 
-`--format json` 会把所有模式包进稳定 envelope，包含 `overall`、`categories[]`、`tone`、`mps`、`gateResult` 和清理后的 `output` 正文。`--quiet` 则为只需要 stdout 的脚本隐藏状态、警告和进度日志。`--format markdown` 是默认值；`--format text` 保留无 YAML tone footer 的用户可见正文。退出码见 [EXIT-CODES.md](docs/EXIT-CODES.md)：`0` 成功，`1` runtime/backend，`2` input/usage，`3` score gate 超限。
+`--format json` 会把所有模式包进稳定的 JSON envelope，包含 `overall`、`categories[]`、`tone`、`mps`、`gateResult` 和清理后的 `output` 正文。`--quiet` 则为只需要 stdout 的脚本隐藏状态、警告和进度日志。`--format markdown` 是默认值；`--format text` 保留无 YAML tone footer 的用户可见正文。退出码见 [EXIT-CODES.md](docs/EXIT-CODES.md)：`0` 成功，`1` runtime/backend，`2` input/usage，`3` score gate 超限。
 
 ### 分数权重漂移检测 (v3.11)
 
-`--score` 运行会把模型输出的 Weight 列与配置中的 `category-weights` 交叉检查。如果模型凭空创造类别（例如 `discord`）或替换成不同数字，stderr 会出现 `[patina]` 警告 — 这只用于可观测性，权重检查本身不会改变分数。确定性 shadow score 也会从 `src/features/*` 记录；当它与 LLM 分数相差超过 20 分时，patina 会警告并使用更悲观的分数作为 gate。
+`--score` 运行会把模型输出的 Weight 列与配置中的 `category-weights` 对照。如果模型凭空创造类别（例如 `discord`）或替换成不同数字，stderr 会出现 `[patina]` 警告。这只用于可观测性，权重检查本身不会改变分数。确定性 shadow score 也会从 `src/features/*` 记录；当它与 LLM 分数相差超过 20 分时，patina 会警告并使用更保守的分数作为 gate。
 
-使用 `--voice-sample <path>` 或配置中的 `voice-sample: <path>`，可以让 rewrite 参考你写过的 1–3 个段落。Profile 和 tone 仍然决定目标 register；sample 只用于学习节奏、具体度、视角和句子纹理，prompt 会明确禁止引入 sample facts。
+使用 `--voice-sample <path>` 或配置中的 `voice-sample: <path>`，可以让 rewrite 参考你写过的 1–3 个段落。Profile 和 tone 仍然决定目标 register；sample 只学习节奏、具体度、视角和句子质感，prompt 会明确禁止引入 sample facts。
 
 ## 语调
 
-`--tone` 是叠加在模式改写之上的具名声音轴。优先级：`--tone` CLI > `tone:` 配置 > `profile:` 配置。
+`--tone` 是叠加在模式改写之上的具名语气轴。优先级：`--tone` CLI > `tone:` 配置 > `profile:` 配置。
 
 | 语调 | 适用 | 主要特征 |
 |------|------|----------|
@@ -229,7 +229,7 @@ Markdown-heavy 工程流程可使用开发者原生 profile shortcut：`code-com
 | `marketing` | 广告文案、落地页、产品公告 | 短促有力、有说服力、CTA 友好 |
 | `instructional` | 教程、操作指南、技术文档 | 命令式动词、编号结构、抑制猜测语 |
 
-`--tone auto` 通过启发式（词汇 + 结构信号）自动选择最契合的语调。zh/ja 上使用任何语调（包括 `auto`）均会发出警告并回退到 profile-only 模式 — Phase 4.5b 启发式仅覆盖 ko/en。
+`--tone auto` 通过启发式（词汇 + 结构信号）自动选择最契合的语气。zh/ja 上使用任何语气（包括 `auto`）都会发出警告并回退到 profile-only 模式，因为 Phase 4.5b 启发式仅覆盖 ko/en。
 
 ## 工作原理
 
@@ -243,12 +243,12 @@ Markdown-heavy 工程流程可使用开发者原生 profile shortcut：`code-com
 [阶段 2]     句子改写 + 锚点验证
 [阶段 3]     自审 (极性、回归、MPS)
   ↓
-自然的文本（语义已验证）
+自然文本（语义已验证）
 ```
 
-任一验证阶段语义偏移则重试或回滚。
+如果任一验证阶段发现语义偏移，patina 会重试或回滚。
 
-**校准** *(2026-05-22 现代模型重基线；方法见 [2026-rebaseline.md](docs/research/2026-rebaseline.md))*：在 GPT-5.5、Claude Sonnet 4.6、Gemini 2.5 Pro CLI 样本上，确定性编辑热点 catch 为 67.3% [63.5–71.0%]（n=600，韩文+英文）。人类对照误检率为 16.0% [11.6–21.7%]（n=200）。语言×模型的细分结果见 [rebaseline-latest.md](docs/benchmarks/rebaseline-latest.md)。这只是编辑信号，不是作者判定或绕过检测的承诺。
+**校准** *(2026-05-22 现代模型重基线；方法见 [2026-rebaseline.md](docs/research/2026-rebaseline.md))*：在 GPT-5.5、Claude Sonnet 4.6、Gemini 2.5 Pro CLI 样本上，确定性编辑热点命中率为 67.3% [63.5–71.0%]（n=600，韩文+英文）。人类对照误检率为 16.0% [11.6–21.7%]（n=200）。语言×模型的细分结果见 [rebaseline-latest.md](docs/benchmarks/rebaseline-latest.md)。这只是编辑信号，不是作者判定，也不是绕过检测的承诺。
 
 ## 配置
 
@@ -261,7 +261,7 @@ output: rewrite           # rewrite | diff | audit | score
 tone:                     # casual | professional | academic | narrative | marketing | instructional | auto
 ```
 
-模式包按语言前缀自动发现。工作目录中的 `.patina.yaml` 会覆盖默认值。扩展检测的列表键（`blocklist`、`allowlist`、`skip-patterns`）会在 default/global/project 配置之间追加合并；其他数组键则直接替换，便于用户明确指定精确值。
+模式包按语言前缀自动发现。工作目录中的 `.patina.yaml` 会覆盖默认值。用于扩展检测的列表键（`blocklist`、`allowlist`、`skip-patterns`）会在 default/global/project 配置之间追加合并；其他数组键会直接替换，方便用户指定精确值。
 
 ## 文档
 


### PR DESCRIPTION
## Summary
- smooth out translation-heavy wording in the Korean, Chinese, and Japanese READMEs
- replace mixed English/Korean/Japanese copy with more natural localized phrasing where possible
- keep commands, links, model names, and behavior descriptions aligned with the English README

## Verification
- `node scripts/precommit-score.mjs README_KR.md README_ZH.md README_JA.md`
- localized README link check script
- `npm run lint:syntax`
- `node --test tests/unit/assets.test.js`
- `git diff --check -- README_KR.md README_ZH.md README_JA.md`