### PR TITLE
feat(cli): redesign the browser diff page for reviewability

### DIFF
--- a/src/browser-diff.js
+++ b/src/browser-diff.js
@@ -44,9 +44,13 @@ export function renderChangedBlocks(original, rewritten) {
     afterBlocks.map((block) => block.text),
   );
 
+  const before = renderBlocks(beforeBlocks, leftMatched, 'before');
+  const after = renderBlocks(afterBlocks, rightMatched, 'after');
   return {
-    beforeHtml: renderBlocks(beforeBlocks, leftMatched),
-    afterHtml: renderBlocks(afterBlocks, rightMatched),
+    beforeHtml: before.html,
+    afterHtml: after.html,
+    beforeChangeCount: before.changeCount,
+    afterChangeCount: after.changeCount,
   };
 }
 
@@ -66,12 +70,30 @@ export function renderBrowserDiffHtml({
   afterScore,
   sourcePath,
 }) {
-  const { beforeHtml, afterHtml } = renderChangedBlocks(original, rewrittenBody);
-  const summary = buildScoreSummary(beforeScore, afterScore);
+  const { beforeHtml, afterHtml, afterChangeCount } = renderChangedBlocks(original, rewrittenBody);
   const escapedSourcePath = htmlEscape(sourcePath);
-  const explanationBody = diffExplanation ? htmlEscape(diffExplanation) : '';
   const failureNotice = diffError
     ? `<p class="warning">Pattern explanation unavailable: ${htmlEscape(diffError)}</p>`
+    : '';
+  const explanationHtml = diffExplanation
+    ? renderExplanationHtml(diffExplanation)
+    : '<p class="explain-empty">No pattern explanation available.</p>';
+
+  const hasChanges = afterChangeCount > 0;
+  const changeChip = hasChanges
+    ? `${afterChangeCount} change${afterChangeCount === 1 ? '' : 's'}`
+    : 'No changes';
+  const jumpNav = hasChanges
+    ? `<nav class="jump" aria-label="Jump to change">${Array.from(
+      { length: afterChangeCount },
+      (_, i) => `<a class="chip jump-chip" href="#after-change-${i + 1}">${i + 1}</a>`,
+    ).join('')}</nav>`
+    : '';
+  const toggleInput = hasChanges
+    ? '<input type="checkbox" id="changes-only" class="toggle-input">'
+    : '';
+  const toggleLabel = hasChanges
+    ? '<label class="chip switch" for="changes-only"><span class="knob"></span>Changes only</label>'
     : '';
 
   return `<!doctype html>
@@ -84,110 +106,332 @@ export function renderBrowserDiffHtml({
   <style>
     :root {
       color-scheme: dark;
-      --bg: #0b0d11;
-      --panel: #12161d;
-      --line: #293242;
-      --muted: #96a3b8;
-      --text: #edf2ff;
-      --accent: #8db4ff;
-      --mark: rgba(255, 215, 102, 0.22);
-      --warn: #ffb86b;
+      --bg: #0b0e0d;
+      --panel: #111614;
+      --line: rgba(132, 168, 152, 0.16);
+      --muted: #8da59a;
+      --text: #e9efe9;
+      --bronze: #c8956c;
+      --bronze-soft: rgba(200, 149, 108, 0.15);
+      --verdigris: #5fc4a8;
+      --verdigris-soft: rgba(95, 196, 168, 0.13);
+      --gold: #d8b66a;
+      --warn: #e8a35f;
+      --serif: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+      --sans: "Avenir Next", "Segoe UI", "Apple SD Gothic Neo", Pretendard, "Noto Sans KR", sans-serif;
+      --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
-      background: var(--bg);
       color: var(--text);
-      font: 14px/1.6 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font: 14px/1.6 var(--sans);
+      background:
+        radial-gradient(1100px 540px at 8% -10%, rgba(95, 196, 168, 0.11), transparent 62%),
+        radial-gradient(900px 520px at 100% 104%, rgba(200, 149, 108, 0.09), transparent 60%),
+        var(--bg);
+    }
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      background: repeating-linear-gradient(0deg, rgba(141, 168, 154, 0.035) 0 1px, transparent 1px 64px);
     }
     main {
-      max-width: 1440px;
+      max-width: 1280px;
       margin: 0 auto;
-      padding: 32px 20px 40px;
+      padding: 36px 24px 56px;
       display: grid;
-      gap: 20px;
+      gap: 18px;
+      position: relative;
+    }
+    main > * { animation: rise 0.55s cubic-bezier(0.22, 0.7, 0.25, 1) both; }
+    main > *:nth-child(2) { animation-delay: 0.07s; }
+    main > *:nth-child(3) { animation-delay: 0.14s; }
+    main > *:nth-child(4) { animation-delay: 0.21s; }
+    @keyframes rise {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: none; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      main > *, mark.changed-block:target { animation: none !important; }
+      .switch .knob::after { transition: none !important; }
     }
     .panel {
       border: 1px solid var(--line);
-      border-radius: 18px;
-      background: var(--panel);
-      padding: 18px;
+      border-radius: 14px;
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.016), transparent 42%), var(--panel);
       overflow: hidden;
     }
-    h1, h2, h3 { margin: 0 0 10px; }
-    .meta { color: var(--muted); margin: 0; word-break: break-all; }
-    .summary-grid, .pane-grid {
+    .masthead {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 18px;
+      justify-content: space-between;
+      align-items: flex-end;
+      padding: 4px 2px 18px;
+      border-bottom: 1px solid var(--line);
+      position: relative;
+    }
+    .masthead::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 3px;
+      height: 1px;
+      background: var(--line);
+    }
+    .eyebrow {
+      margin: 0;
+      font: 600 11px/1 var(--mono);
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      color: var(--verdigris);
+    }
+    h1 {
+      margin: 8px 0 8px;
+      font: 500 clamp(26px, 4vw, 40px)/1.1 var(--serif);
+      letter-spacing: 0.005em;
+    }
+    h1 .arrow { color: var(--verdigris); }
+    .meta {
+      margin: 0;
+      font: 11.5px/1.5 var(--mono);
+      color: var(--muted);
+      word-break: break-all;
+    }
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+      justify-content: flex-end;
+    }
+    .chip {
+      display: inline-block;
+      padding: 5px 11px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      font: 600 11px/1.2 var(--mono);
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      color: var(--muted);
+      background: rgba(17, 22, 20, 0.7);
+    }
+    .jump { display: flex; gap: 6px; flex-wrap: wrap; }
+    .jump-chip {
+      min-width: 28px;
+      text-align: center;
+      text-decoration: none;
+      color: var(--verdigris);
+      border-color: rgba(95, 196, 168, 0.35);
+    }
+    .jump-chip:hover, .jump-chip:focus-visible { background: var(--verdigris-soft); }
+    .toggle-input {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      opacity: 0;
+    }
+    .switch {
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      user-select: none;
+    }
+    .switch .knob {
+      width: 22px;
+      height: 12px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      position: relative;
+    }
+    .switch .knob::after {
+      content: "";
+      position: absolute;
+      left: 1px;
+      top: 1px;
+      width: 8px;
+      height: 8px;
+      border-radius: 999px;
+      background: var(--muted);
+      transition: transform 0.18s ease, background 0.18s ease;
+    }
+    #changes-only:checked ~ main .switch {
+      color: var(--verdigris);
+      border-color: var(--verdigris);
+    }
+    #changes-only:checked ~ main .switch .knob::after {
+      transform: translateX(10px);
+      background: var(--verdigris);
+    }
+    #changes-only:focus-visible ~ main .switch {
+      outline: 2px solid var(--verdigris);
+      outline-offset: 2px;
+    }
+    #changes-only:checked ~ main .prose .ctx { display: none; }
+    #changes-only:checked ~ main .prose .gap { display: block; }
+    .scores {
       display: grid;
       gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     }
-    .summary-grid { grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
-    .pane-grid { grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
-    table {
-      width: 100%;
-      border-collapse: collapse;
-      font-size: 13px;
+    .score-card { padding: 16px 18px 18px; border-top: 2px solid transparent; }
+    .score-card.side-before { border-top-color: var(--bronze); }
+    .score-card.side-after { border-top-color: var(--verdigris); }
+    .score-card h2 {
+      margin: 0 0 12px;
+      font: 600 11px/1 var(--mono);
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      color: var(--muted);
     }
-    th, td {
-      border-top: 1px solid var(--line);
-      padding: 8px 10px;
-      text-align: left;
-      vertical-align: top;
+    .score-number { margin: 0; font: 500 42px/1 var(--serif); }
+    .score-scale { font-size: 14px; color: var(--muted); margin-left: 5px; }
+    .score-verdict { margin: 8px 0 0; color: var(--gold); font-size: 13px; }
+    .score-skip { margin: 0; font: 500 22px/1.2 var(--serif); color: var(--muted); }
+    .score-note { margin: 8px 0 0; color: var(--muted); font-size: 12.5px; }
+    .facts { display: flex; flex-wrap: wrap; gap: 20px; margin: 16px 0 0; }
+    .fact dt {
+      font: 600 10.5px/1 var(--mono);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--muted);
     }
-    th { color: var(--muted); font-weight: 600; }
-    pre {
+    .fact dd { margin: 4px 0 0; font-size: 14px; }
+    .compare {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+      align-items: start;
+    }
+    .pane-title {
+      position: sticky;
+      top: 0;
+      z-index: 1;
       margin: 0;
+      padding: 14px 18px 10px;
+      font: 600 11px/1 var(--mono);
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      background: linear-gradient(180deg, var(--panel) 72%, rgba(17, 22, 20, 0));
+    }
+    .pane-before .pane-title { color: var(--bronze); }
+    .pane-after .pane-title { color: var(--verdigris); }
+    .prose {
+      padding: 4px 18px 18px;
       white-space: pre-wrap;
       word-break: break-word;
-      font: 13px/1.7 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font: 15px/1.85 "Apple SD Gothic Neo", Pretendard, "Noto Sans KR", "Segoe UI", sans-serif;
+      color: #dde7e0;
+    }
+    .prose .gap {
+      display: none;
+      color: var(--muted);
+      text-align: center;
+      letter-spacing: 0.4em;
+      padding: 6px 0;
     }
     mark.changed-block {
       display: inline;
-      background: var(--mark);
       color: inherit;
       border-radius: 4px;
-      padding: 0 2px;
+      padding: 1px 4px;
+      scroll-margin-top: 96px;
     }
-    .pane-title, .eyebrow {
+    .pane-before mark.changed-block {
+      background: var(--bronze-soft);
+      box-shadow: inset 0 -2px 0 var(--bronze);
+    }
+    .pane-after mark.changed-block {
+      background: var(--verdigris-soft);
+      box-shadow: inset 0 -2px 0 var(--verdigris);
+    }
+    mark.changed-block::before {
+      content: attr(data-n);
+      display: inline-block;
+      min-width: 17px;
+      margin-right: 7px;
+      text-align: center;
+      border-radius: 999px;
+      font: 700 10.5px/17px var(--mono);
+    }
+    .pane-before mark.changed-block::before { background: var(--bronze); color: #20150c; }
+    .pane-after mark.changed-block::before { background: var(--verdigris); color: #0b201a; }
+    mark.changed-block:target {
+      animation: flash 1.2s ease 1;
+      outline: 1.5px solid var(--verdigris);
+      outline-offset: 3px;
+    }
+    @keyframes flash {
+      from { filter: brightness(1.9); }
+      to { filter: none; }
+    }
+    .explain { padding: 16px 18px 18px; }
+    .explain .pane-title {
+      position: static;
+      padding: 0 0 12px;
+      background: none;
       color: var(--muted);
-      font-size: 12px;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      margin-bottom: 8px;
     }
-    .warning {
-      margin: 0 0 12px;
-      color: var(--warn);
+    .explain-cards { display: grid; gap: 12px; }
+    .explain-card {
+      border: 1px solid var(--line);
+      border-left: 3px solid var(--verdigris);
+      border-radius: 10px;
+      padding: 12px 16px;
+      background: rgba(95, 196, 168, 0.04);
+      font-size: 13.5px;
+      line-height: 1.75;
     }
-    .explanation {
-      min-height: 120px;
+    .explain-card strong { color: var(--gold); font-weight: 600; }
+    .explain-card code {
+      font: 12.5px var(--mono);
+      background: rgba(200, 149, 108, 0.13);
+      border-radius: 4px;
+      padding: 1px 5px;
+      color: #e8c9a8;
     }
+    .explain-empty { margin: 0; color: var(--muted); }
+    .warning { margin: 0 0 12px; color: var(--warn); }
   </style>
 </head>
 <body>
+  ${toggleInput}
   <main>
-    <section class="panel">
-      <p class="eyebrow">local browser diff</p>
-      <h1>patina before/after comparison</h1>
-      <p class="meta">Source: ${escapedSourcePath}</p>
+    <header class="masthead">
+      <div>
+        <p class="eyebrow">patina · galley proof</p>
+        <h1>Before <span class="arrow">→</span> After</h1>
+        <p class="meta">Source: ${escapedSourcePath}</p>
+      </div>
+      <div class="controls">
+        <span class="chip">${changeChip}</span>
+        ${jumpNav}
+        ${toggleLabel}
+      </div>
+    </header>
+    <section class="scores">
+      ${renderScoreCard('Before', 'side-before', beforeScore)}
+      ${renderScoreCard('After', 'side-after', afterScore)}
     </section>
-    <section class="summary-grid">
-      ${renderScorePanel('Before', summary.before)}
-      ${renderScorePanel('After', summary.after)}
-    </section>
-    <section class="pane-grid">
-      <article class="panel">
-        <p class="pane-title">Before</p>
-        <pre>${beforeHtml}</pre>
+    <section class="compare">
+      <article class="panel pane pane-before">
+        <h2 class="pane-title">Before</h2>
+        <div class="prose">${beforeHtml}</div>
       </article>
-      <article class="panel">
-        <p class="pane-title">After</p>
-        <pre>${afterHtml}</pre>
+      <article class="panel pane pane-after">
+        <h2 class="pane-title">After</h2>
+        <div class="prose">${afterHtml}</div>
       </article>
     </section>
-    <section class="panel">
-      <p class="pane-title">Pattern explanation</p>
+    <section class="panel explain">
+      <h2 class="pane-title">Pattern explanation</h2>
       ${failureNotice}
-      <pre class="explanation">${explanationBody || htmlEscape('No pattern explanation available.')}</pre>
+      <div class="explain-cards">${explanationHtml}</div>
     </section>
   </main>
 </body>
@@ -326,19 +570,54 @@ function resolveOpenCommand(platform, targetPath) {
   return { command: 'xdg-open', args: [targetPath] };
 }
 
-function renderScorePanel(title, rows) {
-  const body = rows.map((row) => `
-        <tr>
-          <th scope="row">${htmlEscape(row.label)}</th>
-          <td>${htmlEscape(row.value)}</td>
-        </tr>`).join('');
-  return `<article class="panel">
-      <h2>${htmlEscape(title)}</h2>
-      <table>
-        <tbody>${body}
-        </tbody>
-      </table>
-    </article>`;
+function renderScoreCard(title, sideClass, score) {
+  const head = `<h2>${htmlEscape(title)}</h2>`;
+  const wrap = (body) => `<article class="panel score-card ${sideClass}">${head}${body}</article>`;
+
+  if (!score || typeof score !== 'object') {
+    return wrap('<p class="score-skip">Not scored</p><p class="score-note">Score unavailable.</p>');
+  }
+  if (score.skipped || score.error || score.overall === null || score.overall === undefined) {
+    return wrap(`<p class="score-skip">Not scored</p><p class="score-note">${htmlEscape(describeSkipReason(score))}</p>`);
+  }
+
+  const facts = [];
+  if (Number.isFinite(score.paragraphCount)) facts.push(['Paragraphs', score.paragraphCount]);
+  if (Number.isFinite(score.hotParagraphs)) facts.push(['Hot paragraphs', score.hotParagraphs]);
+  if (Number.isFinite(score.signalScore)) facts.push(['Signal score', score.signalScore]);
+  const factsHtml = facts.length
+    ? `<dl class="facts">${facts.map(([label, value]) =>
+      `<div class="fact"><dt>${htmlEscape(label)}</dt><dd>${htmlEscape(String(value))}</dd></div>`).join('')}</dl>`
+    : '';
+  const verdict = score.interpretation
+    ? `<p class="score-verdict">${htmlEscape(String(score.interpretation))}</p>`
+    : '';
+  return wrap(`<p class="score-number">${htmlEscape(String(score.overall))}<span class="score-scale">/100</span></p>${verdict}${factsHtml}`);
+}
+
+function describeSkipReason(score) {
+  if (score.skipReason === 'paragraphs<=2') return 'Deterministic scoring needs more than two paragraphs.';
+  if (score.skipReason) return `Scoring skipped: ${score.skipReason}.`;
+  if (score.error) return `Scoring unavailable: ${score.error}.`;
+  return 'Scoring unavailable.';
+}
+
+// Minimal markdown rendering for the diff-explanation text: bold, inline
+// code, and --- section breaks. Everything is HTML-escaped first; anything
+// beyond these three forms stays visible as plain text.
+function renderExplanationHtml(text) {
+  return String(text)
+    .split(/\n\s*---\s*\n/)
+    .map((section) => section.trim())
+    .filter(Boolean)
+    .map((section) => {
+      const body = htmlEscape(section)
+        .replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>')
+        .replace(/`([^`\n]+)`/g, '<code>$1</code>')
+        .replace(/\n/g, '<br>');
+      return `<article class="explain-card">${body}</article>`;
+    })
+    .join('') || '<p class="explain-empty">No pattern explanation available.</p>';
 }
 
 function normalizeScoreRows(score) {
@@ -378,14 +657,37 @@ function splitBySeparator(text, separatorRe) {
   return blocks;
 }
 
-function renderBlocks(blocks, matchedSet) {
-  return blocks.map((block, index) => {
-    const escapedText = htmlEscape(block.text);
-    const escapedSeparator = htmlEscape(block.separator);
-    if (!block.text) return escapedSeparator;
-    if (matchedSet.has(index)) return `${escapedText}${escapedSeparator}`;
-    return `<mark class="changed-block">${escapedText}</mark>${escapedSeparator}`;
+// Consecutive changed blocks form one numbered hunk so readers can count and
+// jump between edits; unchanged runs are wrapped so the CSS-only
+// "changes only" toggle can hide them and reveal a gap marker instead.
+function renderBlocks(blocks, matchedSet, side) {
+  const runs = [];
+  blocks.forEach((block, index) => {
+    const changed = Boolean(block.text) && !matchedSet.has(index);
+    const last = runs[runs.length - 1];
+    if (last && last.changed === changed) last.blocks.push(block);
+    else runs.push({ changed, blocks: [block] });
+  });
+
+  let changeCount = 0;
+  const html = runs.map((run) => {
+    if (!run.changed) {
+      const text = run.blocks
+        .map((block) => `${htmlEscape(block.text)}${htmlEscape(block.separator)}`)
+        .join('');
+      return `<span class="ctx">${text}</span><span class="gap" aria-hidden="true">⋯</span>`;
+    }
+    changeCount += 1;
+    // The run's trailing separator stays outside the mark so the highlight
+    // never paints trailing blank lines.
+    const inner = run.blocks
+      .map((block, index) => htmlEscape(block.text) + (index < run.blocks.length - 1 ? htmlEscape(block.separator) : ''))
+      .join('');
+    const trailing = htmlEscape(run.blocks[run.blocks.length - 1].separator);
+    return `<mark class="changed-block" id="${side}-change-${changeCount}" data-n="${changeCount}">${inner}</mark>${trailing}`;
   }).join('');
+
+  return { html, changeCount };
 }
 
 function matchCommonBlocks(left, right) {

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -360,7 +360,10 @@ describe('CLI End-to-End with Mock API', () => {
       assert.strictEqual(writes[0].encoding, 'utf8');
       assert.ok(writes[0].data.includes('This is the humanized result.'));
       assert.ok(writes[0].data.includes('Pattern: 1. Generic polish'));
-      assert.ok(writes[0].data.includes('Signal score'));
+      // The single-paragraph fixture is below the deterministic-score floor,
+      // so the page shows the skip-aware card instead of raw score rows.
+      assert.ok(writes[0].data.includes('Not scored'));
+      assert.ok(writes[0].data.includes('Deterministic scoring needs more than two paragraphs.'));
       assert.ok(!writes[0].data.includes('[SELF_AUDIT]'));
       assert.ok(!writes[0].data.includes('"mode": "rewrite"'));
       assert.deepStrictEqual(chmods, [

--- a/tests/unit/browser-diff.test.js
+++ b/tests/unit/browser-diff.test.js
@@ -51,20 +51,31 @@ test('formatRewriteBodyForBrowser strips self-audit blocks and tone footer', () 
 });
 
 test('renderChangedBlocks preserves shared blocks and highlights changed ones', () => {
-  const { beforeHtml, afterHtml } = renderChangedBlocks('same\n\nold', 'same\n\nnew');
-  assert.ok(beforeHtml.includes('same'));
-  assert.ok(afterHtml.includes('same'));
-  assert.ok(!beforeHtml.includes('<mark class="changed-block">same</mark>'));
-  assert.ok(beforeHtml.includes('<mark class="changed-block">old</mark>'));
-  assert.ok(afterHtml.includes('<mark class="changed-block">new</mark>'));
+  const { beforeHtml, afterHtml, beforeChangeCount, afterChangeCount } = renderChangedBlocks('same\n\nold', 'same\n\nnew');
+  assert.ok(beforeHtml.includes('<span class="ctx">same'));
+  assert.ok(afterHtml.includes('<span class="ctx">same'));
+  assert.ok(beforeHtml.includes('<mark class="changed-block" id="before-change-1" data-n="1">old</mark>'));
+  assert.ok(afterHtml.includes('<mark class="changed-block" id="after-change-1" data-n="1">new</mark>'));
+  assert.strictEqual(beforeChangeCount, 1);
+  assert.strictEqual(afterChangeCount, 1);
+});
+
+test('renderChangedBlocks groups consecutive changed blocks into one numbered hunk', () => {
+  const { afterHtml, afterChangeCount } = renderChangedBlocks(
+    'same\n\nold-a\n\nold-b\n\nmiddle\n\nold-c',
+    'same\n\nnew-a\n\nnew-b\n\nmiddle\n\nnew-c',
+  );
+  assert.ok(afterHtml.includes('<mark class="changed-block" id="after-change-1" data-n="1">new-a\n\nnew-b</mark>'));
+  assert.ok(afterHtml.includes('<mark class="changed-block" id="after-change-2" data-n="2">new-c</mark>'));
+  assert.strictEqual(afterChangeCount, 2);
 });
 
 test('renderChangedBlocks falls back to index matching for large inputs', () => {
   const before = Array.from({ length: 220 }, (_, index) => `line-${index}`).join('\n');
   const after = Array.from({ length: 220 }, (_, index) => (index === 219 ? 'line-changed' : `line-${index}`)).join('\n');
   const { beforeHtml, afterHtml } = renderChangedBlocks(before, after);
-  assert.ok(!beforeHtml.includes('<mark class="changed-block">line-0</mark>'));
-  assert.ok(afterHtml.includes('<mark class="changed-block">line-changed</mark>'));
+  assert.ok(!beforeHtml.includes('data-n="1">line-0'));
+  assert.ok(afterHtml.includes('<mark class="changed-block" id="after-change-1" data-n="1">line-changed</mark>'));
 });
 
 test('buildScoreSummary keeps skipped and error rows', () => {
@@ -96,6 +107,46 @@ test('renderBrowserDiffHtml escapes untrusted content and keeps the page self-co
   assert.ok(html.includes('Pattern explanation unavailable: boom &lt;script&gt;'));
   assert.ok(!html.includes('http://'));
   assert.ok(!html.includes('https://'));
+});
+
+test('renderBrowserDiffHtml exposes change navigation and the changes-only toggle', () => {
+  const html = renderBrowserDiffHtml({
+    original: 'same\n\nold-a\n\nmiddle\n\nold-b',
+    rewrittenBody: 'same\n\nnew-a\n\nmiddle\n\nnew-b',
+    diffExplanation: '**Pattern: 1. Test**\nRemoved: `old`\nAdded: `new`\n\n---\n\n**Pattern: 2. Other**\nWhy: because',
+    diffError: null,
+    beforeScore: { overall: 40, interpretation: 'mixed', paragraphCount: 4, hotParagraphs: 1, signalScore: 25 },
+    afterScore: { overall: null, skipped: true, skipReason: 'paragraphs<=2' },
+    sourcePath: '/tmp/draft.md',
+  });
+
+  assert.ok(html.includes('2 changes'));
+  assert.ok(html.includes('<input type="checkbox" id="changes-only"'));
+  assert.ok(html.includes('href="#after-change-1"'));
+  assert.ok(html.includes('href="#after-change-2"'));
+  assert.ok(html.includes('<strong>Pattern: 1. Test</strong>'));
+  assert.ok(html.includes('<code>old</code>'));
+  assert.strictEqual((html.match(/<article class="explain-card">/g) || []).length, 2);
+  assert.ok(html.includes('Not scored'));
+  assert.ok(html.includes('Deterministic scoring needs more than two paragraphs.'));
+  assert.ok(html.includes('40<span class="score-scale">/100</span>'));
+});
+
+test('renderBrowserDiffHtml omits the toggle and jump nav when nothing changed', () => {
+  const html = renderBrowserDiffHtml({
+    original: 'same\n\ntext',
+    rewrittenBody: 'same\n\ntext',
+    diffExplanation: '',
+    diffError: null,
+    beforeScore: null,
+    afterScore: null,
+    sourcePath: '/tmp/draft.md',
+  });
+
+  assert.ok(html.includes('No changes'));
+  assert.ok(!html.includes('id="changes-only"'));
+  assert.ok(!html.includes('href="#after-change-1"'));
+  assert.ok(html.includes('No pattern explanation available.'));
 });
 
 test('writeBrowserDiffPage uses a patina-scoped temp dir and restrictive permissions', () => {


### PR DESCRIPTION
## Why

User feedback from real use: the diff page was hard to read. Changes drowned in unchanged text with no way to locate them, the Pattern explanation section showed raw markdown (`**`, backticks), skipped scores rendered as a table of zeros with internal fields (`Skipped: true`, `Skip reason: paragraphs<=2`), and all prose rendered in monospace.

Stacked on #418.

## What

- **Numbered change hunks + navigation.** Consecutive changed blocks group into one numbered `<mark>` with an anchor id; the masthead shows a change count chip and per-change jump chips. `:target` flashes the hunk you jumped to.
- **"Changes only" toggle, zero JS.** The page CSP allows no scripts, so the toggle is a CSS checkbox hack: unchanged runs are wrapped in `.ctx` spans that hide when checked, replaced by `⋯` gap markers. Omitted entirely when nothing changed.
- **Markdown-lite explanation cards.** Bold / inline code / `---` section splits render properly (escape-first, everything else stays plain text).
- **Skip-aware score cards.** `Not scored — Deterministic scoring needs more than two paragraphs.` instead of zero rows; scored cards lead with a large overall number, interpretation, and compact facts.
- **Design.** Verdigris/bronze theme keyed to the project name (bronze = Before, verdigris = After, on both hunk marks and score-card accents), serif masthead, readable Korean-friendly prose typography, staggered reveal animation with `prefers-reduced-motion` support. Still one self-contained file: no external fonts, no URLs, CSP unchanged.

## Tests

- Updated mark-markup assertions; new unit tests for hunk grouping, jump nav/toggle presence, markdown-lite rendering, skip-aware cards, and the no-changes state (17 unit tests in the file).
- e2e: replaced the `Signal score` assertion (single-paragraph fixture is below the deterministic-score floor) with skip-card assertions.
- 576/576 pass, lint clean.
- Manually verified with a real `claude-cli` rewrite of a scraped webpage — the worst-case input that prompted the feedback: 2 hunks, jump chips, and the changes-only toggle make it navigable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)