### PR TITLE
refactor: import shared feature modules in playground

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -7,6 +7,7 @@ Static, audit-only web playground for `patina.vibetip.help`.
 - No LLM rewrite or key proxying.
 - Deterministic browser-side scoring for `ko`, `en`, `zh`, and `ja`.
 - Vercel Web Analytics page-view telemetry for traffic counts; pasted text is not sent.
+- Shared deterministic detectors are imported directly from browser-pure `src/features/*.js` modules; serve/deploy the repository root so `/src/features/…` paths are available.
 
 ## Local preview
 

--- a/playground/analyzer.js
+++ b/playground/analyzer.js
@@ -1,21 +1,83 @@
 // Browser-safe deterministic analyzer for the patina static playground.
-// Mirrors src/features/* without Node-only lexicon loading.
+// Imports browser-pure src/features modules directly; keeps only playground UI/report glue here.
 
 import { PLAYGROUND_LEXICONS } from './data/lexicons.js';
+import { splitParagraphs as splitParagraphsCore, splitSentences, splitProseSentences, tokenize } from '../src/features/segment.js';
+import {
+  DEFAULT_BURSTINESS_BANDS,
+  DEFAULT_MIN_BURSTINESS_SENTENCES,
+  DEFAULT_MATTR_BANDS,
+  DEFAULT_MATTR_WINDOW,
+  DEFAULT_KO_DIAGNOSTIC_BANDS,
+  KO_POST_EDITESE_SCHEMA,
+  burstinessCV,
+  mattr,
+  classifyBurstiness,
+  classifyMattr,
+  classifyKoreanDiagnostics,
+  commaDensity,
+  koreanPosDiversityProxy,
+  koreanSpacingFeatures,
+  koreanPostEditeseFeatures,
+} from '../src/features/stylometry.js';
+import {
+  DEFAULT_LEXICON_DENSITY_THRESHOLD,
+  DEFAULT_LEXICON_MIN_HOT_MATCHES,
+  computeDensity,
+  classifyLexiconHot,
+} from '../src/features/lexicon-core.js';
+import { detectMarkupLeakage } from '../src/features/markup-leakage.js';
+import {
+  detectFakeCandor,
+  detectThematicBreaks,
+  FAKE_CANDOR_MIN as DEFAULT_FAKE_CANDOR_MIN,
+  THEMATIC_BREAK_MIN as DEFAULT_THEMATIC_BREAK_MIN,
+} from '../src/features/discourse-tells.js';
+import {
+  detectTranslationese,
+  TRANSLATIONESE_RULES,
+  ABS_MIN as TRANSLATIONESE_ABS_MIN,
+  DENSITY_MIN as TRANSLATIONESE_DENSITY_MIN,
+  STRONG_MIN as TRANSLATIONESE_STRONG_MIN,
+} from '../src/features/translationese.js';
+
+export {
+  splitSentences,
+  splitProseSentences,
+  tokenize,
+  DEFAULT_BURSTINESS_BANDS,
+  DEFAULT_MIN_BURSTINESS_SENTENCES,
+  DEFAULT_MATTR_BANDS,
+  DEFAULT_MATTR_WINDOW,
+  DEFAULT_KO_DIAGNOSTIC_BANDS,
+  burstinessCV,
+  mattr,
+  classifyBurstiness,
+  classifyMattr,
+  classifyKoreanDiagnostics,
+  commaDensity,
+  koreanPosDiversityProxy,
+  koreanSpacingFeatures,
+  KO_POST_EDITESE_SCHEMA,
+  koreanPostEditeseFeatures,
+  DEFAULT_LEXICON_DENSITY_THRESHOLD,
+  DEFAULT_LEXICON_MIN_HOT_MATCHES,
+  computeDensity,
+  classifyLexiconHot,
+  detectMarkupLeakage,
+  detectFakeCandor,
+  detectThematicBreaks,
+  DEFAULT_FAKE_CANDOR_MIN,
+  DEFAULT_THEMATIC_BREAK_MIN,
+  detectTranslationese,
+  TRANSLATIONESE_RULES,
+  TRANSLATIONESE_ABS_MIN,
+  TRANSLATIONESE_DENSITY_MIN,
+  TRANSLATIONESE_STRONG_MIN,
+};
 
 export const SUPPORTED_LANGS = ['ko', 'en', 'zh', 'ja'];
 export const DEFAULT_LANG = 'ko';
-export const DEFAULT_LEXICON_DENSITY_THRESHOLD = 2.0;
-export const DEFAULT_LEXICON_MIN_HOT_MATCHES = {
-  default: 1,
-  ko: 2,
-  zh: 2,
-  ja: 2,
-};
-export const DEFAULT_BURSTINESS_BANDS = { low: 0.30, high: 0.50 };
-export const DEFAULT_MIN_BURSTINESS_SENTENCES = 3;
-export const DEFAULT_MATTR_BANDS = { low: 0.55, high: 0.70 };
-export const DEFAULT_MATTR_WINDOW = 50;
 // Formatting tells mirror catalog patterns #13/#14/#17.
 // Em dash is doc-level (3+ across the document). Bold fires at 5+ across the
 // document or 3+ within one paragraph. Emoji currently mirrors the catalog's
@@ -29,20 +91,6 @@ export const DEFAULT_FORMATTING_THRESHOLDS = {
 // Model-output leakage (#332) is near-proof-grade, so any hit short-circuits the
 // document score into the 'heavily AI' band, mirroring src/scoring.js.
 export const LEAKAGE_SCORE_FLOOR = 90;
-export const DEFAULT_KO_DIAGNOSTIC_BANDS = {
-  minSentences: 4,
-  minEojeols: 20,
-  spacing: {
-    maxEojeolLengthCV: 0.38,
-  },
-  comma: {
-    maxPerSentence: 1,
-  },
-  posProxy: {
-    minMatchedCount: 10,
-    maxClassDiversity: 0.26,
-  },
-};
 
 export const SAMPLE_TEXT = {
   ko: '이 솔루션은 혁신적인 접근을 통해 업무 생산성을 극대화하고, 다양한 이해관계자에게 지속 가능한 가치를 제공합니다. 더 나아가 조직의 디지털 전환을 가속화하는 핵심 기반으로 자리매김하고 있습니다.\n\n하지만 현장에서 필요한 것은 거창한 선언보다 오늘 바로 줄어드는 반복 작업입니다.',
@@ -50,835 +98,27 @@ export const SAMPLE_TEXT = {
   zh: '总而言之，这一方案能够全面提升用户体验，并为未来发展提供新的可能。从长远来看，它将在数字时代发挥着重要作用。\n\n先看一个具体场景：团队每天少复制三次表格。',
   ja: 'まとめると、この仕組みはユーザー体験を向上させ、より良い未来につながります。重要なのは、さまざまな場面で効果的に活用できる点です。\n\nまずは、毎朝の確認作業が一つ減るかどうかを見ます。',
 };
-// Korean translationese (번역투/calque) advisory signal. This mirrors
-// src/features/translationese.js and intentionally stays out of score/hot
-// coupling; it is exposed as document-level audit metadata only.
-// Mirrors BY_PASSIVE_PREDICATE in src/features/translationese.js.
-const BY_PASSIVE_PREDICATE =
-  '(?:된다|된|될|됨|됐다|됐|돼|되었|되어|되는|되며|되고|됩니다|됩|받는다|받았다|받은|받을|받는|받습니다|받아|당한다|당했다|당하다|당하는|당해|(?:어|아|여)(?:진다|졌다|진|질|지는|집니다|져))';
-export const TRANSLATIONESE_RULES = [
-  {
-    id: 'noun-calque',
-    label: '직역 명사구 (pillar/layer 류 calque)',
-    strong: true,
-    re: () => /커맨드 기둥|명령(?:어)? 기둥|기둥 커맨드|[가-힣]+ 레이어로서/g,
-    example: { before: '세 가지 커맨드 기둥을 설치합니다.', after: '핵심 커맨드 세 가지를 설치합니다.' },
-  },
-  {
-    id: 'dummy-subject',
-    label: '가주어 "그것은/이것은" (English "it is")',
-    strong: true,
-    re: () => /(?:^|[.!?。]\s+|\n)\s*(?:그것은|이것은|그것이|이것이)\s/g,
-    example: { before: '그것은 매우 중요하다.', after: '매우 중요하다.' },
-  },
-  {
-    id: 'direct-address-you',
-    label: '"당신" 직접 호칭 (English "you")',
-    strong: true,
-    re: () => /당신(?:은|이|의|에게|을|를|께서|께)?/g,
-    example: { before: '당신은 이것을 설정할 수 있습니다.', after: '이건 설정할 수 있다.' },
-  },
-  {
-    id: 'a16-pronoun-literal',
-    label: '영어식 3인칭 대명사 직역 (he/she/it/they)',
-    strong: true,
-    // Require a non-Hangul boundary before the pronoun (so 로그/버그/태그 don't match)
-    // and an eojeol boundary after it (so 그녀석/그것참 don't match).
-    re: () => /(?<![가-힣])(?:그녀(?:는|가|를|의|에게|와|도|만)?|그것(?:은|이|을|의|에|에게)?|그들(?:은|이|을|의|에게|과|도)?|그(?:는|가|를|의|에게|와|도|만))(?=\s|[.,!?。]|$)/g,
-    example: { before: '메리는 그녀가 그녀의 어머니에게 전화했다고 말했다.', after: '메리는 어머니에게 전화했다고 말했다.' },
-  },
-  {
-    id: 'a19-double-particle',
-    label: '이중 조사 결합 (-에서의/-으로의/-에의)',
-    strong: true,
-    re: () => /(?:에서의|에로의|으로의|에의|으로부터의|로부터의)/g,
-    example: { before: '회의에서의 결정은 앞으로의 운영으로의 전환을 앞당겼다.', after: '회의에서 나온 결정은 앞으로 운영을 전환하는 일을 앞당겼다.' },
-  },
-  {
-    id: 'passive-e-uihae',
-    label: '"~에 의해" 피동 (English by-passive)',
-    strong: false,
-    re: () => /에 의해/g,
-    example: { before: '작업은 에이전트에 의해 처리됩니다.', after: '에이전트가 작업을 처리합니다.' },
-  },
-  {
-    id: 't2-by-passive',
-    label: '"~에 의해" + 피동 동사 결합',
-    strong: true,
-    // "에 의해" + a passive predicate in the following token. Matches fused
-    // syllable forms (된다/됩니다/될/진다) that the old jamo alternation missed.
-    re: () => new RegExp('에\\s*의(?:해|하여)\\s+\\S{0,12}?' + BY_PASSIVE_PREDICATE, 'g'),
-    example: { before: '이 작업은 에이전트에 의해 처리되었다.', after: '에이전트가 이 작업을 처리했다.' },
-  },
-  {
-    id: 'a8-double-passive',
-    label: '이중 피동 표면형 (-되어진/-보여진/-쓰여진)',
-    strong: true,
-    re: () => /(?:되어진다|되어졌다|되어진|되어지는|보여진다|보여졌다|보여진|쓰여진다|쓰여졌다|쓰여진|잊혀진|잊혀졌|닫혀진|열려진|불려진|놓여진)/g,
-    example: { before: '이 문제는 분석되어진 뒤 보고서에 쓰여진다.', after: '이 문제는 분석된 뒤 보고서에 쓰인다.' },
-  },
-  {
-    id: 'have-overuse',
-    label: '"~을 가지고 있다" (English "have")',
-    strong: false,
-    re: () => /(?:을|를)\s*(?:가지(?:고 있|고 있습니다|고 있다)|갖(?:고 있|고 있습니다|고 있다))/g,
-    example: { before: '이 도구는 유연성을 가지고 있습니다.', after: '이 도구는 유연합니다.' },
-  },
-  {
-    id: 'a7-light-verb',
-    label: '영어식 have/make light verb 직역',
-    strong: false,
-    re: () => /(?:회의를\s*가(?:지|졌)|결정을\s*내(?:리|렸)|(?:을|를)\s*갖고\s*있(?:다|습니다|는|었|으)?)/g,
-    example: { before: '우리는 회의를 가졌고 중요한 결정을 내렸다.', after: '우리는 회의에서 중요한 결정을 했다.' },
-  },
-  {
-    id: 'one-of',
-    label: '"~중 하나" (English "one of the")',
-    strong: false,
-    re: () => /중\s*하나(?:이다|입니다|인|로|다|예요)?/g,
-    example: { before: '가장 빠른 도구 중 하나입니다.', after: '손꼽히게 빠릅니다.' },
-  },
-  {
-    id: 'provides',
-    label: '"~을 제공합니다" (English "provides")',
-    strong: false,
-    re: () => /(?:을|를)\s*제공(?:합니다|한다|해 줍니다|해준다)/g,
-    example: { before: '다양한 기능을 제공합니다.', after: '여러 기능을 쓸 수 있다.' },
-  },
-  {
-    id: 'as-follows',
-    label: '"다음과 같습니다" (English "as follows")',
-    strong: false,
-    re: () => /다음과\s*같(?:습니다|다|은|이)/g,
-    example: { before: '사용법은 다음과 같습니다.', after: '사용법은 이렇다.' },
-  },
-  {
-    id: 'make-easy',
-    label: '"~하게 만들어 준다" (English "make it ~")',
-    strong: false,
-    re: () => /(?:쉽게|가능하게|간단하게|편하게)\s*(?:만들어\s*(?:줍니다|준다|줘)|만듭니다|만든다)/g,
-    example: { before: '설치를 쉽게 만들어 줍니다.', after: '설치가 쉬워진다.' },
-  },
-  {
-    id: 'c11-connective-comma',
-    label: '연결어미 뒤 쉼표 (-고,/-며,/-지만,)',
-    strong: false,
-    minCount: 2,
-    re: () => /(?:고|며|지만|면서|아서|어서)\s*,/g,
-    example: { before: '그는 자료를 검토하고, 결과를 정리하며, 보고서를 작성했다.', after: '그는 자료를 검토하고 결과를 정리한 뒤 보고서를 작성했다.' },
-  },
-];
-
-export const TRANSLATIONESE_ABS_MIN = 4;
-export const TRANSLATIONESE_DENSITY_MIN = 0.5;
-export const TRANSLATIONESE_STRONG_MIN = 1;
-export const KO_POST_EDITESE_SCHEMA = 'koPostEditese.v1';
-
-const KO_POST_EDITESE_SUFFIX_GROUPS = [
-  { className: 'quote', suffixes: ['라고', '이라고'] },
-  { className: 'source', suffixes: ['에게서', '한테서', '으로부터', '로부터'] },
-  { className: 'instrument', suffixes: ['으로써', '로써'] },
-  { className: 'standard', suffixes: ['으로서', '로서'] },
-  { className: 'topic', suffixes: ['은', '는'] },
-  { className: 'subject', suffixes: ['이', '가', '께서'] },
-  { className: 'object', suffixes: ['을', '를'] },
-  { className: 'genitive', suffixes: ['의'] },
-  { className: 'location', suffixes: ['에서', '에게', '한테', '께', '에'] },
-  { className: 'direction', suffixes: ['으로', '로'] },
-  { className: 'conjunction', suffixes: ['와', '과', '하고', '랑'] },
-  { className: 'additive', suffixes: ['도', '또한'] },
-  { className: 'delimiter', suffixes: ['만', '까지', '부터', '마다'] },
-  { className: 'comparison', suffixes: ['보다', '처럼'] },
-  { className: 'formal_ending', suffixes: ['습니다', '습니까', '합니다', '합니까', '입니다'] },
-  { className: 'polite_ending', suffixes: ['어요', '아요', '예요', '이에요', '네요', '군요', '지요'] },
-  { className: 'casual_ending', suffixes: ['죠', '네', '군'] },
-  { className: 'declarative_ending', suffixes: ['한다', '된다', '했다', '였다', '이다', '있다', '없다'] },
-];
-
-const KO_POST_EDITESE_SUFFIX_MATCHERS = KO_POST_EDITESE_SUFFIX_GROUPS
-  .flatMap((group) =>
-    group.suffixes.map((suffix) => ({
-      className: group.className,
-      suffix,
-      length: Array.from(suffix).length,
-    }))
-  )
-  .sort((a, b) => b.length - a.length);
-
-const KO_POST_EDITESE_ENDING_SUFFIXES = [
-  '습니다', '습니까', '합니다', '합니까', '입니다', '어요', '아요', '예요', '이에요',
-  '네요', '군요', '지요', '죠', '한다', '된다', '했다', '였다', '이다', '있다',
-  '없다', '왔다', '봤다', '다',
-].sort((a, b) => Array.from(b).length - Array.from(a).length);
-// Canonical token for regular formal '-ㅂ니다 / -ㅂ니까' endings (됩니다, 줍니다, 합니까…)
-// whose ㅂ marker fuses into the stem syllable and so isn't a literal suffix.
-const KO_POST_EDITESE_FORMAL_NIDA = 'ㅂ니다';
-const KO_POST_EDITESE_FORMAL_ENDINGS = new Set(['습니다', '습니까', '합니다', '합니까', '입니다', KO_POST_EDITESE_FORMAL_NIDA]);
-const KO_POST_EDITESE_POLITE_ENDINGS = new Set(['어요', '아요', '예요', '이에요', '네요', '군요', '지요', '죠']);
-const KO_POST_EDITESE_DECLARATIVE_DA_ENDINGS = new Set(['한다', '된다', '했다', '였다', '이다', '있다', '없다', '왔다', '봤다', '다']);
-
-// Pronoun-literal calques (he/she/it/they → 그/그녀/그것/그들). The (?<![가-힣])
-// lookbehind keeps 로그/태그/블로그 compounds out; the particle cluster accepts
-// stacked particles (에게는, 과의, 처럼…) and the (?![가-힣]) boundary keeps bound
-// nouns like 그녀석/그것참 out (석/참 are not particle syllables). Bare 그 still
-// requires an explicit particle so determiner uses (그 사람) never match.
-// Must stay pattern-identical to POST_EDITESE_PRONOUN_LITERAL_RE in src/features/stylometry.js.
-const KO_POST_EDITESE_PRONOUN_LITERAL_RE = /(?<![가-힣])(?:(?:그녀|그것|그들)[은는이가을를의도만와과랑에게한테께서처럼보다마저조차까지부터로으요]{0,4}|그(?:는|가|를|의|에게|와|도|만))(?![가-힣])/g;
-const KO_POST_EDITESE_DOUBLE_PARTICLE_RE = /(?:에서의|에로의|으로의|에의|으로부터의|로부터의)/g;
-const KO_POST_EDITESE_PROGRESSIVE_ASPECT_RE = /고\s*있(?:다|습니다|는|었|으|고|지|기)?/g;
-const KO_POST_EDITESE_LIGHT_VERB_RE = /(?:회의를\s*가(?:지|졌)|결정을\s*내(?:리|렸)|(?:을|를)\s*갖고\s*있(?:다|습니다|는|었|으)?)/g;
-const KO_POST_EDITESE_BY_PASSIVE_RE = /에\s*의(?:해|하여)/g;
-const KO_POST_EDITESE_DOUBLE_PASSIVE_RE = /(?:되어진다|되어졌다|되어진|되어지는|보여진다|보여졌다|보여진|쓰여진다|쓰여졌다|쓰여진|잊혀진|잊혀졌|닫혀진|열려진|불려진|놓여진)/g;
-const KO_POST_EDITESE_CONNECTIVE_COMMA_RE = /(?:고|며|지만|면서|아서|어서)\s*,/g;
-const KO_POST_EDITESE_RELATIVE_CLAUSE_PROXY_RE = /[가-힣]+(?:하는|되는|받는|받은|쓰인|되어진|보여진|한|할|된|될|던|운|온|인|힌|진|린|킨|쓴)\s+[가-힣]+/g;
-
-
-
-const SENTENCE_SPLIT_RE = /[.!?]+\s+|(?<=[。！？…])|\n+/u;
-const PARAGRAPH_SPLIT_RE = /\n\s*\n/;
-const LIST_LINE_RE = /^\s*(?:[-*+]\s+|\d+[.)]\s+)/u;
-const EDGE_PUNCT_RE = /^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu;
-const CJK_TOKEN_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\u30FC]|[A-Za-z0-9]+/gu;
-const HANGUL_RE = /[\u3131-\u318e\uac00-\ud7a3]/u;
-const COMMA_RE = /[,，、]/gu;
 
 export function normalizeLang(lang) {
   return SUPPORTED_LANGS.includes(lang) ? lang : DEFAULT_LANG;
 }
 
 export function splitParagraphs(text) {
-  if (!text) return [];
-  return text
-    .normalize('NFC')
-    .split(PARAGRAPH_SPLIT_RE)
-    .map((p) => p.trim())
-    .filter((p) => p.length > 0);
-}
-
-function stripListBlocks(paragraph) {
-  const lines = String(paragraph ?? '').split(/\r?\n/);
-  const proseLines = [];
-  let colonListRemaining = 0;
-  for (let i = 0; i < lines.length; i++) {
-    const rawLine = lines[i];
-    const trimmed = rawLine.trim();
-    if (trimmed === '') {
-      colonListRemaining = 0;
-      proseLines.push(rawLine);
-      continue;
-    }
-    if (LIST_LINE_RE.test(rawLine)) continue;
-    if (colonListRemaining > 0) {
-      colonListRemaining--;
-      continue;
-    }
-    if (trimmed.endsWith(':')) {
-      colonListRemaining = countFollowingPlainListLines(lines, i + 1);
-    }
-    proseLines.push(rawLine);
-  }
-  return proseLines.join('\n');
-}
-
-function countFollowingPlainListLines(lines, start) {
-  let count = 0;
-  for (let i = start; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
-    if (trimmed === '') break;
-    if (LIST_LINE_RE.test(lines[i])) continue;
-    count++;
-  }
-  return count >= 2 ? count : 0;
-}
-
-export function splitSentences(paragraph) {
-  if (!paragraph) return [];
-  return paragraph
-    .split(SENTENCE_SPLIT_RE)
-    .map((s) => s.trim().replace(/[.!?。！？…]+$/u, ''))
-    .filter((s) => s.length > 0);
-}
-
-export function splitProseSentences(paragraph) {
-  return splitSentences(stripListBlocks(paragraph));
-}
-
-function tokenizeCjk(text) {
-  const tokens = [];
-  for (const match of text.matchAll(CJK_TOKEN_RE)) {
-    const token = match[0].replace(EDGE_PUNCT_RE, '');
-    if (token) tokens.push(token);
-  }
-  return tokens;
-}
-
-export function tokenize(text, opts = {}) {
-  if (!text) return [];
-  if (opts.lang === 'zh' || opts.lang === 'ja') return tokenizeCjk(text);
-  return text
-    .split(/\s+/)
-    .map((chunk) => chunk.replace(EDGE_PUNCT_RE, ''))
-    .filter((t) => t.length > 0);
-}
-
-export function burstinessCV(sentenceTokenCounts) {
-  if (!Array.isArray(sentenceTokenCounts) || sentenceTokenCounts.length < 2) return null;
-  const n = sentenceTokenCounts.length;
-  const mean = sentenceTokenCounts.reduce((a, b) => a + b, 0) / n;
-  if (mean === 0) return null;
-  const variance = sentenceTokenCounts.reduce((acc, x) => acc + (x - mean) ** 2, 0) / n;
-  return Math.sqrt(variance) / mean;
-}
-
-export function mattr(tokens, window = DEFAULT_MATTR_WINDOW) {
-  if (!Array.isArray(tokens) || tokens.length === 0) return null;
-  const lower = tokens.map((t) => t.toLowerCase());
-  if (lower.length < window) return new Set(lower).size / lower.length;
-  let sum = 0;
-  let count = 0;
-  for (let i = 0; i + window <= lower.length; i++) {
-    const slice = lower.slice(i, i + window);
-    sum += new Set(slice).size / window;
-    count++;
-  }
-  return sum / count;
-}
-
-export function classifyBurstiness(cv, bands = DEFAULT_BURSTINESS_BANDS) {
-  if (cv == null) return null;
-  if (cv < bands.low) return 'low';
-  if (cv > bands.high) return 'high';
-  return 'mid';
-}
-
-export function classifyMattr(value, bands = DEFAULT_MATTR_BANDS) {
-  if (value == null) return null;
-  if (value < bands.low) return 'low';
-  if (value > bands.high) return 'high';
-  return 'mid';
-}
-
-export function koreanSpacingFeatures(paragraph) {
-  const eojeols = koreanEojeols(paragraph);
-  const lengths = eojeols.map(koreanLength).filter((length) => length > 0);
-  const eojeolCount = lengths.length;
-  return {
-    eojeolCount,
-    meanEojeolLength: mean(lengths),
-    eojeolLengthCV: coefficientOfVariation(lengths),
-    singleSyllableRatio:
-      eojeolCount > 0 ? lengths.filter((length) => length === 1).length / eojeolCount : null,
-    longEojeolRatio:
-      eojeolCount > 0 ? lengths.filter((length) => length >= 7).length / eojeolCount : null,
-  };
-}
-
-export function commaDensity(paragraph, sentenceCount = null) {
-  const commaCount = (paragraph.match(COMMA_RE) ?? []).length;
-  const charCount = Array.from(paragraph.replace(/\s+/gu, '')).length;
-  return {
-    count: commaCount,
-    perSentence: sentenceCount > 0 ? commaCount / sentenceCount : null,
-    per100Chars: charCount > 0 ? (commaCount / charCount) * 100 : null,
-  };
-}
-
-export function koreanPosDiversityProxy(paragraph) {
-  const eojeols = koreanEojeols(paragraph);
-  const matches = [];
-
-  for (const token of eojeols) {
-    const match = KO_POST_EDITESE_SUFFIX_MATCHERS.find(
-      (candidate) => token.length > candidate.suffix.length && token.endsWith(candidate.suffix)
-    );
-    if (match) {
-      matches.push({ className: match.className, suffix: match.suffix });
-    }
-  }
-
-  const matchedCount = matches.length;
-  const classes = [...new Set(matches.map((match) => match.className))].sort();
-  const suffixes = [...new Set(matches.map((match) => match.suffix))].sort();
-
-  return {
-    proxy: 'suffix',
-    eojeolCount: eojeols.length,
-    matchedCount,
-    coverage: eojeols.length > 0 ? matchedCount / eojeols.length : null,
-    distinctClassCount: classes.length,
-    classDiversity: matchedCount > 0 ? classes.length / matchedCount : null,
-    distinctSuffixCount: suffixes.length,
-    suffixDiversity: matchedCount > 0 ? suffixes.length / matchedCount : null,
-    classes,
-  };
-}
-
-export function classifyKoreanDiagnostics({
-  sentenceCount = 0,
-  spacing,
-  comma,
-  posDiversity,
-} = {}, bands = DEFAULT_KO_DIAGNOSTIC_BANDS) {
-  const thresholds = mergeKoreanDiagnosticBands(bands);
-  const reasons = [];
-
-  const hasEnoughText =
-    sentenceCount >= thresholds.minSentences &&
-    (spacing?.eojeolCount ?? 0) >= thresholds.minEojeols;
-  if (!hasEnoughText) {
-    return { hot: false, strength: 0, reasons, thresholds };
-  }
-
-  const spacingStrength = lowThresholdStrength(
-    spacing?.eojeolLengthCV,
-    thresholds.spacing.maxEojeolLengthCV
-  );
-  if (spacingStrength > 0) reasons.push('regular-eojeol-length');
-
-  const commaStrength = lowThresholdStrength(
-    comma?.perSentence,
-    thresholds.comma.maxPerSentence
-  );
-  if (commaStrength > 0) reasons.push('low-comma-density');
-
-  const posHasCoverage =
-    (posDiversity?.matchedCount ?? 0) >= thresholds.posProxy.minMatchedCount;
-  const posStrength = posHasCoverage
-    ? lowThresholdStrength(
-        posDiversity?.classDiversity,
-        thresholds.posProxy.maxClassDiversity
-      )
-    : 0;
-  if (posStrength > 0) reasons.push('low-suffix-class-diversity');
-
-  const componentStrengths = [spacingStrength, commaStrength, posStrength];
-  const hot = componentStrengths.every((value) => value > 0);
-
-  return {
-    hot,
-    strength: hot ? Math.min(...componentStrengths) : 0,
-    reasons: hot ? reasons : [],
-    thresholds,
-  };
-}
-
-function phraseToRegex(phrase) {
-  const escaped = phrase.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp(escaped.replace(/~/g, '.{0,40}'), 'u');
-}
-
-export function computeDensity(paragraphText, tokens, lexicon) {
-  const lowerText = paragraphText.toLowerCase();
-  const hits = [];
-  const tokenSet = new Set(tokens.map((t) => t.toLowerCase()));
-  const cjkSubstring = ['ko', 'zh', 'ja'].includes(lexicon.lang);
-
-  for (const entry of lexicon.strict) {
-    const lowerEntry = entry.toLowerCase();
-    if (tokenSet.has(lowerEntry)) {
-      hits.push(entry);
-      continue;
-    }
-    const hasInternalPunct = /[^\p{L}\p{N}]/u.test(lowerEntry);
-    if ((cjkSubstring || hasInternalPunct) && lowerText.includes(lowerEntry)) hits.push(entry);
-  }
-
-  for (const phrase of lexicon.phrases) {
-    if (phraseToRegex(phrase).test(lowerText)) hits.push(phrase);
-  }
-
-  const density = tokens.length > 0 ? (hits.length / tokens.length) * 1000 : 0;
-  return { matches: hits.length, density, hits };
-}
-
-function fmt(value, digits = 2) {
-  return value == null ? 'n/a' : Number(value).toFixed(digits);
-}
-
-// Model-output leakage artifacts (issue #332): tokens LLM tooling injects that
-// never appear in human prose. A single hit is near-proof-grade, so it forces
-// the document hot. Mirrors src/features/markup-leakage.js.
-const MARKUP_LEAKAGE_RULES = [
-  { id: 'oai-citation-markup', label: 'OpenAI citation markup', build: () => /:contentReference|oaicite|oai_citation/gi },
-  { id: 'model-tool-token', label: 'Model tool token', build: () => /\bturn\d+(?:search|view|news|image|forecast|finance|fetch)\d*\b|\bnavlist\b|\bgrok_card\b/gi },
-  { id: 'object-replacement-char', label: 'Object-replacement character (￼)', build: () => /￼/g },
-  { id: 'ai-tracking-param', label: 'AI-tool tracking parameter in URL', build: () => /utm_source=(?:chatgpt\.com|openai\.com|perplexity\.ai|claude\.ai|gemini\.google\.com)|[?&](?:ref|utm_source)=chatgpt/gi },
-  { id: 'explicit-self-identification', label: 'Explicit AI self-identification', build: () => /\bas an? (?:AI|artificial intelligence) language model\b|\bas a large language model\b|\bas a language model\b|\bas an AI assistant\b|\bI am an AI\b|\bI'?m an AI\b/gi },
-];
-
-export function detectMarkupLeakage(text) {
-  const str = typeof text === 'string' ? text : '';
-  const hits = [];
-  if (!str) return { leaked: false, hits };
-  for (const rule of MARKUP_LEAKAGE_RULES) {
-    const m = str.match(rule.build());
-    if (m && m.length > 0) {
-      hits.push({ id: rule.id, label: rule.label, count: m.length, samples: [...new Set(m.map((x) => x.trim()).filter(Boolean))].slice(0, 3) });
-    }
-  }
-  return { leaked: hits.length > 0, hits };
-}
-
-// Density-gated discourse tells (issue #334): fake-candor / manufactured-intimacy
-// openers and decorative thematic breaks. Mirrors src/features/discourse-tells.js.
-const FAKE_CANDOR_RULES = [
-  /\bhere'?s the thing\b/gi,
-  /\bhere'?s the kicker\b/gi,
-  /\blet'?s be honest\b/gi,
-  /\blet'?s be real\b/gi,
-  /\bthe truth is\b/gi,
-  /\bi'?ll be honest(?: with you)?\b/gi,
-  /\breal talk\b/gi,
-];
-export const DEFAULT_FAKE_CANDOR_MIN = 2;
-export const DEFAULT_THEMATIC_BREAK_MIN = 3;
-const THEMATIC_BREAK_LINE = /^[ \t]*(?:-[ \t]*){3,}$|^[ \t]*(?:\*[ \t]*){3,}$|^[ \t]*(?:_[ \t]*){3,}$/;
-const HEADING_LINE = /^[ \t]*#{1,6}[ \t]+\S/;
-
-export function detectFakeCandor(text) {
-  const str = typeof text === 'string' ? text : '';
-  const hits = [];
-  let count = 0;
-  for (const re of FAKE_CANDOR_RULES) {
-    const m = str.match(re);
-    if (m && m.length) {
-      count += m.length;
-      hits.push(...new Set(m.map((x) => x.trim().toLowerCase())));
-    }
-  }
-  return { count, hits: [...new Set(hits)].slice(0, 5), hot: count >= DEFAULT_FAKE_CANDOR_MIN, threshold: DEFAULT_FAKE_CANDOR_MIN };
+  return splitParagraphsCore(text ? String(text).normalize('NFC') : '');
 }
 
 export function countFakeCandor(text) {
   return detectFakeCandor(text).count;
 }
 
-export function detectThematicBreaks(text) {
-  const lines = (typeof text === 'string' ? text : '').split(/\r?\n/);
-  let count = 0;
-  let adjacentToHeading = 0;
-  for (let i = 0; i < lines.length; i++) {
-    if (!THEMATIC_BREAK_LINE.test(lines[i])) continue;
-    count++;
-    for (let j = i + 1; j < lines.length; j++) {
-      if (lines[j].trim() === '') continue;
-      if (HEADING_LINE.test(lines[j])) adjacentToHeading++;
-      break;
-    }
-  }
-  return {
-    count,
-    adjacentToHeading,
-    hot: count >= DEFAULT_THEMATIC_BREAK_MIN,
-    threshold: DEFAULT_THEMATIC_BREAK_MIN,
-  };
-}
-export function detectTranslationese(text, opts = {}) {
-  const lang = opts.lang ?? 'ko';
-  const str = typeof text === 'string' ? text : '';
-  if (lang !== 'ko' || !str) {
-    return {
-      count: 0,
-      density: 0,
-      sentences: 0,
-      byRule: [],
-      hits: [],
-      hot: false,
-      thresholds: { count: TRANSLATIONESE_ABS_MIN, density: TRANSLATIONESE_DENSITY_MIN, strong: TRANSLATIONESE_STRONG_MIN },
-    };
-  }
-
-  const byRule = [];
-  const hits = [];
-  const evidence = [];
-  for (const rule of TRANSLATIONESE_RULES) {
-    const matches = collectTranslationeseRuleMatches(str, rule);
-    const minCount = rule.minCount ?? 1;
-    if (matches.length >= minCount) {
-      byRule.push({ id: rule.id, label: rule.label, strong: rule.strong, count: matches.length, example: rule.example });
-      hits.push(...new Set(matches.map((m) => m.text.trim()).filter(Boolean)));
-      evidence.push(...matches.map((match) => ({ ...match, strong: Boolean(rule.strong) })));
-    }
-  }
-
-  const independentEvidence = selectIndependentTranslationeseEvidence(evidence);
-  const count = independentEvidence.length;
-  const strongCount = independentEvidence.filter((match) => match.strong).length;
-  const sentences = Math.max(1, splitProseSentences(str).length);
-  const density = count / sentences;
-  const hot = count >= TRANSLATIONESE_ABS_MIN &&
-    density >= TRANSLATIONESE_DENSITY_MIN &&
-    strongCount >= TRANSLATIONESE_STRONG_MIN;
-  return {
-    count,
-    density: Number(density.toFixed(3)),
-    sentences,
-    byRule: byRule.sort((a, b) => b.count - a.count),
-    hits: [...new Set(hits)].slice(0, 8),
-    hot,
-    thresholds: { count: TRANSLATIONESE_ABS_MIN, density: TRANSLATIONESE_DENSITY_MIN, strong: TRANSLATIONESE_STRONG_MIN },
-  };
-}
-
-function collectTranslationeseRuleMatches(str, rule) {
-  const re = rule.re();
-  const matches = [];
-  let match;
-  while ((match = re.exec(str)) !== null) {
-    matches.push({
-      text: match[0],
-      start: match.index,
-      end: match.index + match[0].length,
-    });
-    if (match[0] === '') re.lastIndex += 1;
-  }
-  return matches;
-}
-
-function selectIndependentTranslationeseEvidence(matches) {
-  const selected = [];
-  const ranked = [...matches].sort((a, b) => {
-    if (a.strong !== b.strong) return a.strong ? -1 : 1;
-    const lengthDelta = (b.end - b.start) - (a.end - a.start);
-    if (lengthDelta !== 0) return lengthDelta;
-    return a.start - b.start;
-  });
-
-  for (const match of ranked) {
-    if (!selected.some((kept) => translationeseEvidenceOverlaps(kept, match))) {
-      selected.push(match);
-    }
-  }
-
-  return selected.sort((a, b) => a.start - b.start);
-}
-
-function translationeseEvidenceOverlaps(a, b) {
-  return a.start < b.end && b.start < a.end;
-}
-
-
-export function koreanPostEditeseFeatures(text, opts = {}) {
-  const lang = opts.lang ?? 'ko';
-  const str = typeof text === 'string' ? text.normalize('NFC') : '';
-  if (lang !== 'ko') return skippedKoPostEditese(lang, 'non-ko');
-  if (str.trim().length === 0) return skippedKoPostEditese(lang, 'empty');
-
-  const paragraphs = splitParagraphs(str);
-  const totalEojeols = koreanEojeols(str);
-  if (totalEojeols.length === 0) return skippedKoPostEditese(lang, 'no-hangul-eojeols');
-
-  const paragraphRows = paragraphs.map((paragraph, index) => buildKoPostEditeseRow(paragraph, `P${index + 1}`));
-  const docSentences = paragraphs.flatMap((paragraph) => splitProseSentences(paragraph));
-  return {
-    schema: KO_POST_EDITESE_SCHEMA,
-    lang,
-    analyzed: true,
-    skipReason: null,
-    paragraphCount: paragraphRows.length,
-    sentenceCount: docSentences.length,
-    eojeolCount: totalEojeols.length,
-    metrics: buildKoPostEditeseMetrics(str, docSentences),
-    paragraphs: paragraphRows,
-  };
-}
-
-function skippedKoPostEditese(lang, skipReason) {
-  return {
-    schema: KO_POST_EDITESE_SCHEMA,
-    lang,
-    analyzed: false,
-    skipReason,
-    paragraphCount: 0,
-    sentenceCount: 0,
-    eojeolCount: 0,
-    metrics: zeroKoPostEditeseMetrics(),
-    paragraphs: [],
-  };
+function fmt(value, digits = 2) {
+  return value == null ? 'n/a' : Number(value).toFixed(digits);
 }
 
 function zeroKoPostEditeseMetrics() {
-  return {
-    lexical: {
-      tokenCount: 0,
-      typeCount: 0,
-      ttr: null,
-      mattr: null,
-      endingTypeCount: 0,
-      endingDiversity: null,
-    },
-    endings: {
-      declarativeDaCount: 0,
-      declarativeDaRatio: null,
-      handaCount: 0,
-      doendaCount: 0,
-      idaCount: 0,
-      formalEndingCount: 0,
-      politeEndingCount: 0,
-      endingStreakMax: 0,
-    },
-    interference: {
-      pronounLiteralCount: 0,
-      doubleParticleCount: 0,
-      progressiveAspectCount: 0,
-      lightVerbCount: 0,
-      byPassiveCount: 0,
-      doublePassiveCount: 0,
-      connectiveCommaCount: 0,
-      relativeClauseProxyCount: 0,
-    },
-    rhythm: {
-      meanSentenceEojeols: null,
-      sentenceEojeolCV: null,
-      meanEojeolLength: null,
-      eojeolLengthCV: null,
-      commaPerSentence: null,
-      commaPer100Chars: null,
-      suffixMatchedCount: 0,
-      suffixClassDiversity: null,
-      suffixDiversity: null,
-    },
-  };
+  return koreanPostEditeseFeatures('', { lang: 'ko' }).metrics;
 }
 
-function buildKoPostEditeseRow(paragraph, id) {
-  const sentences = splitProseSentences(paragraph);
-  const eojeols = koreanEojeols(paragraph);
-  return {
-    id,
-    sentenceCount: sentences.length,
-    eojeolCount: eojeols.length,
-    metrics: buildKoPostEditeseMetrics(paragraph, sentences),
-  };
-}
-
-function buildKoPostEditeseMetrics(text, sentences = splitProseSentences(text)) {
-  const eojeols = koreanEojeols(text);
-  const lowerEojeols = eojeols.map((token) => token.toLowerCase());
-  const typeCount = new Set(lowerEojeols).size;
-  const lengths = eojeols.map(koreanLength).filter((length) => length > 0);
-  const endings = sentences.map(extractKoPostEditeseSentenceEnding).filter(Boolean);
-  const endingTypeCount = new Set(endings).size;
-  const suffixStats = koPostEditeseSuffixStats(eojeols);
-  const comma = commaDensity(text, sentences.length);
-  const sentenceEojeolCounts = sentences
-    .map((sentence) => koreanEojeols(sentence).length)
-    .filter((count) => count > 0);
-
-  return {
-    lexical: {
-      tokenCount: eojeols.length,
-      typeCount,
-      ttr: ratio(typeCount, eojeols.length),
-      mattr: roundMetric(mattr(eojeols)),
-      endingTypeCount,
-      endingDiversity: ratio(endingTypeCount, sentences.length),
-    },
-    endings: buildKoPostEditeseEndings(endings),
-    interference: {
-      pronounLiteralCount: countPattern(text, KO_POST_EDITESE_PRONOUN_LITERAL_RE),
-      doubleParticleCount: countPattern(text, KO_POST_EDITESE_DOUBLE_PARTICLE_RE),
-      progressiveAspectCount: countPattern(text, KO_POST_EDITESE_PROGRESSIVE_ASPECT_RE),
-      lightVerbCount: countPattern(text, KO_POST_EDITESE_LIGHT_VERB_RE),
-      byPassiveCount: countPattern(text, KO_POST_EDITESE_BY_PASSIVE_RE),
-      doublePassiveCount: countPattern(text, KO_POST_EDITESE_DOUBLE_PASSIVE_RE),
-      connectiveCommaCount: countPattern(text, KO_POST_EDITESE_CONNECTIVE_COMMA_RE),
-      relativeClauseProxyCount: countPattern(text, KO_POST_EDITESE_RELATIVE_CLAUSE_PROXY_RE),
-    },
-    rhythm: {
-      meanSentenceEojeols: ratio(eojeols.length, sentences.length),
-      sentenceEojeolCV: roundMetric(coefficientOfVariation(sentenceEojeolCounts)),
-      meanEojeolLength: roundMetric(mean(lengths)),
-      eojeolLengthCV: roundMetric(coefficientOfVariation(lengths)),
-      commaPerSentence: roundMetric(comma.perSentence),
-      commaPer100Chars: roundMetric(comma.per100Chars),
-      suffixMatchedCount: suffixStats.matchedCount,
-      suffixClassDiversity: roundMetric(suffixStats.classDiversity),
-      suffixDiversity: roundMetric(suffixStats.suffixDiversity),
-    },
-  };
-}
-
-function buildKoPostEditeseEndings(endings) {
-  const declarativeDaCount = endings.filter((ending) => KO_POST_EDITESE_DECLARATIVE_DA_ENDINGS.has(ending)).length;
-  return {
-    declarativeDaCount,
-    declarativeDaRatio: ratio(declarativeDaCount, endings.length),
-    handaCount: endings.filter((ending) => ending === '한다').length,
-    doendaCount: endings.filter((ending) => ending === '된다').length,
-    idaCount: endings.filter((ending) => ending === '이다').length,
-    formalEndingCount: endings.filter((ending) => KO_POST_EDITESE_FORMAL_ENDINGS.has(ending)).length,
-    politeEndingCount: endings.filter((ending) => KO_POST_EDITESE_POLITE_ENDINGS.has(ending)).length,
-    endingStreakMax: maxKoPostEditeseDeclarativeDaStreak(endings),
-  };
-}
-
-function extractKoPostEditeseSentenceEnding(sentence) {
-  const eojeol = koreanEojeols(sentence).at(-1);
-  if (!eojeol) return null;
-  const matched = KO_POST_EDITESE_ENDING_SUFFIXES.find((ending) => eojeol.endsWith(ending)) ?? null;
-  // Regular formal '-ㅂ니다 / -ㅂ니까' (됩니다, 표시됩니다, 합니까…) fuse the ㅂ marker into
-  // the stem syllable, so they fall through to the bare '다' bucket and get miscounted as
-  // declarative '-다' style. Reclassify them as a formal ending.
-  if ((matched === '다' || matched === null) && isKoPostEditeseFormalFusedEnding(eojeol)) {
-    return KO_POST_EDITESE_FORMAL_NIDA;
-  }
-  return matched;
-}
-
-// True for '-ㅂ니다 / -ㅂ니까' formal endings: the syllable before 니다/니까 carries a ㅂ
-// jongseong (batchim index 17). Distinguishes 됩니다/아닙니다 (formal) from 아니다 (plain).
-function isKoPostEditeseFormalFusedEnding(eojeol) {
-  const m = /(.)(?:니다|니까)$/.exec(eojeol);
-  if (!m) return false;
-  const code = m[1].charCodeAt(0);
-  if (code < 0xac00 || code > 0xd7a3) return false;
-  return (code - 0xac00) % 28 === 17;
-}
-
-function maxKoPostEditeseDeclarativeDaStreak(endings) {
-  let current = 0;
-  let max = 0;
-  for (const ending of endings) {
-    if (KO_POST_EDITESE_DECLARATIVE_DA_ENDINGS.has(ending)) {
-      current += 1;
-      max = Math.max(max, current);
-    } else {
-      current = 0;
-    }
-  }
-  return max;
-}
-
-function koPostEditeseSuffixStats(eojeols) {
-  const matches = [];
-  for (const token of eojeols) {
-    const match = KO_POST_EDITESE_SUFFIX_MATCHERS.find(
-      (candidate) => token.length > candidate.suffix.length && token.endsWith(candidate.suffix)
-    );
-    if (match) matches.push({ className: match.className, suffix: match.suffix });
-  }
-  const matchedCount = matches.length;
-  const classCount = new Set(matches.map((match) => match.className)).size;
-  const suffixCount = new Set(matches.map((match) => match.suffix)).size;
-  return {
-    matchedCount,
-    classDiversity: matchedCount > 0 ? classCount / matchedCount : null,
-    suffixDiversity: matchedCount > 0 ? suffixCount / matchedCount : null,
-  };
-}
-
-function countPattern(text, pattern) {
-  return (String(text ?? '').match(pattern) ?? []).length;
-}
-
-function ratio(numerator, denominator) {
-  return denominator > 0 ? roundMetric(numerator / denominator) : null;
-}
-
-function roundMetric(value) {
-  return typeof value === 'number' && Number.isFinite(value) ? Number(value.toFixed(3)) : null;
-}
 const EMOJI_BASE_RE = '\\p{Extended_Pictographic}(?:\\uFE0F|\\uFE0E)?(?:\\p{Emoji_Modifier})?';
 const EMOJI_CLUSTER_PATTERN = `(?:\\p{Regional_Indicator}{2}|[#*0-9]\\uFE0F?\\u20E3|${EMOJI_BASE_RE}(?:\\u200D${EMOJI_BASE_RE})*)`;
 const EMOJI_CLUSTER_RE = new RegExp(EMOJI_CLUSTER_PATTERN, 'u');
@@ -1128,29 +368,6 @@ export function analyzePlaygroundText(text, opts = {}) {
   };
 }
 
-function classifyLexiconHot(
-  lexiconStats,
-  {
-    lang,
-    densityThreshold = DEFAULT_LEXICON_DENSITY_THRESHOLD,
-    minHotMatches = DEFAULT_LEXICON_MIN_HOT_MATCHES,
-  } = {}
-) {
-  const matches = lexiconStats?.matches ?? 0;
-  const density = lexiconStats?.density ?? 0;
-  const minMatches = resolveMinHotMatches(lang, minHotMatches);
-  return matches >= minMatches && density > densityThreshold;
-}
-
-function resolveMinHotMatches(lang, minHotMatches) {
-  if (typeof minHotMatches === 'number' && Number.isFinite(minHotMatches)) {
-    return Math.max(1, minHotMatches);
-  }
-  const normalized = typeof lang === 'string' ? lang.toLowerCase() : 'default';
-  const value = minHotMatches?.[normalized] ?? minHotMatches?.default;
-  return typeof value === 'number' && Number.isFinite(value) ? Math.max(1, value) : 1;
-}
-
 export function scoreBand(score) {
   if (score <= 20) return { key: 'low', label: 'Low AI-likeness', tone: 'good' };
   if (score <= 50) return { key: 'mixed', label: 'Mixed signals', tone: 'warn' };
@@ -1185,76 +402,6 @@ function buildKoreanSignals(paragraph, sentenceCount) {
   };
 }
 
-function cleanKoreanEojeol(chunk) {
-  return String(chunk ?? '')
-    .normalize('NFC')
-    .replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, '');
-}
-
-function koreanEojeols(paragraph) {
-  if (!paragraph || !HANGUL_RE.test(paragraph)) return [];
-  return paragraph
-    .split(/\s+/u)
-    .map(cleanKoreanEojeol)
-    .filter((chunk) => HANGUL_RE.test(chunk));
-}
-
-function koreanLength(value) {
-  return Array.from(value.match(/[\u3131-\u318e\uac00-\ud7a3]/gu) ?? []).length;
-}
-
-function mean(values) {
-  if (!Array.isArray(values) || values.length === 0) return null;
-  return values.reduce((sum, value) => sum + value, 0) / values.length;
-}
-
-function coefficientOfVariation(values) {
-  if (!Array.isArray(values) || values.length < 2) return null;
-  const avg = mean(values);
-  if (!avg) return null;
-  const variance = values.reduce((sum, value) => sum + (value - avg) ** 2, 0) / values.length;
-  return Math.sqrt(variance) / avg;
-}
-
-function mergeKoreanDiagnosticBands(bands = {}) {
-  return {
-    minSentences: resolveNumber(bands.minSentences, DEFAULT_KO_DIAGNOSTIC_BANDS.minSentences),
-    minEojeols: resolveNumber(bands.minEojeols, DEFAULT_KO_DIAGNOSTIC_BANDS.minEojeols),
-    spacing: {
-      maxEojeolLengthCV: resolveNumber(
-        bands.spacing?.maxEojeolLengthCV,
-        DEFAULT_KO_DIAGNOSTIC_BANDS.spacing.maxEojeolLengthCV
-      ),
-    },
-    comma: {
-      maxPerSentence: resolveNumber(
-        bands.comma?.maxPerSentence,
-        DEFAULT_KO_DIAGNOSTIC_BANDS.comma.maxPerSentence
-      ),
-    },
-    posProxy: {
-      minMatchedCount: resolveNumber(
-        bands.posProxy?.minMatchedCount,
-        DEFAULT_KO_DIAGNOSTIC_BANDS.posProxy.minMatchedCount
-      ),
-      maxClassDiversity: resolveNumber(
-        bands.posProxy?.maxClassDiversity,
-        DEFAULT_KO_DIAGNOSTIC_BANDS.posProxy.maxClassDiversity
-      ),
-    },
-  };
-}
-
-function resolveNumber(value, fallback) {
-  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
-}
-
-function lowThresholdStrength(value, threshold) {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
-  if (threshold === 0) return value <= 0 ? 100 : 0;
-  if (!threshold || threshold < 0 || value > threshold) return 0;
-  return Math.max(0, Math.min(100, (1 - value / threshold) * 100));
-}
 
 function collectHitRanges(text, hits) {
   const lower = text.toLowerCase();

--- a/tests/unit/playground.test.js
+++ b/tests/unit/playground.test.js
@@ -28,7 +28,6 @@ import {
 import { analyzeText } from '../../src/features/index.js';
 import {
   detectTranslationese as detectNodeTranslationese,
-  TRANSLATIONESE_RULES as NODE_TRANSLATIONESE_RULES,
   ABS_MIN as NODE_TRANSLATIONESE_ABS_MIN,
   DENSITY_MIN as NODE_TRANSLATIONESE_DENSITY_MIN,
   STRONG_MIN as NODE_TRANSLATIONESE_STRONG_MIN,
@@ -176,24 +175,55 @@ test('playground mirrors ko translationese advisory payload without score coupli
   assert.equal(nonKo.translationese.count, 0);
   assert.equal(nonKo.translationese.hot, false);
 });
-test('playground keeps translationese rules and thresholds in parity with node', () => {
-  const serializeRule = (rule) => ({
-    id: rule.id,
-    label: rule.label,
-    strong: rule.strong,
-    minCount: rule.minCount ?? 1,
-    source: rule.re().source,
-    flags: rule.re().flags,
-    example: rule.example,
-  });
-
+test('translationese rule catalog stays pinned (shared module)', () => {
+  // Playground and node now share one module binding, so a cross-surface
+  // deepEqual would compare the object to itself. Pin the catalog as literals
+  // instead, so accidental rule deletions/renames in src still fail a test.
   assert.deepEqual(
-    PLAYGROUND_TRANSLATIONESE_RULES.map(serializeRule),
-    NODE_TRANSLATIONESE_RULES.map(serializeRule),
+    PLAYGROUND_TRANSLATIONESE_RULES.map((rule) => rule.id),
+    [
+      'noun-calque',
+      'dummy-subject',
+      'direct-address-you',
+      'a16-pronoun-literal',
+      'a19-double-particle',
+      'passive-e-uihae',
+      't2-by-passive',
+      'a8-double-passive',
+      'have-overuse',
+      'a7-light-verb',
+      'one-of',
+      'provides',
+      'as-follows',
+      'make-easy',
+      'c11-connective-comma',
+    ],
   );
-  assert.equal(TRANSLATIONESE_ABS_MIN, NODE_TRANSLATIONESE_ABS_MIN);
-  assert.equal(TRANSLATIONESE_DENSITY_MIN, NODE_TRANSLATIONESE_DENSITY_MIN);
-  assert.equal(TRANSLATIONESE_STRONG_MIN, NODE_TRANSLATIONESE_STRONG_MIN);
+  assert.deepEqual(
+    PLAYGROUND_TRANSLATIONESE_RULES.filter((rule) => rule.strong).map((rule) => rule.id),
+    [
+      'noun-calque',
+      'dummy-subject',
+      'direct-address-you',
+      'a16-pronoun-literal',
+      'a19-double-particle',
+      't2-by-passive',
+      'a8-double-passive',
+    ],
+  );
+  assert.deepEqual(
+    PLAYGROUND_TRANSLATIONESE_RULES.filter((rule) => (rule.minCount ?? 1) !== 1)
+      .map((rule) => [rule.id, rule.minCount]),
+    [['c11-connective-comma', 2]],
+  );
+  for (const rule of PLAYGROUND_TRANSLATIONESE_RULES) {
+    assert.ok(rule.re() instanceof RegExp, `rule ${rule.id} must expose a regex factory`);
+    assert.ok(rule.label, `rule ${rule.id} must have a label`);
+    assert.ok(rule.example?.before, `rule ${rule.id} must have a before example`);
+  }
+  assert.equal(TRANSLATIONESE_ABS_MIN, 4);
+  assert.equal(TRANSLATIONESE_DENSITY_MIN, 0.5);
+  assert.equal(TRANSLATIONESE_STRONG_MIN, 1);
 
   for (const rule of PLAYGROUND_TRANSLATIONESE_RULES) {
     const signal = detectPlaygroundTranslationese(rule.example.before, { lang: 'ko' });
@@ -700,6 +730,64 @@ test('Vercel config exposes the playground at the domain root', () => {
   assert.match(csp, /connect-src 'self'(?:;|$)/);
 });
 
+// Single-pass scanner producing two views of a JS source: comments removed with
+// string contents kept (for reading import specifiers), and comments removed with
+// string/template contents blanked (for detecting dynamic import()/require()
+// without false-positives from words inside literals). Regex literals are not
+// modeled; an unescaped `//` can only appear inside one via a character class,
+// which none of the walked files use.
+function scanJsSource(source) {
+  let withStrings = '';
+  let codeOnly = '';
+  let state = 'code';
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (state === 'code') {
+      if (ch === '/' && next === '/') { state = 'line'; i += 2; continue; }
+      if (ch === '/' && next === '*') { state = 'block'; i += 2; continue; }
+      if (ch === "'") state = 'single';
+      else if (ch === '"') state = 'double';
+      else if (ch === '`') state = 'template';
+      withStrings += ch;
+      codeOnly += ch;
+      i += 1;
+      continue;
+    }
+    if (state === 'line') {
+      if (ch === '\n') { state = 'code'; withStrings += ch; codeOnly += ch; }
+      i += 1;
+      continue;
+    }
+    if (state === 'block') {
+      if (ch === '*' && next === '/') { state = 'code'; i += 2; } else i += 1;
+      continue;
+    }
+    // Inside a string or template literal.
+    if (ch === '\\') {
+      withStrings += ch + (next ?? '');
+      i += 2;
+      continue;
+    }
+    if (
+      (state === 'single' && ch === "'") ||
+      (state === 'double' && ch === '"') ||
+      (state === 'template' && ch === '`')
+    ) {
+      state = 'code';
+      withStrings += ch;
+      codeOnly += ch;
+      i += 1;
+      continue;
+    }
+    withStrings += ch;
+    if (ch === '\n') codeOnly += ch;
+    i += 1;
+  }
+  return { withStrings, codeOnly };
+}
+
 function collectStaticImports(relativeEntry) {
   const seen = new Set();
   const pending = [resolve(REPO_ROOT, relativeEntry)];
@@ -710,7 +798,16 @@ function collectStaticImports(relativeEntry) {
     if (seen.has(file)) continue;
     seen.add(file);
 
-    const source = readFileSync(file, 'utf8');
+    const { withStrings: source, codeOnly } = scanJsSource(readFileSync(file, 'utf8'));
+
+    // The browser graph must stay fully static: dynamic import()/require()
+    // would be invisible to this walker, so their mere presence is a violation.
+    for (const dynamic of codeOnly.matchAll(/(?<![.\w])(?:import|require)\s*\(/g)) {
+      violations.push(
+        `${relative(REPO_ROOT, file)} -> ${dynamic[0].replace(/\s+/g, '')}...) (graph must be static)`,
+      );
+    }
+
     const importPattern = /\b(?:import|export)\s+(?:[^'"()]*?\s+from\s+)?['"]([^'"]+)['"]/g;
     for (const match of source.matchAll(importPattern)) {
       const specifier = match[1];

--- a/tests/unit/playground.test.js
+++ b/tests/unit/playground.test.js
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { readFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
-import { dirname, resolve } from 'node:path';
+import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { PLAYGROUND_LEXICONS } from '../../playground/data/lexicons.js';
@@ -306,18 +306,8 @@ test('playground mirrors ko post-editese schema and metrics in parity with node'
   assert.deepEqual(playgroundPayload, nodePayload);
 });
 
-test('playground pronoun literal regex stays pattern-identical to node (issue #395)', () => {
-  const extractRegexLiteral = (relativePath, constName) => {
-    const source = readFileSync(resolve(REPO_ROOT, relativePath), 'utf8');
-    const match = source.match(new RegExp(`const ${constName} = (/.+/g);`));
-    assert.ok(match, `${constName} regex literal not found in ${relativePath}`);
-    return match[1];
-  };
-
-  assert.equal(
-    extractRegexLiteral('playground/analyzer.js', 'KO_POST_EDITESE_PRONOUN_LITERAL_RE'),
-    extractRegexLiteral('src/features/stylometry.js', 'POST_EDITESE_PRONOUN_LITERAL_RE'),
-  );
+test('playground ko post-editese implementation is the shared node implementation (issue #395)', () => {
+  assert.equal(playgroundKoPostEditeseFeatures, nodeKoPostEditeseFeatures);
 });
 
 test('playground mirrors stacked-particle pronoun literal counts (issue #395)', () => {
@@ -708,6 +698,45 @@ test('Vercel config exposes the playground at the domain root', () => {
   assert.match(csp, /script-src 'self'(?:;|$)/);
   assert.doesNotMatch(csp, /script-src[^;]*'unsafe-inline'/);
   assert.match(csp, /connect-src 'self'(?:;|$)/);
+});
+
+function collectStaticImports(relativeEntry) {
+  const seen = new Set();
+  const pending = [resolve(REPO_ROOT, relativeEntry)];
+  const violations = [];
+
+  while (pending.length > 0) {
+    const file = pending.pop();
+    if (seen.has(file)) continue;
+    seen.add(file);
+
+    const source = readFileSync(file, 'utf8');
+    const importPattern = /\b(?:import|export)\s+(?:[^'"()]*?\s+from\s+)?['"]([^'"]+)['"]/g;
+    for (const match of source.matchAll(importPattern)) {
+      const specifier = match[1];
+      if (specifier.startsWith('node:') || (!specifier.startsWith('.') && !specifier.startsWith('/'))) {
+        violations.push(`${relative(REPO_ROOT, file)} -> ${specifier}`);
+        continue;
+      }
+
+      const child = specifier.startsWith('/')
+        ? resolve(REPO_ROOT, `.${specifier}`)
+        : resolve(dirname(file), specifier);
+      if (!child.startsWith(REPO_ROOT) || !child.endsWith('.js')) {
+        violations.push(`${relative(REPO_ROOT, file)} -> ${specifier}`);
+        continue;
+      }
+      pending.push(child);
+    }
+  }
+
+  return { seen, violations };
+}
+
+test('playground static module graph stays browser-pure', () => {
+  const { seen, violations } = collectStaticImports('playground/app.js');
+  assert.deepEqual(violations, []);
+  assert.ok([...seen].some((file) => file.endsWith('/src/features/segment.js')));
 });
 
 test('generated playground lexicon bundle is in sync with markdown lexicons', () => {


### PR DESCRIPTION
## Summary
- Replace the playground's hand-mirrored detector implementations with direct browser ESM imports from browser-pure `src/features/*` modules.
- Keep playground-only UI/report glue and formatting tells in `playground/analyzer.js`; preserve stable exports for `app.js` and tests.
- Add a static module-graph purity gate that fails on `node:` or bare specifiers reachable from `playground/app.js`.
- Update playground docs to state that root static serving must expose `/src/features/*.js`.

Refs #383, #387. Implements Stage 2 from the #383 implementation brief.

## Verification
- `node --test tests/unit/playground.test.js`
- `npm test`
- `npm run lint`
- `npm run playground:data -- --check`
- `npm run benchmark`
- `npm run release:check`
- `git diff --check`

## Static serving check
- `https://patina.vibetip.help/src/features/segment.js` returned `Content-Type: application/javascript` via the repository-root static deployment path.

## Notes
- No bundler or Vercel config change required.
- Benchmark stayed 47/47 with no expected-ranges changes.
- Remaining behavioral asymmetry is intentionally out of scope: playground-only formatting tells still live in `analyzer.js` until a separate CLI detector issue/PR.