### PR TITLE
Korean post-editese advisory analyzer + audit-driven fixes (4.0.1)

### DIFF
--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "4.0.0"
+version: "4.0.1"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,33 @@ Semver rationale: patch | minor | major — explain whether this changes pattern
 
 ## Unreleased
 
+**Detector calibration fixes and runtime hardening.**
+
+Semver rationale: patch — bug fixes to Korean detection rules and local-CLI backends; no schema or flag changes (one new mutual-exclusivity guard rejects already-invalid flag combinations).
+
+### Fixed
+- Korean `koPostEditese` no longer misclassifies regular formal `-ㅂ니다 / -ㅂ니까` endings (됩니다, 표시됩니다, 합니까…) as declarative `-다` style, so clean 합쇼체 prose is no longer pushed toward register-changing rewrites.
+- Translationese `a16-pronoun-literal` no longer fires on ordinary nouns ending in `그` (로그/버그/태그) or on 그녀석/그것참; it now requires eojeol boundaries on both sides.
+- Translationese `t2-by-passive` now matches the common fused passive forms (된다/됩니다/될/진다) that the previous jamo alternation silently missed.
+- Deterministic audit backstop now respects each rule's `minCount` (e.g. `c11-connective-comma` no longer surfaces on a single match).
+- Local-CLI backends (claude/gemini/kimi) decode stdout as streaming UTF-8, fixing silent corruption of multi-byte CJK output split across pipe reads; all four backends now handle stdin EPIPE instead of crashing the process when a child exits before draining a large prompt.
+- Ouroboros loop strips `[BODY]/[SELF_AUDIT]` tags before scoring and re-feeding, returns the best-scoring text paired with its score, and treats a failed MPS scorer as a floor violation (fail closed, matching fidelity).
+- Rewrite tone-footer removal anchors to the final `---` block, so a markdown thematic break in the body no longer truncates everything after it.
+- `--config <file>` now wins over an ambient `./.patina.yaml` / `~/.patina.yaml` (reproducible runs); config merge is guarded against prototype pollution.
+- Mutually exclusive output modes (`--diff` / `--audit` / `--score` / `--ouroboros`) are now rejected up front instead of silently resolving to one mode (which could make a `--score` CI gate always exit 0).
+
+### Changed
+- `kimi-cli` backend runs with `--max-steps-per-turn 20` (up from 1). It stays in non-interactive `--print` mode with no `--yolo`, so the agent cannot auto-approve shell/file tools — the extra steps only cover reasoning/formatting within a turn (verified that injected tool-use instructions in user text do not execute).
+
+## 4.0.1 — 2026-06-07
+
+**Fix npx package-name execution.**
+
+Semver rationale: patch — adds a bin alias so documented `npx patina-cli ...` commands resolve to the CLI entrypoint.
+
+### Fixed
+- Added the `patina-cli` binary alias alongside `patina`, so `npx patina-cli doctor` works without requiring `npx -p patina-cli patina ...`.
+
 ## 4.0.0 — 2026-06-04
 
 **Surface reset for a smaller, zero-config patina.**

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 4.0.0" src="https://img.shields.io/badge/version-4.0.0-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 4.0.1" src="https://img.shields.io/badge/version-4.0.1-blue"></a>
 </p>
 
 <p align="center">
@@ -51,7 +51,7 @@ More examples: [Before/After Gallery](docs/EXAMPLES.md) ([한국어](docs/EXAMPL
 
 ### Browser audit
 
-Open **[patina.vibetip.help](https://patina.vibetip.help/)** to score KO / EN / ZH / JA text in your browser. The playground is audit-only: it does not rewrite text, call external LLMs, or send API keys to a server.
+Open **[patina.vibetip.help](https://patina.vibetip.help/)** to score KO / EN / ZH / JA text in your browser. The playground is audit-only: it does not rewrite text, call external LLMs, or send API keys to a server. For Korean, the browser and CLI may surface `translationese` / `koPostEditese.v1` metadata as editing hints; this metadata is advisory only, is not calibrated score input, and must not drive hot paragraphs, gates, severity, baselines, percentiles, benchmark claims, prompt/rewrite gates, or authorship verdicts.
 
 ### Agent skill
 
@@ -178,7 +178,7 @@ If meaning drifts, the change is retried or rolled back. Deterministic analysis 
 
 ```yaml
 # .patina.default.yaml
-version: "4.0.0"
+version: "4.0.1"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/README_JA.md
+++ b/README_JA.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#クイックスタート)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-4.0.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-4.0.1-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-en.gif" alt="patina が英語のAIっぽい文を整え、スコアを表示するターミナルデモGIF" width="780">
@@ -254,7 +254,7 @@ rewrite モードでは、モデルは `[BODY]`/`[/BODY]` ブロックを囲む 
 
 ```yaml
 # .patina.default.yaml
-version: "4.0.0"
+version: "4.0.1"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/README_KR.md
+++ b/README_KR.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#빠른-시작)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-4.0.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-4.0.1-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-ko.gif" alt="patina가 한국어 AI풍 문장을 다듬고 결과 점수를 보여주는 터미널 데모 GIF" width="780">
@@ -253,7 +253,7 @@ rewrite 모드에서 모델은 `[BODY]`/`[/BODY]` 블록을 감싸는 `[SELF_AUD
 
 ```yaml
 # .patina.default.yaml
-version: "4.0.0"
+version: "4.0.1"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#快速开始)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-4.0.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-4.0.1-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-en.gif" alt="patina 将带有 AI 味的英文文案改写并显示评分的终端演示 GIF" width="780">
@@ -254,7 +254,7 @@ Markdown 较多的工程流程可以使用开发者 profile：`code-comment` 会
 
 ```yaml
 # .patina.default.yaml
-version: "4.0.0"
+version: "4.0.1"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 4.0.0
+version: 4.0.1
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read
@@ -227,6 +227,10 @@ tone_confidence: high
 전체 알고리즘 정의는 `core/stylometry.md`를 참조한다. 핵심 공식만 인라인으로 제시한다.
 
 **Tokenization** — ko/en은 whitespace 기준 분할 + edge-punctuation strip(ko=어절, en=단어)을 사용한다. zh/ja는 Han/Kana 문자와 ASCII run을 토큰으로 삼는 deterministic character-token fallback을 사용한다. 형태소 분석기 미사용.
+
+### Korean advisory metadata (`translationese`, `koPostEditese.v1`)
+
+Korean deterministic analysis may surface `analysis.translationese` and top-level `koPostEditese` / `koPostEditese.v1` as rewrite editing hints: calque candidates, literal pronouns, by-passives, double particles, uniform endings, rhythm, and suffix-diversity proxies. These hints are **advisory context only** for natural Korean editing and are separate from the 4.6/4.7 hot-zone computation. They must not feed or alter score, hot 판정, gates, benchmark claims, severity, z-score/baseline/percentile logic, prompt/rewrite gates, or authorship verdicts.
 
 **Burstiness (CV, 문장 길이 변동성)**
 

--- a/docs/TRANSLATIONESE-KO.md
+++ b/docs/TRANSLATIONESE-KO.md
@@ -14,8 +14,9 @@ do **not** catch lexical translationese (e.g. "커맨드 기둥" for "command pi
   per-prose-sentence density (≥0.5) are met. A single "~에 의해" means nothing.
 - **Advisory, not a verdict.** `analyzeText` surfaces it as `translationese`
   but deliberately keeps it **out of the document `hot` decision**, so it cannot
-  regress benchmark false positives. The SKILL / callers act on it (e.g. the
-  rewrite loop), and the audit surface can display it.
+  regress benchmark false positives. SKILL, prompt, audit, and browser surfaces
+  may show it as editing context only; they must not treat it as a score, gate,
+  severity, benchmark, or authorship signal.
 - **ko-only** for now (calques are language-specific).
 - Each rule ships a `before → after` example (enforced by a unit test).
 
@@ -41,11 +42,81 @@ analyzeText(text, { lang: 'ko' }).translationese
 //     hits:[...], hot, thresholds:{count,density} }
 ```
 
+```js
+analyzeText(text, { lang: 'ko' }).koPostEditese
+// → { schema:'koPostEditese.v1', lang:'ko', analyzed, skipReason,
+//     paragraphCount, sentenceCount, eojeolCount,
+//     metrics:{ lexical, endings, interference, rhythm },
+//     paragraphs:[{ id, sentenceCount, eojeolCount, metrics }] }
+```
+
+`koPostEditese.v1` is a Korean-only advisory payload for post-edited machine
+translation texture. It exposes raw counts and ratios so an editor can inspect
+literal pronouns, by-passives, light verbs, repetitive endings, suffix/rhythm
+patterns, and related Korean surface features. It is **not calibrated evidence**:
+callers must not treat these raw metrics as an authorship verdict, benchmark
+claim, score input, gate input, severity band, percentile, or baseline-derived
+finding. Audit surfaces may show the payload in a separate editing-hint section
+only; they must not mix it into deterministic severity rows.
+
+## Phase 4 calibration protocol / approval boundary
+
+Phase 4 is a calibration and decision-report protocol only. It can measure whether
+`translationese` or `koPostEditese.v1` correlates with Korean editing needs, but
+it cannot by itself authorize coupling. Any future coupling to score, `hot`,
+gates, severity, prompt/rewrite gates, benchmark pass/fail, or authorship
+language requires a separate product/spec decision and separately approved
+execution plan after the evidence package below is complete.
+
+Required calibration package:
+
+- **Corpus strata:** balanced Korean native-human controls, acceptable human
+  translation/post-edit controls, raw machine-translationese samples, LLM Korean
+  drafts, post-edited LLM drafts, and patina rewrite before/after pairs across
+  blog, docs, marketing, academic/professional, forum/community, technical, and
+  short-form UI/help genres.
+- **Labels:** each item needs source/provenance, domain, length bucket, register,
+  translation/editing status, and blinded human labels for `needs_korean_edit`,
+  `translationese_present`, `post_editese_present`, and
+  `meaning_preservation_risk`. Use at least two Korean-proficient reviewers with
+  adjudication and agreement reporting.
+- **Metrics:** report precision/recall/F1 for the labels above, false-positive
+  rate on native-human and acceptable-human-translation controls,
+  genre-stratified and short-text false-positive rates, confidence intervals,
+  and representative wins/failures. If a separately approved offline prompt or
+  rewrite experiment is proposed, its report format must also include human
+  preference, MPS/fidelity regression, and edit churn.
+- **Ablations:** measure translationese only, `koPostEditese.v1` only, combined
+  signals, raw counts versus normalized ratios, and lexical/endings/interference
+  /rhythm groups independently.
+- **Decision thresholds:** pre-register the minimum precision, maximum control
+  false-positive rate, allowed MPS/fidelity regression bound, and minimum
+  per-stratum sample sizes before looking at holdout results. Thresholds must be
+  justified by holdout evidence, not by convenience on development examples.
+- **Rollback rules for any later approved coupling:** coupled experiments must be
+  feature-flagged or isolated; if false positives, MPS/fidelity regressions,
+  browser/Node parity drift, or domain skew exceed the approved bound, disable
+  the coupled behavior and keep advisory display.
+- **Deliverables:** publish a corpus manifest schema, Korean editor labeling
+  guide, offline experiment script/report format, representative wins/failures
+  appendix, ADR template, and follow-on approval checklist. The ADR may complete
+  inside Phase 4 only as advisory-only or reject-coupling. Prompt-context,
+  rewrite-priority, score/gate, benchmark, or authorship-related options may be
+  documented as follow-on proposals, but none may proceed without a separate
+  product/spec decision and separately approved execution plan.
+- **No-coupling default:** until a later approval explicitly names a coupling and
+  cites completed corpus evidence, no `translationese` or `koPostEditese.v1`
+  metric may feed score, `hot`, gates, severity, z-score, baseline, percentile,
+  prompt gates, rewrite gates, benchmark pass/fail, or authorship verdicts.
+
+
 ## Limitations / next
 
 - Calques are **lexical**; the structural stylometric classifier cannot learn
   them (proven separately). This is a rule catalog, like patina's pattern packs.
 - The catalog is intentionally small and conservative; expand with corpus
   evidence and keep the density gate to protect precision.
-- Not wired into `hot` yet — promote only after validating no FP regression on
-  the benchmark / a diverse human ko control set.
+- `koPostEditese.v1` is not wired into `hot`, scores, gates, severity, z-score,
+  baselines, percentiles, or benchmark decisions. Keep it advisory unless a
+  separate post-Phase4 product/spec approval explicitly authorizes a narrowly
+  scoped coupling.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "patina-cli",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "patina-cli",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"
       },
       "bin": {
         "patina": "bin/patina.js",
+        "patina-cli": "bin/patina.js",
         "patina-score": "scripts/precommit-score.mjs"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "patina-cli",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",
   "bin": {
     "patina": "bin/patina.js",
+    "patina-cli": "bin/patina.js",
     "patina-score": "scripts/precommit-score.mjs"
   },
   "scripts": {

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "4.0.0"
+    "patina-cli": "4.0.1"
   },
   "license": "MIT",
   "repository": {

--- a/playground/analyzer.js
+++ b/playground/analyzer.js
@@ -50,6 +50,183 @@ export const SAMPLE_TEXT = {
   zh: '总而言之，这一方案能够全面提升用户体验，并为未来发展提供新的可能。从长远来看，它将在数字时代发挥着重要作用。\n\n先看一个具体场景：团队每天少复制三次表格。',
   ja: 'まとめると、この仕組みはユーザー体験を向上させ、より良い未来につながります。重要なのは、さまざまな場面で効果的に活用できる点です。\n\nまずは、毎朝の確認作業が一つ減るかどうかを見ます。',
 };
+// Korean translationese (번역투/calque) advisory signal. This mirrors
+// src/features/translationese.js and intentionally stays out of score/hot
+// coupling; it is exposed as document-level audit metadata only.
+// Mirrors BY_PASSIVE_PREDICATE in src/features/translationese.js.
+const BY_PASSIVE_PREDICATE =
+  '(?:된다|된|될|됨|됐다|됐|돼|되었|되어|되는|되며|되고|됩니다|됩|받는다|받았다|받은|받을|받는|받습니다|받아|당한다|당했다|당하다|당하는|당해|(?:어|아|여)(?:진다|졌다|진|질|지는|집니다|져))';
+export const TRANSLATIONESE_RULES = [
+  {
+    id: 'noun-calque',
+    label: '직역 명사구 (pillar/layer 류 calque)',
+    strong: true,
+    re: () => /커맨드 기둥|명령(?:어)? 기둥|기둥 커맨드|[가-힣]+ 레이어로서/g,
+    example: { before: '세 가지 커맨드 기둥을 설치합니다.', after: '핵심 커맨드 세 가지를 설치합니다.' },
+  },
+  {
+    id: 'dummy-subject',
+    label: '가주어 "그것은/이것은" (English "it is")',
+    strong: true,
+    re: () => /(?:^|[.!?。]\s+|\n)\s*(?:그것은|이것은|그것이|이것이)\s/g,
+    example: { before: '그것은 매우 중요하다.', after: '매우 중요하다.' },
+  },
+  {
+    id: 'direct-address-you',
+    label: '"당신" 직접 호칭 (English "you")',
+    strong: true,
+    re: () => /당신(?:은|이|의|에게|을|를|께서|께)?/g,
+    example: { before: '당신은 이것을 설정할 수 있습니다.', after: '이건 설정할 수 있다.' },
+  },
+  {
+    id: 'a16-pronoun-literal',
+    label: '영어식 3인칭 대명사 직역 (he/she/it/they)',
+    strong: true,
+    // Require a non-Hangul boundary before the pronoun (so 로그/버그/태그 don't match)
+    // and an eojeol boundary after it (so 그녀석/그것참 don't match).
+    re: () => /(?<![가-힣])(?:그녀(?:는|가|를|의|에게|와|도|만)?|그것(?:은|이|을|의|에|에게)?|그들(?:은|이|을|의|에게|과|도)?|그(?:는|가|를|의|에게|와|도|만))(?=\s|[.,!?。]|$)/g,
+    example: { before: '메리는 그녀가 그녀의 어머니에게 전화했다고 말했다.', after: '메리는 어머니에게 전화했다고 말했다.' },
+  },
+  {
+    id: 'a19-double-particle',
+    label: '이중 조사 결합 (-에서의/-으로의/-에의)',
+    strong: true,
+    re: () => /(?:에서의|에로의|으로의|에의|으로부터의|로부터의)/g,
+    example: { before: '회의에서의 결정은 앞으로의 운영으로의 전환을 앞당겼다.', after: '회의에서 나온 결정은 앞으로 운영을 전환하는 일을 앞당겼다.' },
+  },
+  {
+    id: 'passive-e-uihae',
+    label: '"~에 의해" 피동 (English by-passive)',
+    strong: false,
+    re: () => /에 의해/g,
+    example: { before: '작업은 에이전트에 의해 처리됩니다.', after: '에이전트가 작업을 처리합니다.' },
+  },
+  {
+    id: 't2-by-passive',
+    label: '"~에 의해" + 피동 동사 결합',
+    strong: true,
+    // "에 의해" + a passive predicate in the following token. Matches fused
+    // syllable forms (된다/됩니다/될/진다) that the old jamo alternation missed.
+    re: () => new RegExp('에\\s*의(?:해|하여)\\s+\\S{0,12}?' + BY_PASSIVE_PREDICATE, 'g'),
+    example: { before: '이 작업은 에이전트에 의해 처리되었다.', after: '에이전트가 이 작업을 처리했다.' },
+  },
+  {
+    id: 'a8-double-passive',
+    label: '이중 피동 표면형 (-되어진/-보여진/-쓰여진)',
+    strong: true,
+    re: () => /(?:되어진다|되어졌다|되어진|되어지는|보여진다|보여졌다|보여진|쓰여진다|쓰여졌다|쓰여진|잊혀진|잊혀졌|닫혀진|열려진|불려진|놓여진)/g,
+    example: { before: '이 문제는 분석되어진 뒤 보고서에 쓰여진다.', after: '이 문제는 분석된 뒤 보고서에 쓰인다.' },
+  },
+  {
+    id: 'have-overuse',
+    label: '"~을 가지고 있다" (English "have")',
+    strong: false,
+    re: () => /(?:을|를)\s*(?:가지(?:고 있|고 있습니다|고 있다)|갖(?:고 있|고 있습니다|고 있다))/g,
+    example: { before: '이 도구는 유연성을 가지고 있습니다.', after: '이 도구는 유연합니다.' },
+  },
+  {
+    id: 'a7-light-verb',
+    label: '영어식 have/make light verb 직역',
+    strong: false,
+    re: () => /(?:회의를\s*가(?:지|졌)|결정을\s*내(?:리|렸)|(?:을|를)\s*갖고\s*있(?:다|습니다|는|었|으)?)/g,
+    example: { before: '우리는 회의를 가졌고 중요한 결정을 내렸다.', after: '우리는 회의에서 중요한 결정을 했다.' },
+  },
+  {
+    id: 'one-of',
+    label: '"~중 하나" (English "one of the")',
+    strong: false,
+    re: () => /중\s*하나(?:이다|입니다|인|로|다|예요)?/g,
+    example: { before: '가장 빠른 도구 중 하나입니다.', after: '손꼽히게 빠릅니다.' },
+  },
+  {
+    id: 'provides',
+    label: '"~을 제공합니다" (English "provides")',
+    strong: false,
+    re: () => /(?:을|를)\s*제공(?:합니다|한다|해 줍니다|해준다)/g,
+    example: { before: '다양한 기능을 제공합니다.', after: '여러 기능을 쓸 수 있다.' },
+  },
+  {
+    id: 'as-follows',
+    label: '"다음과 같습니다" (English "as follows")',
+    strong: false,
+    re: () => /다음과\s*같(?:습니다|다|은|이)/g,
+    example: { before: '사용법은 다음과 같습니다.', after: '사용법은 이렇다.' },
+  },
+  {
+    id: 'make-easy',
+    label: '"~하게 만들어 준다" (English "make it ~")',
+    strong: false,
+    re: () => /(?:쉽게|가능하게|간단하게|편하게)\s*(?:만들어\s*(?:줍니다|준다|줘)|만듭니다|만든다)/g,
+    example: { before: '설치를 쉽게 만들어 줍니다.', after: '설치가 쉬워진다.' },
+  },
+  {
+    id: 'c11-connective-comma',
+    label: '연결어미 뒤 쉼표 (-고,/-며,/-지만,)',
+    strong: false,
+    minCount: 2,
+    re: () => /(?:고|며|지만|면서|아서|어서)\s*,/g,
+    example: { before: '그는 자료를 검토하고, 결과를 정리하며, 보고서를 작성했다.', after: '그는 자료를 검토하고 결과를 정리한 뒤 보고서를 작성했다.' },
+  },
+];
+
+export const TRANSLATIONESE_ABS_MIN = 4;
+export const TRANSLATIONESE_DENSITY_MIN = 0.5;
+export const TRANSLATIONESE_STRONG_MIN = 1;
+export const KO_POST_EDITESE_SCHEMA = 'koPostEditese.v1';
+
+const KO_POST_EDITESE_SUFFIX_GROUPS = [
+  { className: 'quote', suffixes: ['라고', '이라고'] },
+  { className: 'source', suffixes: ['에게서', '한테서', '으로부터', '로부터'] },
+  { className: 'instrument', suffixes: ['으로써', '로써'] },
+  { className: 'standard', suffixes: ['으로서', '로서'] },
+  { className: 'topic', suffixes: ['은', '는'] },
+  { className: 'subject', suffixes: ['이', '가', '께서'] },
+  { className: 'object', suffixes: ['을', '를'] },
+  { className: 'genitive', suffixes: ['의'] },
+  { className: 'location', suffixes: ['에서', '에게', '한테', '께', '에'] },
+  { className: 'direction', suffixes: ['으로', '로'] },
+  { className: 'conjunction', suffixes: ['와', '과', '하고', '랑'] },
+  { className: 'additive', suffixes: ['도', '또한'] },
+  { className: 'delimiter', suffixes: ['만', '까지', '부터', '마다'] },
+  { className: 'comparison', suffixes: ['보다', '처럼'] },
+  { className: 'formal_ending', suffixes: ['습니다', '습니까', '합니다', '합니까', '입니다'] },
+  { className: 'polite_ending', suffixes: ['어요', '아요', '예요', '이에요', '네요', '군요', '지요'] },
+  { className: 'casual_ending', suffixes: ['죠', '네', '군'] },
+  { className: 'declarative_ending', suffixes: ['한다', '된다', '했다', '였다', '이다', '있다', '없다'] },
+];
+
+const KO_POST_EDITESE_SUFFIX_MATCHERS = KO_POST_EDITESE_SUFFIX_GROUPS
+  .flatMap((group) =>
+    group.suffixes.map((suffix) => ({
+      className: group.className,
+      suffix,
+      length: Array.from(suffix).length,
+    }))
+  )
+  .sort((a, b) => b.length - a.length);
+
+const KO_POST_EDITESE_ENDING_SUFFIXES = [
+  '습니다', '습니까', '합니다', '합니까', '입니다', '어요', '아요', '예요', '이에요',
+  '네요', '군요', '지요', '죠', '한다', '된다', '했다', '였다', '이다', '있다',
+  '없다', '왔다', '봤다', '다',
+].sort((a, b) => Array.from(b).length - Array.from(a).length);
+// Canonical token for regular formal '-ㅂ니다 / -ㅂ니까' endings (됩니다, 줍니다, 합니까…)
+// whose ㅂ marker fuses into the stem syllable and so isn't a literal suffix.
+const KO_POST_EDITESE_FORMAL_NIDA = 'ㅂ니다';
+const KO_POST_EDITESE_FORMAL_ENDINGS = new Set(['습니다', '습니까', '합니다', '합니까', '입니다', KO_POST_EDITESE_FORMAL_NIDA]);
+const KO_POST_EDITESE_POLITE_ENDINGS = new Set(['어요', '아요', '예요', '이에요', '네요', '군요', '지요', '죠']);
+const KO_POST_EDITESE_DECLARATIVE_DA_ENDINGS = new Set(['한다', '된다', '했다', '였다', '이다', '있다', '없다', '왔다', '봤다', '다']);
+
+const KO_POST_EDITESE_PRONOUN_LITERAL_RE = /(?:그녀(?:는|가|를|의|에게|와|도|만)?|그것(?:은|이|을|의|에|에게)?|그들(?:은|이|을|의|에게|과|도)?|그(?:는|가|를|의|에게|와|도|만)(?=\s|[.,!?。]|$))/g;
+const KO_POST_EDITESE_DOUBLE_PARTICLE_RE = /(?:에서의|에로의|으로의|에의|으로부터의|로부터의)/g;
+const KO_POST_EDITESE_PROGRESSIVE_ASPECT_RE = /고\s*있(?:다|습니다|는|었|으|고|지|기)?/g;
+const KO_POST_EDITESE_LIGHT_VERB_RE = /(?:회의를\s*가(?:지|졌)|결정을\s*내(?:리|렸)|(?:을|를)\s*갖고\s*있(?:다|습니다|는|었|으)?)/g;
+const KO_POST_EDITESE_BY_PASSIVE_RE = /에\s*의(?:해|하여)/g;
+const KO_POST_EDITESE_DOUBLE_PASSIVE_RE = /(?:되어진다|되어졌다|되어진|되어지는|보여진다|보여졌다|보여진|쓰여진다|쓰여졌다|쓰여진|잊혀진|잊혀졌|닫혀진|열려진|불려진|놓여진)/g;
+const KO_POST_EDITESE_CONNECTIVE_COMMA_RE = /(?:고|며|지만|면서|아서|어서)\s*,/g;
+const KO_POST_EDITESE_RELATIVE_CLAUSE_PROXY_RE = /[가-힣]+(?:하는|되는|받는|받은|쓰인|되어진|보여진|한|할|된|될|던|운|온|인|힌|진|린|킨|쓴)\s+[가-힣]+/g;
+
+
 
 const SENTENCE_SPLIT_RE = /[.!?]+\s+|(?<=[。！？…])|\n+/u;
 const PARAGRAPH_SPLIT_RE = /\n\s*\n/;
@@ -393,7 +570,312 @@ export function detectThematicBreaks(text) {
     threshold: DEFAULT_THEMATIC_BREAK_MIN,
   };
 }
+export function detectTranslationese(text, opts = {}) {
+  const lang = opts.lang ?? 'ko';
+  const str = typeof text === 'string' ? text : '';
+  if (lang !== 'ko' || !str) {
+    return {
+      count: 0,
+      density: 0,
+      sentences: 0,
+      byRule: [],
+      hits: [],
+      hot: false,
+      thresholds: { count: TRANSLATIONESE_ABS_MIN, density: TRANSLATIONESE_DENSITY_MIN, strong: TRANSLATIONESE_STRONG_MIN },
+    };
+  }
 
+  const byRule = [];
+  const hits = [];
+  const evidence = [];
+  for (const rule of TRANSLATIONESE_RULES) {
+    const matches = collectTranslationeseRuleMatches(str, rule);
+    const minCount = rule.minCount ?? 1;
+    if (matches.length >= minCount) {
+      byRule.push({ id: rule.id, label: rule.label, strong: rule.strong, count: matches.length, example: rule.example });
+      hits.push(...new Set(matches.map((m) => m.text.trim()).filter(Boolean)));
+      evidence.push(...matches.map((match) => ({ ...match, strong: Boolean(rule.strong) })));
+    }
+  }
+
+  const independentEvidence = selectIndependentTranslationeseEvidence(evidence);
+  const count = independentEvidence.length;
+  const strongCount = independentEvidence.filter((match) => match.strong).length;
+  const sentences = Math.max(1, splitProseSentences(str).length);
+  const density = count / sentences;
+  const hot = count >= TRANSLATIONESE_ABS_MIN &&
+    density >= TRANSLATIONESE_DENSITY_MIN &&
+    strongCount >= TRANSLATIONESE_STRONG_MIN;
+  return {
+    count,
+    density: Number(density.toFixed(3)),
+    sentences,
+    byRule: byRule.sort((a, b) => b.count - a.count),
+    hits: [...new Set(hits)].slice(0, 8),
+    hot,
+    thresholds: { count: TRANSLATIONESE_ABS_MIN, density: TRANSLATIONESE_DENSITY_MIN, strong: TRANSLATIONESE_STRONG_MIN },
+  };
+}
+
+function collectTranslationeseRuleMatches(str, rule) {
+  const re = rule.re();
+  const matches = [];
+  let match;
+  while ((match = re.exec(str)) !== null) {
+    matches.push({
+      text: match[0],
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+    if (match[0] === '') re.lastIndex += 1;
+  }
+  return matches;
+}
+
+function selectIndependentTranslationeseEvidence(matches) {
+  const selected = [];
+  const ranked = [...matches].sort((a, b) => {
+    if (a.strong !== b.strong) return a.strong ? -1 : 1;
+    const lengthDelta = (b.end - b.start) - (a.end - a.start);
+    if (lengthDelta !== 0) return lengthDelta;
+    return a.start - b.start;
+  });
+
+  for (const match of ranked) {
+    if (!selected.some((kept) => translationeseEvidenceOverlaps(kept, match))) {
+      selected.push(match);
+    }
+  }
+
+  return selected.sort((a, b) => a.start - b.start);
+}
+
+function translationeseEvidenceOverlaps(a, b) {
+  return a.start < b.end && b.start < a.end;
+}
+
+
+export function koreanPostEditeseFeatures(text, opts = {}) {
+  const lang = opts.lang ?? 'ko';
+  const str = typeof text === 'string' ? text.normalize('NFC') : '';
+  if (lang !== 'ko') return skippedKoPostEditese(lang, 'non-ko');
+  if (str.trim().length === 0) return skippedKoPostEditese(lang, 'empty');
+
+  const paragraphs = splitParagraphs(str);
+  const totalEojeols = koreanEojeols(str);
+  if (totalEojeols.length === 0) return skippedKoPostEditese(lang, 'no-hangul-eojeols');
+
+  const paragraphRows = paragraphs.map((paragraph, index) => buildKoPostEditeseRow(paragraph, `P${index + 1}`));
+  const docSentences = paragraphs.flatMap((paragraph) => splitProseSentences(paragraph));
+  return {
+    schema: KO_POST_EDITESE_SCHEMA,
+    lang,
+    analyzed: true,
+    skipReason: null,
+    paragraphCount: paragraphRows.length,
+    sentenceCount: docSentences.length,
+    eojeolCount: totalEojeols.length,
+    metrics: buildKoPostEditeseMetrics(str, docSentences),
+    paragraphs: paragraphRows,
+  };
+}
+
+function skippedKoPostEditese(lang, skipReason) {
+  return {
+    schema: KO_POST_EDITESE_SCHEMA,
+    lang,
+    analyzed: false,
+    skipReason,
+    paragraphCount: 0,
+    sentenceCount: 0,
+    eojeolCount: 0,
+    metrics: zeroKoPostEditeseMetrics(),
+    paragraphs: [],
+  };
+}
+
+function zeroKoPostEditeseMetrics() {
+  return {
+    lexical: {
+      tokenCount: 0,
+      typeCount: 0,
+      ttr: null,
+      mattr: null,
+      endingTypeCount: 0,
+      endingDiversity: null,
+    },
+    endings: {
+      declarativeDaCount: 0,
+      declarativeDaRatio: null,
+      handaCount: 0,
+      doendaCount: 0,
+      idaCount: 0,
+      formalEndingCount: 0,
+      politeEndingCount: 0,
+      endingStreakMax: 0,
+    },
+    interference: {
+      pronounLiteralCount: 0,
+      doubleParticleCount: 0,
+      progressiveAspectCount: 0,
+      lightVerbCount: 0,
+      byPassiveCount: 0,
+      doublePassiveCount: 0,
+      connectiveCommaCount: 0,
+      relativeClauseProxyCount: 0,
+    },
+    rhythm: {
+      meanSentenceEojeols: null,
+      sentenceEojeolCV: null,
+      meanEojeolLength: null,
+      eojeolLengthCV: null,
+      commaPerSentence: null,
+      commaPer100Chars: null,
+      suffixMatchedCount: 0,
+      suffixClassDiversity: null,
+      suffixDiversity: null,
+    },
+  };
+}
+
+function buildKoPostEditeseRow(paragraph, id) {
+  const sentences = splitProseSentences(paragraph);
+  const eojeols = koreanEojeols(paragraph);
+  return {
+    id,
+    sentenceCount: sentences.length,
+    eojeolCount: eojeols.length,
+    metrics: buildKoPostEditeseMetrics(paragraph, sentences),
+  };
+}
+
+function buildKoPostEditeseMetrics(text, sentences = splitProseSentences(text)) {
+  const eojeols = koreanEojeols(text);
+  const lowerEojeols = eojeols.map((token) => token.toLowerCase());
+  const typeCount = new Set(lowerEojeols).size;
+  const lengths = eojeols.map(koreanLength).filter((length) => length > 0);
+  const endings = sentences.map(extractKoPostEditeseSentenceEnding).filter(Boolean);
+  const endingTypeCount = new Set(endings).size;
+  const suffixStats = koPostEditeseSuffixStats(eojeols);
+  const comma = commaDensity(text, sentences.length);
+  const sentenceEojeolCounts = sentences
+    .map((sentence) => koreanEojeols(sentence).length)
+    .filter((count) => count > 0);
+
+  return {
+    lexical: {
+      tokenCount: eojeols.length,
+      typeCount,
+      ttr: ratio(typeCount, eojeols.length),
+      mattr: roundMetric(mattr(eojeols)),
+      endingTypeCount,
+      endingDiversity: ratio(endingTypeCount, sentences.length),
+    },
+    endings: buildKoPostEditeseEndings(endings),
+    interference: {
+      pronounLiteralCount: countPattern(text, KO_POST_EDITESE_PRONOUN_LITERAL_RE),
+      doubleParticleCount: countPattern(text, KO_POST_EDITESE_DOUBLE_PARTICLE_RE),
+      progressiveAspectCount: countPattern(text, KO_POST_EDITESE_PROGRESSIVE_ASPECT_RE),
+      lightVerbCount: countPattern(text, KO_POST_EDITESE_LIGHT_VERB_RE),
+      byPassiveCount: countPattern(text, KO_POST_EDITESE_BY_PASSIVE_RE),
+      doublePassiveCount: countPattern(text, KO_POST_EDITESE_DOUBLE_PASSIVE_RE),
+      connectiveCommaCount: countPattern(text, KO_POST_EDITESE_CONNECTIVE_COMMA_RE),
+      relativeClauseProxyCount: countPattern(text, KO_POST_EDITESE_RELATIVE_CLAUSE_PROXY_RE),
+    },
+    rhythm: {
+      meanSentenceEojeols: ratio(eojeols.length, sentences.length),
+      sentenceEojeolCV: roundMetric(coefficientOfVariation(sentenceEojeolCounts)),
+      meanEojeolLength: roundMetric(mean(lengths)),
+      eojeolLengthCV: roundMetric(coefficientOfVariation(lengths)),
+      commaPerSentence: roundMetric(comma.perSentence),
+      commaPer100Chars: roundMetric(comma.per100Chars),
+      suffixMatchedCount: suffixStats.matchedCount,
+      suffixClassDiversity: roundMetric(suffixStats.classDiversity),
+      suffixDiversity: roundMetric(suffixStats.suffixDiversity),
+    },
+  };
+}
+
+function buildKoPostEditeseEndings(endings) {
+  const declarativeDaCount = endings.filter((ending) => KO_POST_EDITESE_DECLARATIVE_DA_ENDINGS.has(ending)).length;
+  return {
+    declarativeDaCount,
+    declarativeDaRatio: ratio(declarativeDaCount, endings.length),
+    handaCount: endings.filter((ending) => ending === '한다').length,
+    doendaCount: endings.filter((ending) => ending === '된다').length,
+    idaCount: endings.filter((ending) => ending === '이다').length,
+    formalEndingCount: endings.filter((ending) => KO_POST_EDITESE_FORMAL_ENDINGS.has(ending)).length,
+    politeEndingCount: endings.filter((ending) => KO_POST_EDITESE_POLITE_ENDINGS.has(ending)).length,
+    endingStreakMax: maxKoPostEditeseDeclarativeDaStreak(endings),
+  };
+}
+
+function extractKoPostEditeseSentenceEnding(sentence) {
+  const eojeol = koreanEojeols(sentence).at(-1);
+  if (!eojeol) return null;
+  const matched = KO_POST_EDITESE_ENDING_SUFFIXES.find((ending) => eojeol.endsWith(ending)) ?? null;
+  // Regular formal '-ㅂ니다 / -ㅂ니까' (됩니다, 표시됩니다, 합니까…) fuse the ㅂ marker into
+  // the stem syllable, so they fall through to the bare '다' bucket and get miscounted as
+  // declarative '-다' style. Reclassify them as a formal ending.
+  if ((matched === '다' || matched === null) && isKoPostEditeseFormalFusedEnding(eojeol)) {
+    return KO_POST_EDITESE_FORMAL_NIDA;
+  }
+  return matched;
+}
+
+// True for '-ㅂ니다 / -ㅂ니까' formal endings: the syllable before 니다/니까 carries a ㅂ
+// jongseong (batchim index 17). Distinguishes 됩니다/아닙니다 (formal) from 아니다 (plain).
+function isKoPostEditeseFormalFusedEnding(eojeol) {
+  const m = /(.)(?:니다|니까)$/.exec(eojeol);
+  if (!m) return false;
+  const code = m[1].charCodeAt(0);
+  if (code < 0xac00 || code > 0xd7a3) return false;
+  return (code - 0xac00) % 28 === 17;
+}
+
+function maxKoPostEditeseDeclarativeDaStreak(endings) {
+  let current = 0;
+  let max = 0;
+  for (const ending of endings) {
+    if (KO_POST_EDITESE_DECLARATIVE_DA_ENDINGS.has(ending)) {
+      current += 1;
+      max = Math.max(max, current);
+    } else {
+      current = 0;
+    }
+  }
+  return max;
+}
+
+function koPostEditeseSuffixStats(eojeols) {
+  const matches = [];
+  for (const token of eojeols) {
+    const match = KO_POST_EDITESE_SUFFIX_MATCHERS.find(
+      (candidate) => token.length > candidate.suffix.length && token.endsWith(candidate.suffix)
+    );
+    if (match) matches.push({ className: match.className, suffix: match.suffix });
+  }
+  const matchedCount = matches.length;
+  const classCount = new Set(matches.map((match) => match.className)).size;
+  const suffixCount = new Set(matches.map((match) => match.suffix)).size;
+  return {
+    matchedCount,
+    classDiversity: matchedCount > 0 ? classCount / matchedCount : null,
+    suffixDiversity: matchedCount > 0 ? suffixCount / matchedCount : null,
+  };
+}
+
+function countPattern(text, pattern) {
+  return (String(text ?? '').match(pattern) ?? []).length;
+}
+
+function ratio(numerator, denominator) {
+  return denominator > 0 ? roundMetric(numerator / denominator) : null;
+}
+
+function roundMetric(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? Number(value.toFixed(3)) : null;
+}
 const EMOJI_BASE_RE = '\\p{Extended_Pictographic}(?:\\uFE0F|\\uFE0E)?(?:\\p{Emoji_Modifier})?';
 const EMOJI_CLUSTER_PATTERN = `(?:\\p{Regional_Indicator}{2}|[#*0-9]\\uFE0F?\\u20E3|${EMOJI_BASE_RE}(?:\\u200D${EMOJI_BASE_RE})*)`;
 const EMOJI_CLUSTER_RE = new RegExp(EMOJI_CLUSTER_PATTERN, 'u');
@@ -535,6 +1017,8 @@ export function analyzePlaygroundText(text, opts = {}) {
 
   const paraThematicBreaks = paragraphs.map(detectThematicBreaks);
   const docThematicBreaks = detectThematicBreaks(text);
+  const translationese = detectTranslationese(text, { lang });
+  const koPostEditese = koreanPostEditeseFeatures(text, { lang });
 
   const analyzed = paragraphs.map((paragraph, idx) => {
     const sentences = splitProseSentences(paragraph);
@@ -632,6 +1116,8 @@ export function analyzePlaygroundText(text, opts = {}) {
       thematicBreaks: docThematicBreaks,
       hot: docCandor >= DEFAULT_FAKE_CANDOR_MIN || docThematicBreaks.hot,
     },
+    translationese,
+    koPostEditese,
     paragraphs: analyzed,
     auditItems: analyzed.filter((p) => p.hot || p.lexicon.matches > 0),
     note: 'Audit-only deterministic score. It marks editing hotspots, not authorship or intent.',
@@ -695,11 +1181,17 @@ function buildKoreanSignals(paragraph, sentenceCount) {
   };
 }
 
+function cleanKoreanEojeol(chunk) {
+  return String(chunk ?? '')
+    .normalize('NFC')
+    .replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, '');
+}
+
 function koreanEojeols(paragraph) {
   if (!paragraph || !HANGUL_RE.test(paragraph)) return [];
   return paragraph
     .split(/\s+/u)
-    .map((chunk) => chunk.replace(/^[^\u3131-\u318e\uac00-\ud7a3]+|[^\u3131-\u318e\uac00-\ud7a3]+$/gu, ''))
+    .map(cleanKoreanEojeol)
     .filter((chunk) => HANGUL_RE.test(chunk));
 }
 
@@ -817,6 +1309,107 @@ export function renderAuditDiff(analysis) {
       ${reasons}
     </section>`;
   }).join('\n');
+}
+function formatAdvisoryMetric(value, digits = 3) {
+  if (value == null) return 'n/a';
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Number.isInteger(value) ? String(value) : value.toFixed(digits);
+  }
+  return String(value);
+}
+
+function renderAdvisoryMetricRows(rows) {
+  return rows.map(([group, label, value]) => `<tr>
+      <th scope="row">${escapeHtml(group)}</th>
+      <td>${escapeHtml(label)}</td>
+      <td>${escapeHtml(formatAdvisoryMetric(value))}</td>
+    </tr>`).join('');
+}
+
+function renderTranslationeseAdvisory(translationese = {}) {
+  const rules = Array.isArray(translationese.byRule) ? translationese.byRule : [];
+  const samples = Array.isArray(translationese.hits) ? translationese.hits : [];
+  const ruleItems = rules.length > 0
+    ? `<ul class="advisory-list">${rules.map((rule) => {
+      const example = rule.example
+        ? `<span class="advisory-example">Example: <code>${escapeHtml(rule.example.before ?? '')}</code> → <code>${escapeHtml(rule.example.after ?? '')}</code></span>`
+        : '';
+      return `<li>
+          <strong>${escapeHtml(rule.label ?? rule.id ?? 'Translationese rule')}</strong>
+          <span class="muted">count ${escapeHtml(formatAdvisoryMetric(rule.count, 0))}${rule.strong ? ' · strong' : ''}</span>
+          ${example}
+        </li>`;
+    }).join('')}</ul>`
+    : '<p class="quiet">No Korean translationese rules surfaced. Treat this as an editing hint, not a score input.</p>';
+  const sampleHtml = samples.length > 0
+    ? `<p class="hits">Samples: ${samples.map((sample) => `<code>${escapeHtml(sample)}</code>`).join(' ')}</p>`
+    : '';
+  return `<section class="advisory-card" aria-labelledby="translationese-advisory-title">
+    <h3 id="translationese-advisory-title">Translationese hints</h3>
+    <p class="quiet">Advisory-only Korean calque metadata for revision. It does not affect score, hot paragraphs, or audit rows.</p>
+    <dl class="advisory-stats">
+      <div><dt>Count</dt><dd>${escapeHtml(formatAdvisoryMetric(translationese.count, 0))}</dd></div>
+      <div><dt>Density</dt><dd>${escapeHtml(formatAdvisoryMetric(translationese.density))}</dd></div>
+      <div><dt>Sentences</dt><dd>${escapeHtml(formatAdvisoryMetric(translationese.sentences, 0))}</dd></div>
+    </dl>
+    ${ruleItems}
+    ${sampleHtml}
+  </section>`;
+}
+
+function renderKoPostEditeseAdvisory(koPostEditese = {}) {
+  if (!koPostEditese.analyzed) {
+    const reason = koPostEditese.skipReason ?? 'unavailable';
+    return `<section class="advisory-card" aria-labelledby="ko-post-editese-advisory-title">
+      <h3 id="ko-post-editese-advisory-title">Korean post-editese metadata</h3>
+      <p class="quiet">Schema <code>${escapeHtml(koPostEditese.schema ?? KO_POST_EDITESE_SCHEMA)}</code> skipped: ${escapeHtml(reason)}. Advisory metadata is unavailable for this input.</p>
+    </section>`;
+  }
+
+  const metrics = koPostEditese.metrics ?? zeroKoPostEditeseMetrics();
+  const rows = [
+    ['endings', 'declarative -다 count', metrics.endings?.declarativeDaCount],
+    ['endings', 'declarative -다 ratio', metrics.endings?.declarativeDaRatio],
+    ['endings', 'formal ending count', metrics.endings?.formalEndingCount],
+    ['endings', 'polite ending count', metrics.endings?.politeEndingCount],
+    ['endings', 'ending streak max', metrics.endings?.endingStreakMax],
+    ['interference', 'pronoun literal count', metrics.interference?.pronounLiteralCount],
+    ['interference', 'double particle count', metrics.interference?.doubleParticleCount],
+    ['interference', 'progressive aspect count', metrics.interference?.progressiveAspectCount],
+    ['interference', 'light verb count', metrics.interference?.lightVerbCount],
+    ['interference', 'by-passive count', metrics.interference?.byPassiveCount],
+    ['interference', 'double passive count', metrics.interference?.doublePassiveCount],
+    ['interference', 'connective comma count', metrics.interference?.connectiveCommaCount],
+    ['rhythm', 'mean sentence eojeols', metrics.rhythm?.meanSentenceEojeols],
+    ['rhythm', 'sentence eojeol CV', metrics.rhythm?.sentenceEojeolCV],
+    ['rhythm', 'comma per sentence', metrics.rhythm?.commaPerSentence],
+    ['suffix diversity', 'suffix matched count', metrics.rhythm?.suffixMatchedCount],
+    ['suffix diversity', 'suffix class diversity', metrics.rhythm?.suffixClassDiversity],
+    ['suffix diversity', 'suffix diversity', metrics.rhythm?.suffixDiversity],
+  ];
+  return `<section class="advisory-card" aria-labelledby="ko-post-editese-advisory-title">
+    <h3 id="ko-post-editese-advisory-title">Korean post-editese metadata</h3>
+    <p class="quiet">Schema <code>${escapeHtml(koPostEditese.schema ?? KO_POST_EDITESE_SCHEMA)}</code> analyzed as editing guidance only.</p>
+    <dl class="advisory-stats">
+      <div><dt>Paragraphs</dt><dd>${escapeHtml(formatAdvisoryMetric(koPostEditese.paragraphCount, 0))}</dd></div>
+      <div><dt>Sentences</dt><dd>${escapeHtml(formatAdvisoryMetric(koPostEditese.sentenceCount, 0))}</dd></div>
+      <div><dt>Eojeols</dt><dd>${escapeHtml(formatAdvisoryMetric(koPostEditese.eojeolCount, 0))}</dd></div>
+    </dl>
+    <div class="table-wrap advisory-metrics"><table>
+      <thead><tr><th>Group</th><th>Metric</th><th>Value</th></tr></thead>
+      <tbody>${renderAdvisoryMetricRows(rows)}</tbody>
+    </table></div>
+  </section>`;
+}
+
+export function renderKoreanAdvisory(analysis) {
+  if (!analysis || analysis.lang !== 'ko') {
+    return `<p class="empty-state">Korean advisory metadata is unavailable for this language. This panel is separate from scoring, hotspots, and audit diff rendering.</p>`;
+  }
+  return `<div class="advisory-grid">
+    ${renderTranslationeseAdvisory(analysis.translationese)}
+    ${renderKoPostEditeseAdvisory(analysis.koPostEditese)}
+  </div>`;
 }
 
 function heredocDelimiter(text) {

--- a/playground/app.js
+++ b/playground/app.js
@@ -6,6 +6,7 @@ import {
   buildFalsePositiveReportUrl,
   escapeHtml,
   renderAuditDiff,
+  renderKoreanAdvisory,
 } from './analyzer.js';
 
 const doc = globalThis.document;
@@ -28,6 +29,7 @@ const nodes = {
   scoreBar: doc.querySelector('#score-bar'),
   summary: doc.querySelector('#summary'),
   audit: doc.querySelector('#audit'),
+  koreanAdvisory: doc.querySelector('#korean-advisory'),
   diff: doc.querySelector('#diff'),
   cliPreview: doc.querySelector('#cli-preview'),
 };
@@ -88,6 +90,7 @@ function render() {
     <li>Score is an editing signal, not an authorship verdict.</li>
   `;
   nodes.audit.innerHTML = metricsTable(analysis);
+  nodes.koreanAdvisory.innerHTML = renderKoreanAdvisory(analysis);
   nodes.diff.innerHTML = renderAuditDiff(analysis);
   nodes.cliPreview.textContent = buildCliCommand(state.text, state.lang);
 }

--- a/playground/index.html
+++ b/playground/index.html
@@ -41,8 +41,8 @@
         your pasted text anywhere.
       </p>
       <div class="hero__actions" aria-label="Primary actions">
+        <a class="button" href="https://github.com/devswha/patina">Star on GitHub</a>
         <a class="button ghost" href="https://github.com/devswha/patina#quick-start">Install CLI</a>
-        <a class="button ghost" href="https://github.com/devswha/patina/issues/208">Issue #208</a>
       </div>
     </section>
   </header>
@@ -90,6 +90,11 @@
       </div>
 
       <ul class="summary" id="summary"></ul>
+      <div class="star-cta" aria-label="GitHub repository callout">
+        <strong>Useful signal?</strong>
+        <span>Star patina on GitHub so more writers find the audit.</span>
+        <a class="button secondary" href="https://github.com/devswha/patina">Star / view source</a>
+      </div>
 
       <div class="cli-box" aria-labelledby="cli-title">
         <div class="cli-box__head">
@@ -109,6 +114,17 @@
         <p class="quiet">Burstiness, MATTR, AI-favored lexicon density, and Korean rhythm diagnostics.</p>
       </div>
       <div id="audit"></div>
+    </section>
+
+    <section class="panel full" aria-labelledby="korean-advisory-title">
+      <div class="panel__head">
+        <div>
+          <p class="eyebrow">advisory</p>
+          <h2 id="korean-advisory-title">Korean editing hints</h2>
+        </div>
+        <p class="quiet">Translationese and koPostEditese metadata are advisory-only revision hints; they never change score, hotspots, or audit rows.</p>
+      </div>
+      <div id="korean-advisory"></div>
     </section>
 
     <section class="panel full" aria-labelledby="diff-title">

--- a/playground/styles.css
+++ b/playground/styles.css
@@ -191,6 +191,24 @@ textarea:focus, select:focus, button:focus-visible, a:focus-visible {
 
 .summary { display: grid; gap: 8px; padding-left: 1.1rem; color: var(--muted); }
 .summary strong { color: var(--text); }
+.star-cta {
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+  padding: 14px;
+  border: 1px solid color-mix(in srgb, var(--amber) 35%, var(--line));
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--panel-2) 92%, var(--amber));
+  color: var(--muted);
+}
+
+.star-cta strong {
+  color: var(--text);
+}
+
+.star-cta .button {
+  justify-self: start;
+}
 
 .cli-box {
   margin-top: 20px;
@@ -220,6 +238,66 @@ table { width: 100%; border-collapse: collapse; min-width: 850px; }
 th, td { padding: 12px; text-align: left; border-bottom: 1px solid var(--line); vertical-align: top; }
 th { color: var(--muted); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.08em; }
 
+.advisory-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.advisory-card {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: #0b0d11;
+  padding: 16px;
+}
+
+.advisory-card h3 { margin-bottom: 8px; }
+
+.advisory-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 14px 0;
+}
+
+.advisory-stats div {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 10px;
+  background: #151820;
+}
+
+.advisory-stats dt {
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.advisory-stats dd {
+  margin: 4px 0 0;
+  font-weight: 850;
+}
+
+.advisory-list {
+  display: grid;
+  gap: 10px;
+  padding-left: 1.2rem;
+  color: var(--muted);
+}
+
+.advisory-list li strong {
+  display: block;
+  color: var(--text);
+}
+
+.advisory-example {
+  display: block;
+  margin-top: 4px;
+}
+
+.advisory-metrics table { min-width: 620px; }
 .diff-list { display: grid; gap: 14px; }
 .diff-card {
   border: 1px solid var(--line);
@@ -232,7 +310,7 @@ th { color: var(--muted); font-size: 0.8rem; text-transform: uppercase; letter-s
 .diff-card__head { display: flex; justify-content: space-between; gap: 12px; margin-bottom: 10px; color: var(--muted); }
 .diff-card p { line-height: 1.75; }
 .diff-card ul { color: var(--muted); padding-left: 1.2rem; }
-.diff-card code {
+.diff-card code, .advisory-card code {
   display: inline-block;
   margin: 0 4px 6px 0;
   padding: 3px 7px;
@@ -260,6 +338,7 @@ mark {
 
 @media (max-width: 880px) {
   .workspace { grid-template-columns: 1fr; }
+  .advisory-grid { grid-template-columns: 1fr; }
   .nav { align-items: flex-start; }
   .nav__links { flex-wrap: wrap; justify-content: flex-end; }
   .panel__head { align-items: flex-start; flex-direction: column; }

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -7,6 +7,7 @@ const checks = [];
 
 expect(pkg.private === false, 'package.json private must be false');
 expect(pkg.bin?.patina === 'bin/patina.js', 'package.json bin.patina must point to bin/patina.js');
+expect(pkg.bin?.['patina-cli'] === 'bin/patina.js', 'package.json bin.patina-cli must point to bin/patina.js');
 expect(pkg.bin?.['patina-score'] === 'scripts/precommit-score.mjs', 'package.json bin.patina-score must point to scripts/precommit-score.mjs');
 expect(existsSync('bin/patina.js'), 'bin/patina.js must exist');
 expect(readVersionField('SKILL.md') === version, 'SKILL.md version must match package.json');

--- a/src/backends/claude-cli.js
+++ b/src/backends/claude-cli.js
@@ -57,6 +57,10 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
 
     let stdout = '';
     let stderr = '';
+    // Decode with a streaming UTF-8 decoder so multi-byte CJK characters split
+    // across pipe-read boundaries are not corrupted into U+FFFD.
+    proc.stdout.setEncoding('utf8');
+    proc.stderr.setEncoding('utf8');
     proc.stdout.on('data', (chunk) => { stdout += chunk; });
     proc.stderr.on('data', (chunk) => { stderr += chunk; });
 
@@ -88,6 +92,15 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       finishResolve(stdout);
     });
 
+    // A child that exits before draining a large prompt makes the buffered
+    // stdin write fail with EPIPE; without a handler that becomes an unhandled
+    // 'error' event that crashes the process. Ignore EPIPE (the 'close' handler
+    // surfaces the real exit code + stderr); reject on anything else.
+    proc.stdin.on('error', (err) => {
+      if (err && err.code !== 'EPIPE') {
+        finishReject(new Error(`claude-cli backend: stdin error (${err.message})`));
+      }
+    });
     proc.stdin.write(prompt);
     proc.stdin.end();
 

--- a/src/backends/codex-cli.js
+++ b/src/backends/codex-cli.js
@@ -98,6 +98,15 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       }
     });
 
+    // A child that exits before draining a large prompt makes the buffered
+    // stdin write fail with EPIPE; without a handler that becomes an unhandled
+    // 'error' event that crashes the process. Ignore EPIPE (the 'close' handler
+    // surfaces the real exit code + stderr); reject on anything else.
+    proc.stdin.on('error', (err) => {
+      if (err && err.code !== 'EPIPE') {
+        finishReject(new Error(`codex-cli backend: stdin error (${err.message})`));
+      }
+    });
     proc.stdin.write(prompt);
     proc.stdin.end();
 

--- a/src/backends/gemini-cli.js
+++ b/src/backends/gemini-cli.js
@@ -64,6 +64,10 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
 
     let stdout = '';
     let stderr = '';
+    // Decode with a streaming UTF-8 decoder so multi-byte CJK characters split
+    // across pipe-read boundaries are not corrupted into U+FFFD.
+    proc.stdout.setEncoding('utf8');
+    proc.stderr.setEncoding('utf8');
     proc.stdout.on('data', (chunk) => { stdout += chunk; });
     proc.stderr.on('data', (chunk) => { stderr += chunk; });
 
@@ -95,6 +99,15 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       finishResolve(stripGeminiNoise(stdout));
     });
 
+    // A child that exits before draining a large prompt makes the buffered
+    // stdin write fail with EPIPE; without a handler that becomes an unhandled
+    // 'error' event that crashes the process. Ignore EPIPE (the 'close' handler
+    // surfaces the real exit code + stderr); reject on anything else.
+    proc.stdin.on('error', (err) => {
+      if (err && err.code !== 'EPIPE') {
+        finishReject(new Error(`gemini-cli backend: stdin error (${err.message})`));
+      }
+    });
     proc.stdin.write(prompt);
     proc.stdin.end();
 

--- a/src/backends/kimi-cli.js
+++ b/src/backends/kimi-cli.js
@@ -52,6 +52,13 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
 
   const dir = mkdtempSync(join(tmpdir(), 'patina-kimi-'));
   const cliModel = resolveLocalCliModel({ backendName: name, model, modelSource });
+  // `--print` runs non-interactively WITHOUT `--yolo`, so the agent cannot
+  // auto-approve any tool action — there is no terminal to confirm at, so
+  // shell/file tools stay blocked even if user text tries a prompt injection.
+  // (Verified: an injected "run this shell command" prompt produced no tool
+  // execution.) `--max-steps-per-turn 20` only lets the model take more
+  // reasoning/formatting steps within that sandboxed-by-non-interactivity turn;
+  // it does NOT grant tool execution. Keep `--print` and never add `--yolo`.
   const args = [
     '--print',
     '--input-format',
@@ -61,7 +68,7 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
     '--final-message-only',
     '--no-thinking',
     '--max-steps-per-turn',
-    '1',
+    '20',
   ];
   if (cliModel) args.push('--model', cliModel);
 
@@ -70,6 +77,10 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
 
     let stdout = '';
     let stderr = '';
+    // Decode with a streaming UTF-8 decoder so multi-byte CJK characters split
+    // across pipe-read boundaries are not corrupted into U+FFFD.
+    proc.stdout.setEncoding('utf8');
+    proc.stderr.setEncoding('utf8');
     proc.stdout.on('data', (chunk) => { stdout += chunk; });
     proc.stderr.on('data', (chunk) => { stderr += chunk; });
 
@@ -101,6 +112,15 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       finishResolve(stripKimiNoise(stdout));
     });
 
+    // A child that exits before draining a large prompt makes the buffered
+    // stdin write fail with EPIPE; without a handler that becomes an unhandled
+    // 'error' event that crashes the process. Ignore EPIPE (the 'close' handler
+    // surfaces the real exit code + stderr); reject on anything else.
+    proc.stdin.on('error', (err) => {
+      if (err && err.code !== 'EPIPE') {
+        finishReject(new Error(`kimi-cli backend: stdin error (${err.message})`));
+      }
+    });
     proc.stdin.write(prompt);
     proc.stdin.end();
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -95,10 +95,12 @@ export async function main(args) {
     return;
   }
 
+  validateModeExclusivity(parsed);
   validateBrowserRequest(parsed);
 
-  const configPath = parsed.config ? resolve(process.cwd(), parsed.config) : undefined;
-  const config = loadConfig(configPath);
+  const config = loadConfig(undefined, parsed.config
+    ? { overridePath: resolve(process.cwd(), parsed.config) }
+    : {});
 
   if (parsed.lang) config.language = parsed.lang;
   if (parsed.profile) config.profile = parsed.profile;
@@ -579,6 +581,20 @@ function parseArgs(args) {
   }
 
   return parsed;
+}
+
+// The output modes are mutually exclusive (SKILL.md). Without this guard, a
+// combination like `--audit --score` resolves to 'audit' and silently skips the
+// score gate (exit 0 always), and `--score --ouroboros` throws deep in the gate.
+function validateModeExclusivity(parsed) {
+  const active = ['diff', 'audit', 'score', 'ouroboros'].filter((m) => parsed[m]);
+  if (active.length > 1) {
+    throw inputError(
+      `--${active[0]} and --${active[1]} cannot be combined`,
+      'The diff / audit / score / ouroboros output modes are mutually exclusive.',
+      `Pick one of --diff, --audit, --score, or --ouroboros.`
+    );
+  }
 }
 
 function validateBrowserRequest(parsed) {

--- a/src/config.js
+++ b/src/config.js
@@ -10,13 +10,18 @@ const REPO_ROOT = resolve(__dirname, '..');
 /**
  * Load default config and merge global/project .patina.yaml overrides.
  *
+ * Precedence (low → high): base path → ~/.patina.yaml → ./.patina.yaml → overridePath.
+ * The explicit `--config` file is layered LAST so an ambient project .patina.yaml
+ * cannot silently override a pinned config (reproducible CI runs).
+ *
  * @param {string} [path] Base YAML config path.
+ * @param {{overridePath?: string}} [opts] Optional explicit `--config` override.
  * @returns {object} Merged patina configuration object.
  * @throws {Error} When a config file is missing, invalid YAML, or not a mapping.
  * @example
  * const config = loadConfig();
  */
-export function loadConfig(path = resolve(REPO_ROOT, '.patina.default.yaml')) {
+export function loadConfig(path = resolve(REPO_ROOT, '.patina.default.yaml'), { overridePath } = {}) {
   const raw = readFileSync(path, 'utf8');
   const parsed = yaml.load(raw);
   if (!isPlainObject(parsed)) {
@@ -27,16 +32,25 @@ export function loadConfig(path = resolve(REPO_ROOT, '.patina.default.yaml')) {
   // User config: ~/.patina.yaml (global), then ./.patina.yaml (project, takes precedence).
   for (const userPath of [resolve(homedir(), '.patina.yaml'), resolve(process.cwd(), '.patina.yaml')]) {
     if (!existsSync(userPath)) continue;
-    const userRaw = readFileSync(userPath, 'utf8');
-    const userConfig = yaml.load(userRaw);
-    if (userConfig === null || userConfig === undefined) continue; // empty file
-    if (!isPlainObject(userConfig)) {
-      throw new Error(`User config at ${userPath} must be a YAML mapping (got ${Array.isArray(userConfig) ? 'array' : typeof userConfig})`);
-    }
-    deepMerge(config, userConfig);
+    mergeYamlMapping(config, userPath, 'User config');
+  }
+
+  // Explicit --config wins over both defaults and the ambient project/global files.
+  if (overridePath) {
+    mergeYamlMapping(config, resolve(overridePath), 'Config');
   }
 
   return config;
+}
+
+function mergeYamlMapping(config, filePath, label) {
+  const raw = readFileSync(filePath, 'utf8');
+  const parsed = yaml.load(raw);
+  if (parsed === null || parsed === undefined) return; // empty file
+  if (!isPlainObject(parsed)) {
+    throw new Error(`${label} at ${filePath} must be a YAML mapping (got ${Array.isArray(parsed) ? 'array' : typeof parsed})`);
+  }
+  deepMerge(config, parsed);
 }
 
 function isPlainObject(v) {
@@ -44,9 +58,12 @@ function isPlainObject(v) {
 }
 
 const ADDITIVE_LIST_KEYS = new Set(['blocklist', 'allowlist', 'skip-patterns']);
+const PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 function deepMerge(target, source) {
   for (const key in source) {
+    // Guard against prototype pollution from an auto-loaded .patina.yaml.
+    if (!Object.prototype.hasOwnProperty.call(source, key) || PROTO_KEYS.has(key)) continue;
     if (isPlainObject(source[key])) {
       if (!isPlainObject(target[key])) {
         target[key] = {};

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -18,6 +18,7 @@ import {
   DEFAULT_MATTR_BANDS,
   DEFAULT_MATTR_WINDOW,
   DEFAULT_MIN_BURSTINESS_SENTENCES,
+  koreanPostEditeseFeatures,
 } from './stylometry.js';
 import {
   classifyLexiconHot,
@@ -74,6 +75,7 @@ export function analyzeText(text, opts = {}) {
   // surfaced for callers/SKILL but deliberately NOT folded into `hot` (these
   // constructions appear in good Korean too; gating hot would regress FP).
   const translationese = detectTranslationese(normalized, { lang });
+  const koPostEditese = koreanPostEditeseFeatures(normalized, { lang });
   const structuralClassifier = structuralModelVerdict(normalized, { lang, model: structuralModel });
   const lexicon =
     providedLexicon ??
@@ -140,6 +142,7 @@ export function analyzeText(text, opts = {}) {
     markupLeakage,
     discourseTells,
     translationese,
+    koPostEditese,
     hot: markupLeakage.leaked || discourseTells.hot || structuralClassifier.hot === true || analyzed.some((p) => p.hot),
     structuralClassifier,
   };
@@ -158,6 +161,7 @@ export {
   commaDensity,
   koreanPosDiversityProxy,
   koreanSpacingFeatures,
+  koreanPostEditeseFeatures,
   loadLexicon,
   computeDensity,
   extractStructuralFeatures,

--- a/src/features/stylometry.js
+++ b/src/features/stylometry.js
@@ -1,5 +1,6 @@
 // Burstiness CV, MATTR, and dependency-free KO diagnostics per core/stylometry.md.
 // Pure functions over token arrays; no I/O.
+import { splitParagraphs, splitProseSentences } from './segment.js';
 
 export const DEFAULT_BURSTINESS_BANDS = { low: 0.30, high: 0.50 };
 export const DEFAULT_MATTR_BANDS = { low: 0.55, high: 0.70 };
@@ -19,6 +20,7 @@ export const DEFAULT_KO_DIAGNOSTIC_BANDS = {
     maxClassDiversity: 0.26,
   },
 };
+export const KO_POST_EDITESE_SCHEMA = 'koPostEditese.v1';
 
 const HANGUL_RE = /[\u3131-\u318e\uac00-\ud7a3]/u;
 const COMMA_RE = /[,，、]/gu;
@@ -53,6 +55,27 @@ const KO_SUFFIX_MATCHERS = KO_SUFFIX_GROUPS
     }))
   )
   .sort((a, b) => b.length - a.length);
+
+const POST_EDITESE_ENDING_SUFFIXES = [
+  '습니다', '습니까', '합니다', '합니까', '입니다', '어요', '아요', '예요', '이에요',
+  '네요', '군요', '지요', '죠', '한다', '된다', '했다', '였다', '이다', '있다',
+  '없다', '왔다', '봤다', '다',
+].sort((a, b) => Array.from(b).length - Array.from(a).length);
+// Canonical token for regular formal '-ㅂ니다 / -ㅂ니까' endings (됩니다, 줍니다, 합니까…)
+// whose ㅂ marker fuses into the stem syllable and so isn't a literal suffix.
+const POST_EDITESE_FORMAL_NIDA = 'ㅂ니다';
+const POST_EDITESE_FORMAL_ENDINGS = new Set(['습니다', '습니까', '합니다', '합니까', '입니다', POST_EDITESE_FORMAL_NIDA]);
+const POST_EDITESE_POLITE_ENDINGS = new Set(['어요', '아요', '예요', '이에요', '네요', '군요', '지요', '죠']);
+const POST_EDITESE_DECLARATIVE_DA_ENDINGS = new Set(['한다', '된다', '했다', '였다', '이다', '있다', '없다', '왔다', '봤다', '다']);
+
+const POST_EDITESE_PRONOUN_LITERAL_RE = /(?:그녀(?:는|가|를|의|에게|와|도|만)?|그것(?:은|이|을|의|에|에게)?|그들(?:은|이|을|의|에게|과|도)?|그(?:는|가|를|의|에게|와|도|만)(?=\s|[.,!?。]|$))/g;
+const POST_EDITESE_DOUBLE_PARTICLE_RE = /(?:에서의|에로의|으로의|에의|으로부터의|로부터의)/g;
+const POST_EDITESE_PROGRESSIVE_ASPECT_RE = /고\s*있(?:다|습니다|는|었|으|고|지|기)?/g;
+const POST_EDITESE_LIGHT_VERB_RE = /(?:회의를\s*가(?:지|졌)|결정을\s*내(?:리|렸)|(?:을|를)\s*갖고\s*있(?:다|습니다|는|었|으)?)/g;
+const POST_EDITESE_BY_PASSIVE_RE = /에\s*의(?:해|하여)/g;
+const POST_EDITESE_DOUBLE_PASSIVE_RE = /(?:되어진다|되어졌다|되어진|되어지는|보여진다|보여졌다|보여진|쓰여진다|쓰여졌다|쓰여진|잊혀진|잊혀졌|닫혀진|열려진|불려진|놓여진)/g;
+const POST_EDITESE_CONNECTIVE_COMMA_RE = /(?:고|며|지만|면서|아서|어서)\s*,/g;
+const POST_EDITESE_RELATIVE_CLAUSE_PROXY_RE = /[가-힣]+(?:하는|되는|받는|받은|쓰인|되어진|보여진|한|할|된|될|던|운|온|인|힌|진|린|킨|쓴)\s+[가-힣]+/g;
 
 function mean(values) {
   if (!Array.isArray(values) || values.length === 0) return null;
@@ -113,6 +136,228 @@ export function mattr(tokens, window = DEFAULT_MATTR_WINDOW) {
     count++;
   }
   return sum / count;
+}
+
+export function koreanPostEditeseFeatures(text, opts = {}) {
+  const lang = opts.lang ?? 'ko';
+  const str = typeof text === 'string' ? text.normalize('NFC') : '';
+  if (lang !== 'ko') return skippedKoPostEditese(lang, 'non-ko');
+  if (str.trim().length === 0) return skippedKoPostEditese(lang, 'empty');
+
+  const paragraphs = splitParagraphs(str);
+  const totalEojeols = koreanEojeols(str);
+  if (totalEojeols.length === 0) return skippedKoPostEditese(lang, 'no-hangul-eojeols');
+
+  const paragraphRows = paragraphs.map((paragraph, index) => buildKoPostEditeseRow(paragraph, `P${index + 1}`));
+  const docSentences = paragraphs.flatMap((paragraph) => splitProseSentences(paragraph));
+  return {
+    schema: KO_POST_EDITESE_SCHEMA,
+    lang,
+    analyzed: true,
+    skipReason: null,
+    paragraphCount: paragraphRows.length,
+    sentenceCount: docSentences.length,
+    eojeolCount: totalEojeols.length,
+    metrics: buildKoPostEditeseMetrics(str, docSentences),
+    paragraphs: paragraphRows,
+  };
+}
+
+function skippedKoPostEditese(lang, skipReason) {
+  return {
+    schema: KO_POST_EDITESE_SCHEMA,
+    lang,
+    analyzed: false,
+    skipReason,
+    paragraphCount: 0,
+    sentenceCount: 0,
+    eojeolCount: 0,
+    metrics: zeroKoPostEditeseMetrics(),
+    paragraphs: [],
+  };
+}
+
+function zeroKoPostEditeseMetrics() {
+  return {
+    lexical: {
+      tokenCount: 0,
+      typeCount: 0,
+      ttr: null,
+      mattr: null,
+      endingTypeCount: 0,
+      endingDiversity: null,
+    },
+    endings: {
+      declarativeDaCount: 0,
+      declarativeDaRatio: null,
+      handaCount: 0,
+      doendaCount: 0,
+      idaCount: 0,
+      formalEndingCount: 0,
+      politeEndingCount: 0,
+      endingStreakMax: 0,
+    },
+    interference: {
+      pronounLiteralCount: 0,
+      doubleParticleCount: 0,
+      progressiveAspectCount: 0,
+      lightVerbCount: 0,
+      byPassiveCount: 0,
+      doublePassiveCount: 0,
+      connectiveCommaCount: 0,
+      relativeClauseProxyCount: 0,
+    },
+    rhythm: {
+      meanSentenceEojeols: null,
+      sentenceEojeolCV: null,
+      meanEojeolLength: null,
+      eojeolLengthCV: null,
+      commaPerSentence: null,
+      commaPer100Chars: null,
+      suffixMatchedCount: 0,
+      suffixClassDiversity: null,
+      suffixDiversity: null,
+    },
+  };
+}
+
+function buildKoPostEditeseRow(paragraph, id) {
+  const sentences = splitProseSentences(paragraph);
+  const eojeols = koreanEojeols(paragraph);
+  return {
+    id,
+    sentenceCount: sentences.length,
+    eojeolCount: eojeols.length,
+    metrics: buildKoPostEditeseMetrics(paragraph, sentences),
+  };
+}
+
+function buildKoPostEditeseMetrics(text, sentences = splitProseSentences(text)) {
+  const eojeols = koreanEojeols(text);
+  const lowerEojeols = eojeols.map((token) => token.toLowerCase());
+  const typeCount = new Set(lowerEojeols).size;
+  const lengths = eojeols.map(koreanLength).filter((length) => length > 0);
+  const endings = sentences.map(extractSentenceEnding).filter(Boolean);
+  const endingTypeCount = new Set(endings).size;
+  const suffixStats = koPostEditeseSuffixStats(eojeols);
+  const comma = commaDensity(text, sentences.length);
+  const sentenceEojeolCounts = sentences
+    .map((sentence) => koreanEojeols(sentence).length)
+    .filter((count) => count > 0);
+
+  return {
+    lexical: {
+      tokenCount: eojeols.length,
+      typeCount,
+      ttr: ratio(typeCount, eojeols.length),
+      mattr: roundMetric(mattr(eojeols)),
+      endingTypeCount,
+      endingDiversity: ratio(endingTypeCount, sentences.length),
+    },
+    endings: buildKoPostEditeseEndings(endings),
+    interference: {
+      pronounLiteralCount: countPattern(text, POST_EDITESE_PRONOUN_LITERAL_RE),
+      doubleParticleCount: countPattern(text, POST_EDITESE_DOUBLE_PARTICLE_RE),
+      progressiveAspectCount: countPattern(text, POST_EDITESE_PROGRESSIVE_ASPECT_RE),
+      lightVerbCount: countPattern(text, POST_EDITESE_LIGHT_VERB_RE),
+      byPassiveCount: countPattern(text, POST_EDITESE_BY_PASSIVE_RE),
+      doublePassiveCount: countPattern(text, POST_EDITESE_DOUBLE_PASSIVE_RE),
+      connectiveCommaCount: countPattern(text, POST_EDITESE_CONNECTIVE_COMMA_RE),
+      relativeClauseProxyCount: countPattern(text, POST_EDITESE_RELATIVE_CLAUSE_PROXY_RE),
+    },
+    rhythm: {
+      meanSentenceEojeols: ratio(eojeols.length, sentences.length),
+      sentenceEojeolCV: roundMetric(coefficientOfVariation(sentenceEojeolCounts)),
+      meanEojeolLength: roundMetric(mean(lengths)),
+      eojeolLengthCV: roundMetric(coefficientOfVariation(lengths)),
+      commaPerSentence: roundMetric(comma.perSentence),
+      commaPer100Chars: roundMetric(comma.per100Chars),
+      suffixMatchedCount: suffixStats.matchedCount,
+      suffixClassDiversity: roundMetric(suffixStats.classDiversity),
+      suffixDiversity: roundMetric(suffixStats.suffixDiversity),
+    },
+  };
+}
+
+function buildKoPostEditeseEndings(endings) {
+  const declarativeDaCount = endings.filter((ending) => POST_EDITESE_DECLARATIVE_DA_ENDINGS.has(ending)).length;
+  return {
+    declarativeDaCount,
+    declarativeDaRatio: ratio(declarativeDaCount, endings.length),
+    handaCount: endings.filter((ending) => ending === '한다').length,
+    doendaCount: endings.filter((ending) => ending === '된다').length,
+    idaCount: endings.filter((ending) => ending === '이다').length,
+    formalEndingCount: endings.filter((ending) => POST_EDITESE_FORMAL_ENDINGS.has(ending)).length,
+    politeEndingCount: endings.filter((ending) => POST_EDITESE_POLITE_ENDINGS.has(ending)).length,
+    endingStreakMax: maxDeclarativeDaStreak(endings),
+  };
+}
+
+function extractSentenceEnding(sentence) {
+  const eojeol = koreanEojeols(sentence).at(-1);
+  if (!eojeol) return null;
+  const matched = POST_EDITESE_ENDING_SUFFIXES.find((ending) => eojeol.endsWith(ending)) ?? null;
+  // Regular formal '-ㅂ니다 / -ㅂ니까' (됩니다, 표시됩니다, 합니까…) fuse the ㅂ marker into
+  // the stem syllable, so they fall through to the bare '다' bucket and get miscounted as
+  // declarative '-다' style. Reclassify them as a formal ending.
+  if ((matched === '다' || matched === null) && isFormalFusedEnding(eojeol)) {
+    return POST_EDITESE_FORMAL_NIDA;
+  }
+  return matched;
+}
+
+// True for '-ㅂ니다 / -ㅂ니까' formal endings: the syllable before 니다/니까 carries a ㅂ
+// jongseong (batchim index 17). Distinguishes 됩니다/아닙니다 (formal) from 아니다 (plain).
+function isFormalFusedEnding(eojeol) {
+  const m = /(.)(?:니다|니까)$/.exec(eojeol);
+  if (!m) return false;
+  const code = m[1].charCodeAt(0);
+  if (code < 0xac00 || code > 0xd7a3) return false;
+  return (code - 0xac00) % 28 === 17;
+}
+
+function maxDeclarativeDaStreak(endings) {
+  let current = 0;
+  let max = 0;
+  for (const ending of endings) {
+    if (POST_EDITESE_DECLARATIVE_DA_ENDINGS.has(ending)) {
+      current += 1;
+      max = Math.max(max, current);
+    } else {
+      current = 0;
+    }
+  }
+  return max;
+}
+
+function koPostEditeseSuffixStats(eojeols) {
+  const matches = [];
+  for (const token of eojeols) {
+    const match = KO_SUFFIX_MATCHERS.find(
+      (candidate) => token.length > candidate.suffix.length && token.endsWith(candidate.suffix)
+    );
+    if (match) matches.push({ className: match.className, suffix: match.suffix });
+  }
+  const matchedCount = matches.length;
+  const classCount = new Set(matches.map((match) => match.className)).size;
+  const suffixCount = new Set(matches.map((match) => match.suffix)).size;
+  return {
+    matchedCount,
+    classDiversity: matchedCount > 0 ? classCount / matchedCount : null,
+    suffixDiversity: matchedCount > 0 ? suffixCount / matchedCount : null,
+  };
+}
+
+function countPattern(text, pattern) {
+  return (String(text ?? '').match(pattern) ?? []).length;
+}
+
+function ratio(numerator, denominator) {
+  return denominator > 0 ? roundMetric(numerator / denominator) : null;
+}
+
+function roundMetric(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? Number(value.toFixed(3)) : null;
 }
 
 export function koreanSpacingFeatures(paragraph) {

--- a/src/features/translationese.js
+++ b/src/features/translationese.js
@@ -14,8 +14,15 @@
 // ko-only for now (calques are language-specific).
 import { splitProseSentences } from './segment.js';
 
-// strong: rarer in good Korean, weighted higher. weak: common, advisory only.
-// Each rule: { id, label, strong, re() -> fresh global RegExp, example:{before,after} }
+// Surface forms of a passive predicate (되다/받다/당하다/-어지다 families). Listed
+// as composed NFC syllables because the passive marker fuses into the stem
+// syllable (된다 = 되+ㄴ다), which a jamo alternation cannot match.
+const BY_PASSIVE_PREDICATE =
+  '(?:된다|된|될|됨|됐다|됐|돼|되었|되어|되는|되며|되고|됩니다|됩|받는다|받았다|받은|받을|받는|받습니다|받아|당한다|당했다|당하다|당하는|당해|(?:어|아|여)(?:진다|졌다|진|질|지는|집니다|져))';
+
+// Strong rules are rarer and can satisfy the hot gate; weak rules are common
+// advisory evidence and never make the detector hot on their own.
+// Each rule: { id, label, strong, re() -> fresh global RegExp, minCount?, example:{before,after} }
 const RULES = [
   {
     id: 'noun-calque',
@@ -39,6 +46,22 @@ const RULES = [
     example: { before: '당신은 이것을 설정할 수 있습니다.', after: '이건 설정할 수 있다.' },
   },
   {
+    id: 'a16-pronoun-literal',
+    label: '영어식 3인칭 대명사 직역 (he/she/it/they)',
+    strong: true,
+    // Require a non-Hangul boundary before the pronoun (so 로그/버그/태그 don't match)
+    // and an eojeol boundary after it (so 그녀석/그것참 don't match).
+    re: () => /(?<![가-힣])(?:그녀(?:는|가|를|의|에게|와|도|만)?|그것(?:은|이|을|의|에|에게)?|그들(?:은|이|을|의|에게|과|도)?|그(?:는|가|를|의|에게|와|도|만))(?=\s|[.,!?。]|$)/g,
+    example: { before: '메리는 그녀가 그녀의 어머니에게 전화했다고 말했다.', after: '메리는 어머니에게 전화했다고 말했다.' },
+  },
+  {
+    id: 'a19-double-particle',
+    label: '이중 조사 결합 (-에서의/-으로의/-에의)',
+    strong: true,
+    re: () => /(?:에서의|에로의|으로의|에의|으로부터의|로부터의)/g,
+    example: { before: '회의에서의 결정은 앞으로의 운영으로의 전환을 앞당겼다.', after: '회의에서 나온 결정은 앞으로 운영을 전환하는 일을 앞당겼다.' },
+  },
+  {
     id: 'passive-e-uihae',
     label: '"~에 의해" 피동 (English by-passive)',
     strong: false,
@@ -46,11 +69,34 @@ const RULES = [
     example: { before: '작업은 에이전트에 의해 처리됩니다.', after: '에이전트가 작업을 처리합니다.' },
   },
   {
+    id: 't2-by-passive',
+    label: '"~에 의해" + 피동 동사 결합',
+    strong: true,
+    // "에 의해" + a passive predicate in the following token. Matches fused
+    // syllable forms (된다/됩니다/될/진다) that the old jamo alternation missed.
+    re: () => new RegExp('에\\s*의(?:해|하여)\\s+\\S{0,12}?' + BY_PASSIVE_PREDICATE, 'g'),
+    example: { before: '이 작업은 에이전트에 의해 처리되었다.', after: '에이전트가 이 작업을 처리했다.' },
+  },
+  {
+    id: 'a8-double-passive',
+    label: '이중 피동 표면형 (-되어진/-보여진/-쓰여진)',
+    strong: true,
+    re: () => /(?:되어진다|되어졌다|되어진|되어지는|보여진다|보여졌다|보여진|쓰여진다|쓰여졌다|쓰여진|잊혀진|잊혀졌|닫혀진|열려진|불려진|놓여진)/g,
+    example: { before: '이 문제는 분석되어진 뒤 보고서에 쓰여진다.', after: '이 문제는 분석된 뒤 보고서에 쓰인다.' },
+  },
+  {
     id: 'have-overuse',
     label: '"~을 가지고 있다" (English "have")',
     strong: false,
-    re: () => /(?:을|를)\s*가지(?:고 있|고 있습니다|고 있다)/g,
+    re: () => /(?:을|를)\s*(?:가지(?:고 있|고 있습니다|고 있다)|갖(?:고 있|고 있습니다|고 있다))/g,
     example: { before: '이 도구는 유연성을 가지고 있습니다.', after: '이 도구는 유연합니다.' },
+  },
+  {
+    id: 'a7-light-verb',
+    label: '영어식 have/make light verb 직역',
+    strong: false,
+    re: () => /(?:회의를\s*가(?:지|졌)|결정을\s*내(?:리|렸)|(?:을|를)\s*갖고\s*있(?:다|습니다|는|었|으)?)/g,
+    example: { before: '우리는 회의를 가졌고 중요한 결정을 내렸다.', after: '우리는 회의에서 중요한 결정을 했다.' },
   },
   {
     id: 'one-of',
@@ -80,39 +126,53 @@ const RULES = [
     re: () => /(?:쉽게|가능하게|간단하게|편하게)\s*(?:만들어\s*(?:줍니다|준다|줘)|만듭니다|만든다)/g,
     example: { before: '설치를 쉽게 만들어 줍니다.', after: '설치가 쉬워진다.' },
   },
+  {
+    id: 'c11-connective-comma',
+    label: '연결어미 뒤 쉼표 (-고,/-며,/-지만,)',
+    strong: false,
+    minCount: 2,
+    re: () => /(?:고|며|지만|면서|아서|어서)\s*,/g,
+    example: { before: '그는 자료를 검토하고, 결과를 정리하며, 보고서를 작성했다.', after: '그는 자료를 검토하고 결과를 정리한 뒤 보고서를 작성했다.' },
+  },
 ];
 
-const ABS_MIN = 4;      // need at least this many total calque hits, and
-const DENSITY_MIN = 0.5; // at least this many hits per prose sentence, to call it hot.
+const ABS_MIN = 4;        // need at least this many independent evidence spans, and
+const DENSITY_MIN = 0.5;  // at least this many independent spans per prose sentence.
+const STRONG_MIN = 1;     // weak/common rules are advisory-only unless a strong signal also fires.
+
 
 /**
  * Scan ko text for translationese (calque) markers.
  * @param {string} text
  * @param {{lang?: string}} [opts]
- * @returns {{count:number, density:number, sentences:number, byRule:Array, hits:string[], hot:boolean, thresholds:{count:number,density:number}}}
+ * @returns {{count:number, density:number, sentences:number, byRule:Array, hits:string[], hot:boolean, thresholds:{count:number,density:number,strong:number}}}
  */
 export function detectTranslationese(text, opts = {}) {
   const lang = opts.lang ?? 'ko';
   const str = typeof text === 'string' ? text : '';
   if (lang !== 'ko' || !str) {
-    return { count: 0, density: 0, sentences: 0, byRule: [], hits: [], hot: false, thresholds: { count: ABS_MIN, density: DENSITY_MIN } };
+    return { count: 0, density: 0, sentences: 0, byRule: [], hits: [], hot: false, thresholds: { count: ABS_MIN, density: DENSITY_MIN, strong: STRONG_MIN } };
   }
   const byRule = [];
   const hits = [];
-  let count = 0;
+  const evidence = [];
   for (const rule of RULES) {
-    const matches = str.match(rule.re());
-    if (matches && matches.length) {
-      count += matches.length;
+    const matches = collectRuleMatches(str, rule);
+    const minCount = rule.minCount ?? 1;
+    if (matches.length >= minCount) {
       byRule.push({ id: rule.id, label: rule.label, strong: rule.strong, count: matches.length, example: rule.example });
-      hits.push(...new Set(matches.map((m) => m.trim()).filter(Boolean)));
+      hits.push(...new Set(matches.map((m) => m.text.trim()).filter(Boolean)));
+      evidence.push(...matches.map((match) => ({ ...match, strong: Boolean(rule.strong) })));
     }
   }
+  const independentEvidence = selectIndependentEvidence(evidence);
+  const count = independentEvidence.length;
+  const strongCount = independentEvidence.filter((match) => match.strong).length;
   const sentences = Math.max(1, splitProseSentences(str).length);
   const density = count / sentences;
-  // Conservative: needs both an absolute floor AND a per-sentence density, so
-  // long legit docs with a few calques never trip it.
-  const hot = count >= ABS_MIN && density >= DENSITY_MIN;
+  // Conservative: needs enough independent spans, enough density, and at least
+  // one strong signal. Weak/common calques remain advisory even when clustered.
+  const hot = count >= ABS_MIN && density >= DENSITY_MIN && strongCount >= STRONG_MIN;
   return {
     count,
     density: Number(density.toFixed(3)),
@@ -120,8 +180,45 @@ export function detectTranslationese(text, opts = {}) {
     byRule: byRule.sort((a, b) => b.count - a.count),
     hits: [...new Set(hits)].slice(0, 8),
     hot,
-    thresholds: { count: ABS_MIN, density: DENSITY_MIN },
+    thresholds: { count: ABS_MIN, density: DENSITY_MIN, strong: STRONG_MIN },
   };
 }
 
-export { RULES as TRANSLATIONESE_RULES, ABS_MIN, DENSITY_MIN };
+function collectRuleMatches(str, rule) {
+  const re = rule.re();
+  const matches = [];
+  let match;
+  while ((match = re.exec(str)) !== null) {
+    matches.push({
+      text: match[0],
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+    if (match[0] === '') re.lastIndex += 1;
+  }
+  return matches;
+}
+
+function selectIndependentEvidence(matches) {
+  const selected = [];
+  const ranked = [...matches].sort((a, b) => {
+    if (a.strong !== b.strong) return a.strong ? -1 : 1;
+    const lengthDelta = (b.end - b.start) - (a.end - a.start);
+    if (lengthDelta !== 0) return lengthDelta;
+    return a.start - b.start;
+  });
+
+  for (const match of ranked) {
+    if (!selected.some((kept) => overlaps(kept, match))) {
+      selected.push(match);
+    }
+  }
+
+  return selected.sort((a, b) => a.start - b.start);
+}
+
+function overlaps(a, b) {
+  return a.start < b.end && b.start < a.end;
+}
+
+export { RULES as TRANSLATIONESE_RULES, ABS_MIN, DENSITY_MIN, STRONG_MIN };

--- a/src/ouroboros.js
+++ b/src/ouroboros.js
@@ -1,6 +1,7 @@
 import { callLLM as defaultCallLLM } from './api.js';
 import { scoreText, scoreMPS, scoreFidelity, combinedScore } from './scoring.js';
 import { buildPrompt } from './prompt-builder.js';
+import { stripSelfAudit } from './output.js';
 import { createLogger } from './logger.js';
 
 /**
@@ -117,7 +118,7 @@ export async function runOuroboros({
     });
 
     const iterationStartedAt = now ? now() : Date.now();
-    const humanized = await callLLM({
+    const rawOutput = await callLLM({
       prompt,
       apiKey,
       baseURL,
@@ -127,6 +128,11 @@ export async function runOuroboros({
       signal,
       timeout,
     });
+    // The rewrite prompt asks the model to wrap output in [BODY]/[SELF_AUDIT] tags.
+    // Strip them before scoring and before re-feeding: otherwise the AI-likeness
+    // score, MPS, and fidelity all see the self-audit meta-commentary, and the next
+    // iteration humanizes text with nested tags.
+    const humanized = stripSelfAudit(rawOutput, { logger });
 
     const scoreResult = await scoreText({
       text: humanized,
@@ -181,7 +187,10 @@ export async function runOuroboros({
       }),
     ]);
 
-    const mps = mpsResult?.mps ?? 100;
+    // A failed MPS scorer returns { mps: null }. Treat that as a floor violation
+    // (fail closed) rather than defaulting to a passing 100 — scoreFidelity already
+    // fails closed (missing criteria clamp to 0), so MPS must match.
+    const mps = mpsResult?.mps ?? null;
     const fidelity = fidelityResult?.fidelity ?? 100;
     const combined = combinedScore({
       aiLikeness: currentScore,
@@ -207,8 +216,8 @@ export async function runOuroboros({
       reason = 'Fidelity floor violation';
       shouldStop = true;
       shouldRollback = true;
-    } else if (mps < mpsFloor) {
-      reason = 'MPS floor violation';
+    } else if (mps === null || mps < mpsFloor) {
+      reason = mps === null ? 'MPS scorer failure' : 'MPS floor violation';
       shouldStop = true;
       shouldRollback = true;
     } else if (delta <= plateauThreshold) {
@@ -250,8 +259,13 @@ export async function runOuroboros({
     }
   }
 
+  // Return the best-scoring text with its score. A non-rollback stop (plateau/target/max)
+  // leaves currentText at the last iteration, which can score worse than bestScore when
+  // combined-score improvements (e.g. fidelity) let an AI-likeness regression through;
+  // pairing currentText with bestScore would mislabel that text. bestText is only ever
+  // updated on floor-passing iterations, so it is always a safe result.
   return {
-    finalText: currentText,
+    finalText: bestText,
     finalScore: bestScore,
     iterations: iterationLog.length - 1,
     reason: iterationLog[iterationLog.length - 1]?.reason || 'Completed',

--- a/src/output.js
+++ b/src/output.js
@@ -254,9 +254,13 @@ function removeSelfAuditBlocks(body) {
 
 function removeToneFooter(body) {
   if (!hasToneFooter(body)) return body;
-  const match = String(body || '').match(/(^|\n)---\s*\n([\s\S]*?)\n---\s*$/);
+  const str = String(body || '');
+  // Anchor to the LAST '---'-fenced block: the inner content may not contain another
+  // '---' fence line, so a markdown thematic break earlier in the body cannot be
+  // mistaken for the footer opener (which would truncate everything after it).
+  const match = str.match(/(?:^|\n)---[ \t]*\n((?:(?!\n---[ \t]*(?:\n|$))[\s\S])*?)\n---[ \t]*$/);
   if (!match) return body;
-  const block = match[2];
+  const block = match[1];
   if (
     !/\btone\s*:/.test(block)
     || !/\btone_source\s*:/.test(block)
@@ -265,7 +269,7 @@ function removeToneFooter(body) {
   ) {
     return body;
   }
-  return String(body || '').slice(0, match.index).trimEnd();
+  return str.slice(0, match.index).trimEnd();
 }
 
 function renderBody(result) {
@@ -481,14 +485,23 @@ export function buildDeterministicAuditBackstop(text, opts = {}) {
   const str = typeof text === 'string' ? text : '';
   /** @type {Array<{signal:string,label:string,severity:string,location:string}>} */
   const rows = [];
+  /** @type {Array<{signal:string,location:string,hint:string}>} */
+  const translationeseRows = [];
 
   // ko translationese — per-rule, with matched samples (model-independent).
+  // This is an editing-hint surface, not calibrated severity evidence.
   if (lang === 'ko' && str) {
     for (const rule of TRANSLATIONESE_RULES) {
       const matches = str.match(rule.re());
-      if (matches && matches.length) {
+      if (matches && matches.length >= (rule.minCount ?? 1)) {
         const samples = [...new Set(matches.map((m) => m.trim()).filter(Boolean))].slice(0, 4);
-        rows.push({ signal: `번역투: ${rule.id}`, label: rule.label, severity: rule.strong ? 'MEDIUM' : 'LOW', location: samples.join(', ') });
+        translationeseRows.push({
+          signal: `번역투: ${rule.id} — ${rule.label}`,
+          location: samples.join(', '),
+          hint: rule.example?.after
+            ? `자연스러운 한국어 예: ${rule.example.after}`
+            : '문맥을 읽고 자연스러운 한국어 절·문장으로 다듬는다.',
+        });
       }
     }
   }
@@ -509,13 +522,77 @@ export function buildDeterministicAuditBackstop(text, opts = {}) {
     rows.push({ signal: 'structural-classifier', label: '문서 단위 구조 분류기', severity: 'HIGH', location: `score ${a.structuralClassifier.score}` });
   }
 
-  if (rows.length === 0) return '';
+  const koPostEditeseRows = buildKoPostEditeseAdvisoryRows(a.koPostEditese);
+  if (rows.length === 0 && translationeseRows.length === 0 && koPostEditeseRows.length === 0) return '';
+
   const lines = [
     '## 결정적 신호 (deterministic backstop — 모델과 무관하게 항상 검사)',
-    '',
-    '| 신호 | 설명 | 심각도 | 위치 |',
-    '|------|------|--------|------|',
-    ...rows.map((r) => `| ${r.signal} | ${r.label} | ${r.severity} | ${r.location} |`),
   ];
+  if (rows.length > 0) {
+    lines.push(
+      '',
+      '| 신호 | 설명 | 심각도 | 위치 |',
+      '|------|------|--------|------|',
+      ...rows.map((r) => renderMarkdownTableRow([r.signal, r.label, r.severity, r.location])),
+    );
+  }
+  if (translationeseRows.length > 0) {
+    lines.push(
+      '',
+      '### Korean translationese editing hints',
+      '',
+      '| signal | matched sample | editing hint |',
+      '|--------|----------------|--------------|',
+      ...translationeseRows.map((r) => renderMarkdownTableRow([r.signal, r.location, r.hint])),
+    );
+  }
+  if (koPostEditeseRows.length > 0) {
+    lines.push(
+      '',
+      '### koPostEditese.v1 편집 참고 원시 지표',
+      '',
+      '| metric | value | editing hint |',
+      '|--------|-------|--------------|',
+      ...koPostEditeseRows.map((r) => renderMarkdownTableRow([r.metric, formatAdvisoryValue(r.value), r.hint])),
+    );
+  }
+
   return `\n\n${lines.join('\n')}`;
+}
+
+function buildKoPostEditeseAdvisoryRows(payload) {
+  if (!payload?.analyzed || payload.schema !== 'koPostEditese.v1') return [];
+  const metrics = payload.metrics ?? {};
+  return [
+    { metric: 'lexical.tokenCount', value: metrics.lexical?.tokenCount, hint: '표본 크기를 확인하고 짧은 글에서는 다른 지표를 과해석하지 않는다.' },
+    { metric: 'lexical.ttr', value: metrics.lexical?.ttr, hint: '반복 어휘가 많으면 같은 뜻의 한국어 표현으로 압축한다.' },
+    { metric: 'lexical.endingDiversity', value: metrics.lexical?.endingDiversity, hint: '문장 끝맺음이 단조로우면 종결형을 섞어 읽는 리듬을 다듬는다.' },
+    { metric: 'endings.declarativeDaRatio', value: metrics.endings?.declarativeDaRatio, hint: "'다/한다/된다/이다' 종결이 몰리면 일부 문장을 자연스러운 구어·서술형으로 바꾼다." },
+    { metric: 'endings.endingStreakMax', value: metrics.endings?.endingStreakMax, hint: '같은 종결형이 연속되면 문장 순서나 연결 방식을 손본다.' },
+    { metric: 'interference.pronounLiteralCount', value: metrics.interference?.pronounLiteralCount, hint: "'당신/그것/이것' 직역 대명사는 생략하거나 구체 명사로 바꾼다." },
+    { metric: 'interference.byPassiveCount', value: metrics.interference?.byPassiveCount, hint: "'~에 의해' 피동은 가능한 한 행위자 주어 능동문으로 고친다." },
+    { metric: 'interference.lightVerbCount', value: metrics.interference?.lightVerbCount, hint: "'~을 하다/가지다' 류는 더 직접적인 동사나 형용사로 줄인다." },
+    { metric: 'interference.progressiveAspectCount', value: metrics.interference?.progressiveAspectCount, hint: "'~하고 있다' 진행상은 실제 진행이 아니면 단순 현재로 줄인다." },
+    { metric: 'rhythm.meanSentenceEojeols', value: metrics.rhythm?.meanSentenceEojeols, hint: '문장이 길게 늘어지면 한 생각 단위로 끊는다.' },
+    { metric: 'rhythm.commaPerSentence', value: metrics.rhythm?.commaPerSentence, hint: '쉼표가 많으면 접속 구조를 문장 분리나 조사로 정리한다.' },
+    { metric: 'rhythm.suffixDiversity', value: metrics.rhythm?.suffixDiversity, hint: '연결 어미 선택이 좁으면 문장 연결 방식을 다양화한다.' },
+  ].filter((row) => row.value !== undefined && row.value !== null);
+}
+
+function formatAdvisoryValue(value) {
+  if (typeof value === 'number') return Number.isInteger(value) ? String(value) : String(Number(value.toFixed(4)));
+  return String(value);
+}
+function renderMarkdownTableRow(cells) {
+  return `| ${cells.map(escapeMarkdownTableCell).join(' | ')} |`;
+}
+
+function escapeMarkdownTableCell(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/\|/g, '\\|')
+    .replace(/\r?\n/g, ' ')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .trim();
 }

--- a/src/prompt-builder.js
+++ b/src/prompt-builder.js
@@ -135,7 +135,11 @@ export function buildPrompt(options) {
   return prompt;
 }
 
-function buildRewriteInstructions(structurePacks, lexicalPacks, { includeSelfAudit = true, lang = 'ko' } = {}) {
+function buildRewriteInstructions(
+  structurePacks,
+  lexicalPacks,
+  { includeSelfAudit = true, lang = 'ko', includeKoreanAdvisory = true } = {}
+) {
   const phaseCount = includeSelfAudit ? 3 : 2;
   let inst = `Follow the ${phaseCount}-Phase pipeline:\n\n`;
 
@@ -166,6 +170,10 @@ function buildRewriteInstructions(structurePacks, lexicalPacks, { includeSelfAud
   const cjkGuard = buildCjkClauseRewriteGuard(lang);
   if (cjkGuard) {
     inst += `${cjkGuard}\n`;
+  }
+
+  if (includeKoreanAdvisory) {
+    inst += buildKoreanAdvisoryRewriteGuidance(lang);
   }
 
 
@@ -235,6 +243,19 @@ function buildCjkClauseRewriteGuard(lang) {
   }
 
   return `${shared.join('\n')}\n`;
+}
+
+function buildKoreanAdvisoryRewriteGuidance(lang) {
+  if (lang !== 'ko') return '';
+
+  return [
+    `### Korean advisory analyzer metadata`,
+    ``,
+    `If \`analysis.translationese\` or \`koPostEditese.v1\` metadata is available, treat it as advisory editing context only. It is not score, gate, hot-spot, severity, benchmark, z-score, baseline, percentile, prompt/rewrite gate, or authorship-verdict evidence.`,
+    `Use the hints to make natural Korean edits for calques, literal pronouns, by-passives, double particles, overly uniform endings, sentence rhythm, and suffix-diversity proxies.`,
+    `Preserve claims, numbers, polarity, causation, and register; do not add or remove facts to satisfy the metadata.`,
+    ``,
+  ].join('\n');
 }
 
 function buildDiffInstructions() {
@@ -339,6 +360,7 @@ function buildMinimalPrompt({ config, patterns, profile, voiceSample, text, tone
     : `This text reads like AI. Rewrite it so it sounds like a real person wrote it. If you spot any of the phrases below, swap them out for something natural. Don't over-paraphrase — keep the meaning, numbers, and causation intact.`;
 
   let prompt = `${instruction}\n\n`;
+  prompt += buildKoreanAdvisoryRewriteGuidance(lang);
   const cjkGuard = buildCjkClauseRewriteGuard(lang);
   if (cjkGuard) {
     prompt += `${cjkGuard}\n`;
@@ -438,7 +460,11 @@ function buildOuroborosInstructions(config, structurePacks, lexicalPacks) {
   // Skip Phase 3 self-audit: each iteration runs through external evaluators
   // (scoreText, scoreMPS, scoreFidelity) in src/ouroboros.js, so an in-prompt
   // self-audit duplicates work and inflates token cost.
-  inst += buildRewriteInstructions(structurePacks, lexicalPacks, { includeSelfAudit: false, lang });
+  inst += buildRewriteInstructions(structurePacks, lexicalPacks, {
+    includeSelfAudit: false,
+    lang,
+    includeKoreanAdvisory: false,
+  });
 
   return inst;
 }

--- a/tests/unit/audit-backstop.test.js
+++ b/tests/unit/audit-backstop.test.js
@@ -5,6 +5,15 @@ import { buildDeterministicAuditBackstop } from '../../src/output.js';
 
 const CALQUE = '이것은 강력한 도구입니다. 다양한 기능을 제공합니다. 이 작업은 에이전트에 의해 처리됩니다. 당신은 이것을 매우 쉽게 사용할 수 있습니다.';
 
+function koPostEditeseSection(md) {
+  return md.split('### koPostEditese.v1 편집 참고 원시 지표')[1] ?? '';
+}
+function translationeseSection(md) {
+  return md.split('### Korean translationese editing hints')[1]?.split('### koPostEditese.v1')[0] ?? '';
+}
+
+
+
 test('audit backstop surfaces ko translationese even when an LLM would miss it', () => {
   const md = buildDeterministicAuditBackstop(CALQUE, { lang: 'ko' });
   assert.ok(md.includes('deterministic backstop'), 'has backstop header');
@@ -12,14 +21,61 @@ test('audit backstop surfaces ko translationese even when an LLM would miss it',
   assert.ok(md.includes('번역투: direct-address-you'), '당신');
   assert.ok(md.includes('번역투: dummy-subject'), '이것은');
   assert.ok(md.includes('번역투: provides'), '제공합니다');
+  assert.ok(md.includes('### Korean translationese editing hints'));
+  assert.equal(md.includes('| 신호 | 설명 | 심각도 | 위치 |'), false, 'translationese-only backstop stays out of severity table');
   // matched location should show the actual offending substring
   assert.ok(md.includes('에 의해'));
 });
 
-test('audit backstop is empty for clean native ko (no false positives)', () => {
-  const clean = '어제는 비가 많이 왔다. 그래서 집에 있었다. 라면 먹고 영화 봤다. 나쁘지 않았다.';
-  assert.equal(buildDeterministicAuditBackstop(clean, { lang: 'ko' }), '');
+test('audit backstop keeps ko translationese advisory hints separate from true severity rows', () => {
+  const md = buildDeterministicAuditBackstop(`${CALQUE} :contentReference[oaicite:1]{index=1}`, { lang: 'ko' });
+  const severityTable = md.slice(md.indexOf('| 신호 | 설명 | 심각도 | 위치 |'), md.indexOf('### Korean translationese editing hints'));
+  const section = translationeseSection(md);
+
+  assert.ok(severityTable.includes('markup-leakage'));
+  assert.equal(severityTable.includes('번역투:'), false);
+  assert.ok(section.includes('번역투: passive-e-uihae'));
+  assert.equal(section.includes('심각도'), false);
+  assert.equal(/\b(?:LOW|MEDIUM|HIGH)\b/.test(section), false);
 });
+
+test('audit backstop escapes markdown table-breaking characters in advisory samples', () => {
+  const md = buildDeterministicAuditBackstop('이 작업은 에 의해 |처리되었다. :contentReference[oaicite:1]{index=1}', { lang: 'ko' });
+  const section = translationeseSection(md);
+
+  assert.match(section, /에 의해 \\\|처리/);
+  assert.doesNotMatch(section, /\| 에 의해 \|처리/);
+});
+
+test('audit backstop surfaces ko post-editese advisory raw metrics separately', () => {
+  const md = buildDeterministicAuditBackstop(CALQUE, { lang: 'ko' });
+  const section = koPostEditeseSection(md);
+
+  assert.ok(section, 'has separate koPostEditese advisory section');
+  assert.ok(section.includes('| metric | value | editing hint |'), 'uses metric/value/editing-hint framing');
+  assert.ok(section.includes('interference.pronounLiteralCount'), 'includes raw interference metric');
+  assert.ok(section.includes('rhythm.meanSentenceEojeols'), 'includes raw rhythm metric');
+  assert.ok(md.indexOf('### Korean translationese editing hints') < md.indexOf('### koPostEditese.v1'), 'koPostEditese section follows translationese advisory section');
+});
+
+test('audit backstop keeps ko post-editese metrics out of severity framing', () => {
+  const md = buildDeterministicAuditBackstop(`${CALQUE} :contentReference[oaicite:1]{index=1}`, { lang: 'ko' });
+  const severityTable = md.slice(md.indexOf('| 신호 | 설명 | 심각도 | 위치 |'), md.indexOf('### Korean translationese editing hints'));
+  const section = koPostEditeseSection(md);
+
+  assert.equal(severityTable.includes('koPostEditese'), false);
+  assert.equal(severityTable.includes('interference.pronounLiteralCount'), false);
+  assert.equal(section.includes('심각도'), false);
+  assert.equal(/\b(?:LOW|MEDIUM|HIGH)\b/.test(section), false);
+});
+
+test('audit backstop does not turn clean native ko into severity rows', () => {
+  const clean = '어제는 비가 많이 왔다. 그래서 집에 있었다. 라면 먹고 영화 봤다. 나쁘지 않았다.';
+  const md = buildDeterministicAuditBackstop(clean, { lang: 'ko' });
+  assert.ok(md.includes('koPostEditese.v1'), 'clean ko can still show advisory raw metrics');
+  assert.equal(md.includes('| 신호 | 설명 | 심각도 | 위치 |'), false);
+});
+
 
 test('audit backstop catches markup leakage regardless of language', () => {
   const leaked = 'This is fine text :contentReference[oaicite:1]{index=1} and more.';
@@ -30,4 +86,12 @@ test('audit backstop catches markup leakage regardless of language', () => {
 test('audit backstop skips ko translationese rows for non-ko languages', () => {
   const md = buildDeterministicAuditBackstop('You can use this. It is provided by the agent.', { lang: 'en' });
   assert.equal(md.includes('번역투:'), false);
+});
+
+test('audit backstop omits ko post-editese section for skipped inputs', () => {
+  const nonKo = buildDeterministicAuditBackstop('A short plain English note.', { lang: 'en' });
+  const emptyKo = buildDeterministicAuditBackstop('', { lang: 'ko' });
+
+  assert.equal(nonKo.includes('koPostEditese.v1'), false);
+  assert.equal(emptyKo.includes('koPostEditese.v1'), false);
 });

--- a/tests/unit/playground.test.js
+++ b/tests/unit/playground.test.js
@@ -8,14 +8,33 @@ import { fileURLToPath } from 'node:url';
 import { PLAYGROUND_LEXICONS } from '../../playground/data/lexicons.js';
 import {
   analyzePlaygroundText,
+  detectTranslationese as detectPlaygroundTranslationese,
   buildCliCommand,
   buildFalsePositiveReportUrl,
   renderAuditDiff,
+  renderKoreanAdvisory,
   SUPPORTED_LANGS,
   splitProseSentences,
   countFormatting,
+  TRANSLATIONESE_RULES as PLAYGROUND_TRANSLATIONESE_RULES,
+  TRANSLATIONESE_ABS_MIN,
+  TRANSLATIONESE_DENSITY_MIN,
+  TRANSLATIONESE_STRONG_MIN,
+  KO_POST_EDITESE_SCHEMA as PLAYGROUND_KO_POST_EDITESE_SCHEMA,
+  koreanPostEditeseFeatures as playgroundKoPostEditeseFeatures,
 } from '../../playground/analyzer.js';
 import { analyzeText } from '../../src/features/index.js';
+import {
+  detectTranslationese as detectNodeTranslationese,
+  TRANSLATIONESE_RULES as NODE_TRANSLATIONESE_RULES,
+  ABS_MIN as NODE_TRANSLATIONESE_ABS_MIN,
+  DENSITY_MIN as NODE_TRANSLATIONESE_DENSITY_MIN,
+  STRONG_MIN as NODE_TRANSLATIONESE_STRONG_MIN,
+} from '../../src/features/translationese.js';
+import {
+  KO_POST_EDITESE_SCHEMA as NODE_KO_POST_EDITESE_SCHEMA,
+  koreanPostEditeseFeatures as nodeKoPostEditeseFeatures,
+} from '../../src/features/stylometry.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../..');
@@ -26,6 +45,34 @@ const SAMPLES = {
   zh: '总而言之，这一方案能够全面提升用户体验，并为未来发展提供新的可能。',
   ja: 'まとめると、この仕組みはユーザー体験を向上させ、より良い未来につながります。',
 };
+const FORBIDDEN_KO_POST_EDITESE_KEYS = new Set([
+  'hot',
+  'severity',
+  'score',
+  'zScore',
+  'zscore',
+  'baseline',
+  'percentile',
+]);
+
+function collectObjectKeys(value, keys = []) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectObjectKeys(item, keys);
+    return keys;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value)) {
+      keys.push(key);
+      collectObjectKeys(child, keys);
+    }
+  }
+  return keys;
+}
+function cloneForTest(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+
 
 function analyzeNodeText(text, lang) {
   return analyzeText(text, { lang, repoRoot: REPO_ROOT });
@@ -100,6 +147,234 @@ test('playground and node analyzers agree on shared deterministic signals', () =
       `${sample.name} verdict should match node analyzer`,
     );
   }
+});
+test('playground mirrors ko translationese advisory payload without score coupling', () => {
+  const text = '메리는 그녀가 그녀의 책을 갖고 있다. 회의에서의 결정으로의 이동은 에이전트에 의해 처리되었다.';
+  const nodeSignal = detectNodeTranslationese(text, { lang: 'ko' });
+  const playgroundSignal = detectPlaygroundTranslationese(text, { lang: 'ko' });
+  const nodeIds = nodeSignal.byRule.map((x) => x.id).sort();
+  const playgroundIds = playgroundSignal.byRule.map((x) => x.id).sort();
+
+  assert.equal(nodeSignal.hot, true);
+  assert.equal(playgroundSignal.hot, true);
+  assert.deepEqual(playgroundIds, nodeIds);
+  assert.equal(playgroundSignal.thresholds.count, nodeSignal.thresholds.count);
+  assert.equal(playgroundSignal.thresholds.density, nodeSignal.thresholds.density);
+  assert.equal(playgroundSignal.thresholds.strong, nodeSignal.thresholds.strong);
+
+  const analysis = analyzePlaygroundText(text, { lang: 'ko' });
+  assert.equal(analysis.translationese.hot, true);
+  assert.equal(analysis.hotCount, 0);
+  assert.equal(analysis.overall, 0);
+  assert.equal(analysis.auditItems.length, 0);
+
+  const nonKo = analyzePlaygroundText(text, { lang: 'en' });
+  assert.equal(nonKo.translationese.count, 0);
+  assert.equal(nonKo.translationese.hot, false);
+});
+test('playground keeps translationese rules and thresholds in parity with node', () => {
+  const serializeRule = (rule) => ({
+    id: rule.id,
+    label: rule.label,
+    strong: rule.strong,
+    minCount: rule.minCount ?? 1,
+    source: rule.re().source,
+    flags: rule.re().flags,
+    example: rule.example,
+  });
+
+  assert.deepEqual(
+    PLAYGROUND_TRANSLATIONESE_RULES.map(serializeRule),
+    NODE_TRANSLATIONESE_RULES.map(serializeRule),
+  );
+  assert.equal(TRANSLATIONESE_ABS_MIN, NODE_TRANSLATIONESE_ABS_MIN);
+  assert.equal(TRANSLATIONESE_DENSITY_MIN, NODE_TRANSLATIONESE_DENSITY_MIN);
+  assert.equal(TRANSLATIONESE_STRONG_MIN, NODE_TRANSLATIONESE_STRONG_MIN);
+
+  for (const rule of PLAYGROUND_TRANSLATIONESE_RULES) {
+    const signal = detectPlaygroundTranslationese(rule.example.before, { lang: 'ko' });
+    assert.ok(
+      signal.byRule.some((hit) => hit.id === rule.id),
+      `playground rule ${rule.id} does not match its own before example`,
+    );
+  }
+
+  const empty = detectPlaygroundTranslationese('', { lang: 'ko' });
+  assert.deepEqual(empty.thresholds, {
+    count: NODE_TRANSLATIONESE_ABS_MIN,
+    density: NODE_TRANSLATIONESE_DENSITY_MIN,
+    strong: NODE_TRANSLATIONESE_STRONG_MIN,
+  });
+});
+
+test('playground mirrors weak-only and overlap de-duplication translationese semantics', () => {
+  const cases = [
+    {
+      name: 'weak-only advisory density',
+      text: '사용법은 다음과 같습니다. 다양한 기능을 제공합니다. 설치를 쉽게 만들어 줍니다. 가장 빠른 도구 중 하나입니다.',
+      expectedCount: 4,
+      expectedHot: false,
+    },
+    {
+      name: 'overlapping raw rules',
+      text: '그것은 중요하다. 그것은 필요하다. 이 작업은 에이전트에 의해 처리되었다.',
+      expectedCount: 3,
+      expectedHot: false,
+    },
+  ];
+
+  for (const sample of cases) {
+    const nodeSignal = detectNodeTranslationese(sample.text, { lang: 'ko' });
+    const playgroundSignal = detectPlaygroundTranslationese(sample.text, { lang: 'ko' });
+
+    assert.deepEqual(
+      {
+        ids: playgroundSignal.byRule.map((x) => x.id).sort(),
+        count: playgroundSignal.count,
+        density: playgroundSignal.density,
+        hot: playgroundSignal.hot,
+        thresholds: playgroundSignal.thresholds,
+      },
+      {
+        ids: nodeSignal.byRule.map((x) => x.id).sort(),
+        count: nodeSignal.count,
+        density: nodeSignal.density,
+        hot: nodeSignal.hot,
+        thresholds: nodeSignal.thresholds,
+      },
+      `${sample.name} should mirror node`,
+    );
+    assert.equal(playgroundSignal.count, sample.expectedCount, sample.name);
+    assert.equal(playgroundSignal.hot, sample.expectedHot, sample.name);
+  }
+});
+test('playground mirrors ko post-editese schema and metrics in parity with node', () => {
+  const text = [
+    '그녀는 회의에서의 결정을 검토하고 있다.',
+    '이 작업은 에이전트에 의해 처리되어진다.',
+    '',
+    '우리는 회의를 가졌고, 결정을 내렸다.',
+    '그것은 중요한 자료이다.',
+  ].join('\n');
+  const nodePayload = nodeKoPostEditeseFeatures(text, { lang: 'ko' });
+  const playgroundPayload = playgroundKoPostEditeseFeatures(text, { lang: 'ko' });
+
+  assert.equal(PLAYGROUND_KO_POST_EDITESE_SCHEMA, NODE_KO_POST_EDITESE_SCHEMA);
+  assert.equal(playgroundPayload.schema, 'koPostEditese.v1');
+  assert.deepEqual(playgroundPayload, nodePayload);
+});
+
+test('playground returns stable skipped ko post-editese payloads in parity with node', () => {
+  for (const sample of [
+    { text: 'This is plain English.', lang: 'en' },
+    { text: '   ', lang: 'ko' },
+    { text: '... !!!', lang: 'ko' },
+    { text: 'This English-labeled text mentions 그녀 and 그것.', lang: 'en' },
+  ]) {
+    const nodePayload = nodeKoPostEditeseFeatures(sample.text, { lang: sample.lang });
+    const playgroundPayload = playgroundKoPostEditeseFeatures(sample.text, { lang: sample.lang });
+    assert.deepEqual(playgroundPayload, nodePayload);
+    assert.equal(playgroundPayload.analyzed, false);
+    assert.equal(playgroundPayload.paragraphCount, 0);
+    assert.deepEqual(playgroundPayload.paragraphs, []);
+  }
+});
+
+test('playground surfaces ko post-editese without score, hot, or audit coupling', () => {
+  const text = '그녀는 회의에서의 결정을 검토하고 있다. 이 작업은 에이전트에 의해 처리되어진다.';
+  const analysis = analyzePlaygroundText(text, { lang: 'ko' });
+  const expectedHotRatio = analysis.paragraphCount === 0
+    ? 0
+    : Math.round((analysis.hotCount / analysis.paragraphCount) * 100);
+  const expectedOverall = analysis.markupLeakage.leaked
+    ? Math.max(expectedHotRatio, 90)
+    : expectedHotRatio;
+
+  assert.equal(analysis.koPostEditese.schema, 'koPostEditese.v1');
+  assert.equal(analysis.koPostEditese.analyzed, true);
+  assert.ok(analysis.koPostEditese.metrics.interference.pronounLiteralCount >= 1);
+  assert.equal(analysis.hotCount, analysis.paragraphs.filter((paragraph) => paragraph.hot).length);
+  assert.equal(analysis.overall, expectedOverall);
+  assert.deepEqual(
+    analysis.auditItems,
+    analysis.paragraphs.filter((paragraph) => paragraph.hot || paragraph.lexicon.matches > 0),
+  );
+  assert.equal(analysis.paragraphs.some((paragraph) => paragraph.reasons.some((reason) => reason.code.includes('post'))), false);
+
+  const forbidden = collectObjectKeys(analysis.koPostEditese)
+    .filter((key) => FORBIDDEN_KO_POST_EDITESE_KEYS.has(key));
+  assert.deepEqual(forbidden, []);
+});
+
+test('playground renders Korean advisory panel separately from audit and diff', () => {
+  const text = '메리는 그녀의 책을 갖고 있다. 회의에서의 결정은 에이전트에 의해 처리되어진다.';
+  const analysis = analyzePlaygroundText(text, { lang: 'ko' });
+  const before = {
+    overall: analysis.overall,
+    hotCount: analysis.hotCount,
+    auditItems: cloneForTest(analysis.auditItems),
+    paragraphHot: analysis.paragraphs.map((paragraph) => paragraph.hot),
+    reasons: analysis.paragraphs.map((paragraph) => cloneForTest(paragraph.reasons)),
+  };
+
+  const html = renderKoreanAdvisory(analysis);
+
+  assert.match(html, /advisory-grid/);
+  assert.match(html, /Translationese hints/);
+  assert.match(html, /Korean post-editese metadata/);
+  assert.match(html, /count 1/);
+  assert.match(html, /Density/);
+  assert.match(html, /Samples:/);
+  assert.match(html, /koPostEditese\.v1/);
+  assert.match(html, /Paragraphs/);
+  assert.match(html, /pronoun literal count/);
+  assert.match(html, /suffix diversity/);
+  assert.doesNotMatch(html, /diff-card/);
+  assert.doesNotMatch(html, /<mark>/);
+  assert.equal(analysis.overall, before.overall);
+  assert.equal(analysis.hotCount, before.hotCount);
+  assert.deepEqual(analysis.auditItems, before.auditItems);
+  assert.deepEqual(analysis.paragraphs.map((paragraph) => paragraph.hot), before.paragraphHot);
+  assert.deepEqual(analysis.paragraphs.map((paragraph) => paragraph.reasons), before.reasons);
+});
+
+test('playground advisory rendering escapes labels, examples, and samples', () => {
+  const analysis = analyzePlaygroundText('그것은 중요하다.', { lang: 'ko' });
+  analysis.translationese = {
+    count: 1,
+    density: 1,
+    sentences: 1,
+    byRule: [{
+      id: '<rule>',
+      label: '<img src=x onerror=alert(1)>',
+      count: 1,
+      strong: true,
+      example: { before: '<script>bad()</script>', after: '"safe" & revised' },
+    }],
+    hits: ['<b>sample</b>'],
+  };
+
+  const html = renderKoreanAdvisory(analysis);
+
+  assert.doesNotMatch(html, /<img src=x/);
+  assert.doesNotMatch(html, /<script>/);
+  assert.doesNotMatch(html, /<b>sample/);
+  assert.match(html, /&lt;img src=x onerror=alert\(1\)&gt;/);
+  assert.match(html, /&lt;script&gt;bad\(\)&lt;\/script&gt;/);
+  assert.match(html, /&quot;safe&quot; &amp; revised/);
+  assert.match(html, /&lt;b&gt;sample&lt;\/b&gt;/);
+});
+
+test('playground advisory rendering handles skipped and non-Korean states', () => {
+  const emptyKo = analyzePlaygroundText('   ', { lang: 'ko' });
+  const emptyHtml = renderKoreanAdvisory(emptyKo);
+  assert.match(emptyHtml, /skipped: empty/);
+  assert.match(emptyHtml, /No Korean translationese rules surfaced/);
+
+  const en = analyzePlaygroundText('This transformative solution empowers teams.', { lang: 'en' });
+  const enHtml = renderKoreanAdvisory(en);
+  assert.match(enHtml, /unavailable for this language/);
+  assert.doesNotMatch(enHtml, /advisory-grid/);
 });
 
 test('playground ports thematic-break discourse tells from the node analyzer', () => {
@@ -311,6 +586,14 @@ test('playground HTML exposes the false-positive report button', () => {
   const html = readFileSync(resolve(REPO_ROOT, 'playground/index.html'), 'utf8');
   assert.match(html, /id="report-fp"/);
   assert.match(html, /Report false positive/);
+});
+
+test('playground HTML exposes the Korean advisory container with advisory-only copy', () => {
+  const html = readFileSync(resolve(REPO_ROOT, 'playground/index.html'), 'utf8');
+  assert.match(html, /id="korean-advisory"/);
+  assert.match(html, /Korean editing hints/);
+  assert.match(html, /advisory-only revision hints/);
+  assert.match(html, /never change score, hotspots, or audit rows/);
 });
 
 test('playground HTML points canonical and OG metadata at patina.vibetip.help', () => {

--- a/tests/unit/prompt-builder.snapshot.test.js
+++ b/tests/unit/prompt-builder.snapshot.test.js
@@ -235,3 +235,86 @@ describe('CJK clause-level rewrite guard', () => {
     assert.doesNotMatch(prompt, /CJK clause-level rewrite guard/);
   });
 });
+
+describe('Korean advisory rewrite metadata wording', () => {
+  const koConfig = {
+    ...config,
+    language: 'ko',
+    ouroboros: {
+      ...config.ouroboros,
+      'category-weights': {
+        ...config.ouroboros['category-weights'],
+        ko: { content: 1 },
+      },
+    },
+  };
+
+  function buildTestPrompt({ language = 'ko', mode = 'rewrite', promptMode = 'strict' } = {}) {
+    return buildPrompt({
+      config: language === 'ko' ? koConfig : config,
+      patterns,
+      profile,
+      voice,
+      scoring,
+      text: language === 'ko'
+        ? '그것은 사용자에 의해 선택되었으며, 결과적으로 더 나은 경험을 제공합니다.'
+        : inputText,
+      mode,
+      tone,
+      promptMode,
+    });
+  }
+
+  it('is present in strict Korean rewrite prompts', () => {
+    const prompt = buildTestPrompt({ language: 'ko', mode: 'rewrite', promptMode: 'strict' });
+
+    assert.match(prompt, /koPostEditese\.v1/);
+    assert.match(prompt, /advisory editing context only/);
+    assert.match(prompt, /not score, gate, hot-spot, severity, benchmark, z-score, baseline, percentile, prompt\/rewrite gate, or authorship-verdict evidence/);
+    assert.match(prompt, /calques, literal pronouns, by-passives, double particles/);
+    assert.match(prompt, /suffix-diversity proxies/);
+    assert.match(prompt, /Preserve claims, numbers, polarity, causation, and register/);
+  });
+
+  it('is present in minimal Korean rewrite prompts', () => {
+    const prompt = buildTestPrompt({ language: 'ko', mode: 'rewrite', promptMode: 'minimal' });
+
+    assert.match(prompt, /koPostEditese\.v1/);
+    assert.match(prompt, /advisory editing context only/);
+    assert.match(prompt, /not score, gate, hot-spot, severity, benchmark, z-score, baseline, percentile, prompt\/rewrite gate, or authorship-verdict evidence/);
+  });
+
+  it('does not add Korean advisory wording to English rewrite prompts', () => {
+    const strictPrompt = buildTestPrompt({ language: 'en', mode: 'rewrite', promptMode: 'strict' });
+    const minimalPrompt = buildTestPrompt({ language: 'en', mode: 'rewrite', promptMode: 'minimal' });
+
+    assert.doesNotMatch(strictPrompt, /koPostEditese\.v1/);
+    assert.doesNotMatch(strictPrompt, /advisory editing context only/);
+    assert.doesNotMatch(minimalPrompt, /koPostEditese\.v1/);
+    assert.doesNotMatch(minimalPrompt, /advisory editing context only/);
+  });
+
+  it('does not include koPostEditese in score prompts', () => {
+    const prompt = buildTestPrompt({ language: 'ko', mode: 'score', promptMode: 'strict' });
+
+    assert.doesNotMatch(prompt, /koPostEditese/);
+  });
+
+  it('does not include Korean advisory wording in Korean non-rewrite prompts', () => {
+    for (const mode of ['diff', 'audit', 'score', 'ouroboros']) {
+      const prompt = buildTestPrompt({ language: 'ko', mode, promptMode: 'strict' });
+      assert.doesNotMatch(prompt, /koPostEditese\.v1/, mode);
+      assert.doesNotMatch(prompt, /advisory editing context only/, mode);
+    }
+  });
+
+  it('preserves ouroboros formula and termination language', () => {
+    const prompt = buildTestPrompt({ language: 'en', mode: 'ouroboros', promptMode: 'strict' });
+
+    assert.match(prompt, /If score ≤ 30, stop immediately/);
+    assert.match(prompt, /delta = previous - current \(positive = improvement\)/);
+    assert.match(prompt, /0 ≤ delta ≤ 10 → plateau/);
+    assert.match(prompt, /fidelity < 70 → fidelity violation → rollback/);
+    assert.match(prompt, /MPS < 70 → MPS violation → rollback/);
+  });
+});

--- a/tests/unit/translationese.test.js
+++ b/tests/unit/translationese.test.js
@@ -3,6 +3,8 @@ import test from 'node:test';
 
 import { detectTranslationese, TRANSLATIONESE_RULES } from '../../src/features/translationese.js';
 import { analyzeText } from '../../src/features/index.js';
+import { KO_POST_EDITESE_SCHEMA, koreanPostEditeseFeatures } from '../../src/features/stylometry.js';
+
 
 test('calque-dense ko fires (count + density gate met)', () => {
   const text = '당신은 이 도구를 사용할 수 있습니다. 그것은 다양한 기능을 제공합니다. 이 작업은 에이전트에 의해 처리됩니다. 사용법은 다음과 같습니다.';
@@ -49,6 +51,82 @@ test('every rule ships a before/after example', () => {
     assert.ok(rule.re().test(rule.example.before), `rule ${rule.id} does not match its before example`);
   }
 });
+test('ko translationese detects im-not-ai derived advisory rules', () => {
+  const text = [
+    '메리는 그녀가 그녀의 어머니에게 전화했다고 말했다.',
+    '회의에서의 결정은 앞으로의 운영으로의 전환을 앞당겼다.',
+    '우리는 회의를 가졌고 중요한 결정을 내렸다.',
+    '이 작업은 에이전트에 의해 처리되었다.',
+    '이 문제는 분석되어진 뒤 보고서에 쓰여진다.',
+    '그는 자료를 검토하고, 결과를 정리하며, 보고서를 작성했다.',
+  ].join(' ');
+  const r = detectTranslationese(text, { lang: 'ko' });
+  const ids = r.byRule.map((x) => x.id);
+
+  assert.ok(ids.includes('a16-pronoun-literal'), 'A-16 pronoun literal mapping');
+  assert.ok(ids.includes('a19-double-particle'), 'A-19 double particles');
+  assert.ok(ids.includes('a7-light-verb'), 'A-7 light verbs');
+  assert.ok(ids.includes('t2-by-passive'), 'T2 by-passive co-occurrence');
+  assert.ok(ids.includes('a8-double-passive'), 'A-8 double passive');
+  assert.ok(ids.includes('c11-connective-comma'), 'C-11 connective-ending comma');
+  assert.equal(r.hot, true);
+});
+
+test('ko translationese caveats keep common formal Korean below stronger rules', () => {
+  const text = '한국의 미래는 밝다. 그의 의견은 다르다. 위원회에 의해 회의가 열렸다.';
+  const r = detectTranslationese(text, { lang: 'ko' });
+  const ids = r.byRule.map((x) => x.id);
+
+  assert.equal(ids.includes('a19-double-particle'), false, 'bare 의 is not a double particle');
+  assert.equal(ids.includes('t2-by-passive'), false, 'bare 에 의해 without passive co-occurrence is not the strong rule');
+  assert.equal(ids.includes('passive-e-uihae'), true, 'bare 에 의해 remains a weak advisory hit');
+  assert.equal(r.hot, false);
+});
+test('weak-only translationese stays advisory even above count and density gates', () => {
+  const text = [
+    '사용법은 다음과 같습니다.',
+    '다양한 기능을 제공합니다.',
+    '설치를 쉽게 만들어 줍니다.',
+    '가장 빠른 도구 중 하나입니다.',
+  ].join(' ');
+  const r = detectTranslationese(text, { lang: 'ko' });
+  const ids = r.byRule.map((x) => x.id).sort();
+
+  assert.deepEqual(ids, ['as-follows', 'make-easy', 'one-of', 'provides'].sort());
+  assert.equal(r.count, 4);
+  assert.ok(r.density >= r.thresholds.density, `density ${r.density}`);
+  assert.equal(r.thresholds.strong, 1);
+  assert.equal(r.hot, false);
+});
+
+test('overlapping translationese rules count independent evidence spans for the hot gate', () => {
+  const text = [
+    '그것은 중요하다.',
+    '그것은 필요하다.',
+    '이 작업은 에이전트에 의해 처리되었다.',
+  ].join(' ');
+  const r = detectTranslationese(text, { lang: 'ko' });
+  const ids = r.byRule.map((x) => x.id);
+
+  assert.ok(ids.includes('dummy-subject'), 'dummy-subject raw rule remains visible');
+  assert.ok(ids.includes('a16-pronoun-literal'), 'overlapping A-16 raw rule remains visible');
+  assert.ok(ids.includes('passive-e-uihae'), 'weak passive raw rule remains visible');
+  assert.ok(ids.includes('t2-by-passive'), 'overlapping strong T2 raw rule remains visible');
+  assert.equal(r.count, 3);
+  assert.equal(r.hot, false);
+});
+
+test('hot ko translationese remains advisory and outside the document hot verdict', () => {
+  const text = '메리는 그녀가 그녀의 책을 갖고 있다. 회의에서의 결정으로의 이동은 에이전트에 의해 처리되었다.';
+  const r = analyzeText(text, { lang: 'ko' });
+
+  assert.equal(r.translationese.hot, true);
+  assert.equal(
+    r.hot,
+    r.markupLeakage.leaked || r.discourseTells.hot || r.paragraphs.some((p) => p.hot),
+  );
+  assert.equal(r.hot, false);
+});
 
 test('analyzeText surfaces translationese as an advisory signal', () => {
   const text =
@@ -72,4 +150,181 @@ test('analyzeText keeps translationese OUT of the hot verdict (advisory only)', 
   assert.equal(r.translationese.hot, false);
   // hot is driven only by leakage / discourse / paragraph stylometry
   assert.equal(r.hot, r.markupLeakage.leaked || r.discourseTells.hot || r.paragraphs.some((p) => p.hot));
+});
+const FORBIDDEN_KO_POST_EDITESE_KEYS = new Set([
+  'hot',
+  'severity',
+  'score',
+  'zScore',
+  'zscore',
+  'baseline',
+  'percentile',
+]);
+
+function collectObjectKeys(value, keys = []) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectObjectKeys(item, keys);
+    return keys;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value)) {
+      keys.push(key);
+      collectObjectKeys(child, keys);
+    }
+  }
+  return keys;
+}
+
+test('ko post-editese exposes the v1 raw descriptive schema', () => {
+  const text = [
+    '그녀는 회의에서의 결정을 검토하고 있다.',
+    '이 작업은 에이전트에 의해 처리되어진다.',
+    '',
+    '우리는 회의를 가졌고, 결정을 내렸다.',
+    '그것은 중요한 자료이다.',
+  ].join('\n');
+  const payload = koreanPostEditeseFeatures(text, { lang: 'ko' });
+
+  assert.equal(payload.schema, KO_POST_EDITESE_SCHEMA);
+  assert.equal(payload.schema, 'koPostEditese.v1');
+  assert.equal(payload.lang, 'ko');
+  assert.equal(payload.analyzed, true);
+  assert.equal(payload.skipReason, null);
+  assert.equal(payload.paragraphCount, 2);
+  assert.equal(payload.paragraphs.length, 2);
+  assert.ok(payload.sentenceCount >= 4);
+  assert.ok(payload.eojeolCount > 0);
+  const paragraphSentenceTotal = payload.paragraphs.reduce((sum, row) => sum + row.sentenceCount, 0);
+  const paragraphEojeolTotal = payload.paragraphs.reduce((sum, row) => sum + row.eojeolCount, 0);
+  assert.equal(payload.sentenceCount, paragraphSentenceTotal);
+  assert.equal(payload.eojeolCount, paragraphEojeolTotal);
+  assert.deepEqual(Object.keys(payload).sort(), [
+    'analyzed',
+    'eojeolCount',
+    'lang',
+    'metrics',
+    'paragraphCount',
+    'paragraphs',
+    'schema',
+    'sentenceCount',
+    'skipReason',
+  ].sort());
+  for (const row of payload.paragraphs) {
+    assert.deepEqual(Object.keys(row).sort(), ['eojeolCount', 'id', 'metrics', 'sentenceCount'].sort());
+    assert.deepEqual(Object.keys(row.metrics).sort(), ['endings', 'interference', 'lexical', 'rhythm'].sort());
+    assert.deepEqual(Object.keys(row.metrics.lexical).sort(), Object.keys(payload.metrics.lexical).sort());
+    assert.deepEqual(Object.keys(row.metrics.endings).sort(), Object.keys(payload.metrics.endings).sort());
+    assert.deepEqual(Object.keys(row.metrics.interference).sort(), Object.keys(payload.metrics.interference).sort());
+    assert.deepEqual(Object.keys(row.metrics.rhythm).sort(), Object.keys(payload.metrics.rhythm).sort());
+  }
+
+
+  assert.deepEqual(Object.keys(payload.metrics).sort(), ['endings', 'interference', 'lexical', 'rhythm'].sort());
+  assert.deepEqual(Object.keys(payload.metrics.lexical).sort(), [
+    'endingDiversity',
+    'endingTypeCount',
+    'mattr',
+    'tokenCount',
+    'ttr',
+    'typeCount',
+  ].sort());
+  assert.deepEqual(Object.keys(payload.metrics.endings).sort(), [
+    'declarativeDaCount',
+    'declarativeDaRatio',
+    'doendaCount',
+    'endingStreakMax',
+    'formalEndingCount',
+    'handaCount',
+    'idaCount',
+    'politeEndingCount',
+  ].sort());
+  assert.deepEqual(Object.keys(payload.metrics.interference).sort(), [
+    'byPassiveCount',
+    'connectiveCommaCount',
+    'doubleParticleCount',
+    'doublePassiveCount',
+    'lightVerbCount',
+    'progressiveAspectCount',
+    'pronounLiteralCount',
+    'relativeClauseProxyCount',
+  ].sort());
+  assert.deepEqual(Object.keys(payload.metrics.rhythm).sort(), [
+    'commaPer100Chars',
+    'commaPerSentence',
+    'eojeolLengthCV',
+    'meanEojeolLength',
+    'meanSentenceEojeols',
+    'sentenceEojeolCV',
+    'suffixClassDiversity',
+    'suffixDiversity',
+    'suffixMatchedCount',
+  ].sort());
+
+  assert.ok(payload.metrics.interference.pronounLiteralCount >= 2);
+  assert.ok(payload.metrics.interference.doubleParticleCount >= 1);
+  assert.ok(payload.metrics.interference.progressiveAspectCount >= 1);
+  assert.ok(payload.metrics.interference.byPassiveCount >= 1);
+  assert.ok(payload.metrics.interference.doublePassiveCount >= 1);
+  assert.ok(payload.metrics.interference.connectiveCommaCount >= 1);
+  assert.ok(payload.metrics.endings.idaCount >= 1);
+  assert.ok(payload.metrics.rhythm.suffixMatchedCount > 0);
+});
+
+test('ko post-editese skipped payloads are stable and zero-valued', () => {
+  const nonKo = koreanPostEditeseFeatures('This is plain English.', { lang: 'en' });
+  const empty = koreanPostEditeseFeatures('   ', { lang: 'ko' });
+  const punctuation = koreanPostEditeseFeatures('... !!!', { lang: 'ko' });
+  const mixedNonKo = koreanPostEditeseFeatures('This English-labeled text mentions 그녀 and 그것.', { lang: 'en' });
+
+
+  for (const [payload, reason] of [
+    [nonKo, 'non-ko'],
+    [empty, 'empty'],
+    [punctuation, 'no-hangul-eojeols'],
+    [mixedNonKo, 'non-ko'],
+  ]) {
+    assert.equal(payload.schema, 'koPostEditese.v1');
+    assert.equal(payload.analyzed, false);
+    assert.equal(payload.skipReason, reason);
+    assert.equal(payload.paragraphCount, 0);
+    assert.equal(payload.sentenceCount, 0);
+    assert.equal(payload.eojeolCount, 0);
+    assert.deepEqual(payload.paragraphs, []);
+    assert.equal(payload.metrics.lexical.tokenCount, 0);
+    assert.equal(payload.metrics.lexical.ttr, null);
+    assert.equal(payload.metrics.endings.declarativeDaRatio, null);
+    assert.equal(payload.metrics.rhythm.sentenceEojeolCV, null);
+    assert.equal(payload.metrics.rhythm.suffixMatchedCount, 0);
+  }
+});
+
+test('analyzeText surfaces ko post-editese without hot coupling or forbidden keys', () => {
+  const text = '그녀는 회의에서의 결정을 검토하고 있다. 이 작업은 에이전트에 의해 처리되어진다.';
+  const analysis = analyzeText(text, { lang: 'ko' });
+  const expectedHot = analysis.markupLeakage.leaked ||
+    analysis.discourseTells.hot ||
+    analysis.structuralClassifier.hot === true ||
+    analysis.paragraphs.some((p) => p.hot);
+
+  assert.equal(analysis.koPostEditese.schema, 'koPostEditese.v1');
+  assert.equal(analysis.koPostEditese.analyzed, true);
+  assert.ok(analysis.koPostEditese.metrics.interference.pronounLiteralCount >= 1);
+  assert.equal(analysis.hot, expectedHot);
+
+  const keys = collectObjectKeys(analysis.koPostEditese);
+  assert.deepEqual(keys.filter((key) => FORBIDDEN_KO_POST_EDITESE_KEYS.has(key)), []);
+});
+
+test('analyzeText returns skipped ko post-editese for non-ko without changing verdicts', () => {
+  const analysis = analyzeText('A short plain English note.', { lang: 'en' });
+  assert.equal(analysis.koPostEditese.schema, 'koPostEditese.v1');
+  assert.equal(analysis.koPostEditese.analyzed, false);
+  assert.equal(analysis.koPostEditese.skipReason, 'non-ko');
+  assert.equal(
+    analysis.hot,
+    analysis.markupLeakage.leaked ||
+      analysis.discourseTells.hot ||
+      analysis.structuralClassifier.hot === true ||
+      analysis.paragraphs.some((p) => p.hot),
+  );
 });


### PR DESCRIPTION
## Summary

Bundles two strands that were already interleaved in the working tree, organized into six area commits:

1. **Korean post-editese advisory analyzer + 4.0.1 release finalization** — the in-progress `koPostEditese.v1` deterministic metrics, advisory rewrite guidance, playground UI, version bump, and the `patina-cli` bin alias.
2. **Review-driven bug fixes** from a full-repo audit (2026-06-10), which mostly correct the new detector code, so they could not be cleanly separated from the feature they fix.

All advisory metadata is **advisory-only** — it never feeds the hot verdict, score, gates, severity, or benchmark claims.

## Commits (by area)

| Commit | Area | Highlights |
|--------|------|-----------|
| `Harden local-CLI backends` | backends | UTF-8 stdout decoding (fixes silent CJK corruption split across pipe reads), stdin EPIPE handling (no more process crash on early child exit), documented kimi `--max-steps` safety |
| `Add Korean post-editese analyzer + fix detector calibration` | detectors | koPostEditese.v1 feature; **합쇼체 `-ㅂ니다` no longer miscounted as declarative `-다`**; a16 pronoun rule no longer fires on 로그/버그/태그; t2 matches fused passives (된다/됩니다/될); audit backstop respects `minCount`; tone-footer no longer truncates body at a mid-text `---` |
| `Fix Ouroboros loop integrity` | ouroboros | strip `[BODY]/[SELF_AUDIT]` before scoring/refeed; `finalText`/`finalScore` describe the same text; MPS scorer failure now fails closed |
| `Fix CLI mode exclusivity and config` | cli/config | reject combined `--diff/--audit/--score/--ouroboros` (fixes a fail-open CI score gate); `--config` wins over ambient `.patina.yaml`; deepMerge prototype-pollution guard |
| `Playground parity` | playground | surface koPostEditese metrics; mirror the three detector fixes so browser verdict matches the CLI |
| `Sync 4.0.1 release metadata` | docs/release | version sync across package/yaml/SKILL/README; advisory-metadata docs; CHANGELOG |

## Verification

- `npm test` → **472/472 pass**
- `npm run lint` (syntax + eslint + typecheck + spellcheck) → clean
- `npm run release:check` → OK for 4.0.1
- Each detector fix validated behaviorally (e.g. formal Korean now reports `formalEndingCount=3, declarativeDaRatio=0`, was `0 / 1.0`); prototype-pollution and `--config` precedence reproduced as fixed.

## Not included here (filed as issues)

Larger/calibration items from the audit are tracked separately, not in this PR: #383 (canonical pattern catalog), #384 (scoreText rubric), #385 (scoring.md example drift), #386 (cli.js decomposition), #387 (playground dedup), #388 (zh/ja corpus), #389 (FP loop), #390 (release/infra hygiene), #391 (deterministic-score correctness), #392 (cleanup).

Untracked internal dirs (`.gjc/`, `plans/`, `scripts/qa/`, `docs/research/`) were intentionally left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
