### PR TITLE
Retire public launch tracker references

### DIFF
--- a/docs/ISSUE-WAVES.md
+++ b/docs/ISSUE-WAVES.md
@@ -1,12 +1,11 @@
 # Open Issue Wave Plan
 
-Last synced: 2026-05-22. Source of truth is GitHub issues; this file records the current execution grouping so follow-up waves do not re-triage from scratch.
+Last synced: 2026-06-05. Source of truth is GitHub issues; this file records the current execution grouping so follow-up waves do not re-triage from scratch.
 
-## Wave A — launch/growth execution
+## Wave A — growth execution
 
 | issue | status | next action |
 |---|---|---|
-| #286 launch tracker | ready, maintainer-owned | Post or explicitly defer each channel draft, then attach exact score output and feedback links to #286. Agents may prepare copy and score proof, but should not post from maintainer accounts. |
 | #307 awesome-list discovery | ready, external-submission owned | Prepare a short candidate-list/submission checklist for relevant awesome lists; maintainer submits where external account or repo ownership is required. |
 
 Current score proof:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -254,14 +254,14 @@ Do not lead with “bypass AI detectors.” Lead with:
 
 ## 5. Immediate next actions
 
-Last triaged: 2026-05-22, after README demo localization and issue-inventory sync.
+Last triaged: 2026-06-05, after closing the public launch tracker and moving launch posting notes out of GitHub issues.
 
 Current GitHub issue inventory:
 
-- 9 open issues; 145 closed issues; 154 tracked issues total.
+- 9 open issues.
 - Open PRs: 0.
-- Open priority split: 1 high, 1 medium, 7 low, and 0 without priority labels.
-- Current high-priority issue: #286 launch tracking/playbook.
+- Open priority split: 0 high, 1 medium, 8 low, and 0 without priority labels.
+- No current high-priority issue.
 
 Campaign state:
 
@@ -271,7 +271,7 @@ Campaign state:
 - Launch Wave 1 badge work: #297 closed #282; companion patina-action#1 added `badge-json` / `badge-branch`.
 - Launch Wave 2 support work: #299 closed #285; the experimental share-card generator from #283 has since been removed from the CLI surface.
 - Launch Wave 3 static playground work closes #208 and targets <https://patina.vibetip.help/> for the try-it-now URL.
-- Launch execution prep: Korean-first channel drafts live in `docs/social/patina-launch-korean-first.md` and score 0.0%; `docs/social/patina-launch-copy.md` scores 6.3% after the KO diagnostic scoring update. `docs/social/patina-launch-execution.md` now records the maintainer-owned posting checklist and #286 update template.
+- Launch execution prep: Korean-first channel drafts live in `docs/social/patina-launch-korean-first.md` and score 0.0%; `docs/social/patina-launch-copy.md` scores 6.3% after the KO diagnostic scoring update. Launch posting/deferral notes are maintainer-owned operational bookkeeping and should be tracked outside public GitHub issues.
 - Rebaseline claim pass: `npm run benchmark:rebaseline:report` refreshes `docs/benchmarks/rebaseline-latest.{md,json}` from the #155 claim-ready sanitized manifest (800 rows, no raw text).
 - KO/2025+ corpus prep: `docs/research/ko-2025-corpus-sources.md` records usable Korean sources, `artifacts/rebaseline-2025/intake.local.example.jsonl` provides the 25-row pilot skeleton, `artifacts/rebaseline-2025/sources.ko-public.jsonl` inventories public Korean web sources, `artifacts/rebaseline-2025/human-controls.public.jsonl` tracks 250 scored hash-only web human-control candidates at n=50 for each tracked register, `npm run benchmark:rebaseline:web` collects raw text into ignored private rows, and `npm run benchmark:rebaseline:score` refreshes deterministic outcome fields without copying raw text.
 - KO register pilot: `npm run benchmark:register-pilot -- --write --basename register-stratified-latest` refreshes false positives by register without committing raw text; the expanded current pilot shows 42/250 predicted-hot human-control rows, split by register for threshold work.
@@ -282,14 +282,14 @@ Campaign state:
   playground link, translated README references, and re-recording notes; #308
   localizes README hero GIF references so English uses `patina-demo-en.gif`,
   Korean uses `patina-demo-ko.gif`, and ZH/JA intentionally fall back to EN.
-- Closed or verified during the campaign: #99, #104, #155, #156, #157, #160, #303, #165, #186, #191, #199, #209, #210, #304, #305, #306, #308.
-- Kept open with explicit blocker comments or pending external action: #158, #159, #206, #207, #211, #212, #284, #286, #307.
+- Closed or verified during the campaign: #99, #104, #155, #156, #157, #160, #303, #165, #186, #191, #199, #209, #210, #286, #304, #305, #306, #308.
+- Kept open with explicit blocker comments or pending external action: #158, #159, #206, #207, #211, #212, #284, #307, #324.
 - Legacy bot/harness notes were removed from the public repo; restart autonomous bot work only from a fresh, tracked design if it becomes necessary.
 
 Next recommended order:
 
-1. Keep #286 as the launch execution tracker; infra, copy, and the README demo GIF are live, so the next step is maintainer-owned Korean-first posting plus feedback capture.
-2. Prepare #307 awesome-list discovery submissions only as candidate copy/checklists; maintainer-owned external submissions should stay outside automated repo changes.
+1. Prepare #307 awesome-list discovery submissions only as candidate copy/checklists; maintainer-owned external submissions should stay outside automated repo changes.
+2. Re-implement #324 only when live credentialed quality checks are worth the larger local-runner investment.
 3. Treat low-priority research/ecosystem items (#158, #159, #206, #207, #211, #212, #284) as parked until evaluator budget, reviewer pool, redistributable corpus, external repo, hosting, or governance prerequisites exist; keep new campaign PRs short-lived.
 
 Detailed wave grouping lives in `docs/ISSUE-WAVES.md` so launch/growth, completed profile work, evaluation-gated research, and parked ecosystem work can move independently without re-triage.

--- a/docs/social/patina-launch-copy.md
+++ b/docs/social/patina-launch-copy.md
@@ -2,7 +2,7 @@
 
 Use this file as the source of truth for public launch posts. The positioning is deliberately **auditable cleanup / editing tool**, not detector bypass.
 
-Execution checklist and #286 update template:
+Execution checklist:
 [`docs/social/patina-launch-execution.md`](patina-launch-execution.md).
 
 ## Launch sequence

--- a/docs/social/patina-launch-execution.md
+++ b/docs/social/patina-launch-execution.md
@@ -47,17 +47,17 @@ Confirm the links used in broad posts:
 
 | Order | Channel | Copy source | Maintainer action |
 |---:|---|---|---|
-| 1 | GeekNews | `patina-launch-korean-first.md` → GeekNews | Post or mark deferred in #286. |
-| 2 | Velog | `patina-launch-korean-first.md` → Velog | Post or mark deferred in #286. |
-| 3 | Clien-style short post | `patina-launch-korean-first.md` → Clien-style short post | Post or mark deferred in #286. |
+| 1 | GeekNews | `patina-launch-korean-first.md` → GeekNews | Post or mark deferred in the maintainer launch note. |
+| 2 | Velog | `patina-launch-korean-first.md` → Velog | Post or mark deferred in the maintainer launch note. |
+| 3 | Clien-style short post | `patina-launch-korean-first.md` → Clien-style short post | Post or mark deferred in the maintainer launch note. |
 | 4 | Show HN | `patina-launch-copy.md` → Show HN | Post with playground + repo links. |
 | 5 | Product Hunt | `patina-launch-copy.md` → Product Hunt | Use brand/social assets and maker comment. |
 | 6 | Reddit | `patina-launch-copy.md` → Reddit | Pick LocalLLaMA or writing/Korean angle. |
 | 7 | X / Threads / LinkedIn | `patina-launch-copy.md` → X / Threads | Use short copy and link playground first. |
 
-## #286 update template
+## Maintainer update template
 
-After each channel action, add a short comment to #286:
+After each channel action, add a short entry to the maintainer launch note:
 
 ```text
 Channel:
@@ -85,9 +85,9 @@ Capture useful launch feedback with enough detail to reproduce it:
 Public false-positive reports should use:
 <https://github.com/devswha/patina/issues/new?template=false_positive.yml>.
 
-## Close criteria for #286
+## Close criteria for the launch note
 
-Keep #286 open until each channel is either:
+Keep the maintainer launch note open until each channel is either:
 
 - posted with URL and score proof,
 - queued with owner/date,

--- a/docs/social/patina-launch-korean-first.md
+++ b/docs/social/patina-launch-korean-first.md
@@ -77,7 +77,7 @@ playground(<https://patina.vibetip.help/>)의 '오탐 신고' 버튼으로도 �
 ## Posting checklist
 
 - Re-score the exact copied post after edits.
-- Attach the score output to issue #286 or the internal launch note.
+- Attach the score output to the internal launch note.
 - Do not promise authorship proof.
 - Capture false-positive examples with language, register, score output, and the paragraph that fired.
 - Send public false-positive examples to <https://github.com/devswha/patina/issues/new?template=false_positive.yml>.


### PR DESCRIPTION
## Summary
- remove #286 from open-issue wave/roadmap guidance after closing it
- point launch posting/deferral evidence at maintainer-owned internal notes instead of a public GitHub tracker
- refresh immediate-action issue counts after #286 moved out of public tracking

## Verification
- node scripts/precommit-score.mjs docs/ISSUE-WAVES.md docs/ROADMAP.md docs/social/patina-launch-copy.md docs/social/patina-launch-execution.md docs/social/patina-launch-korean-first.md
- git diff --check -- docs/ISSUE-WAVES.md docs/ROADMAP.md docs/social/patina-launch-copy.md docs/social/patina-launch-execution.md docs/social/patina-launch-korean-first.md