### PR TITLE
Add batch safety guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,16 @@ printf '%s\n' 'Coffee has emerged as a pivotal cultural phenomenon.' \
   | npx patina-cli --lang en --backend codex-cli
 ```
 
-Supported local backends: `codex-cli`, `claude-cli`, `gemini-cli`, `kimi-cli`. Without `--model`, patina passes the strongest documented default per backend: `gpt-5.5` for OpenAI/Codex, `claude-sonnet-4-6` for Claude, `gemini-2.5-pro` for Gemini, and `kimi-code/kimi-for-coding` for Kimi Code. See [Authentication](docs/AUTHENTICATION.md) ([한국어](docs/AUTHENTICATION_KR.md)).
+Supported local backends: `codex-cli`, `claude-cli`, `gemini-cli`, `kimi-cli`.
+Without `--model`, patina passes the strongest documented default per backend:
+`gpt-5.5` for OpenAI/Codex, `claude-sonnet-4-6` for Claude, `gemini-2.5-pro`
+for Gemini, and `kimi-code/kimi-for-coding` for Kimi Code. See
+[Authentication](docs/AUTHENTICATION.md) ([한국어](docs/AUTHENTICATION_KR.md)).
+
+For large `--batch` rewrites, prefer an OpenAI-compatible HTTP backend. Local
+CLI backends are agent runtimes; patina caps them conservatively, uses compact
+prompts for them, and exposes `--timeout-ms`, `--max-concurrency`,
+`--max-retries`, `--max-failures`, and `--max-failure-rate` for batch safety.
 
 ## What You Get
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -50,7 +50,7 @@ patina --model codex --lang ko input.txt   # routes to codex-cli, uses gpt-5.5 d
 
 ## claude-cli backend
 
-Spawns local [`claude`](https://docs.anthropic.com/en/docs/claude-code) `-p` with the patina prompt on stdin. Free for anyone with a Claude subscription. The default model passed to Claude Code is `claude-sonnet-4-6`.
+Spawns local [`claude`](https://docs.anthropic.com/en/docs/claude-code) `-p` with the patina prompt on stdin. Free for anyone with a Claude subscription. Claude Code is an agent runtime, so patina treats it conservatively in batch mode: compact prompt mode, default max concurrency `1`, and default retries `0`. The default model passed to Claude Code is `claude-sonnet-4-6`; Claude Code may still apply its own model/session policy outside patina's control.
 
 ```bash
 claude auth login                          # one-time interactive OAuth
@@ -75,7 +75,7 @@ patina --model gemini-3-flash-preview --lang ko input.txt   # auto-routes
 
 ## kimi-cli backend
 
-Spawns local [`kimi`](https://moonshotai.github.io/kimi-cli/) in print mode with the patina prompt on stdin. It works with Kimi Code CLI browser login, `KIMI_API_KEY`, or `MOONSHOT_API_KEY`. The default local CLI model is `kimi-code/kimi-for-coding`.
+Spawns local [`kimi`](https://moonshotai.github.io/kimi-cli/) in print mode with the patina prompt on stdin. It works with Kimi Code CLI browser login, `KIMI_API_KEY`, or `MOONSHOT_API_KEY`. Kimi Code is an agent runtime, so patina treats it conservatively in batch mode: compact prompt mode, default max concurrency `1`, and default retries `0`. The default local CLI model is `kimi-code/kimi-for-coding`; the CLI display name may differ from Moonshot HTTP model IDs.
 
 ```bash
 kimi login                                  # one-time browser OAuth, OR
@@ -94,6 +94,11 @@ patina auth login codex-cli --yes
 Notes: patina passes `--skip-trust` because the prompt runs from a fresh temp directory (containment for prompt-injection in user text). Default timeout is higher than other CLIs because gemini's startup latency is longer.
 
 > **Mode support:** `codex-cli`, `claude-cli`, `gemini-cli`, and `kimi-cli` can be used as rewrite backends without `PATINA_API_KEY` when their local CLIs are already authenticated. API-backed score/audit paths still use the configured HTTP/evaluator key.
+
+For large rewrite batches, prefer `openai-http` or another stateless
+OpenAI-compatible HTTP provider over local agent CLIs. Batch mode exposes
+`--timeout-ms`, `--max-concurrency`, `--max-retries`, `--max-failures`,
+`--max-failure-rate`, and `--stop-on-retryable-storm`; see [CLI.md](CLI.md#batch-safety-controls).
 
 ## HTTP provider examples
 

--- a/docs/AUTHENTICATION_KR.md
+++ b/docs/AUTHENTICATION_KR.md
@@ -50,7 +50,7 @@ patina --model codex --lang ko input.txt   # codex-cli로 라우팅하고 gpt-5.
 
 ## claude-cli backend
 
-로컬 [`claude`](https://docs.anthropic.com/en/docs/claude-code) `-p`에 patina 프롬프트를 stdin으로 넘겨 실행합니다. Claude 구독이 있으면 추가 API 키 없이 쓸 수 있습니다. 기본 모델은 `claude-sonnet-4-6`입니다.
+로컬 [`claude`](https://docs.anthropic.com/en/docs/claude-code) `-p`에 patina 프롬프트를 stdin으로 넘겨 실행합니다. Claude 구독이 있으면 추가 API 키 없이 쓸 수 있습니다. Claude Code는 agent runtime이므로 batch 모드에서는 보수적으로 다룹니다: compact prompt mode, 기본 동시성 `1`, 기본 retry `0`. 기본 모델은 `claude-sonnet-4-6`이지만, Claude Code 자체의 모델/세션 정책은 patina가 완전히 통제하지 못할 수 있습니다.
 
 ```bash
 claude auth login                          # one-time interactive OAuth
@@ -75,7 +75,7 @@ patina --model gemini-3-flash-preview --lang ko input.txt   # auto-routes
 
 ## kimi-cli backend
 
-로컬 [`kimi`](https://moonshotai.github.io/kimi-cli/)를 print mode로 실행하고 patina 프롬프트를 stdin으로 넘깁니다. Kimi Code CLI 브라우저 로그인이나 `KIMI_API_KEY`, `MOONSHOT_API_KEY` 중 하나로 인증할 수 있습니다. 로컬 CLI 기본 모델은 `kimi-code/kimi-for-coding`입니다.
+로컬 [`kimi`](https://moonshotai.github.io/kimi-cli/)를 print mode로 실행하고 patina 프롬프트를 stdin으로 넘깁니다. Kimi Code CLI 브라우저 로그인이나 `KIMI_API_KEY`, `MOONSHOT_API_KEY` 중 하나로 인증할 수 있습니다. Kimi Code는 agent runtime이므로 batch 모드에서는 보수적으로 다룹니다: compact prompt mode, 기본 동시성 `1`, 기본 retry `0`. 로컬 CLI 기본 모델은 `kimi-code/kimi-for-coding`이며, CLI 표시 이름은 Moonshot HTTP 모델 ID와 다를 수 있습니다.
 
 ```bash
 kimi login                                  # one-time browser OAuth, OR
@@ -94,6 +94,12 @@ patina auth login codex-cli --yes
 참고: patina는 사용자 텍스트 안의 prompt injection 영향을 줄이려고 새 임시 디렉터리에서 프롬프트를 실행하고 `--skip-trust`를 함께 넘깁니다. gemini는 시작이 느린 편이라 기본 timeout도 다른 CLI보다 더 길게 잡혀 있습니다.
 
 > **지원 범위:** `codex-cli`, `claude-cli`, `gemini-cli`, `kimi-cli`는 로컬 CLI 로그인만 되어 있으면 `PATINA_API_KEY` 없이 rewrite 백엔드로 쓸 수 있습니다. 반면 API 기반 score/audit 경로는 계속 설정된 HTTP/evaluator 키를 사용합니다.
+
+대량 rewrite batch는 가능한 한 로컬 agent CLI보다 `openai-http` 같은 stateless
+OpenAI-compatible HTTP provider를 쓰세요. Batch 모드는 `--timeout-ms`,
+`--max-concurrency`, `--max-retries`, `--max-failures`,
+`--max-failure-rate`, `--stop-on-retryable-storm`을 제공합니다. 자세한 내용은
+[CLI.md](CLI.md#batch-safety-controls)를 보세요.
 
 ## HTTP provider examples
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -69,11 +69,53 @@ patina --backend claude-cli,codex-cli --lang en draft.md
 ```
 
 All backends share the same invocation contract:
-`invoke({ prompt, model, modelSource, signal, timeout }): Promise<string>`.
+`invoke({ prompt, model, modelSource, signal, timeout, maxRetries }): Promise<string>`.
 Local CLI backends honor `AbortSignal` by killing their child process. When no
 explicit model is set, local backends pass the strongest documented default to
 their CLI (`gpt-5.5`, `claude-sonnet-4-6`, `gemini-2.5-pro`, or
 `kimi-code/kimi-for-coding`); the HTTP backend bridges the same signal into
 fetch.
+
+## Batch safety controls
+
+Batch runs print a preflight safety line before the first request: file count,
+backend chain, prompt mode, backend concurrency cap, retry budget, timeout,
+worst-case request count, and largest/average prompt size.
+
+Defaults are intentionally conservative:
+
+| Backend | Prompt mode | Max concurrency | Max retries |
+|---|---|---:|---:|
+| `openai-http` | strict | 4 | 2 |
+| `codex-cli` | minimal | 2 | 0 |
+| `claude-cli` | minimal | 1 | 0 |
+| `gemini-cli` | minimal | 2 | 0 |
+| `kimi-cli` | minimal | 1 | 0 |
+
+Local CLIs are agent runtimes, not stateless completion APIs. For large rewrite
+batches, prefer an OpenAI-compatible HTTP provider. Override the guardrails only
+when you have measured the backend:
+
+```bash
+patina --batch --backend openai-http --max-concurrency 4 --max-retries 2 docs/*.md
+patina --batch --backend kimi-cli --max-concurrency 1 --max-retries 0 docs/*.md
+```
+
+Circuit breakers stop batch mode after repeated failure instead of burning quota:
+
+```bash
+patina --batch --max-failures 5 --max-failure-rate 0.25 --stop-on-retryable-storm docs/*.md
+patina --batch --timeout-ms 600000 docs/*.md
+```
+
+`--max-failure-rate` accepts either a ratio (`0.25`) or a percent (`25`). By
+default, batch mode stops after a small failure budget, after a 25% failure rate
+once enough files have run, or after repeated retryable storms such as HTTP 429,
+timeouts, empty local-CLI responses, or repeated Kimi/Claude process exits.
+
+MDX/frontmatter note: patina does not parse MDX or rewrite YAML frontmatter
+schemas. For `.mdx` batches, run your site's MDX/build validator after patina
+and keep project-specific guards for frontmatter quoting, trailing model footers,
+and JSX hazards such as malformed `<digit` fragments.
 
 See [EXIT-CODES.md](EXIT-CODES.md) for the full process contract.

--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -1,6 +1,69 @@
 import { spawn } from 'node:child_process';
+import { mkdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-export const DEFAULT_BACKEND_TIMEOUT_MS = 180_000;
+export const DEFAULT_BACKEND_TIMEOUT_MS = 600_000;
+export const DEFAULT_HTTP_MAX_RETRIES = 2;
+export const PROMPT_SIZE_WARNING_CHARS = 20_000;
+
+export const BACKEND_SAFETY_DEFAULTS = Object.freeze({
+  'openai-http': {
+    maxConcurrency: 4,
+    maxRetries: DEFAULT_HTTP_MAX_RETRIES,
+    promptMode: 'strict',
+    agentRuntime: false,
+  },
+  'codex-cli': {
+    maxConcurrency: 2,
+    maxRetries: 0,
+    promptMode: 'minimal',
+    agentRuntime: true,
+  },
+  'claude-cli': {
+    maxConcurrency: 1,
+    maxRetries: 0,
+    promptMode: 'minimal',
+    agentRuntime: true,
+  },
+  'gemini-cli': {
+    maxConcurrency: 2,
+    maxRetries: 0,
+    promptMode: 'minimal',
+    agentRuntime: true,
+  },
+  'kimi-cli': {
+    maxConcurrency: 1,
+    maxRetries: 0,
+    promptMode: 'minimal',
+    agentRuntime: true,
+  },
+});
+
+const UNKNOWN_BACKEND_SAFETY = Object.freeze({
+  maxConcurrency: Infinity,
+  maxRetries: 0,
+  promptMode: 'strict',
+  agentRuntime: false,
+});
+
+export function getBackendSafety(backendName) {
+  return BACKEND_SAFETY_DEFAULTS[backendName] || UNKNOWN_BACKEND_SAFETY;
+}
+
+export function resolveBackendMaxConcurrency(backendName, override) {
+  const n = override === undefined || override === null
+    ? getBackendSafety(backendName).maxConcurrency
+    : Number(override);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : Infinity;
+}
+
+export function resolveBackendMaxRetries(backendName, override) {
+  const n = override === undefined || override === null
+    ? getBackendSafety(backendName).maxRetries
+    : Number(override);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0;
+}
 
 export function isRetryableBackendError(err, { attemptIndex = 0, signal } = {}) {
   if (signal?.aborted) return false;
@@ -12,6 +75,8 @@ export function isRetryableBackendError(err, { attemptIndex = 0, signal } = {}) 
 export function describeBackendError(err) {
   const status = extractStatus(err);
   if (status) return `HTTP ${status}`;
+  const exitCode = extractExitCode(err);
+  if (exitCode) return `exit code ${exitCode}`;
   return err?.name || 'error';
 }
 
@@ -20,6 +85,130 @@ function extractStatus(err) {
   if (Number.isFinite(direct)) return direct;
   const match = String(err?.message || '').match(/\bHTTP\s+(429|503)\b/);
   return match ? Number(match[1]) : null;
+}
+
+function extractExitCode(err) {
+  const direct = Number(err?.code);
+  if (Number.isFinite(direct)) return direct;
+  const match = String(err?.message || '').match(/\bexited with code\s+(\d+)\b/i);
+  return match ? Number(match[1]) : null;
+}
+
+export async function withBackendConcurrencySlot({
+  backendName,
+  maxConcurrency,
+  signal,
+  timeout = DEFAULT_BACKEND_TIMEOUT_MS,
+  pollMs = 250,
+  staleMs = Math.max(timeout * 2, 30 * 60_000),
+  fn,
+} = {}) {
+  if (typeof fn !== 'function') {
+    throw new Error('backend concurrency slot requires fn');
+  }
+  if (!Number.isFinite(maxConcurrency)) {
+    return fn();
+  }
+
+  const slot = await acquireBackendSlot({
+    backendName,
+    maxConcurrency,
+    signal,
+    timeout,
+    pollMs,
+    staleMs,
+  });
+
+  try {
+    return await fn();
+  } finally {
+    releaseBackendSlot(slot);
+  }
+}
+
+async function acquireBackendSlot({
+  backendName,
+  maxConcurrency,
+  signal,
+  timeout,
+  pollMs,
+  staleMs,
+}) {
+  throwIfAborted(signal, `${backendName || 'backend'}: aborted while waiting for concurrency slot`);
+  const startedAt = Date.now();
+  const root = join(tmpdir(), 'patina-backend-slots', safePathSegment(backendName || 'backend'));
+  mkdirSync(root, { recursive: true });
+
+  for (;;) {
+    for (let index = 0; index < maxConcurrency; index++) {
+      const slot = join(root, `slot-${index}`);
+      cleanupStaleSlot(slot, staleMs);
+      try {
+        mkdirSync(slot);
+        writeFileSync(join(slot, 'owner.json'), JSON.stringify({
+          pid: process.pid,
+          backendName,
+          createdAt: new Date().toISOString(),
+        }), 'utf8');
+        return slot;
+      } catch (err) {
+        if (err?.code !== 'EEXIST') throw err;
+      }
+    }
+
+    throwIfAborted(signal, `${backendName || 'backend'}: aborted while waiting for concurrency slot`);
+    if (Date.now() - startedAt >= timeout) {
+      throw new Error(`${backendName || 'backend'}: timed out waiting for concurrency slot (cap ${maxConcurrency})`);
+    }
+    await sleepWithAbort(Math.min(pollMs, timeout), signal, backendName);
+  }
+}
+
+function cleanupStaleSlot(slot, staleMs) {
+  try {
+    const ageMs = Date.now() - statSync(slot).mtimeMs;
+    if (ageMs > staleMs) rmSync(slot, { recursive: true, force: true });
+  } catch {}
+}
+
+function releaseBackendSlot(slot) {
+  try {
+    rmSync(slot, { recursive: true, force: true });
+  } catch {}
+}
+
+function sleepWithAbort(ms, signal, backendName) {
+  if (ms <= 0) return Promise.resolve();
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      cleanup();
+      reject(abortError(`${backendName || 'backend'}: aborted while waiting for concurrency slot`));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function throwIfAborted(signal, message) {
+  if (signal?.aborted) throw abortError(message);
+}
+
+function abortError(message) {
+  const err = new Error(message);
+  err.name = 'AbortError';
+  return err;
+}
+
+function safePathSegment(value) {
+  return String(value).replace(/[^a-z0-9._-]+/gi, '_');
 }
 
 export function runInteractiveCommand({

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -9,7 +9,11 @@ import { DEFAULT_BEST_MODELS } from '../model-defaults.js';
 import {
   DEFAULT_BACKEND_TIMEOUT_MS,
   describeBackendError,
+  getBackendSafety,
   isRetryableBackendError,
+  resolveBackendMaxConcurrency,
+  resolveBackendMaxRetries,
+  withBackendConcurrencySlot,
 } from './contract.js';
 
 const openaiHttp = {
@@ -24,11 +28,12 @@ const openaiHttp = {
     model,
     signal,
     timeout = DEFAULT_BACKEND_TIMEOUT_MS,
+    maxRetries,
     temperature,
     seed,
     onResponse,
   }) =>
-    callLLM({ prompt, apiKey, baseURL, model, signal, timeout, temperature, seed, onResponse }),
+    callLLM({ prompt, apiKey, baseURL, model, signal, timeout, maxRetries, temperature, seed, onResponse }),
 };
 
 const REGISTRY = {
@@ -71,11 +76,17 @@ export function listBackends() {
   return Object.keys(REGISTRY).map((key) => {
     const b = REGISTRY[key];
     const meta = BACKEND_META[key] || { kind: 'unknown', selectWith: `--backend ${key}` };
+    const safety = getBackendSafety(key);
     return {
       name: key,
       kind: meta.kind,
       selectWith: meta.selectWith,
       defaultModel: meta.defaultModel || null,
+      safety,
+      maxConcurrency: safety.maxConcurrency,
+      maxRetries: safety.maxRetries,
+      promptMode: safety.promptMode,
+      agentRuntime: safety.agentRuntime,
       available: b.isAvailable(),
       authenticated: b.isAuthenticated(),
       authHint: b.authHint(),
@@ -154,6 +165,8 @@ export async function invokeBackendChain({
   modelSource,
   signal,
   timeout = DEFAULT_BACKEND_TIMEOUT_MS,
+  maxConcurrency,
+  maxRetries,
   temperature,
   seed,
   onResponse,
@@ -170,8 +183,29 @@ export async function invokeBackendChain({
   let lastError = null;
   for (let attemptIndex = 0; attemptIndex < backends.length; attemptIndex++) {
     const backend = backends[attemptIndex];
+    const effectiveMaxConcurrency = resolveBackendMaxConcurrency(backend.name, maxConcurrency);
+    const effectiveMaxRetries = resolveBackendMaxRetries(backend.name, maxRetries);
     try {
-      return await backend.invoke({ prompt, apiKey, baseURL, model, modelSource, signal, timeout, temperature, seed, onResponse, logger });
+      return await withBackendConcurrencySlot({
+        backendName: backend.name,
+        maxConcurrency: effectiveMaxConcurrency,
+        signal,
+        timeout,
+        fn: () => backend.invoke({
+          prompt,
+          apiKey,
+          baseURL,
+          model,
+          modelSource,
+          signal,
+          timeout,
+          maxRetries: effectiveMaxRetries,
+          temperature,
+          seed,
+          onResponse,
+          logger,
+        }),
+      });
     } catch (err) {
       lastError = err;
       const next = backends[attemptIndex + 1];

--- a/src/cli.js
+++ b/src/cli.js
@@ -18,6 +18,13 @@ import { runDoctor } from './commands/doctor.js';
 import { PatinaCliError, inputError, runtimeError, renderCliError, getExitCode } from './errors.js';
 import { providerHttpKeyEnvVars, resolveHttpApiKey } from './auth.js';
 import { createLogger } from './logger.js';
+import {
+  DEFAULT_BACKEND_TIMEOUT_MS,
+  PROMPT_SIZE_WARNING_CHARS,
+  getBackendSafety,
+  resolveBackendMaxConcurrency,
+  resolveBackendMaxRetries,
+} from './backends/contract.js';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve, basename, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -153,143 +160,182 @@ export async function main(args) {
   }
 
   const inputTexts = await loadInputs(parsed, logger);
+  const timeoutMs = parsed.timeoutMs ?? DEFAULT_BACKEND_TIMEOUT_MS;
+  const backendSelection = parsed.ouroboros
+    ? null
+    : selectBackendChain({
+      name: parsed.backend ?? config.backend ?? (resolved.baseURLSource !== 'default' ? 'openai-http' : undefined),
+      model: resolved.model,
+      modelSource: resolved.modelSource,
+    });
+  const backends = backendSelection?.backends || [];
+  const backend = backends[0] || null;
+
+  if (backendSelection) {
+    if (backendSelection.autoSelected) {
+      logger.info('backend.selected', {
+        message: `[patina] Using ${backend.name} backend (${backendSelection.reason}). Run \`patina auth status\` for details.`,
+      });
+    }
+    if (backends.length > 1) {
+      logger.info('backend.chain', {
+        message: `[patina] Backend fallback chain: ${backends.map((b) => b.name).join(' → ')}`,
+      });
+    }
+    if (backend.name === 'openai-http' && !resolved.apiKey) {
+      const msg = ['No API key found. Set PATINA_API_KEY, PATINA_API_KEY_FILE, OPENAI_API_KEY, or use --api-key-file.'];
+      if (provider) {
+        msg.push(`(--provider ${provider.name} expects ${provider.apiKeyEnv} or PATINA_API_KEY.)`);
+      }
+      const codex = listBackends().find((b) => b.name === 'codex-cli');
+      if (codex && codex.available && codex.authenticated) {
+        msg.push('Or pass `--backend codex-cli` to use the codex-cli backend (no key needed).');
+      } else if (codex && codex.available && !codex.authenticated) {
+        msg.push('Or run `codex login`, then pass `--backend codex-cli`.');
+      } else if (codex && !codex.available) {
+        msg.push('Or install `codex` from https://github.com/openai/codex and pass `--backend codex-cli`.');
+      }
+      throw runtimeError(
+        'no API key found',
+        msg[0],
+        msg.slice(1).join(' ') || 'Set PATINA_API_KEY or pass --backend codex-cli after logging in.'
+      );
+    }
+  }
+
+  const promptMode = backendSelection
+    ? resolvePromptMode({ backend: backend.name, model: resolved.model })
+    : 'strict';
+  const jobs = inputTexts.map(({ path, text }) => ({
+    path,
+    text,
+    prompt: parsed.ouroboros ? null : buildPrompt({
+      config,
+      patterns,
+      profile: profile.body ? profile : null,
+      voice: voice.body ? voice : null,
+      voiceSample,
+      scoring: scoring.body ? scoring : null,
+      text,
+      mode,
+      tone: toneResolution,
+      promptMode,
+    }),
+  }));
+
+  if (backendSelection) {
+    logBatchSafetyPlan({
+      jobs,
+      backends,
+      parsed,
+      promptMode,
+      timeoutMs,
+      logger,
+    });
+  }
+
   const cancellation = createCancellationController({ logger });
+  const batchState = createBatchCircuitBreaker({ parsed, total: jobs.length });
 
   cancellation.install();
   try {
-    for (const { path, text } of inputTexts) {
-      cancellation.throwIfCanceled();
-      const prompt = buildPrompt({
-        config,
-        patterns,
-        profile: profile.body ? profile : null,
-        voice: voice.body ? voice : null,
-        voiceSample,
-        scoring: scoring.body ? scoring : null,
-        text,
-        mode,
-        tone: toneResolution,
-        promptMode: resolvePromptMode({ backend: parsed.backend ?? config.backend, model: resolved.model }),
-      });
+    for (const { path, text, prompt } of jobs) {
+      try {
+        cancellation.throwIfCanceled();
+        let result;
 
-      let result;
-
-      if (parsed.ouroboros) {
-        result = await runOuroboros({
-          config,
-          patterns,
-          profile: profile.body ? profile : null,
-          voice: voice.body ? voice : null,
-          voiceSample,
-          scoring: scoring.body ? scoring : null,
-          text,
-          apiKey: resolved.apiKey,
-          baseURL: resolved.baseURL,
-          model: resolved.model,
-          signal: cancellation.signal,
-          logger,
-        });
-      } else {
-        const { backends, autoSelected, reason } = selectBackendChain({
-          name: parsed.backend ?? config.backend ?? (resolved.baseURLSource !== 'default' ? 'openai-http' : undefined),
-          model: resolved.model,
-          modelSource: resolved.modelSource,
-        });
-        const backend = backends[0];
-
-        if (autoSelected) {
-          logger.info('backend.selected', {
-            message: `[patina] Using ${backend.name} backend (${reason}). Run \`patina auth status\` for details.`,
+        if (parsed.ouroboros) {
+          result = await runOuroboros({
+            config,
+            patterns,
+            profile: profile.body ? profile : null,
+            voice: voice.body ? voice : null,
+            voiceSample,
+            scoring: scoring.body ? scoring : null,
+            text,
+            apiKey: resolved.apiKey,
+            baseURL: resolved.baseURL,
+            model: resolved.model,
+            timeout: timeoutMs,
+            signal: cancellation.signal,
+            logger,
+          });
+        } else {
+          result = await invokeBackendChain({
+            backends,
+            prompt,
+            apiKey: resolved.apiKey,
+            baseURL: resolved.baseURL,
+            model: resolved.model,
+            modelSource: resolved.modelSource,
+            signal: cancellation.signal,
+            timeout: timeoutMs,
+            maxConcurrency: parsed.maxConcurrency,
+            maxRetries: parsed.maxRetries,
+            logger,
           });
         }
-        if (backends.length > 1) {
-          logger.info('backend.chain', {
-            message: `[patina] Backend fallback chain: ${backends.map((b) => b.name).join(' → ')}`,
+        cancellation.throwIfCanceled();
+
+        if (mode === 'score' && !parsed.ouroboros) {
+          result = withDeterministicScore(result, {
+            text,
+            config,
+            repoRoot,
+            logger,
           });
         }
 
-
-        if (backend.name === 'openai-http' && !resolved.apiKey) {
-          const msg = ['No API key found. Set PATINA_API_KEY, PATINA_API_KEY_FILE, OPENAI_API_KEY, or use --api-key-file.'];
-          if (provider) {
-            msg.push(`(--provider ${provider.name} expects ${provider.apiKeyEnv} or PATINA_API_KEY.)`);
+        const auditBackstop =
+          mode === 'audit' && (parsed.format ?? 'markdown') !== 'json' && !parsed.batch
+            ? buildDeterministicAuditBackstop(text, { lang, repoRoot })
+            : '';
+        let output;
+        let scoreValidationOutput = null;
+        if (parsed.ouroboros) {
+          const ouroborosBody = formatOuroborosOutput(result);
+          output = formatOutput(ouroborosBody, mode, parsed, { tone: toneResolution, logger, auditBackstop });
+          scoreValidationOutput = ouroborosBody;
+        } else {
+          output = formatOutput(result, mode, parsed, { tone: toneResolution, logger, auditBackstop });
+          if (mode === 'score') {
+            scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' }, { logger });
           }
-          const codex = listBackends().find((b) => b.name === 'codex-cli');
-          if (codex && codex.available && codex.authenticated) {
-            msg.push('Or pass `--backend codex-cli` to use the codex-cli backend (no key needed).');
-          } else if (codex && codex.available && !codex.authenticated) {
-            msg.push('Or run `codex login`, then pass `--backend codex-cli`.');
-          } else if (codex && !codex.available) {
-            msg.push('Or install `codex` from https://github.com/openai/codex and pass `--backend codex-cli`.');
-          }
-          throw runtimeError(
-            'no API key found',
-            msg[0],
-            msg.slice(1).join(' ') || 'Set PATINA_API_KEY or pass --backend codex-cli after logging in.'
-          );
         }
 
-        result = await invokeBackendChain({
-          backends,
-          prompt,
-          apiKey: resolved.apiKey,
-          baseURL: resolved.baseURL,
-          model: resolved.model,
-          modelSource: resolved.modelSource,
-          signal: cancellation.signal,
-          logger,
-        });
-      }
-      cancellation.throwIfCanceled();
-
-      if (mode === 'score' && !parsed.ouroboros) {
-        result = withDeterministicScore(result, {
-          text,
-          config,
-          repoRoot,
-          logger,
-        });
-      }
-
-      const auditBackstop =
-        mode === 'audit' && (parsed.format ?? 'markdown') !== 'json' && !parsed.batch
-          ? buildDeterministicAuditBackstop(text, { lang, repoRoot })
-          : '';
-      let output;
-      let scoreValidationOutput = null;
-      if (parsed.ouroboros) {
-        const ouroborosBody = formatOuroborosOutput(result);
-        output = formatOutput(ouroborosBody, mode, parsed, { tone: toneResolution, logger, auditBackstop });
-        scoreValidationOutput = ouroborosBody;
-      } else {
-        output = formatOutput(result, mode, parsed, { tone: toneResolution, logger, auditBackstop });
+        // v3.11 Phase 1.3: surface weight drift between config and the score
+        // table the model emitted. Warnings only — does not alter the output.
         if (mode === 'score') {
-          scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' }, { logger });
-        }
-      }
+          const configWeights = config.ouroboros?.['category-weights']?.[lang] || {};
+          const warnings = validateScoreWeights(scoreValidationOutput || output, configWeights);
+          for (const w of warnings) {
+            logger.warn('score.weight_check', { message: `[patina] ${w}` });
+          }
 
-      // v3.11 Phase 1.3: surface weight drift between config and the score
-      // table the model emitted. Warnings only — does not alter the output.
-      if (mode === 'score') {
-        const configWeights = config.ouroboros?.['category-weights']?.[lang] || {};
-        const warnings = validateScoreWeights(scoreValidationOutput || output, configWeights);
-        for (const w of warnings) {
-          logger.warn('score.weight_check', { message: `[patina] ${w}` });
+          if (parsed.gate !== undefined) {
+            applyScoreGate(result, output, parsed.gate, logger);
+          }
         }
 
-        if (parsed.gate !== undefined) {
-          applyScoreGate(result, output, parsed.gate, logger);
+        if (parsed.batch) {
+          await writeBatchOutput(parsed, path, output);
+        } else {
+          console.log(output);
         }
-      }
-
-
-      if (parsed.batch) {
-        await writeBatchOutput(parsed, path, output);
-      } else {
-        console.log(output);
+        batchState.recordSuccess();
+      } catch (err) {
+        if (!shouldHandleBatchFailure(parsed, jobs.length)) throw err;
+        batchState.recordFailure({ path, err });
+        logger.warn('batch.file_failed', {
+          message: `[patina] batch file failed: ${path} (${batchState.failures.length}/${batchState.maxFailures} failures): ${err.message}`,
+        });
+        if (batchState.shouldStop()) throw batchState.toError();
       }
     }
 
+    if (batchState.hasFailures()) {
+      throw batchState.toError({ completed: true });
+    }
   } catch (err) {
     if (cancellation.signal.aborted) throw cancellationError();
     throw err;
@@ -421,6 +467,39 @@ function parseArgs(args) {
         parsed.backend = readOptionValue(args, i, arg);
         i++;
         break;
+      case '--timeout-ms': {
+        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
+        i++;
+        parsed.timeoutMs = parsePositiveIntegerOption(value, arg);
+        break;
+      }
+      case '--max-concurrency': {
+        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
+        i++;
+        parsed.maxConcurrency = parsePositiveIntegerOption(value, arg);
+        break;
+      }
+      case '--max-retries': {
+        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
+        i++;
+        parsed.maxRetries = parseNonNegativeIntegerOption(value, arg);
+        break;
+      }
+      case '--max-failures': {
+        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
+        i++;
+        parsed.maxFailures = parsePositiveIntegerOption(value, arg);
+        break;
+      }
+      case '--max-failure-rate': {
+        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
+        i++;
+        parsed.maxFailureRate = parseFailureRateOption(value, arg);
+        break;
+      }
+      case '--stop-on-retryable-storm':
+        parsed.stopOnRetryableStorm = true;
+        break;
       case '--list-backends':
         parsed.listBackends = true;
         break;
@@ -543,12 +622,60 @@ function readOptionValue(args, index, option, { allowFlagLike = false } = {}) {
   return value;
 }
 
-// Internal prompt style is selected per backend/model. Gemini gets the compact
-// rewrite prompt; everything else keeps the full pattern-pack prompt.
-function resolvePromptMode({ backend, model }) {
+function parsePositiveIntegerOption(value, option) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw inputError(
+      `${option} expects a positive integer`,
+      `Received ${value === undefined ? 'no value' : `"${value}"`}.`,
+      `Use ${option} 1 or another whole number greater than zero.`
+    );
+  }
+  return n;
+}
+
+function parseNonNegativeIntegerOption(value, option) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) {
+    throw inputError(
+      `${option} expects a non-negative integer`,
+      `Received ${value === undefined ? 'no value' : `"${value}"`}.`,
+      `Use ${option} 0 to disable retries, or another whole number.`
+    );
+  }
+  return n;
+}
+
+function parseFailureRateOption(value, option) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) {
+    throw inputError(
+      `${option} expects a ratio or percent`,
+      `Received ${value === undefined ? 'no value' : `"${value}"`}.`,
+      `Use ${option} 0.25 for 25%, or ${option} 25.`
+    );
+  }
+  const ratio = n > 1 ? n / 100 : n;
+  if (ratio > 1) {
+    throw inputError(
+      `${option} expects a value from 0 to 1 or 0 to 100`,
+      `Received "${value}".`,
+      `Use ${option} 0.25 for 25%, or ${option} 25.`
+    );
+  }
+  return ratio;
+}
+
+// Internal prompt style is selected from backend safety metadata. Local agent
+// CLIs use the compact rewrite prompt by default to avoid feeding large pattern
+// packs into batch-oriented agent runtimes.
+export function resolvePromptMode({ backend, model }) {
   const backendStr = (backend || '').toLowerCase();
   const modelStr = (model || '').toLowerCase();
-  if (backendStr.includes('gemini') || modelStr.includes('gemini')) return 'minimal';
+  if (backendStr && backendStr !== 'openai-http') return getBackendSafety(backendStr).promptMode;
+  if (modelStr.includes('gemini')) return 'minimal';
+  if (backendStr) return getBackendSafety(backendStr).promptMode;
+  if (modelStr.includes('kimi') || modelStr.includes('claude') || modelStr.includes('codex')) return 'minimal';
   return 'strict';
 }
 
@@ -582,6 +709,136 @@ function resolveApiKey(parsed, provider) {
     apiKeyFile: parsed.apiKeyFile,
     envVars: providerHttpKeyEnvVars(provider?.apiKeyEnv),
   });
+}
+
+function logBatchSafetyPlan({ jobs, backends, parsed, promptMode, timeoutMs, logger }) {
+  if (!parsed.batch || jobs.length <= 1) return;
+
+  const primary = backends[0];
+  const promptSizes = jobs
+    .map((job) => typeof job.prompt === 'string' ? job.prompt.length : 0)
+    .filter((size) => size > 0);
+  const maxPromptChars = promptSizes.length > 0 ? Math.max(...promptSizes) : 0;
+  const avgPromptChars = promptSizes.length > 0
+    ? Math.round(promptSizes.reduce((sum, size) => sum + size, 0) / promptSizes.length)
+    : 0;
+  const maxConcurrency = resolveBackendMaxConcurrency(primary?.name, parsed.maxConcurrency);
+  const perFileRequests = backends.reduce(
+    (sum, item) => sum + resolveBackendMaxRetries(item.name, parsed.maxRetries) + 1,
+    0
+  );
+
+  logger.info('batch.safety_plan', {
+    message: `[patina] batch safety: files=${jobs.length}, backend=${backends.map((b) => b.name).join('→')}, prompt_mode=${promptMode}, max_concurrency=${formatLimit(maxConcurrency)}, max_retries=${resolveBackendMaxRetries(primary?.name, parsed.maxRetries)}, timeout_ms=${timeoutMs}, worst_case_requests=${jobs.length * perFileRequests}, max_prompt_chars=${maxPromptChars}, avg_prompt_chars=${avgPromptChars}`,
+  });
+
+  if (primary && getBackendSafety(primary.name).agentRuntime) {
+    logger.warn('batch.local_cli_caveat', {
+      message: `[patina] ${primary.name} is a local agent CLI, not a stateless batch completion API. Large batches should prefer an OpenAI-compatible HTTP provider when possible.`,
+    });
+  }
+  if (maxPromptChars >= PROMPT_SIZE_WARNING_CHARS) {
+    logger.warn('batch.prompt_size', {
+      message: `[patina] largest prompt is ~${maxPromptChars.toLocaleString()} chars; failed attempts still send the full prompt.`,
+    });
+  }
+}
+
+function createBatchCircuitBreaker({ parsed, total }) {
+  const active = parsed.batch && total > 1;
+  const maxFailures = active
+    ? (parsed.maxFailures ?? Math.min(10, Math.max(3, Math.ceil(total * 0.1))))
+    : Infinity;
+  const maxFailureRate = active ? (parsed.maxFailureRate ?? 0.25) : Infinity;
+  const stormEnabled = active && (parsed.stopOnRetryableStorm ?? true);
+  const stormLimit = 3;
+  const failures = [];
+  const retryableBuckets = new Map();
+  let successes = 0;
+  let processed = 0;
+  let stopReason = null;
+
+  return {
+    get failures() {
+      return failures;
+    },
+    get maxFailures() {
+      return maxFailures;
+    },
+    recordSuccess() {
+      processed++;
+      successes++;
+    },
+    recordFailure({ path, err }) {
+      processed++;
+      failures.push({ path, err });
+      const bucket = classifyRetryableStorm(err);
+      if (bucket) {
+        retryableBuckets.set(bucket, (retryableBuckets.get(bucket) || 0) + 1);
+      }
+    },
+    hasFailures() {
+      return failures.length > 0;
+    },
+    shouldStop() {
+      if (!active) return false;
+      if (failures.length >= maxFailures) {
+        stopReason = `max failures reached (${failures.length}/${maxFailures})`;
+        return true;
+      }
+      if (
+        Number.isFinite(maxFailureRate) &&
+        processed >= (parsed.maxFailureRate === undefined ? Math.min(total, 4) : 1) &&
+        failures.length / processed > maxFailureRate
+      ) {
+        stopReason = `failure rate ${(failures.length / processed * 100).toFixed(1)}% exceeded ${(maxFailureRate * 100).toFixed(1)}%`;
+        return true;
+      }
+      if (stormEnabled) {
+        for (const [bucket, count] of retryableBuckets) {
+          if (count >= stormLimit) {
+            stopReason = `retryable storm detected (${count} × ${bucket})`;
+            return true;
+          }
+        }
+      }
+      return false;
+    },
+    toError({ completed = false } = {}) {
+      const summary = failures
+        .slice(0, 5)
+        .map((failure) => `${failure.path}: ${failure.err.message}`)
+        .join(' | ');
+      const why = stopReason || (completed
+        ? `Batch completed with ${failures.length} failed file(s).`
+        : `Batch stopped after ${failures.length} failed file(s).`);
+      return runtimeError(
+        completed ? 'batch completed with failures' : 'batch circuit breaker stopped the run',
+        `${why} Successes: ${successes}/${total}. Failures: ${failures.length}/${total}.`,
+        summary || 'Fix the backend failure, lower concurrency/retries, or rerun with a smaller batch.'
+      );
+    },
+  };
+}
+
+function shouldHandleBatchFailure(parsed, total) {
+  return parsed.batch && total > 1;
+}
+
+function classifyRetryableStorm(err) {
+  const message = String(err?.message || err || '');
+  if (/\bHTTP\s+429\b/i.test(message) || err?.status === 429) return 'HTTP 429';
+  if (/\bHTTP\s+503\b/i.test(message) || err?.status === 503) return 'HTTP 503';
+  if (/Provider stream timed out/i.test(message)) return 'provider stream timeout';
+  if (/timed out/i.test(message) || err?.name === 'AbortError') return 'timeout';
+  const exit = message.match(/\bexited with code\s+(75|1)\b/i);
+  if (exit) return `exit ${exit[1]}`;
+  if (/no final response body|empty response|final-message-only/i.test(message)) return 'empty response';
+  return null;
+}
+
+function formatLimit(value) {
+  return Number.isFinite(value) ? String(value) : 'unbounded';
 }
 
 async function loadInputs(parsed, logger = createLogger()) {
@@ -724,6 +981,10 @@ OUTPUT & BATCH
   --in-place              Overwrite original files (with --batch)
   --suffix <ext>          Save as {name}{ext}{extname}
   --outdir <dir>          Save results to directory
+  --max-failures <n>      Stop batch after n failed files
+  --max-failure-rate <r>  Stop batch when failure ratio exceeds r (0.25 or 25)
+  --stop-on-retryable-storm
+                          Stop batch after repeated 429/timeouts/empty local-CLI exits
   --no-interactive        Do not wait for TTY stdin; exit 2 when no input is given
 
 LANGUAGE & PROFILE
@@ -747,6 +1008,9 @@ MODEL & AUTH
   --backend <name[,name]> Backend or explicit fallback chain:
                           ${backendChoices} (default: openai-http)
   --list-backends         List backends, selectors, default models, and auth status
+  --timeout-ms <n>        Per-request/backend timeout in milliseconds
+  --max-concurrency <n>   Cross-process backend cap (safe defaults per backend)
+  --max-retries <n>       Retry budget per backend (local CLIs default to 0)
   --provider <name>       Provider preset: openai, gemini, groq, kimi, moonshot, together
 ADVANCED
   --config <path>         Load config from <path> instead of .patina.default.yaml
@@ -857,7 +1121,7 @@ function printBackendStatus() {
     defaultModel: b.defaultModel || '-',
     available: b.available ? 'yes' : 'no',
     authenticated: b.authenticated ? 'yes' : 'no',
-    note: backendStatusNote(b),
+    note: `${backendSafetyNote(b)} ${backendStatusNote(b)}`.trim(),
   }));
   const widths = {
     name: Math.max('Backend'.length, ...rows.map((r) => r.name.length)),
@@ -890,6 +1154,10 @@ function backendStatusNote(backend) {
   if (backend.authenticated) return 'ready';
   if (backend.loginCommand) return `${backend.authHint} Use \`patina auth login ${backend.name}\` for the guided flow.`;
   return backend.authHint;
+}
+
+function backendSafetyNote(backend) {
+  return `cap=${formatLimit(backend.maxConcurrency)}, retries=${backend.maxRetries}, prompt=${backend.promptMode};`;
 }
 
 async function handleAuth(subArgs) {

--- a/src/ouroboros.js
+++ b/src/ouroboros.js
@@ -21,6 +21,7 @@ import { createLogger } from './logger.js';
  * @param {Function} [options.now] Clock returning epoch milliseconds.
  * @param {Function} [options.sleep] Sleep helper for tests.
  * @param {AbortSignal} [options.signal] External cancellation signal.
+ * @param {number} [options.timeout] Per-attempt backend timeout in milliseconds.
  * @param {object} [options.logger] patina logger.
  * @returns {Promise<{finalText: string, finalScore: number, iterations: number, reason: string, log: object[]}>} Final text and iteration log.
  * @throws {Error} When model calls or scoring fail outside handled schema fallbacks.
@@ -42,6 +43,7 @@ export async function runOuroboros({
   now,
   sleep,
   signal,
+  timeout,
   logger = createLogger(),
 }) {
   const ouroborosConfig = config.ouroboros || {};
@@ -64,6 +66,7 @@ export async function runOuroboros({
     now,
     sleep,
     signal,
+    timeout,
     logger,
   });
 
@@ -122,6 +125,7 @@ export async function runOuroboros({
       now,
       sleep,
       signal,
+      timeout,
     });
 
     const scoreResult = await scoreText({
@@ -135,6 +139,7 @@ export async function runOuroboros({
       now,
       sleep,
       signal,
+      timeout,
       logger,
     });
 
@@ -158,6 +163,7 @@ export async function runOuroboros({
         now,
         sleep,
         signal,
+        timeout,
         logger,
       }),
       scoreFidelity({
@@ -170,6 +176,7 @@ export async function runOuroboros({
         now,
         sleep,
         signal,
+        timeout,
         logger,
       }),
     ]);

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -66,6 +66,7 @@ async function callAndParseJson({
   temperature = 0.1,
   deadline,
   signal,
+  timeout,
   callLLM = /** @type {Function} */ (defaultCallLLM),
   logger = createLogger(),
   now,
@@ -82,6 +83,7 @@ async function callAndParseJson({
       temperature: t,
       deadline,
       signal,
+      timeout,
       now,
       sleep,
     });
@@ -111,6 +113,7 @@ async function callAndParseJson({
  * @param {string} [options.model] Model id.
  * @param {number} [options.deadline] Absolute epoch-millisecond deadline.
  * @param {AbortSignal} [options.signal] External cancellation signal.
+ * @param {number} [options.timeout] Per-attempt backend timeout in milliseconds.
  * @param {Function} [options.callLLM] Injectable LLM implementation.
  * @param {object} [options.logger] patina logger.
  * @param {Function} [options.now] Clock returning epoch milliseconds.
@@ -129,6 +132,7 @@ export async function scoreText({
   model,
   deadline,
   signal,
+  timeout,
   callLLM = defaultCallLLM,
   logger = createLogger(),
   now,
@@ -177,6 +181,7 @@ ${text}
       deadline,
       signal,
       callLLM,
+      timeout,
       logger,
       now,
       sleep,
@@ -400,6 +405,7 @@ export function reconcileScoreOverall({
  * @param {string} [options.model] Model id.
  * @param {number} [options.deadline] Absolute epoch-millisecond deadline.
  * @param {AbortSignal} [options.signal] External cancellation signal.
+ * @param {number} [options.timeout] Per-attempt backend timeout in milliseconds.
  * @param {Function} [options.callLLM] Injectable LLM implementation.
  * @param {object} [options.logger] patina logger.
  * @param {Function} [options.now] Clock returning epoch milliseconds.
@@ -417,6 +423,7 @@ export async function scoreMPS({
   model,
   deadline,
   signal,
+  timeout,
   callLLM = defaultCallLLM,
   logger = createLogger(),
   now,
@@ -461,6 +468,7 @@ ${rewritten}
       model,
       deadline,
       signal,
+      timeout,
       callLLM,
       logger,
       now,
@@ -524,6 +532,7 @@ export function lengthRatioPoints(original, rewritten) {
  * @param {string} [options.model] Model id.
  * @param {number} [options.deadline] Absolute epoch-millisecond deadline.
  * @param {AbortSignal} [options.signal] External cancellation signal.
+ * @param {number} [options.timeout] Per-attempt backend timeout in milliseconds.
  * @param {Function} [options.callLLM] Injectable LLM implementation.
  * @param {object} [options.logger] patina logger.
  * @param {Function} [options.now] Clock returning epoch milliseconds.
@@ -541,6 +550,7 @@ export async function scoreFidelity({
   model,
   deadline,
   signal,
+  timeout,
   callLLM = defaultCallLLM,
   logger = createLogger(),
   now,
@@ -588,6 +598,7 @@ ${rewritten}
       deadline,
       signal,
       callLLM,
+      timeout,
       logger,
       now,
       sleep,

--- a/tests/e2e/backends.test.js
+++ b/tests/e2e/backends.test.js
@@ -6,7 +6,10 @@ import {
   selectBackendChain,
   listBackends,
 } from '../../src/backends/index.js';
-import { DEFAULT_BACKEND_TIMEOUT_MS } from '../../src/backends/contract.js';
+import {
+  DEFAULT_BACKEND_TIMEOUT_MS,
+  getBackendSafety,
+} from '../../src/backends/contract.js';
 import { isAvailable as codexAvailable, isAuthenticated as codexAuthd } from '../../src/backends/codex-cli.js';
 import { DEFAULT_BEST_MODELS } from '../../src/model-defaults.js';
 
@@ -140,6 +143,36 @@ describe('Backend Fallback Chain', () => {
 
     assert.strictEqual(result, 'ok');
     assert.strictEqual(seenTimeout, DEFAULT_BACKEND_TIMEOUT_MS);
+  });
+
+  it('passes backend retry defaults through the backend contract', async () => {
+    let seenMaxRetries = null;
+    const result = await invokeBackendChain({
+      backends: [
+        {
+          name: 'openai-http',
+          invoke: async ({ maxRetries }) => {
+            seenMaxRetries = maxRetries;
+            return 'ok';
+          },
+        },
+      ],
+      prompt: 'rewrite this',
+    });
+
+    assert.strictEqual(result, 'ok');
+    assert.strictEqual(seenMaxRetries, 2);
+  });
+
+  it('uses conservative safety defaults for local agent CLIs', () => {
+    assert.strictEqual(getBackendSafety('claude-cli').maxConcurrency, 1);
+    assert.strictEqual(getBackendSafety('claude-cli').maxRetries, 0);
+    assert.strictEqual(getBackendSafety('claude-cli').promptMode, 'minimal');
+    assert.strictEqual(getBackendSafety('kimi-cli').maxConcurrency, 1);
+    assert.strictEqual(getBackendSafety('kimi-cli').maxRetries, 0);
+    assert.strictEqual(getBackendSafety('kimi-cli').promptMode, 'minimal');
+    assert.strictEqual(getBackendSafety('openai-http').maxConcurrency, 4);
+    assert.strictEqual(getBackendSafety('openai-http').maxRetries, 2);
   });
 
   it('falls through 429/503 backend errors to the next backend', async () => {

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -1,7 +1,7 @@
 import { createServer } from 'node:http';
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
-import { main } from '../../src/cli.js';
+import { main, resolvePromptMode } from '../../src/cli.js';
 import { fileURLToPath } from 'node:url';
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -131,6 +131,13 @@ describe('CLI End-to-End with Mock API', () => {
     const prompt = lastRequestBody.messages[0].content;
     assert.ok(prompt.includes('AI signal words (reference)'));
     assert.ok(!prompt.includes('Follow the 3-Phase pipeline'));
+  });
+
+  it('uses compact prompt mode for local agent CLI backends', () => {
+    assert.strictEqual(resolvePromptMode({ backend: 'claude-cli' }), 'minimal');
+    assert.strictEqual(resolvePromptMode({ backend: 'kimi-cli' }), 'minimal');
+    assert.strictEqual(resolvePromptMode({ backend: 'gemini-cli' }), 'minimal');
+    assert.strictEqual(resolvePromptMode({ backend: 'openai-http', model: 'gpt-5' }), 'strict');
   });
 
   it('should pass correct temperature', async () => {
@@ -462,6 +469,40 @@ describe('CLI End-to-End with Mock API', () => {
   });
 
 
+
+  it('stops batch mode after the configured failure budget', async () => {
+    callCount = 0;
+    lastRequestBody = null;
+    await stopMockServer();
+    await startMockServer('Error occurred', 500);
+
+    const dir = mkdtempSync(join(tmpdir(), 'patina-batch-breaker-'));
+    const first = resolve(dir, 'first.txt');
+    const second = resolve(dir, 'second.txt');
+    const third = resolve(dir, 'third.txt');
+    writeFileSync(first, 'This is the first draft.', 'utf8');
+    writeFileSync(second, 'This is the second draft.', 'utf8');
+    writeFileSync(third, 'This is the third draft.', 'utf8');
+
+    await assert.rejects(
+      () => captureConsole(() => main([
+        '--lang', 'en',
+        '--batch',
+        '--max-retries', '0',
+        '--max-failures', '2',
+        '--api-key-file', mockApiKeyPath,
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        first,
+        second,
+        third,
+      ])),
+      /batch circuit breaker stopped the run/
+    );
+
+    assert.strictEqual(callCount, 2, 'Should stop before the third file');
+    await stopMockServer();
+    await startMockServer('This is the humanized result.');
+  });
   it('should handle API errors gracefully', async () => {
     callCount = 0;
     lastRequestBody = null;


### PR DESCRIPTION
## Summary
- add backend safety defaults: local agent CLIs use compact prompts, zero retries, and conservative cross-process concurrency caps; HTTP keeps a bounded retry budget
- add `--timeout-ms`, `--max-concurrency`, `--max-retries`, `--max-failures`, `--max-failure-rate`, and retryable-storm batch circuit breakers
- print batch preflight visibility for backend, prompt mode, prompt size, timeout, concurrency, retry budget, and worst-case request count
- document Claude/Kimi agent-runtime caveats, large-batch HTTP guidance, and MDX/frontmatter validation limits

Closes #378

## Verification
- `npm test`
- `npm run lint`
