### PR TITLE
refactor: consistency cleanups from #411 — formatLimit home, score-extractor dedupe, @throws sweep

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -236,6 +236,15 @@ cannot silently override a pinned config (reproducible CI runs).</p>
 <dt><a href="#stripSelfAudit">stripSelfAudit(body, [options])</a> ⇒ <code>string</code></dt>
 <dd><p>Remove SELF_AUDIT blocks and unwrap the BODY block from rewrite output.</p>
 </dd>
+<dt><a href="#extractOverallScore">extractOverallScore(result, text, options)</a> ⇒ <code>number</code> | <code>null</code></dt>
+<dd><p>Shared overall-score traversal: structured result field → embedded JSON →
+markdown score table → inline &quot;overall: N&quot; text. Used by extractOverall
+above and by the CLI score gate (src/cli/score-gate.js). The two call sites
+intentionally keep different numeric coercers (toFiniteNumber here strips
+non-numeric characters before Number(); the score gate&#39;s toFiniteScore
+rejects anything that is not already a plain number), so the coercer is a
+parameter rather than shared.</p>
+</dd>
 <dt><a href="#parseFirstJson">parseFirstJson(text)</a> ⇒ <code>object</code> | <code>null</code></dt>
 <dd><p>Parse the first JSON value found in raw text, a fenced code block, or a brace span.</p>
 </dd>
@@ -431,10 +440,6 @@ Decide whether an LLM call failure should be retried.
 
 **Kind**: global function
 **Returns**: <code>boolean</code> - True for retryable HTTP statuses, aborts, and common network failures.
-**Throws**:
-
-- <code>Error</code> Does not intentionally throw; unexpected Error-like inputs may still propagate JavaScript runtime failures.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -451,10 +456,6 @@ Compute retry delay from Retry-After or exponential backoff with jitter.
 
 **Kind**: global function
 **Returns**: <code>number</code> - Delay in milliseconds, capped at opts.max.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -512,10 +513,6 @@ Build the key lookup order for a selected provider.
 
 **Kind**: global function
 **Returns**: <code>Array.&lt;string&gt;</code> - Unique env var names in lookup order.
-**Throws**:
-
-- <code>Error</code> Does not intentionally throw; invalid non-string env names can still propagate JavaScript runtime failures.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -532,10 +529,6 @@ Inspect where an HTTP API key would be read from without exposing the secret.
 
 **Kind**: global function
 **Returns**: <code>Object</code> - Source diagnostics.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -618,10 +611,6 @@ Create a SIGINT-aware cancellation controller for long-running CLI operations.
 
 **Kind**: global function
 **Returns**: <code>Object</code> - Controller facade.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -642,10 +631,6 @@ Resolve a profile name against language-specific profile limits.
 
 **Kind**: global function
 **Returns**: <code>string</code> - Effective profile name.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -690,10 +675,6 @@ Return the repository root inferred from this source file location.
 
 **Kind**: global function
 **Returns**: <code>string</code> - Absolute repository root path.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 **Example**
 ```js
 const root = getRepoRoot();
@@ -728,10 +709,6 @@ Create a user-input error that should exit with code 2.
 
 **Kind**: global function
 **Returns**: <code>PatinaCliError</code> - Structured input error.
-**Throws**:
-
-- <code>Error</code> Does not intentionally throw; returns an Error instance for callers to throw.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -750,10 +727,6 @@ Create a runtime error that should exit with code 1.
 
 **Kind**: global function
 **Returns**: <code>PatinaCliError</code> - Structured runtime error.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -772,10 +745,6 @@ Render any thrown value into the patina CLI error format.
 
 **Kind**: global function
 **Returns**: <code>string</code> - Multi-line user-facing error text.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -792,10 +761,6 @@ Extract a safe process exit code from an error-like value.
 
 **Kind**: global function
 **Returns**: <code>number</code> - Non-negative integer exit code.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -957,10 +922,6 @@ Map a resolved named tone to its primary backbone profile.
 
 **Kind**: global function
 **Returns**: <code>string</code> \| <code>null</code> - Profile name, or null when no mapping exists.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -977,10 +938,6 @@ Create a small stderr logger with text and progress modes.
 
 **Kind**: global function
 **Returns**: <code>Object</code> - Logger facade.
-**Throws**:
-
-- <code>Error</code> Propagates stream write errors from the configured output stream.
-
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -1039,7 +996,7 @@ Format a raw backend result for CLI output mode and requested format.
 **Returns**: <code>string</code> - User-facing formatted output.
 **Throws**:
 
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
+- <code>TypeError</code> When `result` or `opts.tone` carries values JSON.stringify cannot serialize (circular references, BigInt) — the json format serializes the result payload, and the tone footer serializes `opts.tone.tone_evidence`.
 
 
 | Param | Type | Default | Description |
@@ -1079,10 +1036,6 @@ Validate that a model-emitted score table used configured category weights.
 
 **Kind**: global function
 **Returns**: <code>Array.&lt;string&gt;</code> - Human-readable warnings for missing, mismatched, or unexpected categories.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1100,10 +1053,6 @@ Remove SELF_AUDIT blocks and unwrap the BODY block from rewrite output.
 
 **Kind**: global function
 **Returns**: <code>string</code> - Clean user-facing body text.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1115,6 +1064,29 @@ Remove SELF_AUDIT blocks and unwrap the BODY block from rewrite output.
 ```js
 const clean = stripSelfAudit('[BODY]Hello[/BODY]\n[SELF_AUDIT]ok[/SELF_AUDIT]');
 ```
+<a name="extractOverallScore"></a>
+
+## extractOverallScore(result, text, options) ⇒ <code>number</code> \| <code>null</code>
+Shared overall-score traversal: structured result field → embedded JSON →
+markdown score table → inline "overall: N" text. Used by extractOverall
+above and by the CLI score gate (src/cli/score-gate.js). The two call sites
+intentionally keep different numeric coercers (toFiniteNumber here strips
+non-numeric characters before Number(); the score gate's toFiniteScore
+rejects anything that is not already a plain number), so the coercer is a
+parameter rather than shared.
+
+**Kind**: global function
+**Returns**: <code>number</code> \| <code>null</code> - Extracted overall score, or null when none is found.
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| result | <code>string</code> \| <code>object</code> \| <code>null</code> |  | Structured result whose `overall` field is checked first. |
+| text | <code>string</code> |  | Raw output text scanned for embedded JSON, a score table, or inline "overall: N". |
+| options | <code>object</code> |  | Extraction options (required). |
+| options.coerce | <code>function</code> |  | Numeric coercer applied to candidate values. |
+| [options.parseResultFallback] | <code>boolean</code> | <code>false</code> | When the text yields no JSON, also try parsing `result` itself if it is a string (output.js JSON formatter behavior). |
+| [options.pipeBoundary] | <code>boolean</code> | <code>false</code> | Accept a `|` table-cell boundary before "overall" in the inline-text regex (score-gate behavior). |
+
 <a name="parseFirstJson"></a>
 
 ## parseFirstJson(text) ⇒ <code>object</code> \| <code>null</code>
@@ -1190,7 +1162,7 @@ Build the LLM prompt for rewrite, diff, audit, score, or ouroboros mode.
 **Returns**: <code>string</code> - Complete prompt text.
 **Throws**:
 
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
+- <code>TypeError</code> When `options.tone.tone_evidence` contains values JSON.stringify cannot serialize (circular references, BigInt).
 
 
 | Param | Type | Default | Description |
@@ -1224,10 +1196,6 @@ single prompt can never carry two contradictory contracts (issue #397).
 
 **Kind**: global function
 **Returns**: <code>string</code> - Scoring-math instruction block without an output contract.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -1247,10 +1215,6 @@ Classify whether text should use the short-text scoring boost.
 
 **Kind**: global function
 **Returns**: <code>boolean</code> - True when text is <=200 non-whitespace chars or <=3 paragraphs.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1287,10 +1251,6 @@ Resolve effective API key, base URL, and model from explicit values, provider, a
 
 **Kind**: global function
 **Returns**: <code>Object</code> - Resolved provider config.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1344,10 +1304,6 @@ Compute deterministic stylometry/lexicon AI-likeness signals.
 
 **Kind**: global function
 **Returns**: <code>object</code> \| <code>null</code> - Deterministic score payload, skipped payload, or null when disabled.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -1369,10 +1325,6 @@ Merge an LLM score payload with deterministic shadow-score reconciliation.
 
 **Kind**: global function
 **Returns**: <code>object</code> - Score payload preserving llmScore and deterministicScore details.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -1393,10 +1345,6 @@ Reconcile LLM and deterministic overall scores according to config thresholds.
 
 **Kind**: global function
 **Returns**: <code>Object</code> - Reconciled score and preference source.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -1449,10 +1397,6 @@ Convert a numeric AI-likeness score to a human-readable band.
 
 **Kind**: global function
 **Returns**: <code>string</code> - Interpretation band.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1469,10 +1413,6 @@ Score rewritten length ratio on the 0-3 fidelity scale.
 
 **Kind**: global function
 **Returns**: <code>number</code> - Length-ratio points from 0 to 3.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1522,10 +1462,6 @@ Clamp and round a value into the inclusive 0-3 scoring range.
 
 **Kind**: global function
 **Returns**: <code>number</code> - Integer from 0 to 3.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1542,10 +1478,6 @@ Combine AI-likeness, inverted fidelity, and optional deterministic score.
 
 **Kind**: global function
 **Returns**: <code>number</code> - Combined score, lower is better.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1586,10 +1518,6 @@ Check whether a hostname is localhost or loopback.
 
 **Kind**: global function
 **Returns**: <code>boolean</code> - True for localhost, 127/8, or ::1.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1606,10 +1534,6 @@ Detect literal private, reserved, link-local, metadata, or multicast IP hosts.
 
 **Kind**: global function
 **Returns**: <code>boolean</code> - True when the literal IP is private or special-use.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1648,10 +1572,6 @@ Read CLI/env opt-in for non-loopback HTTP base URLs.
 
 **Kind**: global function
 **Returns**: <code>boolean</code> - True when insecure base URLs are explicitly allowed.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1667,10 +1587,6 @@ const allowed = shouldAllowInsecureBaseURL({ allowInsecureBaseURL: true });
 Persist CLI insecure-base-url opt-in into process.env for downstream calls.
 
 **Kind**: global function
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1687,10 +1603,6 @@ Read CLI/env opt-in for private or reserved literal IP base URLs.
 
 **Kind**: global function
 **Returns**: <code>boolean</code> - True when private base URLs are explicitly allowed.
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1706,10 +1618,6 @@ const allowed = shouldAllowPrivateBaseURL({ allowPrivateBaseURL: true });
 Persist CLI private-base-url opt-in into process.env for downstream calls.
 
 **Kind**: global function
-**Throws**:
-
-- <code>Error</code> Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
-
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/docs/research/ai-human-metrics.md
+++ b/docs/research/ai-human-metrics.md
@@ -43,12 +43,12 @@ paragraph is SUSPECT iff
 
 현재 공개 benchmark 스냅샷은 ko/en/zh/ja fixture 39개 기준 전체 accuracy 1.0이다. 다만 이 corpus는 작고 설계된 synthetic/curated fixture이므로, 일반화 성능 증거로 과신하면 안 된다.
 
-### 2.1 단기 benchmark 한계와 rebaseline 계획 (#155/#162)
+### 2.1 단기 benchmark 한계와 rebaseline 계획 (#155/#162, 둘 다 close됨)
 
 현재 체크인된 deterministic report는 회귀 테스트로는 유용하지만, 공개 성능 주장으로 쓰기에는 아직 좁다.
 
 - 표본 수: ko/en/zh/ja suspect-zone fixture 39개. 언어·장르·출처별 신뢰구간을 낼 만큼 크지 않다.
-- 모델 시대성: 2025+ GPT/Claude/Gemini/Llama/Qwen 계열 생성문 rebaseline은 아직 별도 follow-up이다.
+- 모델 시대성: 2025+ GPT/Claude/Gemini/Llama/Qwen 계열 생성문 rebaseline의 실행 프로토콜은 [2025+ Re-baseline Plan](2025-rebaseline-plan.md)이 추적하고, evaluator follow-up은 #158/#159다.
 - 통계 보고: `docs/benchmarks/latest.md`는 fixture 수, lang/class sample size, Wilson 95% CI와 `signal_score` 기반 ROC-AUC / PR-AUC / best-F1 threshold 진단을 공개한다. bootstrap interval은 아직 없다.
 - 범위: 현재 수치는 stylometry/lexicon hot 판정 회귀이며, rewrite 품질·MPS·fidelity의 live 품질 점수가 아니다.
 

--- a/src/api.js
+++ b/src/api.js
@@ -90,7 +90,6 @@ function sleepWithSignal(sleep, ms, signal) {
  *
  * @param {Error|Object} err Error thrown by fetch or {@link HttpError}.
  * @returns {boolean} True for retryable HTTP statuses, aborts, and common network failures.
- * @throws {Error} Does not intentionally throw; unexpected Error-like inputs may still propagate JavaScript runtime failures.
  * @example
  * const retry = isRetryable(new HttpError(429, 'rate limit', '1'));
  */
@@ -115,7 +114,6 @@ export function isRetryable(err) {
  * @param {Function} [opts.now] Clock returning epoch milliseconds.
  * @param {Function} [opts.random] Random number provider used for jitter.
  * @returns {number} Delay in milliseconds, capped at opts.max.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const delay = computeBackoffMs(1, '2'); // 2000
  */

--- a/src/auth.js
+++ b/src/auth.js
@@ -39,7 +39,6 @@ export const DEFAULT_HTTP_KEY_ENV_VARS = [
  *
  * @param {string} [providerApiKeyEnv] Provider-specific key env var, such as GEMINI_API_KEY.
  * @returns {string[]} Unique env var names in lookup order.
- * @throws {Error} Does not intentionally throw; invalid non-string env names can still propagate JavaScript runtime failures.
  * @example
  * const vars = providerHttpKeyEnvVars('GEMINI_API_KEY');
  */
@@ -56,7 +55,6 @@ export function providerHttpKeyEnvVars(providerApiKeyEnv) {
  * @param {Function} [options.readFile] File reader for PATINA_API_KEY_FILE.
  * @param {string[]} [options.envVars=DEFAULT_HTTP_KEY_ENV_VARS] Env vars to check.
  * @returns {{ok: boolean, source: string|null, envVars: string[], filePath: string|null, detail: string}} Source diagnostics.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const source = inspectHttpApiKeySource({ env: { PATINA_API_KEY: 'sk-...' } });
  */

--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -65,6 +65,10 @@ export function resolveBackendMaxRetries(backendName, override) {
   return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0;
 }
 
+export function formatLimit(value) {
+  return Number.isFinite(value) ? String(value) : 'unbounded';
+}
+
 export function isRetryableBackendError(err, { attemptIndex = 0, signal } = {}) {
   if (signal?.aborted) return false;
   const status = extractStatus(err);

--- a/src/cli/batch.js
+++ b/src/cli/batch.js
@@ -1,5 +1,6 @@
 import {
   PROMPT_SIZE_WARNING_CHARS,
+  formatLimit,
   getBackendSafety,
   resolveBackendMaxConcurrency,
   resolveBackendMaxRetries,
@@ -132,10 +133,6 @@ function classifyRetryableStorm(err) {
   if (exit) return `exit ${exit[1]}`;
   if (/no final response body|empty response|final-message-only/i.test(message)) return 'empty response';
   return null;
-}
-
-export function formatLimit(value) {
-  return Number.isFinite(value) ? String(value) : 'unbounded';
 }
 
 export async function writeBatchOutput(parsed, inputPath, output) {

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -348,8 +348,7 @@ function cancellationError() {
  * @param {NodeJS.Process} [options.processObj=process] Process-like object used for signal listeners.
  * @param {NodeJS.WritableStream} [options.stderr=process.stderr] Stream for fallback cancel messages.
  * @param {object|null} [options.logger] Optional patina logger.
- * @returns {{signal: AbortSignal, install: Function, uninstall: Function, throwIfCanceled: Function}} Controller facade.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
+ * @returns {{signal: AbortSignal, install: Function, cleanup: Function, throwIfCanceled: Function}} Controller facade.
  * @example
  * const cancellation = createCancellationController();
  * cancellation.install();
@@ -428,7 +427,6 @@ export function resolvePromptMode({ backend, model }) {
  * @param {string} lang Active language code.
  * @param {object} [logger] Logger with warn(event, payload).
  * @returns {string} Effective profile name.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * resolveProfileForLanguage('namuwiki', 'en') // 'default'
  */

--- a/src/cli/score-gate.js
+++ b/src/cli/score-gate.js
@@ -1,4 +1,4 @@
-import { parseFirstJson } from '../output.js';
+import { extractOverallScore } from '../output.js';
 import { createLogger } from '../logger.js';
 
 export function applyScoreGate(result, output, gate, logger = createLogger()) {
@@ -13,20 +13,10 @@ export function applyScoreGate(result, output, gate, logger = createLogger()) {
 }
 
 export function extractScoreOverall(result, output) {
-  const resultOverall = toFiniteScore(result?.overall);
-  if (resultOverall !== null) return resultOverall;
-
-  const text = String(output ?? result ?? '');
-  const parsed = parseFirstJson(text);
-  const parsedOverall = toFiniteScore(parsed?.overall);
-  if (parsedOverall !== null) return parsedOverall;
-
-  const table = text.match(/(?:^|\n)\|\s*(?:\*\*)?Overall(?:\*\*)?\s*\|[^|]*\|[^|]*\|[^|]*\|\s*(?:\*\*)?([0-9]+(?:\.[0-9]+)?)/i);
-  if (table) return Number(table[1]);
-
-  const match = text.match(/(?:^|[\s|{,"])overall(?:["\s]*[:|]|\s+score\s*[:|]?)\s*(\d+(?:\.\d+)?)/i);
-  if (!match) return null;
-  return Number(match[1]);
+  return extractOverallScore(result, String(output ?? result ?? ''), {
+    coerce: toFiniteScore,
+    pipeBoundary: true,
+  });
 }
 
 // Not the same as output.js toFiniteNumber: that helper strips non-numeric

--- a/src/commands/auth.js
+++ b/src/commands/auth.js
@@ -4,7 +4,7 @@
 import { createInterface } from 'node:readline/promises';
 import { listBackends, listBackendNames, resolveBackend } from '../backends/index.js';
 import { inputError, runtimeError } from '../errors.js';
-import { formatLimit } from '../cli/batch.js';
+import { formatLimit } from '../backends/contract.js';
 
 export function printBackendStatus() {
   const list = listBackends();

--- a/src/config.js
+++ b/src/config.js
@@ -85,7 +85,6 @@ function deepMerge(target, source) {
  * Return the repository root inferred from this source file location.
  *
  * @returns {string} Absolute repository root path.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const root = getRepoRoot();
  */

--- a/src/errors.js
+++ b/src/errors.js
@@ -27,7 +27,6 @@ export class PatinaCliError extends Error {
  * @param {string} why Explanation of the invalid input.
  * @param {string} action Suggested user action.
  * @returns {PatinaCliError} Structured input error.
- * @throws {Error} Does not intentionally throw; returns an Error instance for callers to throw.
  * @example
  * throw inputError('missing input', 'No file was provided.', 'Pass a file path.');
  */
@@ -42,7 +41,6 @@ export function inputError(what, why, action) {
  * @param {string} why Explanation of the runtime failure.
  * @param {string} action Suggested user action.
  * @returns {PatinaCliError} Structured runtime error.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * throw runtimeError('provider failed', 'The API timed out.', 'Retry later.');
  */
@@ -55,7 +53,6 @@ export function runtimeError(what, why, action) {
  *
  * @param {unknown} err Error-like value to render.
  * @returns {string} Multi-line user-facing error text.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const message = renderCliError(inputError('bad flag', 'Unknown flag.', 'Run --help.'));
  */
@@ -74,7 +71,6 @@ export function renderCliError(err) {
  * @param {unknown} err Error-like value.
  * @param {number} [fallback=1] Exit code used when err.exitCode is absent or invalid.
  * @returns {number} Non-negative integer exit code.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const code = getExitCode(inputError('bad', 'why', 'fix')); // 2
  */

--- a/src/loader.js
+++ b/src/loader.js
@@ -170,7 +170,6 @@ const TONE_BACKBONE = {
  *
  * @param {string} tone Tone name.
  * @returns {string|null} Profile name, or null when no mapping exists.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const profile = toneToBackboneProfile('casual'); // blog
  */

--- a/src/logger.js
+++ b/src/logger.js
@@ -14,7 +14,6 @@ const LEVELS = {
  * @param {boolean} [options.quiet=false] Suppress all log output.
  * @param {NodeJS.WritableStream} [options.stream=process.stderr] Progress stream.
  * @returns {{debug: Function, info: Function, warn: Function, error: Function, progress: Function, closeProgress: Function, child: Function}} Logger facade.
- * @throws {Error} Propagates stream write errors from the configured output stream.
  * @example
  * const logger = createLogger();
  * logger.info('event', { message: 'ready' });

--- a/src/output.js
+++ b/src/output.js
@@ -16,7 +16,7 @@ import { TRANSLATIONESE_RULES } from './features/translationese.js';
  * @param {object} [opts.stdout] Stdout-like stream for color decisions.
  * @param {string} [opts.auditBackstop] Deterministic audit-mode section to append before the tone footer.
  * @returns {string} User-facing formatted output.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
+ * @throws {TypeError} When `result` or `opts.tone` carries values JSON.stringify cannot serialize (circular references, BigInt) — the json format serializes the result payload, and the tone footer serializes `opts.tone.tone_evidence`.
  * @example
  * const output = formatOutput('[BODY]Hi[/BODY]', 'rewrite');
  */
@@ -103,7 +103,6 @@ function shouldColorDiff({ parsed = {}, env = process.env, stdout = process.stdo
  * @param {string} output Score-mode markdown output.
  * @param {object} configWeights Expected category weight map.
  * @returns {string[]} Human-readable warnings for missing, mismatched, or unexpected categories.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const warnings = validateScoreWeights('| content | 0.4 | 1 | 10 | 4 |', { content: 0.4 });
  */
@@ -220,7 +219,6 @@ function normalizeCategoryName(raw) {
  * @param {object} [options] Strip options.
  * @param {object} [options.logger] Logger for malformed output warnings.
  * @returns {string} Clean user-facing body text.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const clean = stripSelfAudit('[BODY]Hello[/BODY]\n[SELF_AUDIT]ok[/SELF_AUDIT]');
  */
@@ -334,14 +332,49 @@ function buildGateResult(overall, gate) {
 }
 
 function extractOverall(result, body) {
-  const direct = toFiniteNumber(result?.overall);
+  return extractOverallScore(result, body, {
+    coerce: toFiniteNumber,
+    parseResultFallback: true,
+  });
+}
+
+/**
+ * Shared overall-score traversal: structured result field → embedded JSON →
+ * markdown score table → inline "overall: N" text. Used by extractOverall
+ * above and by the CLI score gate (src/cli/score-gate.js). The two call sites
+ * intentionally keep different numeric coercers (toFiniteNumber here strips
+ * non-numeric characters before Number(); the score gate's toFiniteScore
+ * rejects anything that is not already a plain number), so the coercer is a
+ * parameter rather than shared.
+ *
+ * @param {string|object|null} result Structured result whose `overall` field is checked first.
+ * @param {string} text Raw output text scanned for embedded JSON, a score table, or inline "overall: N".
+ * @param {object} options Extraction options (required).
+ * @param {function(*): (number|null)} options.coerce Numeric coercer applied to candidate values.
+ * @param {boolean} [options.parseResultFallback=false] When the text yields no JSON, also try parsing `result` itself if it is a string (output.js JSON formatter behavior).
+ * @param {boolean} [options.pipeBoundary=false] Accept a `|` table-cell boundary before "overall" in the inline-text regex (score-gate behavior).
+ * @returns {number|null} Extracted overall score, or null when none is found.
+ */
+export function extractOverallScore(result, text, {
+  coerce,
+  parseResultFallback = false,
+  pipeBoundary = false,
+}) {
+  const direct = coerce(result?.overall);
   if (direct !== null) return direct;
-  const parsed = parseFirstJson(body) || (typeof result === 'string' ? parseFirstJson(result) : null);
-  const parsedOverall = toFiniteNumber(parsed?.overall);
+
+  const str = String(text ?? '');
+  const parsed = parseFirstJson(str)
+    || (parseResultFallback && typeof result === 'string' ? parseFirstJson(result) : null);
+  const parsedOverall = coerce(parsed?.overall);
   if (parsedOverall !== null) return parsedOverall;
-  const overallFromTable = String(body || '').match(/(?:^|\n)\|\s*(?:\*\*)?Overall(?:\*\*)?\s*\|[^|]*\|[^|]*\|[^|]*\|\s*(?:\*\*)?([0-9]+(?:\.[0-9]+)?)/i);
+
+  const overallFromTable = str.match(/(?:^|\n)\|\s*(?:\*\*)?Overall(?:\*\*)?\s*\|[^|]*\|[^|]*\|[^|]*\|\s*(?:\*\*)?([0-9]+(?:\.[0-9]+)?)/i);
   if (overallFromTable) return Number(overallFromTable[1]);
-  const overallFromText = String(body || '').match(/(?:^|[\s{,"])overall(?:["\s]*[:|]|\s+score\s*[:|]?)\s*(\d+(?:\.\d+)?)/i);
+
+  const overallFromText = str.match(pipeBoundary
+    ? /(?:^|[\s|{,"])overall(?:["\s]*[:|]|\s+score\s*[:|]?)\s*(\d+(?:\.\d+)?)/i
+    : /(?:^|[\s{,"])overall(?:["\s]*[:|]|\s+score\s*[:|]?)\s*(\d+(?:\.\d+)?)/i);
   return overallFromText ? Number(overallFromText[1]) : null;
 }
 

--- a/src/prompt-builder.js
+++ b/src/prompt-builder.js
@@ -75,7 +75,7 @@ function buildSeverityOverrideNote(config) {
  * @param {string} [options.mode=rewrite] Output mode.
  * @param {object|null} [options.tone=null] Tone resolution metadata.
  * @returns {string} Complete prompt text.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
+ * @throws {TypeError} When `options.tone.tone_evidence` contains values JSON.stringify cannot serialize (circular references, BigInt).
  * @example
  * const prompt = buildPrompt({ config, patterns, profile, voice, scoring, text: 'Draft' });
  */
@@ -364,7 +364,6 @@ function buildAuditInstructions() {
  * @param {string} [text=''] Input text (drives the short-text boost).
  * @param {object[]} [patterns=[]] Loaded pattern packs.
  * @returns {string} Scoring-math instruction block without an output contract.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const core = buildScoreMathCore(config, 'ko', 'Draft', patterns);
  */
@@ -482,7 +481,6 @@ function buildPatternCatalogDigest(patterns = []) {
  *
  * @param {string} text Text to inspect.
  * @returns {boolean} True when text is <=200 non-whitespace chars or <=3 paragraphs.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const short = isShortText('A short note.');
  */

--- a/src/providers.js
+++ b/src/providers.js
@@ -95,7 +95,6 @@ export function selectProvider(name) {
  * @param {string} [options.baseURL] Explicit base URL.
  * @param {string} [options.model] Explicit model id.
  * @returns {{apiKey: string|null, baseURL: string, model: string, apiKeySource: string|null, baseURLSource: string|null, modelSource: string|null}} Resolved provider config.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const resolved = resolveProviderConfig({ provider: selectProvider('openai') });
  */

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -251,7 +251,6 @@ function buildContractExampleCategoryRow(patterns, config) {
  * @param {object} [options.logger] Optional logger for recoverable deterministic warnings.
  * @param {Function} [options.analyzer] Analyzer implementation.
  * @returns {object|null} Deterministic score payload, skipped payload, or null when disabled.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const deterministic = scoreDeterministicSignals({ text: 'Draft', config });
  */
@@ -388,7 +387,6 @@ export function scoreDeterministicSignals({
  * @param {object} [options.config={}] Effective config.
  * @param {object} [options.logger] Logger for reconciliation warnings.
  * @returns {object} Score payload preserving llmScore and deterministicScore details.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const score = withShadowScore({ overall: 20 }, { deterministicScore: { overall: 25 } });
  */
@@ -427,7 +425,6 @@ export function withShadowScore(parsed, { deterministicScore, config = {}, logge
  * @param {object} [options.config={}] Effective config.
  * @param {object} [options.logger] Logger for warnings.
  * @returns {{overall: number|null, scorePreference: (object|null)}} Reconciled score and preference source.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const result = reconcileScoreOverall({ llmOverall: 20, deterministicScore: { overall: 60 } });
  */
@@ -561,7 +558,6 @@ ${rewritten}
  *
  * @param {number} score AI-likeness score from 0 to 100.
  * @returns {string} Interpretation band.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const label = interpretScore(28); // mostly human
  */
@@ -580,7 +576,6 @@ export function interpretScore(score) {
  * @param {string} original Original text.
  * @param {string} rewritten Rewritten text.
  * @returns {number} Length-ratio points from 0 to 3.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const points = lengthRatioPoints('abcd', 'abcde');
  */
@@ -708,7 +703,6 @@ ${rewritten}
  *
  * @param {number|string} v Value to clamp.
  * @returns {number} Integer from 0 to 3.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const value = clamp03(4.2); // 3
  */
@@ -736,7 +730,6 @@ function rethrowIfAborted(err, signal) {
  * @param {object} [options.config] Effective config.
  * @param {number|object|null} [options.deterministicScore] Optional deterministic score.
  * @returns {number} Combined score, lower is better.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const score = combinedScore({ aiLikeness: 20, fidelity: 90, profile: 'default', config: {} });
  */

--- a/src/security.js
+++ b/src/security.js
@@ -32,7 +32,6 @@ export function validateProfileName(name) {
  *
  * @param {string} hostname Hostname from a URL.
  * @returns {boolean} True for localhost, 127/8, or ::1.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const local = isLoopbackHost('127.0.0.1');
  */
@@ -54,7 +53,6 @@ export function isLoopbackHost(hostname) {
  *
  * @param {string} hostname Hostname or bracketed IPv6 literal.
  * @returns {boolean} True when the literal IP is private or special-use.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const blocked = isPrivateOrSpecialIP('169.254.169.254');
  */
@@ -152,7 +150,6 @@ export function validateBaseURL(baseURL, { allowInsecure = false, allowPrivate =
  *
  * @param {object} [parsed] Parsed CLI options.
  * @returns {boolean} True when insecure base URLs are explicitly allowed.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const allowed = shouldAllowInsecureBaseURL({ allowInsecureBaseURL: true });
  */
@@ -167,7 +164,6 @@ export function shouldAllowInsecureBaseURL(parsed) {
  *
  * @param {object} [parsed] Parsed CLI options.
  * @returns {void}
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * applyInsecureBaseURLOptIn({ allowInsecureBaseURL: true });
  */
@@ -182,7 +178,6 @@ export function applyInsecureBaseURLOptIn(parsed) {
  *
  * @param {object} [parsed] Parsed CLI options.
  * @returns {boolean} True when private base URLs are explicitly allowed.
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * const allowed = shouldAllowPrivateBaseURL({ allowPrivateBaseURL: true });
  */
@@ -197,7 +192,6 @@ export function shouldAllowPrivateBaseURL(parsed) {
  *
  * @param {object} [parsed] Parsed CLI options.
  * @returns {void}
- * @throws {Error} Propagates validation, filesystem, network, or dependency failures when the underlying operation cannot complete.
  * @example
  * applyPrivateBaseURLOptIn({ allowPrivateBaseURL: true });
  */

--- a/tests/quality/README.md
+++ b/tests/quality/README.md
@@ -197,7 +197,7 @@ sample can become a public fixture.
 
 - LLM-based scoring (`src/scoring.js`). The LLM is non-deterministic by
   design and adds API cost / latency, so it stays out of this layer.
-  A separate live-mode benchmark would be its own follow-up.
+  A separate live-mode benchmark is its own follow-up (#412).
 - Mandatory rewrite quality gates. Live rewrite quality lives in
   `tests/quality/live-quality.mjs` and remains opt-in because it can shell out
   to OpenCode:

--- a/tests/unit/score-overall-coercion.test.js
+++ b/tests/unit/score-overall-coercion.test.js
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { extractScoreOverall } from '../../src/cli/score-gate.js';
+import { formatOutput } from '../../src/output.js';
+
+// Pins the intentional divergence between the two numeric coercers behind the
+// shared overall-score traversal (src/output.js extractOverallScore):
+// - score-gate toFiniteScore: plain Number() — rejects anything that is not
+//   already a plain number, but accepts exponent notation.
+// - output.js toFiniteNumber: strips non-numeric characters before Number()
+//   (so "**12**" or "12px" parse), which mangles exponent notation.
+// These must NOT be merged; see the comment in src/cli/score-gate.js.
+
+function jsonOverall(overall) {
+  const out = formatOutput({ raw: '', overall }, 'score', { format: 'json' });
+  return JSON.parse(out).overall;
+}
+
+test('coercer divergence: "1e3" → 1000 via score gate, 13 via JSON output', () => {
+  assert.equal(extractScoreOverall({ overall: '1e3' }, ''), 1000);
+  assert.equal(jsonOverall('1e3'), 13);
+});
+
+test('coercer divergence: "12px" → null via score gate, 12 via JSON output', () => {
+  assert.equal(extractScoreOverall({ overall: '12px' }, ''), null);
+  assert.equal(jsonOverall('12px'), 12);
+});
+
+test('coercers agree on plain numbers', () => {
+  assert.equal(extractScoreOverall({ overall: 21 }, ''), 21);
+  assert.equal(jsonOverall(21), 21);
+  assert.equal(extractScoreOverall({ overall: '21.5' }, ''), 21.5);
+  assert.equal(jsonOverall('21.5'), 21.5);
+});


### PR DESCRIPTION
## Summary

Items 2, 3, 5 of #411 plus doc hygiene. Zero behavior change.

- **formatLimit** moved byte-identical from `src/cli/batch.js` to `src/backends/contract.js` (next to the concurrency/retry resolvers); `src/commands/auth.js` and `batch.js` import from there — the last cross-extraction import from #409 is gone.
- **Overall-score extractor dedupe**: shared walker `extractOverallScore(result, text, {coerce, parseResultFallback, pipeBoundary})` in `src/output.js`; `extractOverall` (output.js) and `extractScoreOverall` (score-gate.js) are now thin wrappers. The coercers stay unmerged per the recorded semantics difference (`'1e3'` → 1000 via gate vs 13 via output; `'12px'` → null vs 12) — now pinned by `tests/unit/score-overall-coercion.test.js` (+3 tests).
- **@throws sweep**: 33 boilerplate `@throws` doclets removed after reading each function body; 23 genuine ones kept; 2 accurate ones added (`formatOutput`/`buildPrompt` can throw `TypeError` via `JSON.stringify` on circular/BigInt input); `createCancellationController` `@returns` fixed (`uninstall` → `cleanup`). `docs/API.md` regenerated; `extractOverallScore` documented.
- **Doc hygiene**: `tests/quality/README.md` now links the live-mode benchmark follow-up to #412; `docs/research/ai-human-metrics.md` §2.1 updated for closed #155/#162, pointing to `docs/research/2025-rebaseline-plan.md` and open evaluator follow-ups #158/#159.

## Review

Two independent passes: a 3-lens adversarial review (coercion semantics / JSDoc accuracy / docs & policy), then a clean-room re-review that differential-fuzzed the extractors against main across 1,323 adversarial input pairs — **0 mismatches** — and read all 31 removed-doclet bodies. 0 blockers; both minors fixed in this PR. Known nit (accepted): `extractScoreOverall` now stringifies its text argument eagerly rather than after the direct-field check; divergent only for a throwing custom `toString` alongside a finite `result.overall`, unreachable from both real call sites.

## Verification

- `npm test`: 568/568 pass (565 baseline + 3 new pin tests)
- `npm run lint`: all four stages clean

Part of #411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)