### PR TITLE
fix(cli): always print browser diff page path to stderr

### DIFF
--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -300,10 +300,12 @@ export async function runDefault(parsed, logger) {
         } else {
           console.log(output);
           if (browserPagePath) {
+            // Always surface the path: a headless opener can exit 0 without
+            // showing anything, leaving the user with no way to find the page.
+            console.error(`[patina] Browser diff page saved at ${browserPagePath}`);
             try {
               await openBrowserDiffPage(browserPagePath);
             } catch (err) {
-              console.error(`[patina] Browser diff page saved at ${browserPagePath}`);
               console.error(`[patina] Browser open failed: ${err.message}`);
             }
           }

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -349,7 +349,9 @@ describe('CLI End-to-End with Mock API', () => {
       ]));
 
       assert.strictEqual(browserRun.logs.join('\n'), baseline.logs.join('\n'));
-      assert.deepStrictEqual(browserRun.errors, []);
+      assert.deepStrictEqual(browserRun.errors, [
+        '[patina] Browser diff page saved at /tmp/patina-browser-diff-123/browser-diff-123.html',
+      ]);
       assert.strictEqual(mock.callCount, 2);
       assert.strictEqual(mock.requestBodies.length, 2);
       assert.strictEqual(spawns[0].command, 'xdg-open');


### PR DESCRIPTION
## Problem

On headless servers (SSH, no DISPLAY), `xdg-open` can exit 0 without showing anything. Since the saved-at message was only printed when the opener **failed**, the user had no way to find the generated diff page.

Found while testing `--browser` on a headless box: the rewrite succeeded, the HTML artifact was written to a 0700 tmpdir, but stdout/stderr never mentioned where.

## Fix

Print `[patina] Browser diff page saved at <path>` to stderr unconditionally before attempting to open. On open failure, only the failure line is added. stdout stays pure (pipe-safe) — verified by the existing `keeps stdout pure` e2e test.

## Tests

- Updated the `--browser` success-path e2e test to assert stderr contains exactly the saved-at line.
- Full suite 568/568 pass, lint clean.
- Manually verified on a headless server: stderr now shows the path, stdout unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)