### PR TITLE
refactor: split browser-pure lexicon core

### DIFF
--- a/scripts/generate-playground-data.mjs
+++ b/scripts/generate-playground-data.mjs
@@ -5,6 +5,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseLexiconBody } from '../src/features/lexicon-core.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -23,32 +24,13 @@ function parseFrontmatter(raw) {
   return { meta, body: raw.slice(end + 4) };
 }
 
-function parseLexiconBody(body) {
-  const strict = [];
-  const phrases = [];
-  let mode = null;
-  for (const rawLine of body.split('\n')) {
-    const line = rawLine.trim();
-    if (line.startsWith('## ')) {
-      const heading = line.toLowerCase();
-      if (heading.includes('strict matches')) mode = 'strict';
-      else if (heading.includes('multi-word phrases')) mode = 'phrases';
-      else mode = null;
-      continue;
-    }
-    if (!mode || !line.startsWith('- ')) continue;
-    const entry = line.slice(2).trim().normalize('NFC');
-    if (entry && !entry.startsWith('_')) (mode === 'strict' ? strict : phrases).push(entry);
-  }
-  return { strict, phrases };
-}
 
 const lexicons = {};
 for (const lang of LANGS) {
   const source = `lexicon/ai-${lang}.md`;
   const raw = readFileSync(resolve(REPO_ROOT, source), 'utf8');
   const { meta, body } = parseFrontmatter(raw);
-  const parsed = parseLexiconBody(body);
+  const parsed = parseLexiconBody(body, { skipUnderscore: true });
   lexicons[lang] = {
     lang,
     source,

--- a/src/features/lexicon-core.js
+++ b/src/features/lexicon-core.js
@@ -1,0 +1,105 @@
+// Browser-pure AI-lexicon parsing and density helpers per core/stylometry.md §16.
+
+export const DEFAULT_LEXICON_DENSITY_THRESHOLD = 2.0;
+export const DEFAULT_LEXICON_MIN_HOT_MATCHES = {
+  default: 1,
+  ko: 2,
+  zh: 2,
+  ja: 2,
+};
+
+// Parses the two well-known sections out of a lexicon markdown file.
+// Returns { strict: string[], phrases: string[] }.
+export function parseLexiconBody(body, { skipUnderscore = false } = {}) {
+  const strict = [];
+  const phrases = [];
+  let mode = null;
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.trim();
+    if (line.startsWith('## ')) {
+      const heading = line.toLowerCase();
+      if (heading.includes('strict matches')) mode = 'strict';
+      else if (heading.includes('multi-word phrases')) mode = 'phrases';
+      else mode = null;
+      continue;
+    }
+    if (mode && line.startsWith('- ')) {
+      // Normalize to NFC so visually identical entries don't fail to match
+      // tokens that arrive in a different normalization form.
+      const entry = line.slice(2).trim().normalize('NFC');
+      if (entry && (!skipUnderscore || !entry.startsWith('_'))) {
+        (mode === 'strict' ? strict : phrases).push(entry);
+      }
+    }
+  }
+  return { strict, phrases };
+}
+
+// Phrases may include `~` as a wildcard standing in for up to 40 chars.
+export function phraseToRegex(phrase) {
+  const escaped = phrase
+    .toLowerCase()
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const withWildcard = escaped.replace(/~/g, '.{0,40}');
+  return new RegExp(withWildcard);
+}
+
+// Counts paragraph-level lexicon hits. Strict entries match whole-word
+// (Unicode-aware boundaries via \p{L}\p{N}); phrases match as substrings
+// with `~` wildcard support. Each entry counts at most once per paragraph.
+export function computeDensity(paragraphText, tokens, lexicon) {
+  const lowerText = paragraphText.toLowerCase();
+  const hits = [];
+  const tokenSet = new Set(tokens.map((t) => t.toLowerCase()));
+
+  // §16: English strict entries match whole-word; CJK strict entries are
+  // approximated by substring. Korean inflection and zh/ja character fallback
+  // mean `자리매김`, `可以说`, or `まとめると` may not survive as whole tokens.
+  // Punctuated entries always need substring fallback because tokenization
+  // strips edge punct.
+  const cjkSubstring = ['ko', 'zh', 'ja'].includes(lexicon.lang);
+  for (const entry of lexicon.strict) {
+    const lowerEntry = entry.toLowerCase();
+    if (tokenSet.has(lowerEntry)) {
+      hits.push(entry);
+      continue;
+    }
+    const hasInternalPunct = /[^\p{L}\p{N}]/u.test(lowerEntry);
+    if ((cjkSubstring || hasInternalPunct) && lowerText.includes(lowerEntry)) {
+      hits.push(entry);
+    }
+  }
+  for (const phrase of lexicon.phrases) {
+    if (phraseToRegex(phrase).test(lowerText)) hits.push(phrase);
+  }
+
+  const density = tokens.length > 0 ? (hits.length / tokens.length) * 1000 : 0;
+  return { matches: hits.length, density, hits };
+}
+
+/**
+ * @param {{ matches?: number, density?: number }} [lexiconStats]
+ * @param {{ lang?: string, densityThreshold?: number, minHotMatches?: (number|Record<string, number>) }} [options]
+ */
+export function classifyLexiconHot(
+  lexiconStats,
+  {
+    lang,
+    densityThreshold = DEFAULT_LEXICON_DENSITY_THRESHOLD,
+    minHotMatches = DEFAULT_LEXICON_MIN_HOT_MATCHES,
+  } = {}
+) {
+  const matches = lexiconStats?.matches ?? 0;
+  const density = lexiconStats?.density ?? 0;
+  const minMatches = resolveMinHotMatches(lang, minHotMatches);
+  return matches >= minMatches && density > densityThreshold;
+}
+
+export function resolveMinHotMatches(lang, minHotMatches) {
+  if (typeof minHotMatches === 'number' && Number.isFinite(minHotMatches)) {
+    return Math.max(1, minHotMatches);
+  }
+  const normalized = typeof lang === 'string' ? lang.toLowerCase() : 'default';
+  const value = minHotMatches?.[normalized] ?? minHotMatches?.default;
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(1, value) : 1;
+}

--- a/src/features/lexicon.js
+++ b/src/features/lexicon.js
@@ -1,43 +1,20 @@
-// AI-lexicon loading and density per core/stylometry.md §16.
-// Loads the markdown lexicon at lexicon/ai-{lang}.md and computes
-// hits-per-1000-tokens density. Custom lexicons under custom/lexicon/
-// take precedence when present.
+// AI-lexicon loading per core/stylometry.md §16.
+// Loads the markdown lexicon at lexicon/ai-{lang}.md. Custom lexicons under
+// custom/lexicon/ take precedence when present.
 
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { parseLexiconBody } from './lexicon-core.js';
 
-export const DEFAULT_LEXICON_DENSITY_THRESHOLD = 2.0;
-export const DEFAULT_LEXICON_MIN_HOT_MATCHES = {
-  default: 1,
-  ko: 2,
-  zh: 2,
-  ja: 2,
-};
-
-// Parses the two well-known sections out of a lexicon markdown file.
-// Returns { strict: string[], phrases: string[] }.
-function parseLexiconBody(body) {
-  const strict = [];
-  const phrases = [];
-  let mode = null;
-  for (const rawLine of body.split('\n')) {
-    const line = rawLine.trim();
-    if (line.startsWith('## ')) {
-      const heading = line.toLowerCase();
-      if (heading.includes('strict matches')) mode = 'strict';
-      else if (heading.includes('multi-word phrases')) mode = 'phrases';
-      else mode = null;
-      continue;
-    }
-    if (mode && line.startsWith('- ')) {
-      // Normalize to NFC so visually identical entries don't fail to match
-      // tokens that arrive in a different normalization form.
-      const entry = line.slice(2).trim().normalize('NFC');
-      if (entry) (mode === 'strict' ? strict : phrases).push(entry);
-    }
-  }
-  return { strict, phrases };
-}
+export {
+  DEFAULT_LEXICON_DENSITY_THRESHOLD,
+  DEFAULT_LEXICON_MIN_HOT_MATCHES,
+  parseLexiconBody,
+  phraseToRegex,
+  computeDensity,
+  classifyLexiconHot,
+  resolveMinHotMatches,
+} from './lexicon-core.js';
 
 export function loadLexicon(lang, repoRoot) {
   const candidates = [
@@ -52,73 +29,4 @@ export function loadLexicon(lang, repoRoot) {
     }
   }
   return { lang, path: null, strict: [], phrases: [] };
-}
-
-// Phrases may include `~` as a wildcard standing in for up to 40 chars.
-function phraseToRegex(phrase) {
-  const escaped = phrase
-    .toLowerCase()
-    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const withWildcard = escaped.replace(/~/g, '.{0,40}');
-  return new RegExp(withWildcard);
-}
-
-// Counts paragraph-level lexicon hits. Strict entries match whole-word
-// (Unicode-aware boundaries via \p{L}\p{N}); phrases match as substrings
-// with `~` wildcard support. Each entry counts at most once per paragraph.
-export function computeDensity(paragraphText, tokens, lexicon) {
-  const lowerText = paragraphText.toLowerCase();
-  const hits = [];
-  const tokenSet = new Set(tokens.map((t) => t.toLowerCase()));
-
-  // §16: English strict entries match whole-word; CJK strict entries are
-  // approximated by substring. Korean inflection and zh/ja character fallback
-  // mean `자리매김`, `可以说`, or `まとめると` may not survive as whole tokens.
-  // Punctuated entries always need substring fallback because tokenization
-  // strips edge punct.
-  const cjkSubstring = ['ko', 'zh', 'ja'].includes(lexicon.lang);
-  for (const entry of lexicon.strict) {
-    const lowerEntry = entry.toLowerCase();
-    if (tokenSet.has(lowerEntry)) {
-      hits.push(entry);
-      continue;
-    }
-    const hasInternalPunct = /[^\p{L}\p{N}]/u.test(lowerEntry);
-    if ((cjkSubstring || hasInternalPunct) && lowerText.includes(lowerEntry)) {
-      hits.push(entry);
-    }
-  }
-  for (const phrase of lexicon.phrases) {
-    if (phraseToRegex(phrase).test(lowerText)) hits.push(phrase);
-  }
-
-  const density = tokens.length > 0 ? (hits.length / tokens.length) * 1000 : 0;
-  return { matches: hits.length, density, hits };
-}
-
-/**
- * @param {{ matches?: number, density?: number }} [lexiconStats]
- * @param {{ lang?: string, densityThreshold?: number, minHotMatches?: (number|Record<string, number>) }} [options]
- */
-export function classifyLexiconHot(
-  lexiconStats,
-  {
-    lang,
-    densityThreshold = DEFAULT_LEXICON_DENSITY_THRESHOLD,
-    minHotMatches = DEFAULT_LEXICON_MIN_HOT_MATCHES,
-  } = {}
-) {
-  const matches = lexiconStats?.matches ?? 0;
-  const density = lexiconStats?.density ?? 0;
-  const minMatches = resolveMinHotMatches(lang, minHotMatches);
-  return matches >= minMatches && density > densityThreshold;
-}
-
-function resolveMinHotMatches(lang, minHotMatches) {
-  if (typeof minHotMatches === 'number' && Number.isFinite(minHotMatches)) {
-    return Math.max(1, minHotMatches);
-  }
-  const normalized = typeof lang === 'string' ? lang.toLowerCase() : 'default';
-  const value = minHotMatches?.[normalized] ?? minHotMatches?.default;
-  return typeof value === 'number' && Number.isFinite(value) ? Math.max(1, value) : 1;
 }

--- a/src/features/signal-strength.js
+++ b/src/features/signal-strength.js
@@ -1,4 +1,4 @@
-import { DEFAULT_LEXICON_DENSITY_THRESHOLD } from './lexicon.js';
+import { DEFAULT_LEXICON_DENSITY_THRESHOLD } from './lexicon-core.js';
 import { DEFAULT_BURSTINESS_BANDS, DEFAULT_MATTR_BANDS } from './stylometry.js';
 
 /**


### PR DESCRIPTION
## Summary
- Split browser-pure lexicon parsing/density helpers into `src/features/lexicon-core.js`.
- Keep `src/features/lexicon.js` as the Node loader plus re-export shim, preserving existing caller imports.
- Repoint `signal-strength` and playground data generation to the pure core; remove the third lexicon parser copy from the generator.

Refs #383, #387. Implements Stage 1 from the #383 implementation brief.

## Verification
- node --test tests/unit/lexicon.test.js tests/unit/prose-score.test.js tests/unit/playground.test.js
- npm run playground:data -- --check
- npm test
- npm run lint
- npm run benchmark
- git diff --check

## Notes
- Behavior-preserving refactor. `phraseToRegex` keeps the existing src no-`u` RegExp behavior; the generator preserves its underscore-entry skip policy through `parseLexiconBody(..., { skipUnderscore: true })`.