### PR TITLE
feat(cli): add --serve for viewing the browser diff page on headless machines

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -70,10 +70,24 @@ Contract:
 - Rejects stdin, multiple files, `--batch`, URL-like input, and non-rewrite modes such as `--diff`, `--audit`, `--score`, and `--ouroboros`.
 - Preserves the normal rewrite stdout output byte-for-byte for the selected `--format`.
 - Generates a self-contained local HTML page under an OS temp directory and attempts to open it in the default browser.
-- Browser-open fallback reports the saved HTML path on stderr; it never appends the path to stdout.
+- The saved HTML path is always reported on stderr (a headless opener can exit 0 without showing anything); it never appends the path to stdout.
 - The page shows side-by-side before/after text, conservative changed-block highlights, deterministic before/after score summaries, and Pattern/Removed/Added/Why explanation from a best-effort secondary diff call.
 - `--browser` makes one additional diff-explanation model/backend call after the primary rewrite, so it can add latency and consume extra backend quota.
 - If the secondary diff explanation call fails, the rewrite still succeeds and the page shows a failure notice in the explanation area.
+
+### Headless servers: `--serve`
+
+On a machine with no display (SSH, containers), add `--serve` to serve the diff page over HTTP instead of opening a window:
+
+```bash
+patina --browser --serve draft.md
+```
+
+Contract:
+- Requires `--browser`; replaces the window opener (nothing is spawned).
+- Binds `127.0.0.1` on a random port and serves only `GET`/`HEAD` of one unguessable token URL (`http://127.0.0.1:<port>/<token>/`); everything else is 404. Responses send `nosniff`, `no-referrer`, and `no-store` headers, and the page keeps its restrictive CSP.
+- Prints the URL on stderr. From a remote shell, forward it with `ssh -L <port>:127.0.0.1:<port> <host>`; VS Code/Cursor remote terminals forward localhost URLs automatically.
+- Keeps running until 10 minutes pass with no request, then stops on its own; Ctrl-C stops it immediately. The saved HTML file remains either way.
 
 
 ## Backend fallback chains

--- a/src/browser-diff.js
+++ b/src/browser-diff.js
@@ -2,10 +2,13 @@ import { mkdtempSync, writeFileSync, chmodSync } from 'node:fs';
 import { tmpdir as osTmpdir } from 'node:os';
 import { join, resolve as resolvePath } from 'node:path';
 import { spawn as spawnChild } from 'node:child_process';
+import { createServer as createHttpServer } from 'node:http';
+import { randomBytes } from 'node:crypto';
 
 const DEFAULT_CSP = "default-src 'none'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'";
 let testRuntimeOverrides = {};
 const MAX_LCS_MATRIX_CELLS = 20000;
+export const DEFAULT_SERVE_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 
 export function buildBrowserDiffPromptInput(original, rewritten) {
   return [
@@ -224,6 +227,82 @@ export function openBrowserDiffPage(path, options = {}) {
       reject(new Error(`browser opener exited with code ${code}`));
     });
   });
+}
+
+export function serveBrowserDiffPage(html, options = {}) {
+  const createServer = getRuntimeValue(options, 'createServer', createHttpServer);
+  const randomToken = getRuntimeValue(options, 'randomToken', defaultRandomToken);
+  const idleTimeoutMs = getRuntimeValue(options, 'idleTimeoutMs', DEFAULT_SERVE_IDLE_TIMEOUT_MS);
+  const signal = options.signal;
+  const token = randomToken();
+  const pagePath = `/${token}/`;
+
+  return new Promise((resolveServer, rejectServer) => {
+    let idleTimer = null;
+    let closed = false;
+    let resolveDone;
+    const done = new Promise((resolve) => {
+      resolveDone = resolve;
+    });
+
+    const server = createServer((req, res) => {
+      resetIdleTimer();
+      // Connection: close keeps shutdown deterministic on every Node 18.x —
+      // server.close() never has to wait out a browser keep-alive socket.
+      if ((req.method !== 'GET' && req.method !== 'HEAD') || req.url !== pagePath) {
+        res.writeHead(404, {
+          'Content-Type': 'text/plain; charset=utf-8',
+          'Connection': 'close',
+        });
+        res.end(req.method === 'HEAD' ? undefined : 'not found');
+        return;
+      }
+      res.writeHead(200, {
+        'Content-Type': 'text/html; charset=utf-8',
+        'X-Content-Type-Options': 'nosniff',
+        'Referrer-Policy': 'no-referrer',
+        'Cache-Control': 'no-store',
+        'Connection': 'close',
+      });
+      res.end(req.method === 'HEAD' ? undefined : html);
+    });
+
+    function close() {
+      if (closed) return;
+      closed = true;
+      if (idleTimer) clearTimeout(idleTimer);
+      signal?.removeEventListener?.('abort', close);
+      server.close(() => resolveDone());
+    }
+
+    function resetIdleTimer() {
+      if (closed) return;
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(close, idleTimeoutMs);
+    }
+
+    server.on('error', rejectServer);
+    server.listen(0, '127.0.0.1', () => {
+      // Read the address before close() — a pre-aborted signal closes the
+      // listening socket, after which server.address() returns null.
+      const { port } = server.address();
+      if (signal?.aborted) {
+        close();
+      } else {
+        signal?.addEventListener?.('abort', close, { once: true });
+        resetIdleTimer();
+      }
+      resolveServer({
+        url: `http://127.0.0.1:${port}${pagePath}`,
+        close,
+        done,
+      });
+    });
+  });
+}
+
+function defaultRandomToken() {
+  return randomBytes(16).toString('hex');
 }
 
 export function setBrowserDiffRuntimeForTests(overrides = {}) {

--- a/src/cli/args.js
+++ b/src/cli/args.js
@@ -47,6 +47,9 @@ export function parseArgs(args) {
       case '--browser':
         parsed.browser = true;
         break;
+      case '--serve':
+        parsed.serve = true;
+        break;
       case '--diff':
         parsed.diff = true;
         break;
@@ -207,6 +210,13 @@ export function validateModeExclusivity(parsed) {
 }
 
 export function validateBrowserRequest(parsed) {
+  if (parsed.serve && !parsed.browser) {
+    throw inputError(
+      '--serve requires --browser',
+      '--serve replaces the local window opener for the browser diff page.',
+      'Run `patina --browser --serve path/to/file.md`.'
+    );
+  }
   if (!parsed.browser) return;
   if (parsed.batch) {
     throw inputError(
@@ -315,6 +325,8 @@ MODES
   --exit-on <n>           With --score, exit 3 when overall score > n
   --ouroboros             Iterative self-improvement loop
   --browser               Rewrite one local file, then open a local before/after diff page (adds one diff explanation call)
+  --serve                 With --browser: serve the diff page at a token URL on 127.0.0.1
+                          instead of opening a window (headless/SSH; stops after 10 idle minutes)
 
 OUTPUT & BATCH
   --format <fmt>          Stdout format: markdown (default), text, json

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -16,6 +16,7 @@ import {
   renderBrowserDiffHtml,
   writeBrowserDiffPage,
   openBrowserDiffPage,
+  serveBrowserDiffPage,
 } from '../browser-diff.js';
 import { runOuroboros } from '../ouroboros.js';
 import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals } from '../scoring.js';
@@ -236,6 +237,7 @@ export async function runDefault(parsed, logger) {
           });
         }
         let browserPagePath = null;
+        let browserPageHtml = null;
 
         const auditBackstop =
           mode === 'audit' && (parsed.format ?? 'markdown') !== 'json' && !parsed.batch
@@ -255,7 +257,7 @@ export async function runDefault(parsed, logger) {
         }
 
         if (parsed.browser && mode === 'rewrite') {
-          ({ pagePath: browserPagePath } = await buildBrowserDiffArtifact({
+          ({ pagePath: browserPagePath, html: browserPageHtml } = await buildBrowserDiffArtifact({
             originalText: text,
             rawRewriteResult: result,
             sourcePath: path,
@@ -303,10 +305,19 @@ export async function runDefault(parsed, logger) {
             // Always surface the path: a headless opener can exit 0 without
             // showing anything, leaving the user with no way to find the page.
             console.error(`[patina] Browser diff page saved at ${browserPagePath}`);
-            try {
-              await openBrowserDiffPage(browserPagePath);
-            } catch (err) {
-              console.error(`[patina] Browser open failed: ${err.message}`);
+            if (parsed.serve) {
+              const { url, done } = await serveBrowserDiffPage(browserPageHtml, {
+                signal: cancellation.signal,
+              });
+              console.error(`[patina] Serving diff page at ${url}`);
+              console.error('[patina] Stops after 10 idle minutes; press Ctrl+C to stop now.');
+              await done;
+            } else {
+              try {
+                await openBrowserDiffPage(browserPagePath);
+              } catch (err) {
+                console.error(`[patina] Browser open failed: ${err.message}`);
+              }
             }
           }
         }
@@ -553,6 +564,7 @@ async function buildBrowserDiffArtifact({
   return {
     pagePath: writeBrowserDiffPage(html),
     rewrittenBody,
+    html,
   };
 }
 

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -485,6 +485,81 @@ describe('CLI End-to-End with Mock API', () => {
     }
   });
 
+  it('serves the diff page at a token URL with --browser --serve and stops when idle', async () => {
+    const rewriteResponse = '[BODY]\nThis is the humanized result.\n[/BODY]';
+    const diffResponse = 'Pattern: 1. Generic polish\nRemoved: old\nAdded: new\nWhy: reason';
+    const testFile = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
+
+    const spawns = [];
+    setBrowserDiffRuntimeForTests({
+      tmpdir: () => '/tmp',
+      mkdtemp: () => '/tmp/patina-browser-diff-serve',
+      writeFile: () => {},
+      chmod: () => {},
+      now: () => 999,
+      platform: 'linux',
+      spawn: makeFakeSpawn(({ command, args }) => {
+        spawns.push({ command, args });
+      }),
+      randomToken: () => 'e2etoken',
+      idleTimeoutMs: 750,
+    });
+
+    mock.callCount = 0;
+    mock.requestBodies = [];
+    const logs = [];
+    const errors = [];
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = (...args) => logs.push(args.join(' '));
+    console.error = (...args) => errors.push(args.join(' '));
+    try {
+      await mock.stop();
+      mock = await startMockServer([
+        { responseText: rewriteResponse },
+        { responseText: diffResponse },
+      ]);
+
+      const mainPromise = main([
+        '--browser',
+        '--serve',
+        '--lang', 'en',
+        '--api-key-file', mockApiKeyPath,
+        '--base-url', `http://127.0.0.1:${mock.port}`,
+        testFile,
+      ]);
+
+      const deadline = Date.now() + 5000;
+      let serveLine;
+      while (!(serveLine = errors.find((line) => line.includes('Serving diff page at')))) {
+        if (Date.now() > deadline) throw new Error('serve URL never appeared on stderr');
+        await new Promise((r) => setTimeout(r, 10));
+      }
+      const url = serveLine.match(/http:\/\/127\.0\.0\.1:\d+\/e2etoken\//)?.[0];
+      assert.ok(url, `expected token URL in: ${serveLine}`);
+
+      const page = await fetch(url);
+      assert.strictEqual(page.status, 200);
+      const body = await page.text();
+      assert.ok(body.includes('This is the humanized result.'));
+      assert.ok(body.includes('Pattern: 1. Generic polish'));
+
+      await mainPromise;
+
+      assert.deepStrictEqual(spawns, [], 'serve mode must not spawn a window opener');
+      assert.ok(errors.some((line) => line.includes('Browser diff page saved at /tmp/patina-browser-diff-serve/browser-diff-999.html')));
+      assert.ok(errors.some((line) => line.includes('Stops after 10 idle minutes')));
+      assert.ok(logs.join('\n').includes('This is the humanized result.'));
+      assert.strictEqual(mock.callCount, 2);
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+      resetBrowserDiffRuntimeForTests();
+      await mock.stop();
+      mock = await startMockServer('This is the humanized result.');
+    }
+  });
+
   it('rejects unsupported --browser inputs before any backend call', async () => {
     const first = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
     const second = first;
@@ -494,6 +569,7 @@ describe('CLI End-to-End with Mock API', () => {
       { args: ['--browser', '--batch', first], pattern: /does not support --batch/ },
       { args: ['--browser', '--diff', first], pattern: /only works in rewrite mode/ },
       { args: ['--browser', 'https://example.test'], pattern: /does not support URL input yet/ },
+      { args: ['--serve', first], pattern: /--serve requires --browser/ },
     ];
 
     for (const testCase of cases) {

--- a/tests/unit/browser-diff.test.js
+++ b/tests/unit/browser-diff.test.js
@@ -10,6 +10,7 @@ import {
   renderBrowserDiffHtml,
   writeBrowserDiffPage,
   openBrowserDiffPage,
+  serveBrowserDiffPage,
 } from '../../src/browser-diff.js';
 import { formatRewriteBodyForBrowser } from '../../src/output.js';
 
@@ -169,4 +170,67 @@ test('openBrowserDiffPage selects the platform opener and propagates close failu
     }),
     /browser opener exited with code 1/,
   );
+});
+
+test('serveBrowserDiffPage serves only the token URL on loopback with hardened headers', async () => {
+  const html = '<html><body>diff page</body></html>';
+  const { url, close, done } = await serveBrowserDiffPage(html, {
+    randomToken: () => 'tok123',
+    idleTimeoutMs: 60_000,
+  });
+  assert.match(url, /^http:\/\/127\.0\.0\.1:\d+\/tok123\/$/);
+
+  const ok = await fetch(url);
+  assert.strictEqual(ok.status, 200);
+  assert.strictEqual(ok.headers.get('content-type'), 'text/html; charset=utf-8');
+  assert.strictEqual(ok.headers.get('x-content-type-options'), 'nosniff');
+  assert.strictEqual(ok.headers.get('referrer-policy'), 'no-referrer');
+  assert.strictEqual(ok.headers.get('cache-control'), 'no-store');
+  assert.strictEqual(await ok.text(), html);
+
+  const head = await fetch(url, { method: 'HEAD' });
+  assert.strictEqual(head.status, 200);
+
+  const wrongToken = await fetch(url.replace('tok123', 'other'));
+  assert.strictEqual(wrongToken.status, 404);
+
+  const wrongMethod = await fetch(url, { method: 'POST' });
+  assert.strictEqual(wrongMethod.status, 404);
+
+  close();
+  await done;
+});
+
+test('serveBrowserDiffPage stops on its own after the idle timeout', async () => {
+  const { url, done } = await serveBrowserDiffPage('idle page', {
+    randomToken: () => 'tok',
+    idleTimeoutMs: 40,
+  });
+  await done;
+  await assert.rejects(() => fetch(url));
+});
+
+test('serveBrowserDiffPage with an already-aborted signal resolves and closes immediately', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const { url, done } = await serveBrowserDiffPage('pre-aborted', {
+    randomToken: () => 'tok',
+    idleTimeoutMs: 60_000,
+    signal: controller.signal,
+  });
+  assert.match(url, /^http:\/\/127\.0\.0\.1:\d+\/tok\/$/);
+  await done;
+  await assert.rejects(() => fetch(url));
+});
+
+test('serveBrowserDiffPage closes when the abort signal fires', async () => {
+  const controller = new AbortController();
+  const { url, done } = await serveBrowserDiffPage('abort page', {
+    randomToken: () => 'tok',
+    idleTimeoutMs: 60_000,
+    signal: controller.signal,
+  });
+  controller.abort();
+  await done;
+  await assert.rejects(() => fetch(url));
 });


### PR DESCRIPTION
## Why

`--browser` on a headless box (SSH, no DISPLAY) writes the diff page to a tmpdir but the user has no way to view it. Stacked on #417 (which makes the saved path always print); this PR adds the viewing path.

## What

`patina --browser --serve draft.md` replaces the window opener with a loopback HTTP server:

- Binds `127.0.0.1` on a random port; serves only `GET`/`HEAD` of one unguessable token URL (`/<32-hex>/`), 404 for everything else — same threat model as the existing 0600 file permissions.
- Responses send `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, `Cache-Control: no-store`, and `Connection: close` (deterministic `server.close()` on every Node 18.x, no keep-alive sockets to wait out).
- Auto-stops after 10 idle minutes (each request resets the timer); Ctrl-C stops immediately via the existing CLI cancellation signal. A signal already aborted when serving starts is handled (found by manual SIGINT testing — `server.address()` is read before close).
- URL printed on stderr; stdout stays byte-for-byte identical to a plain rewrite. With `ssh -L` or a VS Code/Cursor remote terminal (auto port-forward) the page opens in the local browser.
- `--serve` without `--browser` is rejected with a guard error, consistent with the existing `--browser` input guards.
- Zero new dependencies (`node:http`, `node:crypto`); injectable runtime values follow the existing `setBrowserDiffRuntimeForTests` pattern.

## Tests

- Unit: token-URL serving + headers, 404 on wrong token/method, idle auto-stop, `close()`, abort signal, pre-aborted signal.
- E2E: full `--browser --serve` run against the mock backend — URL appears on stderr, page fetch returns the rewritten body + explanation, no opener spawned, `main()` resolves after idle shutdown; guard case added to the rejects table.
- 573/573 pass, lint clean.
- Manually verified on a real headless server with the `claude-cli` backend: 200 on token URL, 404 on wrong token, clean SIGINT shutdown.

## Docs

`docs/CLI.md`: new "Headless servers: --serve" section; updated the stderr-path line to match #417 behavior. Help text updated. CHANGELOG intentionally untouched (handled at release time per the release flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)