### PR TITLE
Fix browser open fallback reporting

### DIFF
--- a/src/browser-diff.js
+++ b/src/browser-diff.js
@@ -223,7 +223,6 @@ export function openBrowserDiffPage(path, options = {}) {
       }
       reject(new Error(`browser opener exited with code ${code}`));
     });
-    child.unref?.();
   });
 }
 

--- a/tests/unit/browser-diff.test.js
+++ b/tests/unit/browser-diff.test.js
@@ -142,16 +142,20 @@ test('writeBrowserDiffPage fails loudly when chmod hardening fails on a POSIX-li
 
 test('openBrowserDiffPage selects the platform opener and propagates close failures', async () => {
   let seen = null;
+  let unrefCalled = false;
   const successSpawn = (command, args) => {
     seen = { command, args };
     const child = new EventEmitter();
-    child.unref = () => {};
+    child.unref = () => {
+      unrefCalled = true;
+    };
     process.nextTick(() => child.emit('close', 0));
     return child;
   };
 
   await openBrowserDiffPage('/tmp/demo.html', { platform: 'linux', spawn: successSpawn });
   assert.deepStrictEqual(seen, { command: 'xdg-open', args: ['/tmp/demo.html'] });
+  assert.strictEqual(unrefCalled, false);
 
   await assert.rejects(
     () => openBrowserDiffPage('/tmp/demo.html', {


### PR DESCRIPTION
## Summary
- keep the browser opener process referenced until it exits
- restore stderr fallback reporting when the platform opener fails
- assert the opener is not unrefed in the unit test

## Verification
- node --test tests/unit/browser-diff.test.js
- npm run lint:eslint
- browser fallback smoke with failing xdg-open stub
