### PR TITLE
Add private structural model runtime

### DIFF
--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -157,6 +157,11 @@ ouroboros:
 stylometry:
   enabled: true              # set false to bypass 4.6단계 entirely
   languages: [ko, en, zh, ja] # zh/ja use deterministic character-token fallback
+  # Optional private local structural classifier. Public releases ship the
+  # loader and feature extractor only; trained model files stay outside git/npm.
+  # You can also set PATINA_STRUCTURAL_MODEL=/path/to/model-ko.json.
+  # structural_model:
+  #   path: .patina/models/model-ko.json
   burstiness:
     bands:
       low: 0.30              # CV < 0.30 → low (suspect). Calibrated v3.5.1 from

--- a/src/backends/patina-hosted-schema.js
+++ b/src/backends/patina-hosted-schema.js
@@ -1,0 +1,135 @@
+// Public wire contract for optional hosted Patina services. This file is safe to
+// publish: it contains only schema validation and generic signal categories, not
+// service code, corpora, model weights, lexicon internals, or private IDs.
+
+export const HOSTED_SCHEMA_VERSION = '1';
+
+export const GENERAL_SPAN_CATEGORIES = Object.freeze([
+  'burstiness',
+  'lexical-diversity',
+  'lexicon-density',
+  'markup-leakage',
+  'discourse',
+  'other',
+]);
+
+export const FORBIDDEN_SPAN_KEYS = Object.freeze([
+  'patternId',
+  'patternIds',
+  'pattern',
+  'patterns',
+  'ruleId',
+  'ruleIds',
+  'lexiconId',
+  'lexiconIds',
+  'lexicon',
+  'match',
+  'matches',
+  'matchedText',
+  'sample',
+  'samples',
+  'sourceText',
+  'debug',
+  'internal',
+  '_internal',
+]);
+
+const CATEGORY_SET = new Set(GENERAL_SPAN_CATEGORIES);
+const FORBIDDEN_KEY_SET = new Set(FORBIDDEN_SPAN_KEYS);
+
+export class HostedSchemaError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'HostedSchemaError';
+  }
+}
+
+function fail(message) {
+  throw new HostedSchemaError(message);
+}
+
+function assertPlainObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${label} must be an object`);
+}
+
+function assertText(value, label) {
+  if (typeof value !== 'string') fail(`${label} must be a string`);
+}
+
+function assertOffset(value, label, textLength) {
+  if (!Number.isInteger(value)) fail(`${label} must be an integer`);
+  if (value < 0 || value > textLength) fail(`${label} must be within text bounds`);
+}
+
+function assertScore(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
+    fail(`${label} must be a number between 0 and 1`);
+  }
+}
+
+/**
+ * Build a versioned hosted request envelope.
+ *
+ * @param {{text: string, lang?: string | null, mode?: string}} input Request fields.
+ * @returns {{schemaVersion: string, mode: string, text: string, lang?: string}}
+ */
+export function buildHostedRequest({ text, lang = null, mode = 'humanize' } = {}) {
+  assertText(text, 'text');
+  if (text.length === 0) fail('text must be non-empty');
+  if (typeof mode !== 'string' || mode.length === 0) fail('mode must be a non-empty string');
+  if (lang != null && (typeof lang !== 'string' || lang.length === 0)) fail('lang must be a non-empty string when provided');
+
+  const request = {
+    schemaVersion: HOSTED_SCHEMA_VERSION,
+    mode,
+    text,
+  };
+  if (lang != null) request.lang = lang;
+  return request;
+}
+
+/**
+ * Validate and normalize a hosted response.
+ *
+ * The response exposes only generic spans. Internal pattern IDs, matched text,
+ * lexicon entries, and debug payloads are rejected to keep public API responses
+ * decoupled from private implementation details.
+ *
+ * @param {unknown} body Response JSON body.
+ * @returns {{schemaVersion: string, text: string, spans: Array<{start: number, end: number, score: number, category: string}>}}
+ */
+export function parseHostedResponse(body) {
+  assertPlainObject(body, 'hosted response');
+  if (String(body.schemaVersion) !== HOSTED_SCHEMA_VERSION) {
+    fail(`unsupported schemaVersion: ${body.schemaVersion}`);
+  }
+  assertText(body.text, 'text');
+  if (!Array.isArray(body.spans)) fail('spans must be an array');
+
+  const textLength = body.text.normalize('NFC').length;
+  const spans = body.spans.map((span, index) => {
+    assertPlainObject(span, `spans[${index}]`);
+    for (const key of Object.keys(span)) {
+      if (FORBIDDEN_KEY_SET.has(key)) fail(`spans[${index}] contains forbidden internal key: ${key}`);
+    }
+
+    assertOffset(span.start, `spans[${index}].start`, textLength);
+    assertOffset(span.end, `spans[${index}].end`, textLength);
+    if (span.end <= span.start) fail(`spans[${index}].end must be greater than start`);
+    assertScore(span.score, `spans[${index}].score`);
+    if (!CATEGORY_SET.has(span.category)) fail(`spans[${index}].category is not supported: ${span.category}`);
+
+    return {
+      start: span.start,
+      end: span.end,
+      score: span.score,
+      category: span.category,
+    };
+  });
+
+  return {
+    schemaVersion: HOSTED_SCHEMA_VERSION,
+    text: body.text,
+    spans,
+  };
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -288,7 +288,7 @@ export async function main(args) {
 
         const auditBackstop =
           mode === 'audit' && (parsed.format ?? 'markdown') !== 'json' && !parsed.batch
-            ? buildDeterministicAuditBackstop(text, { lang, repoRoot })
+            ? buildDeterministicAuditBackstop(text, { lang, repoRoot, config })
             : '';
         let output;
         let scoreValidationOutput = null;

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -29,6 +29,17 @@ import {
 import { detectMarkupLeakage } from './markup-leakage.js';
 import { detectDiscourseTells } from './discourse-tells.js';
 import { detectTranslationese } from './translationese.js';
+import { extractStructuralFeatures, structuralFeatureRecord, STRUCTURAL_FEATURE_NAMES } from './structural-features.js';
+import {
+  applyScaler,
+  fitScaler,
+  normalizeStructuralModel,
+  predictStructuralScore,
+  structuralModelVerdict,
+  thresholdForMaxFpr,
+  trainLogReg,
+} from './structural-classifier.js';
+import { loadStructuralModel, resolveStructuralModelPath } from './structural-model-loader.js';
 
 export function analyzeText(text, opts = {}) {
   const {
@@ -43,6 +54,7 @@ export function analyzeText(text, opts = {}) {
     lexiconDensityThreshold = DEFAULT_LEXICON_DENSITY_THRESHOLD,
     lexiconMinHotMatches = DEFAULT_LEXICON_MIN_HOT_MATCHES,
     lexicon: providedLexicon,
+    structuralModel = null,
   } = opts;
 
   // Normalize to NFC at the boundary so downstream tokenization and lexicon
@@ -62,6 +74,7 @@ export function analyzeText(text, opts = {}) {
   // surfaced for callers/SKILL but deliberately NOT folded into `hot` (these
   // constructions appear in good Korean too; gating hot would regress FP).
   const translationese = detectTranslationese(normalized, { lang });
+  const structuralClassifier = structuralModelVerdict(normalized, { lang, model: structuralModel });
   const lexicon =
     providedLexicon ??
     (repoRoot ? loadLexicon(lang, repoRoot) : { strict: [], phrases: [] });
@@ -127,7 +140,8 @@ export function analyzeText(text, opts = {}) {
     markupLeakage,
     discourseTells,
     translationese,
-    hot: markupLeakage.leaked || discourseTells.hot || analyzed.some((p) => p.hot),
+    hot: markupLeakage.leaked || discourseTells.hot || structuralClassifier.hot === true || analyzed.some((p) => p.hot),
+    structuralClassifier,
   };
 }
 
@@ -146,6 +160,18 @@ export {
   koreanSpacingFeatures,
   loadLexicon,
   computeDensity,
+  extractStructuralFeatures,
+  structuralFeatureRecord,
+  STRUCTURAL_FEATURE_NAMES,
+  applyScaler,
+  fitScaler,
+  normalizeStructuralModel,
+  predictStructuralScore,
+  structuralModelVerdict,
+  thresholdForMaxFpr,
+  trainLogReg,
+  loadStructuralModel,
+  resolveStructuralModelPath,
 };
 
 function buildKoreanSignals(paragraph, sentenceCount, { enabled, bands }) {

--- a/src/features/structural-classifier.js
+++ b/src/features/structural-classifier.js
@@ -1,0 +1,158 @@
+// Small, dependency-free logistic classifier helpers for optional structural
+// stylometry models. The public package ships the code path, not trained private
+// weights; callers must provide a model explicitly.
+import { extractStructuralFeatures, STRUCTURAL_FEATURE_NAMES } from './structural-features.js';
+
+export const DEFAULT_STRUCTURAL_THRESHOLD = 0.5;
+
+function sigmoid(value) {
+  return 1 / (1 + Math.exp(-value));
+}
+
+function assertMatrix(X) {
+  if (!Array.isArray(X) || X.length === 0 || !Array.isArray(X[0]) || X[0].length === 0) {
+    throw new TypeError('training features must be a non-empty matrix');
+  }
+  const width = X[0].length;
+  for (const row of X) {
+    if (!Array.isArray(row) || row.length !== width || row.some((value) => !Number.isFinite(value))) {
+      throw new TypeError('training features must be rectangular finite-number rows');
+    }
+  }
+}
+
+function assertLabels(y, expectedLength) {
+  if (!Array.isArray(y) || y.length !== expectedLength || y.some((value) => value !== 0 && value !== 1)) {
+    throw new TypeError('training labels must be 0/1 values aligned to features');
+  }
+}
+
+export function fitScaler(X) {
+  assertMatrix(X);
+  const width = X[0].length;
+  const mu = new Array(width).fill(0);
+  const sigma = new Array(width).fill(0);
+
+  for (const row of X) {
+    for (let j = 0; j < width; j++) mu[j] += row[j];
+  }
+  for (let j = 0; j < width; j++) mu[j] /= X.length;
+
+  for (const row of X) {
+    for (let j = 0; j < width; j++) sigma[j] += (row[j] - mu[j]) ** 2;
+  }
+  for (let j = 0; j < width; j++) sigma[j] = Math.sqrt(sigma[j] / X.length) || 1;
+
+  return { mu, sigma };
+}
+
+export function applyScaler({ mu, sigma }, row) {
+  if (!Array.isArray(mu) || !Array.isArray(sigma) || !Array.isArray(row)) {
+    throw new TypeError('scaler and row must be arrays');
+  }
+  if (mu.length !== sigma.length || row.length !== mu.length) {
+    throw new TypeError('scaler dimensions must match row dimensions');
+  }
+  return row.map((value, index) => (value - mu[index]) / sigma[index]);
+}
+
+export function trainLogReg(X, y, { lr = 0.1, epochs = 2000, l2 = 0.01 } = {}) {
+  assertMatrix(X);
+  assertLabels(y, X.length);
+  if (!Number.isFinite(lr) || lr <= 0) throw new TypeError('lr must be a positive finite number');
+  if (!Number.isInteger(epochs) || epochs <= 0) throw new TypeError('epochs must be a positive integer');
+  if (!Number.isFinite(l2) || l2 < 0) throw new TypeError('l2 must be a non-negative finite number');
+
+  const scaler = fitScaler(X);
+  const Z = X.map((row) => applyScaler(scaler, row));
+  const width = Z[0].length;
+  const w = new Array(width).fill(0);
+  let b = 0;
+
+  for (let epoch = 0; epoch < epochs; epoch++) {
+    const gradientW = new Array(width).fill(0);
+    let gradientB = 0;
+
+    for (let i = 0; i < Z.length; i++) {
+      const probability = sigmoid(Z[i].reduce((sum, value, index) => sum + value * w[index], b));
+      const error = probability - y[i];
+      for (let j = 0; j < width; j++) gradientW[j] += error * Z[i][j];
+      gradientB += error;
+    }
+
+    for (let j = 0; j < width; j++) w[j] -= lr * (gradientW[j] / Z.length + l2 * w[j]);
+    b -= lr * (gradientB / Z.length);
+  }
+
+  return { weights: w, bias: b, scaler, featureNames: STRUCTURAL_FEATURE_NAMES };
+}
+
+export function normalizeStructuralModel(model) {
+  if (!model || typeof model !== 'object') return null;
+  const weights = model.weights ?? model.w;
+  const bias = model.bias ?? model.b;
+  const scaler = model.scaler;
+  const threshold = model.threshold ?? DEFAULT_STRUCTURAL_THRESHOLD;
+
+  if (!Array.isArray(weights) || !Number.isFinite(bias) || !scaler || !Number.isFinite(threshold)) {
+    throw new TypeError('structural model requires weights, bias, scaler, and optional threshold');
+  }
+  if (!Array.isArray(scaler.mu) || !Array.isArray(scaler.sigma)) {
+    throw new TypeError('structural model scaler requires mu and sigma arrays');
+  }
+  if (weights.length !== scaler.mu.length || weights.length !== scaler.sigma.length) {
+    throw new TypeError('structural model dimensions must match scaler dimensions');
+  }
+  if (weights.some((value) => !Number.isFinite(value)) || scaler.mu.some((value) => !Number.isFinite(value)) || scaler.sigma.some((value) => !Number.isFinite(value))) {
+    throw new TypeError('structural model values must be finite numbers');
+  }
+  if (Array.isArray(model.featureNames) && model.featureNames.join('\0') !== STRUCTURAL_FEATURE_NAMES.join('\0')) {
+    throw new TypeError('structural model featureNames do not match this patina version');
+  }
+
+  return {
+    ...model,
+    weights,
+    bias,
+    scaler,
+    threshold,
+    featureNames: STRUCTURAL_FEATURE_NAMES,
+  };
+}
+
+export function predictStructuralScore(model, row) {
+  const normalized = normalizeStructuralModel(model);
+  if (!normalized) throw new TypeError('structural model is required');
+  const scaled = applyScaler(normalized.scaler, row);
+  const score = sigmoid(scaled.reduce((sum, value, index) => sum + value * normalized.weights[index], normalized.bias));
+  return score;
+}
+
+export function thresholdForMaxFpr(model, Xtrain, ytrain, maxFpr = 0.1) {
+  const normalized = normalizeStructuralModel(model);
+  assertMatrix(Xtrain);
+  assertLabels(ytrain, Xtrain.length);
+  if (!Number.isFinite(maxFpr) || maxFpr < 0 || maxFpr > 1) {
+    throw new TypeError('maxFpr must be a finite number between 0 and 1');
+  }
+  const negativeScores = Xtrain
+    .filter((_, index) => ytrain[index] === 0)
+    .map((row) => predictStructuralScore(normalized, row))
+    .sort((a, b) => a - b);
+  if (negativeScores.length === 0) return DEFAULT_STRUCTURAL_THRESHOLD;
+  const index = Math.min(negativeScores.length - 1, Math.floor((1 - maxFpr) * negativeScores.length));
+  return Math.max(DEFAULT_STRUCTURAL_THRESHOLD, negativeScores[index]);
+}
+
+export function structuralModelVerdict(text, { lang = 'ko', model = null } = {}) {
+  if (!model) return { available: false, hot: null, score: null };
+  const normalized = normalizeStructuralModel(model);
+  if (normalized.lang && normalized.lang !== lang) return { available: false, hot: null, score: null };
+  const row = extractStructuralFeatures(text, { lang });
+  const score = predictStructuralScore(normalized, row);
+  return {
+    available: true,
+    hot: score >= normalized.threshold,
+    score: Number(score.toFixed(4)),
+  };
+}

--- a/src/features/structural-features.js
+++ b/src/features/structural-features.js
@@ -1,0 +1,126 @@
+// Document-level structural features shared by the public analyzer and hosted
+// services. These are model-agnostic stylometry signals: no corpus rows, labels,
+// trained weights, prompts, or private assets live here.
+import { splitParagraphs, splitProseSentences, tokenize } from './segment.js';
+import { burstinessCV, mattr } from './stylometry.js';
+
+export const STRUCTURAL_FEATURE_NAMES = Object.freeze([
+  'burstiness_cv',
+  'mean_sent_len',
+  'std_sent_len',
+  'ttr',
+  'mattr',
+  'hapax_ratio',
+  'mean_tok_len',
+  'comma_per_sent',
+  'punct_ratio',
+  'ending_diversity',
+  'connective_ratio',
+  'digit_ratio',
+]);
+
+const KO_CONNECTIVES = new Set([
+  '또한',
+  '게다가',
+  '뿐만',
+  '따라서',
+  '그러나',
+  '하지만',
+  '결론적으로',
+  '즉',
+  '특히',
+  '한편',
+  '그리고',
+  '그래서',
+  '때문에',
+  '통해',
+  '위해',
+  '대한',
+  '다양한',
+  '효과적으로',
+  '중요하다고',
+  '있습니다',
+  '바랍니다',
+]);
+
+function mean(values) {
+  return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
+}
+
+function stddev(values) {
+  if (values.length < 2) return 0;
+  const avg = mean(values);
+  return Math.sqrt(mean(values.map((value) => (value - avg) ** 2)));
+}
+
+function countMatches(values, predicate) {
+  let count = 0;
+  for (const value of values) {
+    if (predicate(value)) count += 1;
+  }
+  return count;
+}
+
+/**
+ * Extract a numeric vector aligned with STRUCTURAL_FEATURE_NAMES.
+ *
+ * @param {string} text Text to analyze.
+ * @param {{lang?: string, mattrWindow?: number}} [opts] Language/tokenizer options.
+ * @returns {number[]} Numeric feature vector.
+ */
+export function extractStructuralFeatures(text, { lang = 'ko', mattrWindow = 40 } = {}) {
+  const normalized = (text || '').normalize('NFC');
+  const paragraphs = splitParagraphs(normalized);
+  const sentences = paragraphs.flatMap((paragraph) => splitProseSentences(paragraph));
+  const sentenceTokens = sentences.map((sentence) => tokenize(sentence, { lang }));
+  const sentenceLengths = sentenceTokens.map((tokens) => tokens.length).filter((count) => count > 0);
+  const tokens = sentenceTokens.flat();
+  const types = new Set(tokens);
+
+  const frequencies = new Map();
+  for (const token of tokens) frequencies.set(token, (frequencies.get(token) || 0) + 1);
+  const hapaxCount = countMatches(frequencies.values(), (count) => count === 1);
+
+  const compactChars = [...normalized.replace(/\s/g, '')];
+  const punctCount = countMatches(compactChars, (char) => /[.,!?;:·…"'()[\]{}—\-~]/.test(char));
+  const digitCount = countMatches(compactChars, (char) => /[0-9]/.test(char));
+  const commaCount = (normalized.match(/[,，]/g) || []).length;
+
+  const endings = sentences
+    .map((sentence) => {
+      const trimmed = sentence.trim();
+      return trimmed.slice(-3).replace(/[.!?]/g, '').slice(-2);
+    })
+    .filter(Boolean);
+  const endingDiversity = sentences.length ? new Set(endings).size / sentences.length : 0;
+  const connectiveHits = countMatches(tokens, (token) => KO_CONNECTIVES.has(token));
+
+  return [
+    sentenceLengths.length >= 2 ? burstinessCV(sentenceLengths) : 0,
+    mean(sentenceLengths),
+    stddev(sentenceLengths),
+    tokens.length ? types.size / tokens.length : 0,
+    mattr(tokens, mattrWindow),
+    types.size ? hapaxCount / types.size : 0,
+    tokens.length ? mean(tokens.map((token) => token.length)) : 0,
+    sentences.length ? commaCount / sentences.length : 0,
+    compactChars.length ? punctCount / compactChars.length : 0,
+    endingDiversity,
+    tokens.length ? connectiveHits / tokens.length : 0,
+    compactChars.length ? digitCount / compactChars.length : 0,
+  ];
+}
+
+/**
+ * Pair a feature vector with names for logging/debug output.
+ *
+ * @param {number[]} vector Numeric feature vector.
+ * @param {readonly string[]} [names] Feature names aligned to vector positions.
+ * @returns {Record<string, number>}
+ */
+export function structuralFeatureRecord(vector, names = STRUCTURAL_FEATURE_NAMES) {
+  /** @type {Record<string, number>} */
+  const record = {};
+  for (let i = 0; i < names.length; i++) record[names[i]] = vector[i] ?? 0;
+  return record;
+}

--- a/src/features/structural-model-loader.js
+++ b/src/features/structural-model-loader.js
@@ -1,0 +1,115 @@
+// Optional local loader for private structural classifier weights. The public
+// repo ships this resolver so the same `patina` CLI can use a private local
+// model when one is installed, while the model file itself remains outside this
+// repository and outside the npm tarball.
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve, isAbsolute } from 'node:path';
+import { homedir } from 'node:os';
+import { normalizeStructuralModel } from './structural-classifier.js';
+
+const MODEL_ENV_KEYS = Object.freeze(['PATINA_STRUCTURAL_MODEL', 'PATINA_MODEL_PATH']);
+const MODEL_PATH_KEYS = Object.freeze([
+  ['stylometry', 'structural_model', 'path'],
+  ['stylometry', 'classifier', 'model_path'],
+  ['private_model', 'path'],
+]);
+
+function getPathValue(object, keys) {
+  let cursor = object;
+  for (const key of keys) {
+    if (!cursor || typeof cursor !== 'object') return null;
+    cursor = cursor[key];
+  }
+  return typeof cursor === 'string' && cursor.trim() ? cursor.trim() : null;
+}
+
+function expandHome(path) {
+  if (path === '~') return homedir();
+  if (path.startsWith('~/')) return resolve(homedir(), path.slice(2));
+  return path;
+}
+
+function resolvePath(path, cwd) {
+  const expanded = expandHome(path);
+  return isAbsolute(expanded) ? expanded : resolve(cwd, expanded);
+}
+
+function defaultCandidatePaths(lang, cwd) {
+  const name = `model-${lang}.json`;
+  return [
+    resolve(cwd, '.patina/models', name),
+    resolve(cwd, '.patina', name),
+    resolve(homedir(), '.patina/models', name),
+    resolve(homedir(), '.patina', name),
+  ];
+}
+
+/**
+ * Resolve the structural model file path, if any.
+ *
+ * Explicit env/config paths are required and fail when missing. Default search
+ * locations are optional and simply mean "no private model installed" when
+ * absent.
+ *
+ * @param {object} [config] Effective patina config.
+ * @param {object} [opts]
+ * @param {string} [opts.lang]
+ * @param {Record<string, string|undefined>} [opts.env]
+ * @param {string} [opts.cwd]
+ * @returns {{path:string, source:string, required:boolean}|null}
+ */
+export function resolveStructuralModelPath(config = {}, { lang = 'ko', env = process.env, cwd = process.cwd() } = {}) {
+  for (const key of MODEL_ENV_KEYS) {
+    const value = env[key];
+    if (typeof value === 'string' && value.trim()) {
+      return { path: resolvePath(value.trim(), cwd), source: key, required: true };
+    }
+  }
+
+  for (const keys of MODEL_PATH_KEYS) {
+    const value = getPathValue(config, keys);
+    if (value) {
+      return { path: resolvePath(value, cwd), source: keys.join('.'), required: true };
+    }
+  }
+
+  for (const path of defaultCandidatePaths(lang, cwd)) {
+    if (existsSync(path)) return { path, source: 'default-search', required: false };
+  }
+
+  return null;
+}
+
+/**
+ * Load and validate a private structural classifier model, if installed.
+ *
+ * @param {object} [config] Effective patina config.
+ * @param {object} [opts]
+ * @param {string} [opts.lang]
+ * @param {Record<string, string|undefined>} [opts.env]
+ * @param {string} [opts.cwd]
+ * @returns {object|null} Normalized model or null when no optional default model exists.
+ */
+export function loadStructuralModel(config = {}, opts = {}) {
+  const resolved = resolveStructuralModelPath(config, opts);
+  if (!resolved) return null;
+  if (!existsSync(resolved.path)) {
+    if (resolved.required) {
+      throw new Error(`Configured structural model not found (${resolved.source}): ${resolved.path}`);
+    }
+    return null;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(resolved.path, 'utf8'));
+  } catch (err) {
+    throw new Error(`Could not read structural model at ${resolved.path}: ${err.message}`);
+  }
+
+  try {
+    return normalizeStructuralModel(parsed);
+  } catch (err) {
+    throw new Error(`Invalid structural model at ${resolved.path}: ${err.message}`);
+  }
+}

--- a/src/output.js
+++ b/src/output.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { createLogger } from './logger.js';
-import { analyzeText } from './features/index.js';
+import { analyzeText, loadStructuralModel } from './features/index.js';
 import { TRANSLATIONESE_RULES } from './features/translationese.js';
 
 /**
@@ -449,6 +449,7 @@ function normalizeFooterTail(lines) {
  * @param {object} [opts]
  * @param {string} [opts.lang]
  * @param {string} [opts.repoRoot]
+ * @param {object} [opts.config]
  * @returns {string} Markdown section (empty string when nothing fired).
  */
 export function buildDeterministicAuditBackstop(text, opts = {}) {
@@ -469,7 +470,8 @@ export function buildDeterministicAuditBackstop(text, opts = {}) {
   }
 
   // markup leakage (near-proof) + density-gated discourse tells — language-agnostic.
-  const a = analyzeText(str, { lang, repoRoot: opts.repoRoot });
+  const structuralModel = loadStructuralModel(opts.config ?? {}, { lang });
+  const a = analyzeText(str, { lang, repoRoot: opts.repoRoot, structuralModel });
   for (const h of a.markupLeakage?.hits ?? []) {
     rows.push({ signal: 'markup-leakage', label: h.label, severity: 'HIGH', location: (h.samples ?? []).join(', ') });
   }
@@ -478,6 +480,9 @@ export function buildDeterministicAuditBackstop(text, opts = {}) {
   }
   if (a.discourseTells?.thematicBreaks?.hot) {
     rows.push({ signal: 'discourse: thematic-breaks', label: '장식용 구분선 남용', severity: 'LOW', location: `${a.discourseTells.thematicBreaks.count}개` });
+  }
+  if (a.structuralClassifier?.hot) {
+    rows.push({ signal: 'structural-classifier', label: '문서 단위 구조 분류기', severity: 'HIGH', location: `score ${a.structuralClassifier.score}` });
   }
 
   if (rows.length === 0) return '';

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { callLLM as defaultCallLLM } from './api.js';
 import { getRepoRoot } from './config.js';
-import { analyzeText } from './features/index.js';
+import { analyzeText, loadStructuralModel } from './features/index.js';
 import { summarizeSignalStrength } from './features/signal-strength.js';
 import { createLogger } from './logger.js';
 
@@ -27,6 +27,15 @@ export const DEFAULT_DETERMINISTIC_DIVERGENCE_THRESHOLD = 20;
  * @type {number}
  */
 export const LEAKAGE_SCORE_FLOOR = 90;
+
+/**
+ * Structural classifier score is a calibrated probability-like document signal.
+ * It only affects the deterministic score when a private local model is loaded
+ * and the model verdict is hot; absent model means baseline behavior.
+ *
+ * @type {number}
+ */
+export const STRUCTURAL_CLASSIFIER_MIN_FLOOR = 70;
 
 class SchemaError extends Error {
   constructor(message, raw) {
@@ -241,6 +250,7 @@ export function scoreDeterministicSignals({
 
   try {
     const lexiconAllowed = isLexiconEnabledForLanguage(config, lang);
+    const structuralModel = loadStructuralModel(config, { lang });
     const result = analyzer(String(text || ''), {
       lang,
       repoRoot,
@@ -250,6 +260,7 @@ export function scoreDeterministicSignals({
       koDiagnosticsEnabled: config.stylometry?.ko_diagnostics?.enabled !== false,
       koDiagnosticBands: config.stylometry?.ko_diagnostics?.bands,
       lexiconDensityThreshold: config.lexicon?.density_threshold,
+      structuralModel,
       ...(lexiconAllowed ? {} : { lexicon: { lang, path: null, strict: [], phrases: [] } }),
     });
     const paragraphs = Array.isArray(result?.paragraphs) ? result.paragraphs : [];
@@ -259,7 +270,14 @@ export function scoreDeterministicSignals({
     // Model-output leakage (#332) is near-proof-grade and lives at the document
     // level, so it short-circuits the hot-ratio score into the 'heavily AI' band.
     const leaked = Boolean(result?.markupLeakage?.leaked);
-    const overall = leaked ? Math.max(hotRatioOverall, LEAKAGE_SCORE_FLOOR) : hotRatioOverall;
+    const structuralClassifier = result?.structuralClassifier ?? { available: false, hot: null, score: null };
+    const structuralFloor =
+      structuralClassifier.hot === true && typeof structuralClassifier.score === 'number'
+        ? Math.max(STRUCTURAL_CLASSIFIER_MIN_FLOOR, roundScore(structuralClassifier.score * 100))
+        : 0;
+    const overall = leaked
+      ? Math.max(hotRatioOverall, LEAKAGE_SCORE_FLOOR)
+      : Math.max(hotRatioOverall, structuralFloor);
     const signalScore = roundScore(summarizeSignalStrength(paragraphs, {
       burstinessBands: config.stylometry?.burstiness?.bands,
       mattrBands: config.stylometry?.ttr?.bands,
@@ -289,6 +307,12 @@ export function scoreDeterministicSignals({
           leaked,
           hits: Array.isArray(result?.markupLeakage?.hits) ? result.markupLeakage.hits.length : 0,
           floor: LEAKAGE_SCORE_FLOOR,
+        },
+        structuralClassifier: {
+          available: Boolean(structuralClassifier.available),
+          hot: structuralClassifier.hot ?? null,
+          score: structuralClassifier.score ?? null,
+          floor: structuralClassifier.hot === true ? structuralFloor : 0,
         },
       },
     };
@@ -725,6 +749,7 @@ function emptyDeterministicBands() {
     mattr: { low: 0, mid: 0, high: 0, null: 0 },
     lexicon: { hot: 0, threshold: null },
     koDiagnostics: { hot: 0, thresholds: null },
+    structuralClassifier: { available: false, hot: null, score: null, floor: 0 },
   };
 }
 

--- a/tests/unit/patina-hosted-schema.test.js
+++ b/tests/unit/patina-hosted-schema.test.js
@@ -1,0 +1,85 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  HOSTED_SCHEMA_VERSION,
+  GENERAL_SPAN_CATEGORIES,
+  HostedSchemaError,
+  buildHostedRequest,
+  parseHostedResponse,
+} from '../../src/backends/patina-hosted-schema.js';
+
+test('buildHostedRequest emits a versioned envelope', () => {
+  const body = buildHostedRequest({ text: '초안 텍스트', lang: 'ko' });
+  assert.equal(body.schemaVersion, HOSTED_SCHEMA_VERSION);
+  assert.equal(body.mode, 'humanize');
+  assert.equal(body.text, '초안 텍스트');
+  assert.equal(body.lang, 'ko');
+});
+
+test('parseHostedResponse accepts a valid scored span', () => {
+  const { spans } = parseHostedResponse({
+    schemaVersion: HOSTED_SCHEMA_VERSION,
+    text: 'x',
+    spans: [{ start: 0, end: 1, score: 0.5, category: 'burstiness' }],
+  });
+  assert.equal(spans.length, 1);
+  assert.equal(spans[0].category, 'burstiness');
+});
+
+test('parseHostedResponse rejects forbidden internal identifiers', () => {
+  assert.throws(
+    () =>
+      parseHostedResponse({
+        schemaVersion: HOSTED_SCHEMA_VERSION,
+        text: 'x',
+        spans: [{ start: 0, end: 1, score: 0.5, category: 'other', lexiconId: 'secret' }],
+      }),
+    HostedSchemaError,
+  );
+});
+
+test('parseHostedResponse rejects out-of-range score, bad offset, unknown category, and version mismatch', () => {
+  assert.throws(
+    () => parseHostedResponse({ schemaVersion: HOSTED_SCHEMA_VERSION, text: 'x', spans: [{ start: 0, end: 1, score: 1.5, category: 'other' }] }),
+    HostedSchemaError,
+  );
+  assert.throws(
+    () => parseHostedResponse({ schemaVersion: HOSTED_SCHEMA_VERSION, text: 'x', spans: [{ start: -1, end: 1, score: 0.5, category: 'other' }] }),
+    HostedSchemaError,
+  );
+  assert.throws(
+    () => parseHostedResponse({ schemaVersion: HOSTED_SCHEMA_VERSION, text: 'x', spans: [{ start: 0, end: 1, score: 0.5, category: 'nope' }] }),
+    HostedSchemaError,
+  );
+  assert.throws(
+    () => parseHostedResponse({ schemaVersion: '2', text: 'x', spans: [] }),
+    HostedSchemaError,
+  );
+});
+
+test('parseHostedResponse preserves only public span fields', () => {
+  const parsed = parseHostedResponse({
+    schemaVersion: HOSTED_SCHEMA_VERSION,
+    text: 'xx',
+    spans: [{ start: 0, end: 1, score: 0.7, category: 'other', note: 'public metadata is stripped' }],
+  });
+  assert.deepEqual(parsed.spans[0], { start: 0, end: 1, score: 0.7, category: 'other' });
+});
+
+test('buildHostedRequest rejects malformed input explicitly', () => {
+  assert.throws(() => buildHostedRequest({ text: '' }), HostedSchemaError);
+  assert.throws(() => buildHostedRequest({ text: 'x', lang: '' }), HostedSchemaError);
+  assert.throws(() => buildHostedRequest(), HostedSchemaError);
+});
+
+test('every general category is accepted', () => {
+  for (const category of GENERAL_SPAN_CATEGORIES) {
+    const { spans } = parseHostedResponse({
+      schemaVersion: HOSTED_SCHEMA_VERSION,
+      text: 'x',
+      spans: [{ start: 0, end: 1, score: 0.1, category }],
+    });
+    assert.equal(spans[0].category, category);
+  }
+});

--- a/tests/unit/structural-classifier.test.js
+++ b/tests/unit/structural-classifier.test.js
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  STRUCTURAL_FEATURE_NAMES,
+  analyzeText,
+  extractStructuralFeatures,
+  structuralFeatureRecord,
+  structuralModelVerdict,
+  trainLogReg,
+  predictStructuralScore,
+} from '../../src/features/index.js';
+
+function constantModel({ bias = 10, threshold = 0.5, lang = 'ko' } = {}) {
+  return {
+    lang,
+    weights: new Array(STRUCTURAL_FEATURE_NAMES.length).fill(0),
+    bias,
+    threshold,
+    scaler: {
+      mu: new Array(STRUCTURAL_FEATURE_NAMES.length).fill(0),
+      sigma: new Array(STRUCTURAL_FEATURE_NAMES.length).fill(1),
+    },
+    featureNames: STRUCTURAL_FEATURE_NAMES,
+  };
+}
+
+test('extractStructuralFeatures returns a stable named vector', () => {
+  const vector = extractStructuralFeatures('첫 문장입니다. 두 번째 문장은 조금 더 깁니다.', { lang: 'ko' });
+  assert.equal(vector.length, STRUCTURAL_FEATURE_NAMES.length);
+  assert.ok(vector.every(Number.isFinite));
+
+  const record = structuralFeatureRecord(vector);
+  assert.deepEqual(Object.keys(record), [...STRUCTURAL_FEATURE_NAMES]);
+  assert.ok(record.mean_sent_len > 0);
+  assert.ok(record.ttr > 0);
+});
+
+test('structuralModelVerdict is explicitly unavailable without supplied weights', () => {
+  const verdict = structuralModelVerdict('오늘은 날씨가 좋았다. 점심을 먹었다.', { lang: 'ko' });
+  assert.deepEqual(verdict, { available: false, hot: null, score: null });
+
+  const analysis = analyzeText('오늘은 날씨가 좋았다. 점심을 먹었다.', { lang: 'ko' });
+  assert.deepEqual(analysis.structuralClassifier, { available: false, hot: null, score: null });
+  assert.equal(
+    analysis.hot,
+    analysis.markupLeakage.leaked || analysis.discourseTells.hot || analysis.paragraphs.some((p) => p.hot),
+  );
+});
+
+test('analyzeText can opt into a supplied structural model as a document-level OR signal', () => {
+  const text = '오늘은 날씨가 좋았다. 점심을 먹었다.';
+  const baseline = analyzeText(text, { lang: 'ko' });
+  assert.equal(baseline.hot, false);
+
+  const modeled = analyzeText(text, { lang: 'ko', structuralModel: constantModel() });
+  assert.equal(modeled.structuralClassifier.available, true);
+  assert.equal(modeled.structuralClassifier.hot, true);
+  assert.ok(modeled.structuralClassifier.score > 0.99);
+  assert.equal(modeled.hot, true);
+});
+
+test('structural model refuses the wrong language instead of scoring silently', () => {
+  const verdict = structuralModelVerdict('Plain English text.', {
+    lang: 'en',
+    model: constantModel({ lang: 'ko' }),
+  });
+  assert.deepEqual(verdict, { available: false, hot: null, score: null });
+});
+
+test('logistic helper trains and scores a simple separable toy model', () => {
+  const X = [[0], [0.1], [1], [1.1]];
+  const y = [0, 0, 1, 1];
+  const model = trainLogReg(X, y, { lr: 0.2, epochs: 400, l2: 0 });
+
+  assert.ok(predictStructuralScore(model, [0]) < 0.5);
+  assert.ok(predictStructuralScore(model, [1.1]) > 0.5);
+});

--- a/tests/unit/structural-model-loader.test.js
+++ b/tests/unit/structural-model-loader.test.js
@@ -1,0 +1,99 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+import { loadConfig } from '../../src/config.js';
+import { scoreDeterministicSignals } from '../../src/scoring.js';
+import {
+  STRUCTURAL_FEATURE_NAMES,
+  loadStructuralModel,
+  resolveStructuralModelPath,
+} from '../../src/features/index.js';
+import { buildDeterministicAuditBackstop } from '../../src/output.js';
+
+function constantModel({ bias = 10, threshold = 0.5, lang = 'ko' } = {}) {
+  return {
+    lang,
+    weights: new Array(STRUCTURAL_FEATURE_NAMES.length).fill(0),
+    bias,
+    threshold,
+    scaler: {
+      mu: new Array(STRUCTURAL_FEATURE_NAMES.length).fill(0),
+      sigma: new Array(STRUCTURAL_FEATURE_NAMES.length).fill(1),
+    },
+    featureNames: STRUCTURAL_FEATURE_NAMES,
+  };
+}
+
+function writeModel(dir, model = constantModel()) {
+  const path = resolve(dir, 'model-ko.json');
+  writeFileSync(path, JSON.stringify(model), 'utf8');
+  return path;
+}
+
+test('resolveStructuralModelPath prefers explicit env/config and treats default search as optional', () => {
+  const dir = mkdtempSync(resolve(tmpdir(), 'patina-model-'));
+  const envPath = writeModel(dir);
+  const configPath = resolve(dir, 'config-model.json');
+
+  assert.deepEqual(resolveStructuralModelPath({}, { cwd: dir, env: {}, lang: 'ko' }), null);
+  assert.equal(
+    resolveStructuralModelPath({ stylometry: { structural_model: { path: configPath } } }, { cwd: dir, env: {}, lang: 'ko' }).path,
+    configPath,
+  );
+  assert.equal(
+    resolveStructuralModelPath({ stylometry: { structural_model: { path: configPath } } }, { cwd: dir, env: { PATINA_STRUCTURAL_MODEL: envPath }, lang: 'ko' }).path,
+    envPath,
+  );
+});
+
+test('loadStructuralModel loads private weights from an explicit path', () => {
+  const dir = mkdtempSync(resolve(tmpdir(), 'patina-model-'));
+  const path = writeModel(dir);
+  const model = loadStructuralModel({ stylometry: { structural_model: { path } } }, { env: {}, cwd: dir, lang: 'ko' });
+
+  assert.equal(model.lang, 'ko');
+  assert.deepEqual(model.featureNames, STRUCTURAL_FEATURE_NAMES);
+});
+
+test('configured private model lifts deterministic scoring without hosted service', () => {
+  const dir = mkdtempSync(resolve(tmpdir(), 'patina-model-'));
+  const path = writeModel(dir);
+  const text = '오늘은 날씨가 좋았다. 점심을 먹었다.';
+  const baseConfig = loadConfig();
+
+  const baseline = scoreDeterministicSignals({ text, config: baseConfig });
+  assert.equal(baseline.overall, 0);
+  assert.deepEqual(baseline.bands.structuralClassifier, { available: false, hot: null, score: null, floor: 0 });
+
+  const enhanced = scoreDeterministicSignals({
+    text,
+    config: {
+      ...baseConfig,
+      stylometry: {
+        ...baseConfig.stylometry,
+        structural_model: { path },
+      },
+    },
+  });
+
+  assert.equal(enhanced.bands.structuralClassifier.available, true);
+  assert.equal(enhanced.bands.structuralClassifier.hot, true);
+  assert.ok(enhanced.bands.structuralClassifier.score > 0.99);
+  assert.ok(enhanced.overall >= 99);
+  assert.equal(enhanced.interpretation, 'heavily AI');
+});
+
+test('audit backstop surfaces a hot private structural model verdict', () => {
+  const dir = mkdtempSync(resolve(tmpdir(), 'patina-model-'));
+  const path = writeModel(dir);
+  const md = buildDeterministicAuditBackstop('오늘은 날씨가 좋았다. 점심을 먹었다.', {
+    lang: 'ko',
+    config: { stylometry: { structural_model: { path } } },
+  });
+
+  assert.match(md, /structural-classifier/);
+  assert.match(md, /문서 단위 구조 분류기/);
+});


### PR DESCRIPTION
## Summary
- add public structural feature extraction and classifier runtime for optional private local model weights
- wire score/audit flows to load a private structural model via config or PATINA_STRUCTURAL_MODEL
- add hosted schema validation and focused tests without publishing private assets

## Verification
- node --test tests/unit/structural-classifier.test.js tests/unit/structural-model-loader.test.js tests/unit/patina-hosted-schema.test.js tests/unit/scoring.test.js tests/unit/audit-backstop.test.js
- npm run typecheck
- npm run lint:eslint
- npm test
- npm run benchmark
- npm run check:no-private-assets