### PR TITLE
Add doctor help/unknown-option tests and codify the score-only examples policy

### DIFF
--- a/tests/e2e/cli-adoption.test.js
+++ b/tests/e2e/cli-adoption.test.js
@@ -148,6 +148,20 @@ describe('CLI adoption commands', () => {
     }
   });
 
+  it('patina doctor --help and -h print usage and exit 0', () => {
+    for (const flag of ['--help', '-h']) {
+      const result = spawnSync(process.execPath, [BIN, 'doctor', flag], {
+        cwd: REPO_ROOT,
+        input: '',
+        encoding: 'utf8',
+      });
+      assert.strictEqual(result.status, 0, `doctor ${flag} should exit 0`);
+      assert.match(result.stdout, /patina doctor — check local CLI readiness/);
+      assert.match(result.stdout, /Usage: patina doctor \[--json\]/);
+      assert.doesNotMatch(result.stdout, /Checks:/, `doctor ${flag} should short-circuit the report`);
+    }
+  });
+
   it('patina --list-backends shows selectors and setup guidance', async () => {
     await withEnv({
       PATINA_API_KEY: 'test-key',
@@ -338,6 +352,17 @@ describe('CLI adoption exit/error behavior', () => {
       assert.strictEqual(result.status, 2, `${args.join(' ')} should exit 2`);
       assert.match(result.stderr, message);
     }
+  });
+
+  it('doctor rejects unknown options with usage exits', () => {
+    const result = spawnSync(process.execPath, [BIN, 'doctor', '--bogus'], {
+      cwd: REPO_ROOT,
+      input: '',
+      encoding: 'utf8',
+    });
+    assert.strictEqual(result.status, 2);
+    assert.match(result.stderr, /unknown doctor option --bogus/);
+    assert.match(result.stderr, /Run `patina doctor --help` for usage\./);
   });
 
   it('--exit-on outside score mode names the alias and exits 2', () => {


### PR DESCRIPTION
Closes #392.

Closes out the two remaining test gaps from the cleanup bundle and codifies the maintainer decision on the "examples 34–42" item:

- New spawned-binary test `patina doctor --help and -h print usage and exit 0`: asserts exit 0, the real `printDoctorHelp` strings (`patina doctor — check local CLI readiness`, `Usage: patina doctor [--json]`), and — per review — `assert.doesNotMatch(stdout, /Checks:/)` so `--help` is verified to short-circuit the report rather than merely prepend usage text.
- New test `doctor rejects unknown options with usage exits`: `doctor --bogus` exits 2 with `unknown doctor option --bogus` and the `Run `patina doctor --help` for usage.` hint on stderr, following the existing `--format` error-test pattern.

**"Examples 34–42" resolution (maintainer decision, option b):** there is no 34–42 numbering — the 9 extra patterns per pack are the viral-hook pack, `score_only: true` ("rewrite 시 변경하지 않음"). Score-only packs are exempt from the per-pattern corrected-example (교정 예시) requirement; detection examples suffice, and viral-hook 6–9's in-file Before/After stay enforced by `tests/unit/pattern-docs.test.js:167-183`. The coverage guard (`pattern-docs.test.js:355-381`) already encodes exactly this, so no pattern files or test guards change.

The policy is codified in the local (gitignored, 97b1018) `CLAUDE.md` Development Guidelines — recorded here verbatim since that file cannot ride a PR:

> OLD: `- 패턴 추가 시 반드시 실제 AI 생성 예시와 교정 예시를 포함`
> NEW: `- 패턴 추가 시 반드시 실제 AI 생성 예시와 교정 예시를 포함 (score-only 팩(`score_only: true`, 예: viral-hook)은 rewrite 시 변경하지 않으므로 탐지 예시만 필수)`

Tests: 551/551 pass (549 + 2 new); lint clean.

Implemented and adversarially reviewed (correctness + completeness lenses) by Claude; the short-circuit assertion was added from review findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
