### PR TITLE
Add browser diff page for rewrites

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -56,6 +56,25 @@ stays reserved for the transformed text or JSON envelope.
 - Ouroboros reports per-iteration score movement and latency.
 
 
+## Browser diff page
+
+`--browser` is a rewrite-mode add-on for reviewing one local file in the browser without changing stdout semantics.
+
+```bash
+patina --browser draft.md
+patina --browser --format json draft.md
+```
+
+Contract:
+- Supports exactly one local file path.
+- Rejects stdin, multiple files, `--batch`, URL-like input, and non-rewrite modes such as `--diff`, `--audit`, `--score`, and `--ouroboros`.
+- Preserves the normal rewrite stdout output byte-for-byte for the selected `--format`.
+- Generates a self-contained local HTML page under an OS temp directory and attempts to open it in the default browser.
+- Browser-open fallback reports the saved HTML path on stderr; it never appends the path to stdout.
+- The page shows side-by-side before/after text, conservative changed-block highlights, deterministic before/after score summaries, and Pattern/Removed/Added/Why explanation from a best-effort secondary diff call.
+- `--browser` makes one additional diff-explanation model/backend call after the primary rewrite, so it can add latency and consume extra backend quota.
+- If the secondary diff explanation call fails, the rewrite still succeeds and the page shows a failure notice in the explanation area.
+
 
 ## Backend fallback chains
 

--- a/src/browser-diff.js
+++ b/src/browser-diff.js
@@ -1,0 +1,360 @@
+import { mkdtempSync, writeFileSync, chmodSync } from 'node:fs';
+import { tmpdir as osTmpdir } from 'node:os';
+import { join, resolve as resolvePath } from 'node:path';
+import { spawn as spawnChild } from 'node:child_process';
+
+const DEFAULT_CSP = "default-src 'none'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'";
+let testRuntimeOverrides = {};
+const MAX_LCS_MATRIX_CELLS = 20000;
+
+export function buildBrowserDiffPromptInput(original, rewritten) {
+  return [
+    'Compare BEFORE to AFTER.',
+    'Do not rewrite either text.',
+    'Report only changes present in AFTER relative to BEFORE.',
+    '',
+    '## BEFORE',
+    original,
+    '',
+    '## AFTER',
+    rewritten,
+  ].join('\n');
+}
+
+export function htmlEscape(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function renderChangedBlocks(original, rewritten) {
+  const beforeBlocks = splitTextIntoBlocks(original);
+  const afterBlocks = splitTextIntoBlocks(rewritten);
+  const matcher = beforeBlocks.length * afterBlocks.length > MAX_LCS_MATRIX_CELLS
+    ? matchBlocksByIndex
+    : matchCommonBlocks;
+  const { leftMatched, rightMatched } = matcher(
+    beforeBlocks.map((block) => block.text),
+    afterBlocks.map((block) => block.text),
+  );
+
+  return {
+    beforeHtml: renderBlocks(beforeBlocks, leftMatched),
+    afterHtml: renderBlocks(afterBlocks, rightMatched),
+  };
+}
+
+export function buildScoreSummary(beforeScore, afterScore) {
+  return {
+    before: normalizeScoreRows(beforeScore),
+    after: normalizeScoreRows(afterScore),
+  };
+}
+
+export function renderBrowserDiffHtml({
+  original,
+  rewrittenBody,
+  diffExplanation,
+  diffError,
+  beforeScore,
+  afterScore,
+  sourcePath,
+}) {
+  const { beforeHtml, afterHtml } = renderChangedBlocks(original, rewrittenBody);
+  const summary = buildScoreSummary(beforeScore, afterScore);
+  const escapedSourcePath = htmlEscape(sourcePath);
+  const explanationBody = diffExplanation ? htmlEscape(diffExplanation) : '';
+  const failureNotice = diffError
+    ? `<p class="warning">Pattern explanation unavailable: ${htmlEscape(diffError)}</p>`
+    : '';
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Content-Security-Policy" content="${htmlEscape(DEFAULT_CSP)}">
+  <title>patina browser diff</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b0d11;
+      --panel: #12161d;
+      --line: #293242;
+      --muted: #96a3b8;
+      --text: #edf2ff;
+      --accent: #8db4ff;
+      --mark: rgba(255, 215, 102, 0.22);
+      --warn: #ffb86b;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 14px/1.6 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      max-width: 1440px;
+      margin: 0 auto;
+      padding: 32px 20px 40px;
+      display: grid;
+      gap: 20px;
+    }
+    .panel {
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      background: var(--panel);
+      padding: 18px;
+      overflow: hidden;
+    }
+    h1, h2, h3 { margin: 0 0 10px; }
+    .meta { color: var(--muted); margin: 0; word-break: break-all; }
+    .summary-grid, .pane-grid {
+      display: grid;
+      gap: 16px;
+    }
+    .summary-grid { grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+    .pane-grid { grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    th, td {
+      border-top: 1px solid var(--line);
+      padding: 8px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { color: var(--muted); font-weight: 600; }
+    pre {
+      margin: 0;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font: 13px/1.7 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+    mark.changed-block {
+      display: inline;
+      background: var(--mark);
+      color: inherit;
+      border-radius: 4px;
+      padding: 0 2px;
+    }
+    .pane-title, .eyebrow {
+      color: var(--muted);
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 8px;
+    }
+    .warning {
+      margin: 0 0 12px;
+      color: var(--warn);
+    }
+    .explanation {
+      min-height: 120px;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="panel">
+      <p class="eyebrow">local browser diff</p>
+      <h1>patina before/after comparison</h1>
+      <p class="meta">Source: ${escapedSourcePath}</p>
+    </section>
+    <section class="summary-grid">
+      ${renderScorePanel('Before', summary.before)}
+      ${renderScorePanel('After', summary.after)}
+    </section>
+    <section class="pane-grid">
+      <article class="panel">
+        <p class="pane-title">Before</p>
+        <pre>${beforeHtml}</pre>
+      </article>
+      <article class="panel">
+        <p class="pane-title">After</p>
+        <pre>${afterHtml}</pre>
+      </article>
+    </section>
+    <section class="panel">
+      <p class="pane-title">Pattern explanation</p>
+      ${failureNotice}
+      <pre class="explanation">${explanationBody || htmlEscape('No pattern explanation available.')}</pre>
+    </section>
+  </main>
+</body>
+</html>`;
+}
+
+export function writeBrowserDiffPage(html, options = {}) {
+  const tmpdir = getRuntimeValue(options, 'tmpdir', osTmpdir);
+  const mkdtemp = getRuntimeValue(options, 'mkdtemp', mkdtempSync);
+  const writeFile = getRuntimeValue(options, 'writeFile', writeFileSync);
+  const chmod = getRuntimeValue(options, 'chmod', chmodSync);
+  const now = getRuntimeValue(options, 'now', Date.now);
+  const platform = getRuntimeValue(options, 'platform', process.platform);
+  const baseTmpDir = typeof tmpdir === 'function' ? tmpdir() : tmpdir;
+  const dirPath = mkdtemp(join(baseTmpDir, 'patina-browser-diff-'));
+  enforcePermissions(chmod, dirPath, 0o700, { required: platform !== 'win32' });
+  const filePath = join(dirPath, `browser-diff-${now()}.html`);
+  writeFile(filePath, html, 'utf8');
+  enforcePermissions(chmod, filePath, 0o600, { required: platform !== 'win32' });
+  return filePath;
+}
+
+export function openBrowserDiffPage(path, options = {}) {
+  const platform = getRuntimeValue(options, 'platform', process.platform);
+  const spawn = getRuntimeValue(options, 'spawn', spawnChild);
+  const targetPath = resolvePath(path);
+  const { command, args } = resolveOpenCommand(platform, targetPath);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: 'ignore' });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`browser opener exited with code ${code}`));
+    });
+    child.unref?.();
+  });
+}
+
+export function setBrowserDiffRuntimeForTests(overrides = {}) {
+  testRuntimeOverrides = { ...overrides };
+}
+
+export function resetBrowserDiffRuntimeForTests() {
+  testRuntimeOverrides = {};
+}
+
+function getRuntimeValue(options, key, fallback) {
+  if (Object.prototype.hasOwnProperty.call(options, key)) return options[key];
+  if (Object.prototype.hasOwnProperty.call(testRuntimeOverrides, key)) return testRuntimeOverrides[key];
+  return fallback;
+}
+
+
+function resolveOpenCommand(platform, targetPath) {
+  if (platform === 'darwin') return { command: 'open', args: [targetPath] };
+  if (platform === 'win32') return { command: 'cmd', args: ['/c', 'start', '', targetPath] };
+  return { command: 'xdg-open', args: [targetPath] };
+}
+
+function renderScorePanel(title, rows) {
+  const body = rows.map((row) => `
+        <tr>
+          <th scope="row">${htmlEscape(row.label)}</th>
+          <td>${htmlEscape(row.value)}</td>
+        </tr>`).join('');
+  return `<article class="panel">
+      <h2>${htmlEscape(title)}</h2>
+      <table>
+        <tbody>${body}
+        </tbody>
+      </table>
+    </article>`;
+}
+
+function normalizeScoreRows(score) {
+  if (!score || typeof score !== 'object') {
+    return [{ label: 'Status', value: 'Unavailable' }];
+  }
+
+  const rows = [];
+  if (score.overall !== null && score.overall !== undefined) rows.push({ label: 'Overall', value: String(score.overall) });
+  if (score.interpretation) rows.push({ label: 'Interpretation', value: String(score.interpretation) });
+  if (Number.isFinite(score.paragraphCount)) rows.push({ label: 'Paragraphs', value: String(score.paragraphCount) });
+  if (Number.isFinite(score.hotParagraphs)) rows.push({ label: 'Hot paragraphs', value: String(score.hotParagraphs) });
+  if (Number.isFinite(score.signalScore)) rows.push({ label: 'Signal score', value: String(score.signalScore) });
+  if (score.skipped) rows.push({ label: 'Skipped', value: 'true' });
+  if (score.skipReason) rows.push({ label: 'Skip reason', value: String(score.skipReason) });
+  if (score.error) rows.push({ label: 'Error', value: String(score.error) });
+  return rows.length > 0 ? rows : [{ label: 'Status', value: 'Unavailable' }];
+}
+
+function splitTextIntoBlocks(text) {
+  const normalized = String(text ?? '').replace(/\r\n/g, '\n');
+  if (normalized.length === 0) return [{ text: '', separator: '' }];
+  if (/\n{2,}/.test(normalized)) return splitBySeparator(normalized, /\n{2,}/g);
+  if (/\n/.test(normalized)) return splitBySeparator(normalized, /\n/g);
+  return [{ text: normalized, separator: '' }];
+}
+
+function splitBySeparator(text, separatorRe) {
+  const blocks = [];
+  let lastIndex = 0;
+  let match;
+  while ((match = separatorRe.exec(text)) !== null) {
+    blocks.push({ text: text.slice(lastIndex, match.index), separator: match[0] });
+    lastIndex = match.index + match[0].length;
+  }
+  blocks.push({ text: text.slice(lastIndex), separator: '' });
+  return blocks;
+}
+
+function renderBlocks(blocks, matchedSet) {
+  return blocks.map((block, index) => {
+    const escapedText = htmlEscape(block.text);
+    const escapedSeparator = htmlEscape(block.separator);
+    if (!block.text) return escapedSeparator;
+    if (matchedSet.has(index)) return `${escapedText}${escapedSeparator}`;
+    return `<mark class="changed-block">${escapedText}</mark>${escapedSeparator}`;
+  }).join('');
+}
+
+function matchCommonBlocks(left, right) {
+  const table = Array.from({ length: left.length + 1 }, () => new Array(right.length + 1).fill(0));
+  for (let i = left.length - 1; i >= 0; i--) {
+    for (let j = right.length - 1; j >= 0; j--) {
+      if (left[i] === right[j]) table[i][j] = table[i + 1][j + 1] + 1;
+      else table[i][j] = Math.max(table[i + 1][j], table[i][j + 1]);
+    }
+  }
+
+  const leftMatched = new Set();
+  const rightMatched = new Set();
+  let i = 0;
+  let j = 0;
+  while (i < left.length && j < right.length) {
+    if (left[i] === right[j]) {
+      leftMatched.add(i);
+      rightMatched.add(j);
+      i++;
+      j++;
+      continue;
+    }
+    if (table[i + 1][j] >= table[i][j + 1]) i++;
+    else j++;
+  }
+
+  return { leftMatched, rightMatched };
+}
+
+function matchBlocksByIndex(left, right) {
+  const leftMatched = new Set();
+  const rightMatched = new Set();
+  const count = Math.min(left.length, right.length);
+  for (let i = 0; i < count; i++) {
+    if (left[i] === right[i]) {
+      leftMatched.add(i);
+      rightMatched.add(i);
+    }
+  }
+  return { leftMatched, rightMatched };
+}
+
+function enforcePermissions(chmod, path, mode, { required }) {
+  try {
+    chmod(path, mode);
+  } catch (err) {
+    if (required) throw err;
+  }
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,7 +11,13 @@ import { buildPrompt } from './prompt-builder.js';
 import { invokeBackendChain, selectBackendChain, listBackends, listBackendNames, resolveBackend } from './backends/index.js';
 import { selectProvider, resolveProviderConfig } from './providers.js';
 import { validateBaseURL, applyInsecureBaseURLOptIn, applyPrivateBaseURLOptIn } from './security.js';
-import { formatOutput, validateScoreWeights, buildDeterministicAuditBackstop } from './output.js';
+import { formatOutput, formatRewriteBodyForBrowser, validateScoreWeights, buildDeterministicAuditBackstop } from './output.js';
+import {
+  buildBrowserDiffPromptInput,
+  renderBrowserDiffHtml,
+  writeBrowserDiffPage,
+  openBrowserDiffPage,
+} from './browser-diff.js';
 import { runOuroboros } from './ouroboros.js';
 import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals } from './scoring.js';
 import { runDoctor } from './commands/doctor.js';
@@ -88,6 +94,8 @@ export async function main(args) {
     printBackendStatus();
     return;
   }
+
+  validateBrowserRequest(parsed);
 
   const configPath = parsed.config ? resolve(process.cwd(), parsed.config) : undefined;
   const config = loadConfig(configPath);
@@ -285,6 +293,7 @@ export async function main(args) {
             logger,
           });
         }
+        let browserPagePath = null;
 
         const auditBackstop =
           mode === 'audit' && (parsed.format ?? 'markdown') !== 'json' && !parsed.batch
@@ -301,6 +310,33 @@ export async function main(args) {
           if (mode === 'score') {
             scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' }, { logger });
           }
+        }
+
+        if (parsed.browser && mode === 'rewrite') {
+          ({ pagePath: browserPagePath } = await buildBrowserDiffArtifact({
+            originalText: text,
+            rawRewriteResult: result,
+            sourcePath: path,
+            parsed,
+            config,
+            repoRoot,
+            patterns,
+            profile: profile.body ? profile : null,
+            voice: voice.body ? voice : null,
+            voiceSample,
+            scoring: scoring.body ? scoring : null,
+            promptMode,
+            backends,
+            apiKey: resolved.apiKey,
+            baseURL: resolved.baseURL,
+            model: resolved.model,
+            modelSource: resolved.modelSource,
+            signal: cancellation.signal,
+            timeout: timeoutMs,
+            maxConcurrency: parsed.maxConcurrency,
+            maxRetries: parsed.maxRetries,
+            logger,
+          }));
         }
 
         // v3.11 Phase 1.3: surface weight drift between config and the score
@@ -321,6 +357,14 @@ export async function main(args) {
           await writeBatchOutput(parsed, path, output);
         } else {
           console.log(output);
+          if (browserPagePath) {
+            try {
+              await openBrowserDiffPage(browserPagePath);
+            } catch (err) {
+              console.error(`[patina] Browser diff page saved at ${browserPagePath}`);
+              console.error(`[patina] Browser open failed: ${err.message}`);
+            }
+          }
         }
         batchState.recordSuccess();
       } catch (err) {
@@ -388,6 +432,9 @@ function parseArgs(args) {
       case '--voice-sample':
         parsed.voiceSample = readOptionValue(args, i, arg);
         i++;
+        break;
+      case '--browser':
+        parsed.browser = true;
         break;
       case '--diff':
         parsed.diff = true;
@@ -532,6 +579,38 @@ function parseArgs(args) {
   }
 
   return parsed;
+}
+
+function validateBrowserRequest(parsed) {
+  if (!parsed.browser) return;
+  if (parsed.batch) {
+    throw inputError(
+      '--browser does not support --batch',
+      'The browser diff page is limited to one local file in this first release.',
+      'Run `patina --browser path/to/file.md`, or omit --browser for batch rewrites.'
+    );
+  }
+  if (parsed.diff || parsed.audit || parsed.score || parsed.ouroboros) {
+    throw inputError(
+      '--browser only works in rewrite mode',
+      'Browser diff pages are an additive rewrite surface, not a diff/audit/score/ouroboros mode.',
+      'Use `patina --browser path/to/file.md` by itself, without --diff, --audit, --score, or --ouroboros.'
+    );
+  }
+  if (parsed.files.length !== 1) {
+    throw inputError(
+      '--browser requires exactly one local file',
+      'No file, stdin, or multiple files were provided.',
+      'Pass one local file path such as `patina --browser draft.md`.'
+    );
+  }
+  if (/^https?:\/\//i.test(String(parsed.files[0] || ''))) {
+    throw inputError(
+      '--browser does not support URL input yet',
+      'This first PR is limited to a single local file and does not fetch homepage URLs.',
+      'Download the page to a local file first, or run plain patina without --browser.'
+    );
+  }
 }
 
 function cancellationError() {
@@ -973,9 +1052,10 @@ MODES
   --score                 Output AI-likeness score (0-100)
   --exit-on <n>           With --score, exit 3 when overall score > n
   --ouroboros             Iterative self-improvement loop
+  --browser               Rewrite one local file, then open a local before/after diff page (adds one diff explanation call)
 
 OUTPUT & BATCH
-  --format <fmt>          Output format: markdown (default), text, json
+  --format <fmt>          Stdout format: markdown (default), text, json
   --quiet                 Suppress patina status/warning logs on stderr
   --batch                 Process multiple files
   --in-place              Overwrite original files (with --batch)
@@ -1036,6 +1116,90 @@ If no API key is set, pass --backend codex-cli to use a logged-in codex CLI
 (no key required). Auto-fallback was removed in v3.9 to keep agent-mode
 backends opt-in (issue #88).
 `);
+}
+
+async function buildBrowserDiffArtifact({
+  originalText,
+  rawRewriteResult,
+  sourcePath,
+  parsed,
+  config,
+  repoRoot,
+  patterns,
+  profile,
+  voice,
+  voiceSample,
+  scoring,
+  promptMode,
+  backends,
+  apiKey,
+  baseURL,
+  model,
+  modelSource,
+  signal,
+  timeout,
+  maxConcurrency,
+  maxRetries,
+  logger,
+}) {
+  const rewrittenBody = formatRewriteBodyForBrowser(rawRewriteResult, { logger });
+  const beforeScore = scoreDeterministicSignals({ text: originalText, config, repoRoot });
+  const afterScore = scoreDeterministicSignals({ text: rewrittenBody, config, repoRoot });
+
+  let diffExplanation = '';
+  let diffError = null;
+  try {
+    const diffPrompt = buildPrompt({
+      config,
+      patterns,
+      profile,
+      voice,
+      voiceSample,
+      scoring,
+      text: buildBrowserDiffPromptInput(originalText, rewrittenBody),
+      mode: 'diff',
+      promptMode,
+    });
+    const diffResult = await invokeBackendChain({
+      backends,
+      prompt: diffPrompt,
+      apiKey,
+      baseURL,
+      model,
+      modelSource,
+      signal,
+      timeout,
+      maxConcurrency,
+      maxRetries,
+      logger,
+    });
+    diffExplanation = formatOutput(
+      diffResult,
+      'diff',
+      { ...parsed, format: 'markdown', noColor: true },
+      { logger, stdout: { isTTY: false } },
+    );
+  } catch (err) {
+    diffError = err?.message || 'browser diff explanation failed';
+    logger.warn('browser.diff_failed', {
+      message: `[patina] browser diff explanation failed: ${diffError}`,
+    });
+  }
+
+  const html = renderBrowserDiffHtml({
+    original: originalText,
+    rewrittenBody,
+    diffExplanation,
+    diffError,
+    beforeScore,
+    afterScore,
+    sourcePath,
+  });
+
+  return {
+    pagePath: writeBrowserDiffPage(html),
+    rewrittenBody,
+  };
 }
 
 function withDeterministicScore(rawResult, { text, config, repoRoot, logger }) {

--- a/src/output.js
+++ b/src/output.js
@@ -238,13 +238,34 @@ export function stripSelfAudit(body, { logger = createLogger() } = {}) {
     }
     return body;
   }
-  const inner = body.slice(bodyOpen + '[BODY]'.length, bodyClose).trim();
+  const inner = removeSelfAuditBlocks(body.slice(bodyOpen + '[BODY]'.length, bodyClose)).trim();
   const tail = removeSelfAuditBlocks(body.slice(bodyClose + '[/BODY]'.length)).trim();
   return tail ? `${inner}\n\n${tail}` : inner;
 }
+export function formatRewriteBodyForBrowser(result, { logger = createLogger() } = {}) {
+  const body = stripSelfAudit(renderBody(result), { logger }).trim();
+  return removeToneFooter(body);
+}
+
 
 function removeSelfAuditBlocks(body) {
   return String(body || '').replace(/\[SELF_AUDIT\][\s\S]*?\[\/SELF_AUDIT\]/g, '');
+}
+
+function removeToneFooter(body) {
+  if (!hasToneFooter(body)) return body;
+  const match = String(body || '').match(/(^|\n)---\s*\n([\s\S]*?)\n---\s*$/);
+  if (!match) return body;
+  const block = match[2];
+  if (
+    !/\btone\s*:/.test(block)
+    || !/\btone_source\s*:/.test(block)
+    || !/\btone_evidence\s*:/.test(block)
+    || !/\btone_confidence\s*:/.test(block)
+  ) {
+    return body;
+  }
+  return String(body || '').slice(0, match.index).trimEnd();
 }
 
 function renderBody(result) {
@@ -385,11 +406,14 @@ function toFiniteNumber(value) {
 
 function parseFirstJson(text) {
   if (!text || typeof text !== 'string') return null;
-  const candidates = [
+  const rawCandidates = [
     text.trim(),
     text.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1],
     text.match(/\{[\s\S]*\}/)?.[0],
-  ].filter(Boolean);
+  ];
+  const candidates = /** @type {string[]} */ (
+    rawCandidates.filter((candidate) => typeof candidate === 'string' && candidate.length > 0)
+  );
   for (const candidate of candidates) {
     try {
       return JSON.parse(candidate);

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -1,7 +1,9 @@
 import { createServer } from 'node:http';
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
+import { EventEmitter } from 'node:events';
 import { main, resolvePromptMode } from '../../src/cli.js';
+import { setBrowserDiffRuntimeForTests, resetBrowserDiffRuntimeForTests } from '../../src/browser-diff.js';
 import { fileURLToPath } from 'node:url';
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -16,8 +18,17 @@ let callCount = 0;
 let lastRequestBody = null;
 let lastAuthorization = null;
 let mockApiKeyPath;
+let requestBodies = [];
 
 function startMockServer(responseText, statusCode = 200, extraResponse = {}) {
+  const queue = Array.isArray(responseText)
+    ? responseText.map((entry) => ({
+        responseText: entry.responseText,
+        statusCode: entry.statusCode ?? 200,
+        extraResponse: entry.extraResponse ?? {},
+      }))
+    : null;
+
   return new Promise((resolve) => {
     mockServer = createServer((req, res) => {
       callCount++;
@@ -26,10 +37,16 @@ function startMockServer(responseText, statusCode = 200, extraResponse = {}) {
       req.on('data', (chunk) => { body += chunk; });
       req.on('end', () => {
         lastRequestBody = JSON.parse(body);
-        res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+        requestBodies.push(lastRequestBody);
+        const current = queue ? (queue.shift() || { responseText: '', statusCode: 200, extraResponse: {} }) : {
+          responseText,
+          statusCode,
+          extraResponse,
+        };
+        res.writeHead(current.statusCode, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
-          choices: [{ message: { content: responseText } }],
-          ...extraResponse,
+          choices: [{ message: { content: current.responseText } }],
+          ...current.extraResponse,
         }));
       });
     });
@@ -60,6 +77,15 @@ async function captureConsole(fn) {
     console.error = originalError;
   }
   return { logs, errors };
+}
+
+function makeFakeSpawn(onSpawn) {
+  return (command, args) => {
+    const child = new EventEmitter();
+    child.unref = () => {};
+    onSpawn?.({ command, args, child });
+    return child;
+  };
 }
 
 async function withEnv(envOverrides, fn) {
@@ -288,6 +314,239 @@ describe('CLI End-to-End with Mock API', () => {
     await startMockServer('This is the humanized result.');
   });
 
+  it('supports --browser with JSON stdout while rendering prose HTML and a second diff call', async () => {
+    const rewriteResponse = [
+      '[BODY]',
+      'This is the humanized result.',
+      '[/BODY]',
+      '',
+      '[SELF_AUDIT]',
+      '- residual signals: none',
+      '[/SELF_AUDIT]',
+      '',
+      '---',
+      'tone: null',
+      'tone_source: profile_only',
+      'tone_evidence: []',
+      'tone_confidence: null',
+      '---',
+    ].join('\n');
+    const diffResponse = [
+      'Pattern: 1. Generic polish',
+      'Removed: This is the draft.',
+      'Added: This is the humanized result.',
+      'Why: one short reason',
+    ].join('\n');
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+
+    requestBodies = [];
+    await stopMockServer();
+    await startMockServer(rewriteResponse);
+    const baseline = await captureConsole(() => main([
+      '--lang', 'en',
+      '--format', 'json',
+      '--api-key-file', mockApiKeyPath,
+      '--base-url', `http://127.0.0.1:${mockPort}`,
+      testFile,
+    ]));
+
+    const writes = [];
+    const chmods = [];
+    const spawns = [];
+    setBrowserDiffRuntimeForTests({
+      tmpdir: () => '/tmp',
+      mkdtemp: (prefix) => {
+        assert.match(prefix, /patina-browser-diff-/);
+        return '/tmp/patina-browser-diff-123';
+      },
+      writeFile: (path, data, encoding) => {
+        writes.push({ path, data, encoding });
+      },
+      chmod: (path, mode) => {
+        chmods.push({ path, mode });
+      },
+      now: () => 123,
+      platform: 'linux',
+      spawn: makeFakeSpawn(({ command, args, child }) => {
+        spawns.push({ command, args });
+        process.nextTick(() => child.emit('close', 0));
+      }),
+    });
+
+    callCount = 0;
+    requestBodies = [];
+    lastRequestBody = null;
+    try {
+      await stopMockServer();
+      await startMockServer([
+        { responseText: rewriteResponse },
+        { responseText: diffResponse },
+      ]);
+
+      const browserRun = await captureConsole(() => main([
+        '--browser',
+        '--lang', 'en',
+        '--format', 'json',
+        '--api-key-file', mockApiKeyPath,
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        testFile,
+      ]));
+
+      assert.strictEqual(browserRun.logs.join('\n'), baseline.logs.join('\n'));
+      assert.deepStrictEqual(browserRun.errors, []);
+      assert.strictEqual(callCount, 2);
+      assert.strictEqual(requestBodies.length, 2);
+      assert.strictEqual(spawns[0].command, 'xdg-open');
+      assert.deepStrictEqual(spawns[0].args, ['/tmp/patina-browser-diff-123/browser-diff-123.html']);
+      assert.strictEqual(writes[0].path, '/tmp/patina-browser-diff-123/browser-diff-123.html');
+      assert.strictEqual(writes[0].encoding, 'utf8');
+      assert.ok(writes[0].data.includes('This is the humanized result.'));
+      assert.ok(writes[0].data.includes('Pattern: 1. Generic polish'));
+      assert.ok(writes[0].data.includes('Signal score'));
+      assert.ok(!writes[0].data.includes('[SELF_AUDIT]'));
+      assert.ok(!writes[0].data.includes('"mode": "rewrite"'));
+      assert.deepStrictEqual(chmods, [
+        { path: '/tmp/patina-browser-diff-123', mode: 0o700 },
+        { path: '/tmp/patina-browser-diff-123/browser-diff-123.html', mode: 0o600 },
+      ]);
+
+      const diffPrompt = requestBodies[1].messages[0].content;
+      assert.match(diffPrompt, /Compare BEFORE to AFTER\./);
+      assert.match(diffPrompt, /Do not rewrite either text\./);
+      assert.match(diffPrompt, /report only changes present in AFTER relative to BEFORE/i);
+      assert.match(diffPrompt, /## BEFORE/);
+      assert.match(diffPrompt, /## AFTER/);
+    } finally {
+      resetBrowserDiffRuntimeForTests();
+      await stopMockServer();
+      await startMockServer('This is the humanized result.');
+    }
+  });
+
+  it('keeps stdout pure and reports the temp path on stderr when browser open fails', async () => {
+    const rewriteResponse = '[BODY]\nThis is the humanized result.\n[/BODY]';
+    const diffResponse = 'Pattern: 1. Generic polish\nRemoved: old\nAdded: new\nWhy: reason';
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+
+    await stopMockServer();
+    await startMockServer(rewriteResponse);
+    const baseline = await captureConsole(() => main([
+      '--lang', 'en',
+      '--api-key-file', mockApiKeyPath,
+      '--base-url', `http://127.0.0.1:${mockPort}`,
+      testFile,
+    ]));
+
+    setBrowserDiffRuntimeForTests({
+      tmpdir: () => '/tmp',
+      mkdtemp: () => '/tmp/patina-browser-diff-456',
+      writeFile: () => {},
+      chmod: () => {},
+      now: () => 456,
+      platform: 'linux',
+      spawn: makeFakeSpawn(({ child }) => {
+        process.nextTick(() => child.emit('close', 1));
+      }),
+    });
+
+    callCount = 0;
+    requestBodies = [];
+    try {
+      await stopMockServer();
+      await startMockServer([
+        { responseText: rewriteResponse },
+        { responseText: diffResponse },
+      ]);
+
+      const browserRun = await captureConsole(() => main([
+        '--browser',
+        '--lang', 'en',
+        '--api-key-file', mockApiKeyPath,
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        testFile,
+      ]));
+
+      assert.strictEqual(browserRun.logs.join('\n'), baseline.logs.join('\n'));
+      assert.strictEqual(callCount, 2);
+      assert.ok(browserRun.errors.some((line) => line.includes('Browser diff page saved at /tmp/patina-browser-diff-456/browser-diff-456.html')));
+      assert.ok(browserRun.errors.some((line) => line.includes('Browser open failed: browser opener exited with code 1')));
+    } finally {
+      resetBrowserDiffRuntimeForTests();
+      await stopMockServer();
+      await startMockServer('This is the humanized result.');
+    }
+  });
+
+  it('keeps rewrite success and writes an HTML warning when the secondary diff call fails', async () => {
+    const rewriteResponse = '[BODY]\nThis is the humanized result.\n[/BODY]';
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+    const writes = [];
+
+    setBrowserDiffRuntimeForTests({
+      tmpdir: () => '/tmp',
+      mkdtemp: () => '/tmp/patina-browser-diff-789',
+      writeFile: (_path, data) => {
+        writes.push(data);
+      },
+      chmod: () => {},
+      now: () => 789,
+      platform: 'linux',
+      spawn: makeFakeSpawn(({ child }) => {
+        process.nextTick(() => child.emit('close', 0));
+      }),
+    });
+
+    callCount = 0;
+    requestBodies = [];
+    try {
+      await stopMockServer();
+      await startMockServer([
+        { responseText: rewriteResponse },
+        { responseText: 'backend failed', statusCode: 500 },
+      ]);
+
+      const browserRun = await captureConsole(() => main([
+        '--browser',
+        '--lang', 'en',
+        '--max-retries',
+        '0',
+        '--api-key-file', mockApiKeyPath,
+        '--base-url', `http://127.0.0.1:${mockPort}`,
+        testFile,
+      ]));
+
+      assert.match(browserRun.logs.join('\n'), /This is the humanized result\./);
+      assert.strictEqual(callCount, 2);
+      assert.ok(browserRun.errors.some((line) => line.includes('browser diff explanation failed')));
+      assert.ok(writes[0].includes('Pattern explanation unavailable:'));
+      assert.ok(writes[0].includes('HTTP 500'));
+    } finally {
+      resetBrowserDiffRuntimeForTests();
+      await stopMockServer();
+      await startMockServer('This is the humanized result.');
+    }
+  });
+
+  it('rejects unsupported --browser inputs before any backend call', async () => {
+    const first = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+    const second = first;
+    const cases = [
+      { args: ['--browser'], pattern: /requires exactly one local file/ },
+      { args: ['--browser', first, second], pattern: /requires exactly one local file/ },
+      { args: ['--browser', '--batch', first], pattern: /does not support --batch/ },
+      { args: ['--browser', '--diff', first], pattern: /only works in rewrite mode/ },
+      { args: ['--browser', 'https://example.test'], pattern: /does not support URL input yet/ },
+    ];
+
+    for (const testCase of cases) {
+      callCount = 0;
+      requestBodies = [];
+      await assert.rejects(() => main(testCase.args), testCase.pattern);
+      assert.strictEqual(callCount, 0, testCase.args.join(' '));
+      assert.strictEqual(requestBodies.length, 0, testCase.args.join(' '));
+    }
+  });
+
 
   it('should group help output and list current backend names', async () => {
     const { logs } = await captureConsole(() => main(['--help']));
@@ -306,6 +565,7 @@ describe('CLI End-to-End with Mock API', () => {
     assert.ok(!help.includes('--list-providers'), 'help should not document removed provider listing');
     assert.ok(!/\n\s*--json\s+Alias for --format json/.test(help), 'help should not document removed json alias');
     assert.ok(help.includes('--no-color'), 'help should document diff color opt-out');
+    assert.ok(help.includes('--browser'), 'help should document browser diff mode');
     assert.ok(
       help.includes('openai-http, codex-cli, claude-cli, gemini-cli, kimi-cli'),
       'help should list every backend name'

--- a/tests/unit/browser-diff.test.js
+++ b/tests/unit/browser-diff.test.js
@@ -1,0 +1,168 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { EventEmitter } from 'node:events';
+
+import {
+  buildBrowserDiffPromptInput,
+  htmlEscape,
+  renderChangedBlocks,
+  buildScoreSummary,
+  renderBrowserDiffHtml,
+  writeBrowserDiffPage,
+  openBrowserDiffPage,
+} from '../../src/browser-diff.js';
+import { formatRewriteBodyForBrowser } from '../../src/output.js';
+
+test('buildBrowserDiffPromptInput carries the explicit compare contract', () => {
+  const prompt = buildBrowserDiffPromptInput('before text', 'after text');
+  assert.match(prompt, /Compare BEFORE to AFTER\./);
+  assert.match(prompt, /Do not rewrite either text\./);
+  assert.match(prompt, /Report only changes present in AFTER relative to BEFORE\./);
+  assert.match(prompt, /## BEFORE\nbefore text/);
+  assert.match(prompt, /## AFTER\nafter text/);
+});
+
+test('htmlEscape escapes markup-significant characters', () => {
+  assert.strictEqual(
+    htmlEscape(`<tag attr="x">'&`),
+    '&lt;tag attr=&quot;x&quot;&gt;&#39;&amp;',
+  );
+});
+
+test('formatRewriteBodyForBrowser strips self-audit blocks and tone footer', () => {
+  const raw = [
+    '[BODY]',
+    'Human result.',
+    '[/BODY]',
+    '',
+    '[SELF_AUDIT]',
+    '- note',
+    '[/SELF_AUDIT]',
+    '',
+    '---',
+    'tone: null',
+    'tone_source: profile_only',
+    'tone_evidence: []',
+    'tone_confidence: null',
+    '---',
+  ].join('\n');
+  assert.strictEqual(formatRewriteBodyForBrowser(raw), 'Human result.');
+});
+
+test('renderChangedBlocks preserves shared blocks and highlights changed ones', () => {
+  const { beforeHtml, afterHtml } = renderChangedBlocks('same\n\nold', 'same\n\nnew');
+  assert.ok(beforeHtml.includes('same'));
+  assert.ok(afterHtml.includes('same'));
+  assert.ok(!beforeHtml.includes('<mark class="changed-block">same</mark>'));
+  assert.ok(beforeHtml.includes('<mark class="changed-block">old</mark>'));
+  assert.ok(afterHtml.includes('<mark class="changed-block">new</mark>'));
+});
+
+test('renderChangedBlocks falls back to index matching for large inputs', () => {
+  const before = Array.from({ length: 220 }, (_, index) => `line-${index}`).join('\n');
+  const after = Array.from({ length: 220 }, (_, index) => (index === 219 ? 'line-changed' : `line-${index}`)).join('\n');
+  const { beforeHtml, afterHtml } = renderChangedBlocks(before, after);
+  assert.ok(!beforeHtml.includes('<mark class="changed-block">line-0</mark>'));
+  assert.ok(afterHtml.includes('<mark class="changed-block">line-changed</mark>'));
+});
+
+test('buildScoreSummary keeps skipped and error rows', () => {
+  const summary = buildScoreSummary(
+    { overall: 12, interpretation: 'mostly human', paragraphCount: 2, hotParagraphs: 0, signalScore: 8 },
+    { overall: null, skipped: true, skipReason: 'language-disabled', error: 'disabled' },
+  );
+  assert.deepStrictEqual(summary.before[0], { label: 'Overall', value: '12' });
+  assert.ok(summary.after.some((row) => row.label === 'Skipped' && row.value === 'true'));
+  assert.ok(summary.after.some((row) => row.label === 'Skip reason' && row.value === 'language-disabled'));
+  assert.ok(summary.after.some((row) => row.label === 'Error' && row.value === 'disabled'));
+});
+
+test('renderBrowserDiffHtml escapes untrusted content and keeps the page self-contained', () => {
+  const html = renderBrowserDiffHtml({
+    original: '<script>alert(1)</script>',
+    rewrittenBody: '<img src=x onerror="alert(2)">',
+    diffExplanation: 'Pattern: <b>Unsafe</b>',
+    diffError: 'boom <script>',
+    beforeScore: { overall: 30, interpretation: 'mixed', paragraphCount: 1, hotParagraphs: 1, signalScore: 20 },
+    afterScore: { overall: 10, interpretation: 'mostly human', paragraphCount: 1, hotParagraphs: 0, signalScore: 5 },
+    sourcePath: '/tmp/draft.md',
+  });
+
+  assert.ok(html.includes('Content-Security-Policy'));
+  assert.ok(html.includes('&lt;script&gt;alert(1)&lt;/script&gt;'));
+  assert.ok(html.includes('&lt;img src=x onerror=&quot;alert(2)&quot;&gt;'));
+  assert.ok(html.includes('Pattern: &lt;b&gt;Unsafe&lt;/b&gt;'));
+  assert.ok(html.includes('Pattern explanation unavailable: boom &lt;script&gt;'));
+  assert.ok(!html.includes('http://'));
+  assert.ok(!html.includes('https://'));
+});
+
+test('writeBrowserDiffPage uses a patina-scoped temp dir and restrictive permissions', () => {
+  const writes = [];
+  const chmods = [];
+  const path = writeBrowserDiffPage('<html/>', {
+    tmpdir: () => '/tmp',
+    mkdtemp: (prefix) => {
+      assert.match(prefix, /patina-browser-diff-/);
+      return '/tmp/patina-browser-diff-abc';
+    },
+    writeFile: (filePath, content, encoding) => {
+      writes.push({ filePath, content, encoding });
+    },
+    chmod: (filePath, mode) => {
+      chmods.push({ filePath, mode });
+    },
+    now: () => 42,
+  });
+
+  assert.strictEqual(path, '/tmp/patina-browser-diff-abc/browser-diff-42.html');
+  assert.deepStrictEqual(writes, [{ filePath: '/tmp/patina-browser-diff-abc/browser-diff-42.html', content: '<html/>', encoding: 'utf8' }]);
+  assert.deepStrictEqual(chmods, [
+    { filePath: '/tmp/patina-browser-diff-abc', mode: 0o700 },
+    { filePath: '/tmp/patina-browser-diff-abc/browser-diff-42.html', mode: 0o600 },
+  ]);
+});
+
+test('writeBrowserDiffPage fails loudly when chmod hardening fails on a POSIX-like platform', () => {
+  assert.throws(
+    () =>
+      writeBrowserDiffPage('<html/>', {
+        tmpdir: () => '/tmp',
+        mkdtemp: () => '/tmp/patina-browser-diff-fail',
+        writeFile: () => {},
+        chmod: () => {
+          throw new Error('chmod failed');
+        },
+        now: () => 7,
+        platform: 'linux',
+      }),
+    /chmod failed/,
+  );
+});
+
+test('openBrowserDiffPage selects the platform opener and propagates close failures', async () => {
+  let seen = null;
+  const successSpawn = (command, args) => {
+    seen = { command, args };
+    const child = new EventEmitter();
+    child.unref = () => {};
+    process.nextTick(() => child.emit('close', 0));
+    return child;
+  };
+
+  await openBrowserDiffPage('/tmp/demo.html', { platform: 'linux', spawn: successSpawn });
+  assert.deepStrictEqual(seen, { command: 'xdg-open', args: ['/tmp/demo.html'] });
+
+  await assert.rejects(
+    () => openBrowserDiffPage('/tmp/demo.html', {
+      platform: 'darwin',
+      spawn: () => {
+        const child = new EventEmitter();
+        child.unref = () => {};
+        process.nextTick(() => child.emit('close', 1));
+        return child;
+      },
+    }),
+    /browser opener exited with code 1/,
+  );
+});

--- a/tests/unit/tone.test.js
+++ b/tests/unit/tone.test.js
@@ -205,6 +205,12 @@ test('stripSelfAudit: extracts [BODY] block and drops [SELF_AUDIT]', () => {
   assert.equal(out, 'Hello world');
 });
 
+test('stripSelfAudit: removes nested SELF_AUDIT blocks inside BODY', () => {
+  const raw = '[BODY]\nHello\n[SELF_AUDIT]\ninternal\n[/SELF_AUDIT]\nworld\n[/BODY]';
+  const out = formatOutput(raw, 'rewrite', {});
+  assert.equal(out, 'Hello\n\nworld');
+});
+
 test('stripSelfAudit: keeps YAML footer that follows [/BODY]', () => {
   const raw = '[BODY]\nHello world\n[/BODY]\n\n[SELF_AUDIT]\nstuff\n[/SELF_AUDIT]\n\n---\ntone: null\ntone_source: profile_only\ntone_evidence: []\ntone_confidence: null\n---';
   const out = formatOutput(raw, 'rewrite', {});


### PR DESCRIPTION
## Summary
- add a  rewrite-mode option that opens a local before/after diff page for one local file
- preserve existing stdout output while generating a hardened temp HTML artifact with deterministic score summaries and best-effort diff explanation
- add focused unit/e2e coverage for unsupported inputs, JSON stdout parity, browser-open fallback, diff fallback, nested self-audit stripping, and permission hardening

## Verification
- npm run lint:eslint
- npm run typecheck
- npm test
- npm run check:no-private-assets