### PR TITLE
feat(preview): --ocr — detect & rewrite AI text inside page images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ artifacts/rebaseline-*/generations.private.jsonl
 artifacts/rebaseline-*/*.private.jsonl
 artifacts/rebaseline-*/private/
 .vercel
+
+# local test samples / shareable bundles (user-owned, not repo fixtures)
+sample/

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -113,6 +113,19 @@ File contract:
 - The whole file is rewritten (same scope as a plain rewrite) and rendered as a single reading document. Hunks are paired by LCS, so the model does not need to preserve paragraph counts.
 - stdout carries the rewritten prose (pipe-safe) in both forms; the page path and serve URL go to stderr, same as `--browser`.
 
+### Image text: `--ocr`
+
+Marketing pages often carry their most AI-sounding copy inside images (card-news, banners). `--ocr` extends detection to them:
+
+```bash
+patina --preview --ocr https://example.com/product
+```
+
+- Image candidates come from `<img>` sources (including `srcset` and Next.js `/_next/image` wrappers, unwrapped to the original asset) plus document-wide base64 data URIs (card-news content frequently ships as CSS `background-image` data URIs). SVG is skipped; caps: 8 images per page by priority, 2MB per image, 10MB total.
+- Text extraction runs through an image-capable local CLI backend — `claude-cli`, `gemini-cli`, or `codex-cli` (your selected backend when capable, otherwise the first capable one available). One extra backend call per image; images are staged into the backend's isolated temp dir, preserving the empty-cwd prompt-injection containment. `kimi-cli` and `openai-http` cannot read images.
+- Extracted text joins the same rewrite call as extra blocks. Since pixels cannot be rewritten, a changed finding renders as an annotation: dashed bronze outline + `I`-numbered badge on the image, and a notes card showing the extracted text next to the suggested rewrite.
+- stdout never includes OCR text (pipe-safe); the flagged-image count is reported on stderr.
+
 
 ## Backend fallback chains
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -105,7 +105,7 @@ patina --preview --serve https://example.com/article   # headless: serve at a to
 
 URL contract:
 - Rewrites only plain-text prose blocks (`p`, headings, `li`, `blockquote`, …) with no nested markup; navigation, prices, tables, and mixed-markup paragraphs are left untouched. One rewrite call plus one best-effort explanation call.
-- The snapshot is inert: scripts are removed (hydration would revert the swapped text), inline event handlers and `javascript:` URLs are neutralized, and a `<base href>` keeps the page's own CSS and images loading. React 18 streaming pages are resolved statically (`$RC`/`$RS` swaps applied at snapshot time) so Suspense content renders instead of loading spinners.
+- The snapshot is inert: scripts are removed (hydration would revert the swapped text), inline event handlers and `javascript:` URLs are neutralized, and a `<base href>` keeps the page's own CSS and images loading. React 18 streaming pages are resolved statically (`$RC`/`$RS` swaps applied at snapshot time) so Suspense content renders instead of loading spinners. `<iframe srcdoc="…">` detail content (sites embed long below-the-fold pages this way) is decoded and inlined so its copy and images are extracted and rewritten too.
 - Works on server-rendered pages. Client-rendered SPAs ship an empty HTML shell, so there is nothing to extract — patina fails with a clear message instead of showing a blank snapshot.
 - If the model returns a different paragraph count than the extracted blocks, patina falls back to LCS anchoring plus order-monotonic bigram-similarity pairing; blocks with no confident partner keep their original text (reported on stderr) instead of failing the run.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -121,9 +121,9 @@ Marketing pages often carry their most AI-sounding copy inside images (card-news
 patina --preview --ocr https://example.com/product
 ```
 
-- Image candidates come from `<img>` sources (including `srcset` and Next.js `/_next/image` wrappers, unwrapped to the original asset) plus document-wide base64 data URIs (card-news content frequently ships as CSS `background-image` data URIs). SVG is skipped; caps: 8 images per page by priority, 2MB per image, 10MB total.
-- Text extraction runs through an image-capable local CLI backend — `claude-cli`, `gemini-cli`, or `codex-cli` (your selected backend when capable, otherwise the first capable one available). One extra backend call per image; images are staged into the backend's isolated temp dir, preserving the empty-cwd prompt-injection containment. `kimi-cli` and `openai-http` cannot read images.
-- Extracted text joins the same rewrite call as extra blocks. Since pixels cannot be rewritten, a changed finding renders as an annotation: dashed bronze outline + `I`-numbered badge on the image, and a notes card showing the extracted text next to the suggested rewrite.
+- Image candidates come from `<img>` sources (including `srcset` and Next.js `/_next/image` wrappers, unwrapped to the original asset) plus document-wide base64 data URIs (card-news content frequently ships as CSS `background-image` data URIs). SVG is skipped; caps: 8 images per page by priority, 6MB per image, 16MB total.
+- Text extraction runs through an image-capable local CLI backend — `claude-cli`, `gemini-cli`, or `codex-cli` (your selected backend when capable, otherwise the first capable one available). One extra backend call per image; images are staged into the backend's isolated temp dir, preserving the empty-cwd prompt-injection containment. `kimi-cli` and `openai-http` cannot read images. Remote pages can only reference remote (http/https) images — `file:` images are accepted only for local `.html` previews.
+- Extracted text joins the same rewrite call as extra blocks. Since pixels cannot be rewritten, each changed finding appears in the auto-opened "patina notes" panel as a card embedding **the exact image patina OCR'd** (a thumbnail) next to the extracted text and the suggested rewrite — so findings on carousel slides, lazy-loaded images, or CSS background images are visible regardless of how the snapshot froze. A plain `<img>` in the DOM additionally gets a dashed-bronze `I`-badge in place.
 - stdout never includes OCR text (pipe-safe); the flagged-image count is reported on stderr.
 
 

--- a/src/backends/claude-cli.js
+++ b/src/backends/claude-cli.js
@@ -2,10 +2,11 @@ import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { DEFAULT_BACKEND_TIMEOUT_MS, runInteractiveCommand } from './contract.js';
+import { DEFAULT_BACKEND_TIMEOUT_MS, runInteractiveCommand, stageCliImages } from './contract.js';
 import { resolveLocalCliModel } from '../model-defaults.js';
 
 export const name = 'claude-cli';
+export const supportsImages = true;
 export const loginCommand = 'claude auth login';
 export const installHint = 'Install Claude Code first, then run `patina auth login claude-cli` again.';
 
@@ -39,7 +40,7 @@ export function login(options = {}) {
   });
 }
 
-export async function invoke({ prompt, model, modelSource, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS } = {}) {
+export async function invoke({ prompt, model, modelSource, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS, images } = {}) {
   if (!prompt || typeof prompt !== 'string') {
     throw new Error('claude-cli backend: prompt must be a non-empty string');
   }
@@ -51,6 +52,15 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
   // cannot read or write inside the caller's repo. claude -p prints to
   // stdout, so no output file plumbing is needed (unlike codex-cli).
   const dir = mkdtempSync(join(tmpdir(), 'patina-claude-'));
+
+  // Vision input: images are staged INTO the temp cwd — claude's in-cwd Read
+  // tool is auto-allowed in print mode, while paths outside cwd would be
+  // permission-denied (and granting them would weaken the containment above).
+  let effectivePrompt = prompt;
+  if (Array.isArray(images) && images.length > 0) {
+    const staged = stageCliImages(dir, images);
+    effectivePrompt = `${prompt}\n\nAttached image file(s) in the working directory: ${staged.map((f) => `./${f}`).join(', ')} — read them before answering.`;
+  }
 
   return new Promise((resolve, reject) => {
     const proc = spawn('claude', ['-p', '--model', cliModel], { stdio: ['pipe', 'pipe', 'pipe'], cwd: dir });
@@ -101,7 +111,7 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
         finishReject(new Error(`claude-cli backend: stdin error (${err.message})`));
       }
     });
-    proc.stdin.write(prompt);
+    proc.stdin.write(effectivePrompt);
     proc.stdin.end();
 
     function cleanup() {

--- a/src/backends/codex-cli.js
+++ b/src/backends/codex-cli.js
@@ -2,10 +2,11 @@ import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { DEFAULT_BACKEND_TIMEOUT_MS, runInteractiveCommand } from './contract.js';
+import { DEFAULT_BACKEND_TIMEOUT_MS, runInteractiveCommand, stageCliImages } from './contract.js';
 import { resolveLocalCliModel } from '../model-defaults.js';
 
 export const name = 'codex-cli';
+export const supportsImages = true;
 export const loginCommand = 'codex login';
 export const installHint = 'Install it from https://github.com/openai/codex, then run `patina auth login codex-cli` again.';
 
@@ -36,7 +37,7 @@ export function login(options = {}) {
   });
 }
 
-export async function invoke({ prompt, model, modelSource, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS } = {}) {
+export async function invoke({ prompt, model, modelSource, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS, images } = {}) {
   if (!prompt || typeof prompt !== 'string') {
     throw new Error('codex-cli backend: prompt must be a non-empty string');
   }
@@ -51,6 +52,15 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
   const dir = mkdtempSync(join(tmpdir(), 'patina-codex-'));
   const outFile = join(dir, 'last-message.txt');
 
+  // Vision input: codex exec attaches images natively via -i; staging them
+  // into the temp cwd keeps the read-only sandbox + empty-cwd containment.
+  const imageArgs = [];
+  if (Array.isArray(images) && images.length > 0) {
+    for (const staged of stageCliImages(dir, images)) {
+      imageArgs.push('-i', join(dir, staged));
+    }
+  }
+
   return new Promise((resolve, reject) => {
     const proc = spawn('codex', [
       'exec',
@@ -59,6 +69,7 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       '-C', dir,
       '--model', cliModel,
       '--output-last-message', outFile,
+      ...imageArgs,
     ], { stdio: ['pipe', 'pipe', 'pipe'], cwd: dir });
 
     let stderr = '';

--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { mkdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -67,6 +67,19 @@ export function resolveBackendMaxRetries(backendName, override) {
 
 export function formatLimit(value) {
   return Number.isFinite(value) ? String(value) : 'unbounded';
+}
+
+// Copy image attachments into a CLI backend's per-invocation temp dir so a
+// vision-capable CLI can read them from its own (otherwise empty) cwd. This
+// preserves the prompt-injection containment of the empty-cwd spawn: the CLI
+// never needs access to the caller's paths. Returns the staged filenames.
+export function stageCliImages(dir, images = []) {
+  return images.map((imagePath, index) => {
+    const ext = (/\.([a-z0-9]{1,5})$/i.exec(String(imagePath))?.[1] || 'png').toLowerCase();
+    const staged = `ocr-image-${index}.${ext}`;
+    copyFileSync(imagePath, join(dir, staged));
+    return staged;
+  });
 }
 
 export function isRetryableBackendError(err, { attemptIndex = 0, signal } = {}) {

--- a/src/backends/gemini-cli.js
+++ b/src/backends/gemini-cli.js
@@ -2,10 +2,11 @@ import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { DEFAULT_BACKEND_TIMEOUT_MS, runInteractiveCommand } from './contract.js';
+import { DEFAULT_BACKEND_TIMEOUT_MS, runInteractiveCommand, stageCliImages } from './contract.js';
 import { resolveLocalCliModel } from '../model-defaults.js';
 
 export const name = 'gemini-cli';
+export const supportsImages = true;
 export const loginCommand = 'gemini';
 export const installHint = 'Install Gemini CLI first, then run `patina auth login gemini-cli` again.';
 
@@ -44,7 +45,7 @@ export function login(options = {}) {
   });
 }
 
-export async function invoke({ prompt, model, modelSource, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS } = {}) {
+export async function invoke({ prompt, model, modelSource, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS, images } = {}) {
   if (!prompt || typeof prompt !== 'string') {
     throw new Error('gemini-cli backend: prompt must be a non-empty string');
   }
@@ -58,6 +59,14 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
   const dir = mkdtempSync(join(tmpdir(), 'patina-gemini-'));
   const cliModel = resolveLocalCliModel({ backendName: name, model, modelSource });
   const args = ['-p', '', '--output-format', 'text', '--skip-trust', '-m', cliModel];
+
+  // Vision input: gemini's @-includes are confined to the workspace root, so
+  // images are staged into the temp cwd and referenced as @<filename>.
+  let effectivePrompt = prompt;
+  if (Array.isArray(images) && images.length > 0) {
+    const staged = stageCliImages(dir, images);
+    effectivePrompt = `${staged.map((f) => `@${f}`).join(' ')}\n${prompt}`;
+  }
 
   return new Promise((resolve, reject) => {
     const proc = spawn('gemini', args, { stdio: ['pipe', 'pipe', 'pipe'], cwd: dir });
@@ -108,7 +117,7 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
         finishReject(new Error(`gemini-cli backend: stdin error (${err.message})`));
       }
     });
-    proc.stdin.write(prompt);
+    proc.stdin.write(effectivePrompt);
     proc.stdin.end();
 
     function cleanup() {

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -32,8 +32,13 @@ const openaiHttp = {
     temperature,
     seed,
     onResponse,
-  }) =>
-    callLLM({ prompt, apiKey, baseURL, model, signal, timeout, maxRetries, temperature, seed, onResponse }),
+    images,
+  }) => {
+    if (Array.isArray(images) && images.length > 0) {
+      throw new Error('openai-http backend: image input is not supported yet — use codex-cli, claude-cli, or gemini-cli for OCR');
+    }
+    return callLLM({ prompt, apiKey, baseURL, model, signal, timeout, maxRetries, temperature, seed, onResponse });
+  },
 };
 
 const REGISTRY = {
@@ -89,6 +94,7 @@ export function listBackends() {
       agentRuntime: safety.agentRuntime,
       available: b.isAvailable(),
       authenticated: b.isAuthenticated(),
+      supportsImages: Boolean(b.supportsImages),
       authHint: b.authHint(),
       loginCommand: b.loginCommand || null,
       installHint: b.installHint || null,
@@ -156,6 +162,22 @@ export function selectBackendChain({ name, model, modelSource } = {}) {
   };
 }
 
+// Image-capable backends in default OCR preference order: claude verbatim
+// Korean fidelity (measured), gemini near-verbatim and slightly faster,
+// codex native -i attachment. kimi-cli and openai-http reject images.
+const OCR_BACKEND_ORDER = ['claude-cli', 'gemini-cli', 'codex-cli'];
+
+// Resolve the backend chain for OCR calls: keep the user's selected
+// image-capable backends (their order), otherwise fall back to the available
+// + authenticated capable CLIs.
+export function selectOcrBackends(selectedBackends = []) {
+  const capable = selectedBackends.filter((backend) => REGISTRY[backend.name]?.supportsImages);
+  if (capable.length > 0) return capable;
+  return OCR_BACKEND_ORDER
+    .map((name) => REGISTRY[name])
+    .filter((backend) => backend.isAvailable() && backend.isAuthenticated());
+}
+
 export async function invokeBackendChain({
   backends,
   prompt,
@@ -171,6 +193,7 @@ export async function invokeBackendChain({
   seed,
   onResponse,
   logger,
+  images,
 }) {
   if (!Array.isArray(backends) || backends.length === 0) {
     throw inputError(
@@ -204,6 +227,7 @@ export async function invokeBackendChain({
           seed,
           onResponse,
           logger,
+          images,
         }),
       });
     } catch (err) {

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -170,12 +170,21 @@ const OCR_BACKEND_ORDER = ['claude-cli', 'gemini-cli', 'codex-cli'];
 // Resolve the backend chain for OCR calls: keep the user's selected
 // image-capable backends (their order), otherwise fall back to the available
 // + authenticated capable CLIs.
-export function selectOcrBackends(selectedBackends = []) {
+export function selectOcrBackends(selectedBackends = [], { logger } = {}) {
   const capable = selectedBackends.filter((backend) => REGISTRY[backend.name]?.supportsImages);
   if (capable.length > 0) return capable;
-  return OCR_BACKEND_ORDER
+  const fallback = OCR_BACKEND_ORDER
     .map((name) => REGISTRY[name])
     .filter((backend) => backend.isAvailable() && backend.isAuthenticated());
+  if (fallback.length > 0) {
+    // The selected backend cannot read images, so OCR falls back to an
+    // image-capable CLI the user did not name. Surface it at warn level
+    // (issue #88: agent-CLI use should be visible) — only --quiet hides it.
+    logger?.warn?.('ocr.backend_fallback', {
+      message: `[patina] --ocr is using ${fallback[0].name} for image text (the selected backend cannot read images).`,
+    });
+  }
+  return fallback;
 }
 
 export async function invokeBackendChain({

--- a/src/backends/kimi-cli.js
+++ b/src/backends/kimi-cli.js
@@ -44,9 +44,14 @@ export function login(options = {}) {
   });
 }
 
-export async function invoke({ prompt, model, modelSource, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS } = {}) {
+export async function invoke({ prompt, model, modelSource, signal, timeout = DEFAULT_BACKEND_TIMEOUT_MS, images } = {}) {
   if (!prompt || typeof prompt !== 'string') {
     throw new Error('kimi-cli backend: prompt must be a non-empty string');
+  }
+  if (Array.isArray(images) && images.length > 0) {
+    // kimi --print runs with tools hard-disabled by design (see the security
+    // comment below) — there is no safe way for it to open an image file.
+    throw new Error('kimi-cli backend: image input is not supported');
   }
   throwIfAborted(signal);
 

--- a/src/cli/args.js
+++ b/src/cli/args.js
@@ -50,6 +50,9 @@ export function parseArgs(args) {
       case '--preview':
         parsed.preview = true;
         break;
+      case '--ocr':
+        parsed.ocr = true;
+        break;
       case '--serve':
         parsed.serve = true;
         break;
@@ -213,6 +216,13 @@ export function validateModeExclusivity(parsed) {
 }
 
 export function validatePreviewRequest(parsed) {
+  if (parsed.ocr && !parsed.preview) {
+    throw inputError(
+      '--ocr requires --preview',
+      'OCR scans the images of a preview page for text.',
+      'Run `patina --preview --ocr <url>`.'
+    );
+  }
   if (!parsed.preview) return;
   if (parsed.browser) {
     throw inputError(
@@ -370,6 +380,9 @@ MODES
   --browser               Rewrite one local file, then open a local before/after diff page (adds one diff explanation call)
   --preview               Rewrite one http(s) URL in place on a snapshot of the page, or one
                           local file as an in-place reading document (adds one explanation call)
+  --ocr                   With --preview (URL/.html): extract text inside page images via an
+                          image-capable local CLI (claude/gemini/codex) and include it in
+                          detection — one extra backend call per image
   --serve                 With --browser or --preview: serve the page at a token URL on 127.0.0.1
                           instead of opening a window (headless/SSH; stops after 10 idle minutes)
 

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -20,7 +20,7 @@ import {
   serveBrowserDiffPage,
 } from '../browser-diff.js';
 import { fetchPreviewPage, prepareSnapshotHtml, extractProseBlocks, alignRewrites, buildPreviewHtml, buildFilePreviewHtml } from '../preview.js';
-import { collectImageCandidates, stageOcrImages, ocrStagedImages, describeImage } from '../ocr.js';
+import { collectImageCandidates, stageOcrImages, ocrStagedImages, describeImage, hasOcrRunnerOverride } from '../ocr.js';
 import { rmSync } from 'node:fs';
 import { runOuroboros } from '../ouroboros.js';
 import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals } from '../scoring.js';
@@ -654,11 +654,14 @@ async function runPreviewJob({
       pageHtml = prepareSnapshotHtml(snapshotSource);
       const extracted = extractProseBlocks(pageHtml);
       blocks = extracted.blocks;
-      if (blocks.length === 0) {
+      // With --ocr, a page whose copy lives entirely in images has no DOM
+      // prose but is exactly the case OCR exists for — defer the no-prose
+      // error until after OCR has had a chance to find image text.
+      if (blocks.length === 0 && !parsed.ocr) {
         throw runtimeError(
           'no prose found on the page',
           'The page has no plain-text prose blocks patina can rewrite in place (often a client-rendered SPA, or text split by inline markup).',
-          'Try a server-rendered page, or save the article text to a file and run `patina --preview file.md`.'
+          'Try a server-rendered page, save the article text to a file, or add --ocr to scan image text.'
         );
       }
       if (extracted.truncated) {
@@ -667,9 +670,11 @@ async function runPreviewJob({
         });
       }
       originalText = blocks.map((block) => block.text).join('\n\n');
-      logger.info('preview.blocks', {
-        message: `[patina] Rewriting ${blocks.length} prose block(s) from ${sourceUrl}`,
-      });
+      if (blocks.length > 0) {
+        logger.info('preview.blocks', {
+          message: `[patina] Rewriting ${blocks.length} prose block(s) from ${sourceUrl}`,
+        });
+      }
     }
 
     const basePromptInputs = {
@@ -718,7 +723,18 @@ async function runPreviewJob({
       }
     }
 
-    const rewriteText = [originalText, ...ocrImages.map((image) => image.text)].join('\n\n');
+    // A page with no DOM prose AND no image text has nothing to rewrite.
+    if (blocks !== null && blocks.length === 0 && ocrImages.length === 0) {
+      throw runtimeError(
+        'no prose found on the page',
+        'The page has no plain-text prose blocks, and --ocr found no text in its images.',
+        'Try a server-rendered page, or save the article text to a file and run `patina --preview file.md`.'
+      );
+    }
+
+    const rewriteText = [originalText, ...ocrImages.map((image) => image.text)]
+      .filter(Boolean)
+      .join('\n\n');
     const rawResult = await invokeBackendChain({
       ...invokeInputs,
       prompt: buildPrompt({ ...basePromptInputs, text: rewriteText, mode: 'rewrite' }),
@@ -752,7 +768,10 @@ async function runPreviewJob({
     }
     cancellation.throwIfCanceled();
 
-    const beforeScore = scoreDeterministicSignals({ text: originalText, config, repoRoot, logger });
+    // Score symmetric scopes: with --ocr the rewrite covers DOM text + image
+    // text, so the "before" must too (rewriteText), or the chip would compare
+    // unequal scopes and misreport the change.
+    const beforeScore = scoreDeterministicSignals({ text: rewriteText, config, repoRoot, logger });
     const afterScore = scoreDeterministicSignals({ text: rewrittenBody, config, repoRoot, logger });
     const scoreChip = !beforeScore?.skipped && !afterScore?.skipped
       && beforeScore?.overall !== null && beforeScore?.overall !== undefined
@@ -830,8 +849,10 @@ async function runPreviewJob({
 }
 
 async function runOcrStage({ pageHtml, sourceUrl, parsed, backends, resolved, timeoutMs, cancellation, logger }) {
-  const ocrBackends = selectOcrBackends(backends);
-  if (ocrBackends.length === 0) {
+  // A test-injected OCR runner replaces backend selection entirely (CI has no
+  // installed vision CLI). In production we require a real image-capable CLI.
+  const ocrBackends = hasOcrRunnerOverride() ? [] : selectOcrBackends(backends, { logger });
+  if (!hasOcrRunnerOverride() && ocrBackends.length === 0) {
     throw runtimeError(
       'no image-capable backend for --ocr',
       'OCR needs an available, authenticated claude-cli, gemini-cli, or codex-cli (kimi-cli and openai-http cannot read images).',
@@ -851,7 +872,7 @@ async function runOcrStage({ pageHtml, sourceUrl, parsed, backends, resolved, ti
   }
 
   logger.info('ocr.start', {
-    message: `[patina] OCR: scanning ${candidates.length} image(s) via ${ocrBackends.map((b) => b.name).join(' → ')}…`,
+    message: `[patina] OCR: scanning ${candidates.length} image(s)${ocrBackends.length ? ` via ${ocrBackends.map((b) => b.name).join(' → ')}` : ''}…`,
   });
   const { dir, staged, skipped } = await stageOcrImages(candidates, { signal: cancellation.signal });
   try {
@@ -877,6 +898,10 @@ async function runOcrStage({ pageHtml, sourceUrl, parsed, backends, resolved, ti
       logger,
     });
     const images = await ocrStagedImages(staged, { invokeChain, signal: cancellation.signal, logger });
+    // A swallowed abort inside the OCR fan-out resolves to fewer results; make
+    // Ctrl-C surface as the standard cancellation error, not a later
+    // backend-flavored AbortError from the rewrite call.
+    cancellation.throwIfCanceled();
     logger.info('ocr.done', {
       message: `[patina] OCR: text found in ${images.length} of ${staged.length} image(s)`,
     });

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -7,7 +7,7 @@ import {
   toneToBackboneProfile,
 } from '../loader.js';
 import { buildPrompt } from '../prompt-builder.js';
-import { invokeBackendChain, selectBackendChain, listBackends } from '../backends/index.js';
+import { invokeBackendChain, selectBackendChain, selectOcrBackends, listBackends } from '../backends/index.js';
 import { selectProvider, resolveProviderConfig } from '../providers.js';
 import { validateBaseURL, applyInsecureBaseURLOptIn, applyPrivateBaseURLOptIn } from '../security.js';
 import { formatOutput, formatRewriteBodyForBrowser, validateScoreWeights, buildDeterministicAuditBackstop } from '../output.js';
@@ -20,6 +20,8 @@ import {
   serveBrowserDiffPage,
 } from '../browser-diff.js';
 import { fetchPreviewPage, prepareSnapshotHtml, extractProseBlocks, alignRewrites, buildPreviewHtml, buildFilePreviewHtml } from '../preview.js';
+import { collectImageCandidates, stageOcrImages, ocrStagedImages, describeImage } from '../ocr.js';
+import { rmSync } from 'node:fs';
 import { runOuroboros } from '../ouroboros.js';
 import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals } from '../scoring.js';
 import { logBatchSafetyPlan, createBatchCircuitBreaker, shouldHandleBatchFailure, writeBatchOutput } from './batch.js';
@@ -693,9 +695,33 @@ async function runPreviewJob({
       logger,
     };
 
+    // --ocr: extract text from page images and let it ride the same rewrite
+    // call as extra paragraph blocks. Image text cannot be swapped back into
+    // pixels, so changed findings render as annotations + notes cards.
+    let ocrImages = [];
+    if (parsed.ocr) {
+      if (pageHtml === null) {
+        logger.warn('ocr.skipped', {
+          message: '[patina] --ocr applies to URL/.html previews; plain-text input has no images.',
+        });
+      } else {
+        ocrImages = await runOcrStage({
+          pageHtml,
+          sourceUrl,
+          parsed,
+          backends,
+          resolved,
+          timeoutMs,
+          cancellation,
+          logger,
+        });
+      }
+    }
+
+    const rewriteText = [originalText, ...ocrImages.map((image) => image.text)].join('\n\n');
     const rawResult = await invokeBackendChain({
       ...invokeInputs,
-      prompt: buildPrompt({ ...basePromptInputs, text: originalText, mode: 'rewrite' }),
+      prompt: buildPrompt({ ...basePromptInputs, text: rewriteText, mode: 'rewrite' }),
     });
     cancellation.throwIfCanceled();
     const rewrittenBody = formatRewriteBodyForBrowser(rawResult, { logger });
@@ -708,7 +734,7 @@ async function runPreviewJob({
         ...invokeInputs,
         prompt: buildPrompt({
           ...basePromptInputs,
-          text: buildBrowserDiffPromptInput(originalText, rewrittenBody),
+          text: buildBrowserDiffPromptInput(rewriteText, rewrittenBody),
           mode: 'diff',
         }),
       });
@@ -735,10 +761,11 @@ async function runPreviewJob({
       : null;
 
     let built;
+    let stdoutBody = rewrittenBody;
     if (pageHtml !== null) {
       let rewrites;
       try {
-        const aligned = alignRewrites(blocks, rewrittenBody);
+        const aligned = alignRewrites([...blocks, ...ocrImages], rewrittenBody);
         rewrites = aligned.rewrites;
         if (aligned.unalignedCount > 0) {
           logger.warn('preview.partial_alignment', {
@@ -752,13 +779,22 @@ async function runPreviewJob({
           'Re-run the command (model output varies), or save the page text to a file and run `patina --preview file.md`.'
         );
       }
+      const imageFindings = ocrImages.map((image, index) => {
+        const rewritten = rewrites[blocks.length + index];
+        return { ...image, rewritten, changed: rewritten !== image.text };
+      });
+      if (ocrImages.length > 0) {
+        // Keep stdout pipe-safe: only the page's own text, never OCR blocks.
+        stdoutBody = rewrites.slice(0, blocks.length).join('\n\n');
+      }
       built = buildPreviewHtml({
         html: pageHtml,
         blocks,
-        rewrites,
+        rewrites: rewrites.slice(0, blocks.length),
         sourceUrl,
         explanationHtml,
         scoreChip,
+        imageFindings,
       });
     } else {
       built = buildFilePreviewHtml({
@@ -769,10 +805,11 @@ async function runPreviewJob({
         scoreChip,
       });
     }
-    console.log(rewrittenBody);
+    console.log(stdoutBody);
 
     const pagePath = writeBrowserDiffPage(built.html, { prefix: 'patina-preview-' });
-    console.error(`[patina] Preview page saved at ${pagePath} (${built.changedCount} of ${built.totalCount} blocks rewritten)`);
+    const imageSummary = built.imageChangedCount > 0 ? `, ${built.imageChangedCount} image(s) flagged` : '';
+    console.error(`[patina] Preview page saved at ${pagePath} (${built.changedCount} of ${built.totalCount} blocks rewritten${imageSummary})`);
     if (parsed.serve) {
       const { url: servedUrl, done } = await serveBrowserDiffPage(built.html, {
         signal: cancellation.signal,
@@ -789,6 +826,63 @@ async function runPreviewJob({
     }
   } finally {
     cancellation.cleanup();
+  }
+}
+
+async function runOcrStage({ pageHtml, sourceUrl, parsed, backends, resolved, timeoutMs, cancellation, logger }) {
+  const ocrBackends = selectOcrBackends(backends);
+  if (ocrBackends.length === 0) {
+    throw runtimeError(
+      'no image-capable backend for --ocr',
+      'OCR needs an available, authenticated claude-cli, gemini-cli, or codex-cli (kimi-cli and openai-http cannot read images).',
+      'Run `patina doctor` to check backend status, or drop --ocr.'
+    );
+  }
+
+  const { candidates, truncated } = collectImageCandidates(pageHtml, sourceUrl);
+  if (truncated) {
+    logger.warn('ocr.truncated', {
+      message: '[patina] Page has more images than the OCR limit; lower-priority images were skipped.',
+    });
+  }
+  if (candidates.length === 0) {
+    logger.info('ocr.empty', { message: '[patina] OCR: no eligible images on the page.' });
+    return [];
+  }
+
+  logger.info('ocr.start', {
+    message: `[patina] OCR: scanning ${candidates.length} image(s) via ${ocrBackends.map((b) => b.name).join(' → ')}…`,
+  });
+  const { dir, staged, skipped } = await stageOcrImages(candidates, { signal: cancellation.signal });
+  try {
+    for (const skip of skipped) {
+      logger.warn('ocr.skip', {
+        message: `[patina] OCR skipped ${describeImage(skip.candidate)}: ${skip.reason}`,
+      });
+    }
+    cancellation.throwIfCanceled();
+
+    // No model override: an OCR fallback backend may differ from the text
+    // backend, so each CLI uses its own default model.
+    const invokeChain = ({ prompt, images }) => invokeBackendChain({
+      backends: ocrBackends,
+      prompt,
+      images,
+      apiKey: resolved.apiKey,
+      baseURL: resolved.baseURL,
+      signal: cancellation.signal,
+      timeout: timeoutMs,
+      maxConcurrency: parsed.maxConcurrency,
+      maxRetries: parsed.maxRetries,
+      logger,
+    });
+    const images = await ocrStagedImages(staged, { invokeChain, signal: cancellation.signal, logger });
+    logger.info('ocr.done', {
+      message: `[patina] OCR: text found in ${images.length} of ${staged.length} image(s)`,
+    });
+    return images;
+  } finally {
+    try { rmSync(dir, { recursive: true, force: true }); } catch {}
   }
 }
 

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -189,8 +189,9 @@ function formatDoctorText(report) {
   lines.push('', 'Backends:');
   for (const backend of report.backends) {
     const ok = backend.available && backend.authenticated;
+    const images = backend.supportsImages ? ', images=yes' : '';
     lines.push(
-      `  ${ok ? '✓' : '!'} ${backend.name}: available=${yesNo(backend.available)}, authenticated=${yesNo(backend.authenticated)}`
+      `  ${ok ? '✓' : '!'} ${backend.name}: available=${yesNo(backend.available)}, authenticated=${yesNo(backend.authenticated)}${images}`
     );
     if (!ok && backend.authHint) lines.push(`    → ${backend.authHint}`);
   }

--- a/src/ocr.js
+++ b/src/ocr.js
@@ -1,12 +1,16 @@
-import { mkdtempSync, writeFileSync, copyFileSync, statSync, chmodSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, copyFileSync, readFileSync, statSync, chmodSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const DEFAULT_MAX_IMAGES = 8;
-const DEFAULT_MAX_IMAGE_BYTES = 2 * 1024 * 1024;
-const DEFAULT_TOTAL_BUDGET_BYTES = 10 * 1024 * 1024;
+const DEFAULT_MAX_IMAGE_BYTES = 6 * 1024 * 1024; // tall detail images can be a few MB
+const DEFAULT_TOTAL_BUDGET_BYTES = 16 * 1024 * 1024;
 const DEFAULT_FETCH_TIMEOUT_MS = 20000;
+// Inline thumbnail embedded in a finding card so the user sees the exact
+// image patina read, regardless of carousel/lazy/background-image rendering.
+const MAX_THUMBNAIL_BYTES = 240 * 1024;
+const MIME_BY_EXT = { jpg: 'jpeg', jpeg: 'jpeg', png: 'png', webp: 'webp', gif: 'gif' };
 const MIN_DATA_URI_BYTES = 2 * 1024; // below this: blur placeholders, icons
 const MAX_DATA_URI_BYTES = 512 * 1024;
 const ACCEPTED_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'webp', 'gif']);
@@ -304,7 +308,7 @@ export async function ocrStagedImages(staged, { invokeChain, signal, logger, min
         : await invokeChain({ prompt: OCR_PROMPT, images: [image.path] });
       const text = normalizeOcrText(rawText);
       if (!text || text.length < minTextLength) return null;
-      return { ...image, text };
+      return { ...image, text, previewDataUri: buildThumbnail(image) };
     } catch (err) {
       if (signal?.aborted) return null;
       logger?.warn?.('ocr.image_failed', {
@@ -314,6 +318,25 @@ export async function ocrStagedImages(staged, { invokeChain, signal, logger, min
     }
   }));
   return results.filter(Boolean);
+}
+
+// Build a capped inline data URI for a finding card so the user sees the
+// exact OCR'd image. Returns null when no bytes are readable (e.g. test
+// runner) or the image exceeds the embed cap.
+function buildThumbnail(image) {
+  try {
+    if (image.kind === 'data') {
+      const payload = image.dataUri.slice(image.dataUri.indexOf(',') + 1);
+      return Math.floor(payload.length * 3 / 4) <= MAX_THUMBNAIL_BYTES ? image.dataUri : null;
+    }
+    if (!image.path || !existsSync(image.path)) return null;
+    const bytes = readFileSync(image.path);
+    if (bytes.length > MAX_THUMBNAIL_BYTES) return null;
+    const mime = MIME_BY_EXT[image.ext] || 'png';
+    return `data:image/${mime};base64,${bytes.toString('base64')}`;
+  } catch {
+    return null;
+  }
 }
 
 export function normalizeOcrText(rawText) {

--- a/src/ocr.js
+++ b/src/ocr.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 const DEFAULT_MAX_IMAGES = 8;
 const DEFAULT_MAX_IMAGE_BYTES = 2 * 1024 * 1024;
 const DEFAULT_TOTAL_BUDGET_BYTES = 10 * 1024 * 1024;
+const DEFAULT_FETCH_TIMEOUT_MS = 20000;
 const MIN_DATA_URI_BYTES = 2 * 1024; // below this: blur placeholders, icons
 const MAX_DATA_URI_BYTES = 512 * 1024;
 const ACCEPTED_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'webp', 'gif']);
@@ -19,6 +20,12 @@ export function setOcrRuntimeForTests(overrides = {}) {
 
 export function resetOcrRuntimeForTests() {
   testRuntimeOverrides = {};
+}
+
+// True when a test has injected an OCR runner, so the CLI flow can skip the
+// real backend-availability check (no installed vision CLI on CI).
+export function hasOcrRunnerOverride() {
+  return typeof testRuntimeOverrides.runOcr === 'function';
 }
 
 function getRuntimeValue(options, key, fallback) {
@@ -38,11 +45,18 @@ export function collectImageCandidates(html, baseUrl, options = {}) {
   const seen = new Set();
   const candidates = [];
 
+  // Only a local (.html) preview may reference local file: images. A fetched
+  // remote page must never make patina read local files — otherwise an
+  // attacker page with <img src="file:///home/you/private.png"> could
+  // exfiltrate local image content to the OCR backend (SSRF / local-file
+  // disclosure). This mirrors the empty-cwd CLI containment.
+  const allowFileImages = String(baseUrl || '').startsWith('file:');
+
   const imgRe = /<img\b[^>]*>/gi;
   let match;
   while ((match = imgRe.exec(source)) !== null) {
     const tag = match[0];
-    const url = pickImageUrl(tag, baseUrl);
+    const url = pickImageUrl(tag, baseUrl, allowFileImages);
     if (!url) continue;
     if (url.startsWith('data:')) {
       addDataUri(candidates, seen, url, tag);
@@ -91,7 +105,7 @@ function addDataUri(candidates, seen, dataUri, tag) {
   });
 }
 
-function pickImageUrl(tag, baseUrl) {
+function pickImageUrl(tag, baseUrl, allowFileImages) {
   const fromAttr = (name) => {
     const m = new RegExp(`\\b${name}="([^"]*)"`, 'i').exec(tag);
     return m ? decodeHtmlAttr(m[1]) : null;
@@ -110,7 +124,8 @@ function pickImageUrl(tag, baseUrl) {
       const inner = resolved.searchParams.get('url');
       if (inner) resolved = new URL(inner, resolved);
     }
-    if (!/^(https?|file):$/.test(resolved.protocol)) return null;
+    const allowedProtocols = allowFileImages ? /^(https?|file):$/ : /^https?:$/;
+    if (!allowedProtocols.test(resolved.protocol)) return null;
     return resolved.href;
   } catch {
     return null;
@@ -168,8 +183,10 @@ function scorePriority(url, tag) {
 export async function stageOcrImages(candidates, options = {}) {
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_IMAGE_BYTES;
   const totalBudget = options.totalBudget ?? DEFAULT_TOTAL_BUDGET_BYTES;
+  const fetchTimeoutMs = options.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
   const fetchImpl = getRuntimeValue(options, 'fetchImpl', fetch);
   const signal = options.signal;
+  const tooBig = `larger than ${Math.round(maxBytes / 1024)}KB`;
 
   const dir = mkdtempSync(join(tmpdir(), 'patina-ocr-'));
   try { chmodSync(dir, 0o700); } catch {}
@@ -177,8 +194,13 @@ export async function stageOcrImages(candidates, options = {}) {
   const staged = [];
   const skipped = [];
   let spent = 0;
+  let budgetExhausted = false;
   for (const [index, candidate] of candidates.entries()) {
     if (signal?.aborted) break;
+    if (budgetExhausted) {
+      skipped.push({ candidate, reason: 'total image budget reached' });
+      continue;
+    }
     try {
       let bytes;
       if (candidate.kind === 'data') {
@@ -186,24 +208,29 @@ export async function stageOcrImages(candidates, options = {}) {
       } else if (candidate.kind === 'file') {
         const filePath = fileURLToPath(candidate.url);
         const size = statSync(filePath).size;
-        if (size > maxBytes) throw new Error(`larger than ${Math.round(maxBytes / 1024)}KB`);
+        if (size > maxBytes) throw new Error(tooBig);
+        if (spent + size > totalBudget) {
+          skipped.push({ candidate, reason: 'total image budget reached' });
+          budgetExhausted = true;
+          continue;
+        }
         const target = join(dir, `img-${index}.${candidate.ext}`);
         copyFileSync(filePath, target);
-        staged.push({ ...candidate, path: target, bytes: size });
+        try { chmodSync(target, 0o600); } catch {}
         spent += size;
-        if (spent > totalBudget) break;
+        staged.push({ ...candidate, path: target, bytes: size });
         continue;
       } else {
-        const response = await fetchImpl(candidate.url, { signal, redirect: 'follow' });
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        const declared = Number(response.headers.get('content-length'));
-        if (Number.isFinite(declared) && declared > maxBytes) throw new Error(`larger than ${Math.round(maxBytes / 1024)}KB`);
-        bytes = Buffer.from(await response.arrayBuffer());
+        // Cap by streaming at the per-image limit: never trust Content-Length
+        // presence/value, and bound an unbounded chunked stream before it
+        // exhausts memory. The total budget is enforced below.
+        bytes = await fetchImageBytes(fetchImpl, candidate.url, { signal, maxBytes, fetchTimeoutMs, tooBig });
       }
-      if (bytes.length > maxBytes) throw new Error(`larger than ${Math.round(maxBytes / 1024)}KB`);
+      if (bytes.length > maxBytes) throw new Error(tooBig);
       if (spent + bytes.length > totalBudget) {
         skipped.push({ candidate, reason: 'total image budget reached' });
-        break;
+        budgetExhausted = true;
+        continue;
       }
       const target = join(dir, `img-${index}.${candidate.ext}`);
       writeFileSync(target, bytes);
@@ -216,6 +243,47 @@ export async function stageOcrImages(candidates, options = {}) {
     }
   }
   return { dir, staged, skipped };
+}
+
+// Fetch with a hard timeout and a streaming byte cap. The body is read
+// chunk by chunk so a chunked/Content-Length-less response cannot buffer
+// unbounded data into memory before the size check.
+async function fetchImageBytes(fetchImpl, url, { signal, maxBytes, fetchTimeoutMs, tooBig }) {
+  const controller = new AbortController();
+  const onOuterAbort = () => controller.abort(signal.reason);
+  if (signal) {
+    if (signal.aborted) controller.abort(signal.reason);
+    else signal.addEventListener('abort', onOuterAbort, { once: true });
+  }
+  const timer = setTimeout(() => controller.abort(new Error('image fetch timed out')), fetchTimeoutMs);
+  try {
+    const response = await fetchImpl(url, { signal: controller.signal, redirect: 'follow' });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const declared = Number(response.headers.get('content-length'));
+    if (Number.isFinite(declared) && declared > maxBytes) throw new Error(tooBig);
+    if (!response.body || typeof response.body.getReader !== 'function') {
+      const buf = Buffer.from(await response.arrayBuffer());
+      if (buf.length > maxBytes) throw new Error(tooBig);
+      return buf;
+    }
+    const reader = response.body.getReader();
+    const chunks = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.length;
+      if (total > maxBytes) {
+        controller.abort(new Error(tooBig));
+        throw new Error(tooBig);
+      }
+      chunks.push(value);
+    }
+    return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+  } finally {
+    clearTimeout(timer);
+    signal?.removeEventListener?.('abort', onOuterAbort);
+  }
 }
 
 export const OCR_PROMPT = [

--- a/src/ocr.js
+++ b/src/ocr.js
@@ -1,0 +1,266 @@
+import { mkdtempSync, writeFileSync, copyFileSync, statSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_MAX_IMAGES = 8;
+const DEFAULT_MAX_IMAGE_BYTES = 2 * 1024 * 1024;
+const DEFAULT_TOTAL_BUDGET_BYTES = 10 * 1024 * 1024;
+const MIN_DATA_URI_BYTES = 2 * 1024; // below this: blur placeholders, icons
+const MAX_DATA_URI_BYTES = 512 * 1024;
+const ACCEPTED_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'webp', 'gif']);
+const PRIORITY_URL_RE = /(thumbnail|banner|card|og[-_image]*|detail|shot|news|hero|cover|poster)/i;
+
+let testRuntimeOverrides = {};
+
+export function setOcrRuntimeForTests(overrides = {}) {
+  testRuntimeOverrides = { ...overrides };
+}
+
+export function resetOcrRuntimeForTests() {
+  testRuntimeOverrides = {};
+}
+
+function getRuntimeValue(options, key, fallback) {
+  if (Object.prototype.hasOwnProperty.call(options, key)) return options[key];
+  if (Object.prototype.hasOwnProperty.call(testRuntimeOverrides, key)) return testRuntimeOverrides[key];
+  return fallback;
+}
+
+// Collect OCR candidates from a prepared snapshot: <img> sources (src,
+// srcset, common lazy-load attributes; Next.js /_next/image wrappers are
+// unwrapped to the original asset) plus document-wide base64 data URIs —
+// card-news content frequently ships as CSS background-image data URIs, not
+// <img> tags. SVG is skipped (vector text belongs to the DOM extractor).
+export function collectImageCandidates(html, baseUrl, options = {}) {
+  const maxImages = options.maxImages ?? DEFAULT_MAX_IMAGES;
+  const source = String(html ?? '');
+  const seen = new Set();
+  const candidates = [];
+
+  const imgRe = /<img\b[^>]*>/gi;
+  let match;
+  while ((match = imgRe.exec(source)) !== null) {
+    const tag = match[0];
+    const url = pickImageUrl(tag, baseUrl);
+    if (!url) continue;
+    if (url.startsWith('data:')) {
+      addDataUri(candidates, seen, url, tag);
+      continue;
+    }
+    const ext = extensionOf(url);
+    if (!ACCEPTED_EXTENSIONS.has(ext)) continue;
+    if (seen.has(url)) continue;
+    seen.add(url);
+    candidates.push({
+      kind: url.startsWith('file:') ? 'file' : 'url',
+      url,
+      ext,
+      anchor: extractSrcAttr(tag),
+      alt: /\balt="([^"]*)"/i.exec(tag)?.[1] ?? '',
+      priority: scorePriority(url, tag),
+    });
+  }
+
+  // Document-wide data URIs (CSS backgrounds, payload remnants).
+  const dataRe = /data:image\/(jpeg|jpg|png|webp|gif);base64,([A-Za-z0-9+/=]+)/g;
+  while ((match = dataRe.exec(source)) !== null) {
+    addDataUri(candidates, seen, match[0], '');
+  }
+
+  candidates.sort((a, b) => b.priority - a.priority);
+  const kept = candidates.slice(0, maxImages);
+  return { candidates: kept, truncated: candidates.length > kept.length };
+}
+
+function addDataUri(candidates, seen, dataUri, tag) {
+  const payload = dataUri.slice(dataUri.indexOf(',') + 1);
+  const decodedBytes = Math.floor(payload.length * 3 / 4);
+  if (decodedBytes < MIN_DATA_URI_BYTES || decodedBytes > MAX_DATA_URI_BYTES) return;
+  const key = `data:${payload.length}:${payload.slice(0, 64)}`;
+  if (seen.has(key)) return;
+  seen.add(key);
+  const ext = /data:image\/(\w+)/.exec(dataUri)?.[1]?.replace('jpeg', 'jpg') ?? 'png';
+  candidates.push({
+    kind: 'data',
+    dataUri,
+    ext: ext === 'jpg' ? 'jpg' : ext,
+    anchor: tag ? extractSrcAttr(tag) : null,
+    alt: tag ? (/\balt="([^"]*)"/i.exec(tag)?.[1] ?? '') : '',
+    priority: 1 + (tag ? scorePriority('', tag) : 0),
+  });
+}
+
+function pickImageUrl(tag, baseUrl) {
+  const fromAttr = (name) => {
+    const m = new RegExp(`\\b${name}="([^"]*)"`, 'i').exec(tag);
+    return m ? decodeHtmlAttr(m[1]) : null;
+  };
+  let raw = fromAttr('src') || fromAttr('data-src') || fromAttr('data-lazy') || fromAttr('data-original');
+  if (!raw) {
+    const srcset = fromAttr('srcset');
+    if (srcset) raw = pickFromSrcset(srcset);
+  }
+  if (!raw) return null;
+  if (raw.startsWith('data:')) return raw;
+  try {
+    let resolved = new URL(raw, baseUrl || undefined);
+    // Next.js image proxy: recover the original asset URL.
+    if (resolved.pathname.endsWith('/_next/image')) {
+      const inner = resolved.searchParams.get('url');
+      if (inner) resolved = new URL(inner, resolved);
+    }
+    if (!/^(https?|file):$/.test(resolved.protocol)) return null;
+    return resolved.href;
+  } catch {
+    return null;
+  }
+}
+
+// Prefer a mid-sized srcset candidate: big enough for legible OCR, far
+// smaller than the w=3840 variants.
+function pickFromSrcset(srcset) {
+  const entries = srcset.split(',').map((entry) => {
+    const [url, descriptor] = entry.trim().split(/\s+/);
+    const width = parseInt(descriptor, 10) || 0;
+    return { url, width };
+  }).filter((entry) => entry.url);
+  if (entries.length === 0) return null;
+  const sorted = entries.sort((a, b) => a.width - b.width);
+  const preferred = sorted.find((entry) => entry.width >= 480 && entry.width <= 1200);
+  return (preferred ?? sorted[Math.floor(sorted.length / 2)]).url;
+}
+
+function extractSrcAttr(tag) {
+  return /\bsrc="([^"]*)"/i.exec(tag)?.[1] ?? null;
+}
+
+function decodeHtmlAttr(value) {
+  return String(value)
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>');
+}
+
+function extensionOf(url) {
+  try {
+    const pathname = new URL(url).pathname;
+    return (/\.([a-z0-9]+)$/i.exec(pathname)?.[1] || '').toLowerCase().replace('jpeg', 'jpg');
+  } catch {
+    return '';
+  }
+}
+
+function scorePriority(url, tag) {
+  let score = 0;
+  if (PRIORITY_URL_RE.test(url)) score += 4;
+  const alt = /\balt="([^"]*)"/i.exec(tag)?.[1] ?? '';
+  if (/[가-힣぀-ヿ㐀-鿿]/.test(alt)) score += 3;
+  else if (alt.trim().length > 8) score += 1;
+  return score;
+}
+
+// Download/decode candidates into a 0700 temp dir, enforcing per-image and
+// total byte budgets. Oversized or failing images are skipped (and reported),
+// never truncated.
+export async function stageOcrImages(candidates, options = {}) {
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_IMAGE_BYTES;
+  const totalBudget = options.totalBudget ?? DEFAULT_TOTAL_BUDGET_BYTES;
+  const fetchImpl = getRuntimeValue(options, 'fetchImpl', fetch);
+  const signal = options.signal;
+
+  const dir = mkdtempSync(join(tmpdir(), 'patina-ocr-'));
+  try { chmodSync(dir, 0o700); } catch {}
+
+  const staged = [];
+  const skipped = [];
+  let spent = 0;
+  for (const [index, candidate] of candidates.entries()) {
+    if (signal?.aborted) break;
+    try {
+      let bytes;
+      if (candidate.kind === 'data') {
+        bytes = Buffer.from(candidate.dataUri.slice(candidate.dataUri.indexOf(',') + 1), 'base64');
+      } else if (candidate.kind === 'file') {
+        const filePath = fileURLToPath(candidate.url);
+        const size = statSync(filePath).size;
+        if (size > maxBytes) throw new Error(`larger than ${Math.round(maxBytes / 1024)}KB`);
+        const target = join(dir, `img-${index}.${candidate.ext}`);
+        copyFileSync(filePath, target);
+        staged.push({ ...candidate, path: target, bytes: size });
+        spent += size;
+        if (spent > totalBudget) break;
+        continue;
+      } else {
+        const response = await fetchImpl(candidate.url, { signal, redirect: 'follow' });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const declared = Number(response.headers.get('content-length'));
+        if (Number.isFinite(declared) && declared > maxBytes) throw new Error(`larger than ${Math.round(maxBytes / 1024)}KB`);
+        bytes = Buffer.from(await response.arrayBuffer());
+      }
+      if (bytes.length > maxBytes) throw new Error(`larger than ${Math.round(maxBytes / 1024)}KB`);
+      if (spent + bytes.length > totalBudget) {
+        skipped.push({ candidate, reason: 'total image budget reached' });
+        break;
+      }
+      const target = join(dir, `img-${index}.${candidate.ext}`);
+      writeFileSync(target, bytes);
+      try { chmodSync(target, 0o600); } catch {}
+      spent += bytes.length;
+      staged.push({ ...candidate, path: target, bytes: bytes.length });
+    } catch (err) {
+      if (signal?.aborted) break;
+      skipped.push({ candidate, reason: err?.message || 'fetch failed' });
+    }
+  }
+  return { dir, staged, skipped };
+}
+
+export const OCR_PROMPT = [
+  'Extract every piece of legible text visible in the attached image, exactly as written, preserving reading order and line breaks.',
+  'Output only the extracted text — no commentary, no translation, no formatting marks.',
+  'If the image contains no legible text, output exactly: NO_TEXT',
+].join('\n');
+
+// OCR each staged image through the backend chain. `runOcr` is injectable
+// for tests; the default routes through invokeBackendChain with the image
+// attached, so timeout/abort/concurrency-slot plumbing applies per call.
+export async function ocrStagedImages(staged, { invokeChain, signal, logger, minTextLength = 8 } = {}) {
+  const runOcr = getRuntimeValue({}, 'runOcr', null);
+  const results = await Promise.all(staged.map(async (image) => {
+    try {
+      const rawText = runOcr
+        ? await runOcr(image)
+        : await invokeChain({ prompt: OCR_PROMPT, images: [image.path] });
+      const text = normalizeOcrText(rawText);
+      if (!text || text.length < minTextLength) return null;
+      return { ...image, text };
+    } catch (err) {
+      if (signal?.aborted) return null;
+      logger?.warn?.('ocr.image_failed', {
+        message: `[patina] OCR failed for ${describeImage(image)}: ${err?.message || 'unknown error'}`,
+      });
+      return null;
+    }
+  }));
+  return results.filter(Boolean);
+}
+
+export function normalizeOcrText(rawText) {
+  const text = String(rawText ?? '').trim();
+  if (!text || /^NO_TEXT\b/.test(text)) return null;
+  // Collapse runs of blank lines so OCR text behaves as ONE paragraph block
+  // in the rewrite call — paragraph alignment depends on it.
+  return text.replace(/\s*\n\s*/g, ' / ').replace(/\s+/g, ' ').trim();
+}
+
+export function describeImage(image) {
+  if (image.kind === 'data') return `embedded image (${Math.round((image.bytes ?? 0) / 1024)}KB data URI)`;
+  try {
+    return new URL(image.url).pathname.split('/').pop() || image.url;
+  } catch {
+    return image.url ?? 'image';
+  }
+}

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,4 +1,5 @@
 import { htmlEscape, diffBlockPairs } from './browser-diff.js';
+import { describeImage } from './ocr.js';
 
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
 const DEFAULT_FETCH_TIMEOUT_MS = 30000;
@@ -351,7 +352,7 @@ function bigramCounts(text) {
   return counts;
 }
 
-export function buildPreviewHtml({ html, blocks, rewrites, sourceUrl, explanationHtml = '', scoreChip = null }) {
+export function buildPreviewHtml({ html, blocks, rewrites, sourceUrl, explanationHtml = '', scoreChip = null, imageFindings = [] }) {
   let changedCount = 0;
   const planned = blocks.map((block, index) => {
     const rewritten = rewrites[index];
@@ -369,10 +370,55 @@ export function buildPreviewHtml({ html, blocks, rewrites, sourceUrl, explanatio
     out = out.slice(0, block.start) + replacement + out.slice(block.end);
   }
 
+  const image = annotateImageFindings(out, imageFindings);
+  out = image.html;
+
   out = stripActiveContent(out);
   out = injectHead(out, sourceUrl);
-  out = injectChrome(out, { changedCount, totalCount: blocks.length, explanationHtml, scoreChip });
-  return { html: out, changedCount, totalCount: blocks.length };
+  out = injectChrome(out, {
+    changedCount,
+    totalCount: blocks.length,
+    explanationHtml,
+    scoreChip,
+    imageCardsHtml: image.cardsHtml,
+    imageChangedCount: image.changedCount,
+  });
+  return { html: out, changedCount, totalCount: blocks.length, imageChangedCount: image.changedCount };
+}
+
+// OCR findings cannot be swapped into pixels, so changed image text is
+// surfaced as an annotation: the <img> gets a dashed bronze outline with an
+// I-numbered badge, and a notes card shows the extracted text next to the
+// suggested rewrite. Findings with no DOM anchor (CSS-background data URIs)
+// get a card only.
+function annotateImageFindings(html, imageFindings) {
+  let out = html;
+  let changedCount = 0;
+  const cards = [];
+  for (const finding of imageFindings) {
+    if (!finding.changed) continue;
+    changedCount += 1;
+    const n = changedCount;
+    if (finding.anchor) {
+      const tagRe = new RegExp(`<img\\b[^>]*src="${escapeRegExp(finding.anchor)}"[^>]*>`, 'i');
+      let wrapped = false;
+      out = out.replace(tagRe, (tag) => {
+        wrapped = true;
+        return `<span class="ptna-img" id="ptna-img-${n}" data-n="I${n}">${tag}</span>`;
+      });
+      finding.anchored = wrapped;
+    }
+    cards.push(
+      `<article class="explain-card ptna-img-card"><strong>I${n}</strong> · ${htmlEscape(describeImage(finding))}`
+      + `<br>Image text: ${htmlEscape(finding.text)}`
+      + `<br>Suggested: <span class="ptna-img-suggest">${htmlEscape(finding.rewritten)}</span></article>`,
+    );
+  }
+  return { html: out, cardsHtml: cards.join(''), changedCount };
+}
+
+function escapeRegExp(text) {
+  return String(text).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 // File input has no host page to overlay, so render the text as a reading
@@ -440,7 +486,7 @@ function injectHead(html, sourceUrl) {
   return `<head>${injection}</head>${html}`;
 }
 
-function injectChrome(html, { changedCount, totalCount, explanationHtml = '', scoreChip = null }) {
+function injectChrome(html, { changedCount, totalCount, explanationHtml = '', scoreChip = null, imageCardsHtml = '', imageChangedCount = 0 }) {
   const inputs = changedCount > 0
     ? '<input type="radio" name="ptna-view" id="ptna-v-rew" class="ptna-toggle-input" checked>'
       + '<input type="radio" name="ptna-view" id="ptna-v-orig" class="ptna-toggle-input">'
@@ -451,6 +497,8 @@ function injectChrome(html, { changedCount, totalCount, explanationHtml = '', sc
   const overflow = changedCount > MAX_JUMP_CHIPS
     ? `<span class="ptna-chip ptna-chip-more">+${changedCount - MAX_JUMP_CHIPS}</span>`
     : '';
+  const imageChips = Array.from({ length: Math.min(imageChangedCount, MAX_JUMP_CHIPS) }, (_, i) =>
+    `<a class="ptna-chip ptna-chip-img" href="#ptna-img-${i + 1}">I${i + 1}</a>`).join('');
   const views = changedCount > 0
     ? '<div class="ptna-views">'
       + '<label class="ptna-view" for="ptna-v-rew">rewritten</label>'
@@ -458,13 +506,15 @@ function injectChrome(html, { changedCount, totalCount, explanationHtml = '', sc
       + '<label class="ptna-view" for="ptna-v-both">both</label>'
       + '</div>'
     : '';
-  const notes = explanationHtml
-    ? `<details class="ptna-notes"><summary>patina notes</summary><div class="ptna-notes-body">${explanationHtml}</div></details>`
+  const notesBody = `${explanationHtml}${imageCardsHtml}`;
+  const notes = notesBody
+    ? `<details class="ptna-notes"><summary>patina notes</summary><div class="ptna-notes-body">${notesBody}</div></details>`
     : '';
   const bar = `<div class="ptna-bar"><span class="ptna-brand">patina</span>`
     + `<span class="ptna-count">${changedCount} of ${totalCount} blocks rewritten</span>`
+    + (imageChangedCount > 0 ? `<span class="ptna-count ptna-count-img">${imageChangedCount} image(s)</span>` : '')
     + (scoreChip ? `<span class="ptna-score">${htmlEscape(scoreChip)}</span>` : '')
-    + (chips ? `<nav class="ptna-jump" aria-label="Jump to rewrite">${chips}${overflow}</nav>` : '')
+    + (chips || imageChips ? `<nav class="ptna-jump" aria-label="Jump to rewrite">${chips}${overflow}${imageChips}</nav>` : '')
     + views
     + '</div>';
 
@@ -529,6 +579,14 @@ const PREVIEW_CSS = `
 .ptna-chip{min-width:22px;text-align:center;padding:3px 0;border:1px solid rgba(95,196,168,0.35);border-radius:999px;color:#5fc4a8 !important;text-decoration:none !important;font:inherit !important;}
 .ptna-chip:hover{background:rgba(95,196,168,0.15);}
 .ptna-chip-more{border-color:rgba(141,165,154,0.3);color:#8da59a !important;}
+.ptna-chip-img{color:#c8956c !important;border-color:rgba(200,149,108,0.4);}
+.ptna-chip-img:hover{background:rgba(200,149,108,0.15);}
+.ptna-count-img{color:#c8956c !important;}
+.ptna-img{display:inline-block;position:relative;outline:2px dashed #c8956c !important;outline-offset:3px;border-radius:4px;scroll-margin-top:90px;}
+.ptna-img::after{content:attr(data-n);position:absolute;top:6px;left:6px;padding:1px 7px;border-radius:999px;background:#c8956c;color:#20150c;font:700 10.5px/16px ui-monospace,Menlo,Consolas,monospace !important;}
+.ptna-img:target{outline-style:solid !important;outline-width:3px !important;}
+.ptna-img-card{border-left-color:#c8956c !important;background:rgba(200,149,108,0.05) !important;}
+.ptna-img-suggest{color:#5fc4a8;}
 .ptna-views{display:inline-flex;border:1px solid rgba(141,165,154,0.4);border-radius:999px;overflow:hidden;}
 .ptna-view{padding:4px 11px;cursor:pointer;user-select:none;color:#8da59a;font:inherit;}
 .ptna-view:hover{color:#cfe2d8;}

--- a/src/preview.js
+++ b/src/preview.js
@@ -57,12 +57,38 @@ export async function fetchPreviewPage(url, options = {}) {
 
 // Prepare fetched HTML for extraction and overlay: harvest the React
 // streaming swap operations while the inline scripts still exist, drop
-// active content, then statically resolve the stream so Suspense content
-// is visible without JS.
+// active content, statically resolve the stream so Suspense content is
+// visible without JS, then inline srcdoc iframes so their content becomes
+// first-class DOM (prose extraction + OCR + the overlay all reach it).
 export function prepareSnapshotHtml(html) {
   const raw = String(html ?? '');
   const ops = harvestStreamOps(raw);
-  return resolveStreamedHtml(stripActiveContent(raw), ops);
+  return inlineSrcdocIframes(resolveStreamedHtml(stripActiveContent(raw), ops));
+}
+
+// Sites embed long detail pages (the scrollable below-the-fold content) in
+// <iframe srcdoc="...">. The detail HTML lives escaped inside an attribute,
+// so prose extraction never sees it. Decode each srcdoc, strip its active
+// content, and inline it as a <div> so the detail copy and images are
+// rewritten and annotated like the rest of the page.
+export function inlineSrcdocIframes(html) {
+  // Internal quotes inside srcdoc are entity-escaped (&quot;), so the value
+  // never contains a raw double quote — [^"]* is a safe attribute capture.
+  const iframeRe = /<iframe\b[^>]*\bsrcdoc="([^"]*)"[^>]*>(?:[\s\S]*?<\/iframe\s*>)?/gi;
+  return String(html ?? '').replace(iframeRe, (_, srcdoc) => {
+    const decoded = stripActiveContent(decodeHtmlEntities(srcdoc));
+    return `<div class="ptna-srcdoc">${decoded}</div>`;
+  });
+}
+
+function decodeHtmlEntities(value) {
+  return String(value)
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/gi, "'")
+    .replace(/&amp;/gi, '&');
 }
 
 // React 18 streaming SSR ships late content as hidden segments

--- a/src/preview.js
+++ b/src/preview.js
@@ -391,6 +391,12 @@ export function buildPreviewHtml({ html, blocks, rewrites, sourceUrl, explanatio
 // I-numbered badge, and a notes card shows the extracted text next to the
 // suggested rewrite. Findings with no DOM anchor (CSS-background data URIs)
 // get a card only.
+// OCR findings cannot be swapped into pixels and the host image is often a
+// CSS background, a carousel slide, or lazy-loaded — none reliably visible on
+// the frozen snapshot. So each finding's card embeds the exact image patina
+// OCR'd (capped thumbnail) alongside the extracted text and suggested rewrite;
+// the card itself is the jump target, so a finding is always reachable. When
+// the image IS a plain <img> in the DOM it also gets an on-page badge.
 function annotateImageFindings(html, imageFindings) {
   let out = html;
   let changedCount = 0;
@@ -401,17 +407,18 @@ function annotateImageFindings(html, imageFindings) {
     const n = changedCount;
     if (finding.anchor) {
       const tagRe = new RegExp(`<img\\b[^>]*src="${escapeRegExp(finding.anchor)}"[^>]*>`, 'i');
-      let wrapped = false;
-      out = out.replace(tagRe, (tag) => {
-        wrapped = true;
-        return `<span class="ptna-img" id="ptna-img-${n}" data-n="I${n}">${tag}</span>`;
-      });
-      finding.anchored = wrapped;
+      out = out.replace(tagRe, (tag) => `<span class="ptna-img" data-n="I${n}">${tag}</span>`);
     }
+    const thumb = finding.previewDataUri
+      ? `<img class="ptna-img-thumb" alt="" src="${htmlEscape(finding.previewDataUri)}">`
+      : '';
     cards.push(
-      `<article class="explain-card ptna-img-card"><strong>I${n}</strong> · ${htmlEscape(describeImage(finding))}`
-      + `<br>Image text: ${htmlEscape(finding.text)}`
-      + `<br>Suggested: <span class="ptna-img-suggest">${htmlEscape(finding.rewritten)}</span></article>`,
+      `<article class="explain-card ptna-img-card" id="ptna-img-${n}">`
+      + `<div class="ptna-img-head"><strong>I${n}</strong> · ${htmlEscape(describeImage(finding))}</div>`
+      + thumb
+      + `<div class="ptna-img-text"><span class="ptna-img-label">image text</span>${htmlEscape(finding.text)}</div>`
+      + `<div class="ptna-img-text"><span class="ptna-img-label">suggested</span><span class="ptna-img-suggest">${htmlEscape(finding.rewritten)}</span></div>`
+      + '</article>',
     );
   }
   return { html: out, cardsHtml: cards.join(''), changedCount };
@@ -507,8 +514,12 @@ function injectChrome(html, { changedCount, totalCount, explanationHtml = '', sc
       + '</div>'
     : '';
   const notesBody = `${explanationHtml}${imageCardsHtml}`;
+  // Auto-open when there are image findings — they have no in-page diff, so a
+  // collapsed panel would hide the only place they appear.
+  const open = imageChangedCount > 0 ? ' open' : '';
+  const summaryLabel = imageChangedCount > 0 ? `patina notes · ${imageChangedCount} image text` : 'patina notes';
   const notes = notesBody
-    ? `<details class="ptna-notes"><summary>patina notes</summary><div class="ptna-notes-body">${notesBody}</div></details>`
+    ? `<details class="ptna-notes"${open}><summary>${summaryLabel}</summary><div class="ptna-notes-body">${notesBody}</div></details>`
     : '';
   const bar = `<div class="ptna-bar"><span class="ptna-brand">patina</span>`
     + `<span class="ptna-count">${changedCount} of ${totalCount} blocks rewritten</span>`
@@ -585,7 +596,13 @@ const PREVIEW_CSS = `
 .ptna-img{display:inline-block;position:relative;outline:2px dashed #c8956c !important;outline-offset:3px;border-radius:4px;scroll-margin-top:90px;}
 .ptna-img::after{content:attr(data-n);position:absolute;top:6px;left:6px;padding:1px 7px;border-radius:999px;background:#c8956c;color:#20150c;font:700 10.5px/16px ui-monospace,Menlo,Consolas,monospace !important;}
 .ptna-img:target{outline-style:solid !important;outline-width:3px !important;}
-.ptna-img-card{border-left-color:#c8956c !important;background:rgba(200,149,108,0.05) !important;}
+.ptna-img-card{border-left-color:#c8956c !important;background:rgba(200,149,108,0.05) !important;scroll-margin-top:16px;}
+.ptna-img-card:target{outline:2px solid #c8956c !important;outline-offset:2px;}
+.ptna-img-head{font-size:11px;color:#8da59a;margin-bottom:7px;}
+.ptna-img-head strong{color:#c8956c;}
+.ptna-img-thumb{display:block;max-width:100%;max-height:220px;width:auto;border-radius:6px;border:1px solid rgba(132,168,152,0.25);margin:0 0 8px;}
+.ptna-img-text{margin:5px 0;line-height:1.6;}
+.ptna-img-label{display:inline-block;min-width:62px;font:600 9.5px/1.6 ui-monospace,Menlo,Consolas,monospace !important;text-transform:uppercase;letter-spacing:0.08em;color:#8da59a;vertical-align:top;}
 .ptna-img-suggest{color:#5fc4a8;}
 .ptna-views{display:inline-flex;border:1px solid rgba(141,165,154,0.4);border-radius:999px;overflow:hidden;}
 .ptna-view{padding:4px 11px;cursor:pointer;user-select:none;color:#8da59a;font:inherit;}

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -4,6 +4,7 @@ import { EventEmitter } from 'node:events';
 import { createServer } from 'node:http';
 import { main, resolvePromptMode } from '../../src/cli.js';
 import { setBrowserDiffRuntimeForTests, resetBrowserDiffRuntimeForTests } from '../../src/browser-diff.js';
+import { setOcrRuntimeForTests, resetOcrRuntimeForTests } from '../../src/ocr.js';
 import { startMockServer } from './helpers/mock-server.js';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
@@ -770,6 +771,83 @@ describe('CLI End-to-End with Mock API', () => {
     }
   });
 
+  it('annotates image text findings with --preview --ocr', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'patina-ocr-e2e-'));
+    const htmlPath = join(dir, 'page.html');
+    writeFileSync(join(dir, 'banner.png'), Buffer.from('fake-png-bytes'));
+    writeFileSync(htmlPath, [
+      '<html><head><title>ocr</title></head><body>',
+      '<p>The first paragraph is long enough to be rewritten by the preview flow.</p>',
+      '<img src="banner.png" alt="배너">',
+      '</body></html>',
+    ].join('\n'));
+
+    // Rewrite returns 2 paragraphs: the DOM block + the OCR block, both changed.
+    const rewriteResponse = [
+      '[BODY]',
+      'First paragraph rewritten by the mock backend for the preview test.',
+      '',
+      '이미지 문구를 사람답게 고쳐 쓴 결과입니다',
+      '[/BODY]',
+    ].join('\n');
+
+    const writes = [];
+    setBrowserDiffRuntimeForTests({
+      tmpdir: () => '/tmp',
+      mkdtemp: () => '/tmp/patina-preview-ocr',
+      writeFile: (path, data) => {
+        writes.push({ path, data });
+      },
+      chmod: () => {},
+      now: () => 11,
+      platform: 'linux',
+      spawn: makeFakeSpawn(({ child }) => {
+        process.nextTick(() => child.emit('close', 0));
+      }),
+    });
+    setOcrRuntimeForTests({
+      runOcr: async () => '혁신적인 솔루션으로 생산성을 극대화하세요',
+    });
+
+    mock.callCount = 0;
+    try {
+      await mock.stop();
+      mock = await startMockServer([
+        { responseText: rewriteResponse },
+        { responseText: 'Pattern: 1. Marketing puffery\nRemoved: old\nAdded: new\nWhy: reason' },
+      ]);
+
+      const previewRun = await captureConsole(() => main([
+        '--preview',
+        '--ocr',
+        '--lang', 'ko',
+        '--api-key-file', mockApiKeyPath,
+        '--base-url', `http://127.0.0.1:${mock.port}`,
+        htmlPath,
+      ]));
+
+      assert.strictEqual(mock.callCount, 2);
+      assert.ok(previewRun.errors.some((line) => line.includes('1 image(s) flagged')));
+      // stdout stays pipe-safe: the page's own text only, no OCR block.
+      const stdout = previewRun.logs.join('\n');
+      assert.ok(stdout.includes('First paragraph rewritten by the mock backend'));
+      assert.ok(!stdout.includes('이미지 문구를 사람답게'));
+
+      const page = writes[0].data;
+      assert.ok(page.includes('<span class="ptna-img" id="ptna-img-1" data-n="I1">'));
+      assert.ok(page.includes('Image text: 혁신적인 솔루션으로 생산성을 극대화하세요'));
+      assert.ok(page.includes('이미지 문구를 사람답게 고쳐 쓴 결과입니다'));
+      assert.ok(page.includes('href="#ptna-img-1"'));
+      assert.ok(page.includes('1 image(s)'));
+    } finally {
+      resetBrowserDiffRuntimeForTests();
+      resetOcrRuntimeForTests();
+      rmSync(dir, { recursive: true, force: true });
+      await mock.stop();
+      mock = await startMockServer('This is the humanized result.');
+    }
+  });
+
   it('rejects unsupported --browser inputs before any backend call', async () => {
     const first = resolve(REPO_ROOT, 'tests/e2e/test-input-en.txt');
     const second = first;
@@ -783,6 +861,7 @@ describe('CLI End-to-End with Mock API', () => {
       { args: ['--preview'], pattern: /--preview requires exactly one input/ },
       { args: ['--preview', first, second], pattern: /--preview requires exactly one input/ },
       { args: ['--preview', 'draft.pdf'], pattern: /--preview supports http\(s\) URLs, \.html, \.md, and \.txt input/ },
+      { args: ['--ocr', first], pattern: /--ocr requires --preview/ },
       { args: ['--preview', '--batch', 'https://example.test'], pattern: /does not support --batch/ },
       { args: ['--preview', '--browser', 'https://example.test'], pattern: /cannot be combined/ },
     ];

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -834,11 +834,17 @@ describe('CLI End-to-End with Mock API', () => {
       assert.ok(!stdout.includes('이미지 문구를 사람답게'));
 
       const page = writes[0].data;
-      assert.ok(page.includes('<span class="ptna-img" id="ptna-img-1" data-n="I1">'));
-      assert.ok(page.includes('Image text: 혁신적인 솔루션으로 생산성을 극대화하세요'));
+      // The <img> gets an on-page badge, and the finding card embeds the
+      // extracted text + suggestion (+ a thumbnail of the OCR'd image).
+      assert.ok(page.includes('<span class="ptna-img" data-n="I1">'));
+      assert.ok(page.includes('id="ptna-img-1"'));
+      assert.ok(page.includes('혁신적인 솔루션으로 생산성을 극대화하세요'));
       assert.ok(page.includes('이미지 문구를 사람답게 고쳐 쓴 결과입니다'));
+      assert.ok(page.includes('ptna-img-thumb'));
       assert.ok(page.includes('href="#ptna-img-1"'));
       assert.ok(page.includes('1 image(s)'));
+      // The notes panel auto-opens so image findings aren't hidden.
+      assert.ok(/<details class="ptna-notes" open>/.test(page));
     } finally {
       resetBrowserDiffRuntimeForTests();
       resetOcrRuntimeForTests();

--- a/tests/unit/ocr.test.js
+++ b/tests/unit/ocr.test.js
@@ -41,6 +41,20 @@ test('collectImageCandidates resolves sources, unwraps Next.js proxies, and dedu
   assert.strictEqual(candidates.filter((c) => c.kind === 'data').length, 1);
 });
 
+test('collectImageCandidates rejects file:// images from a remote page', () => {
+  const html = '<img src="file:///home/user/private.png" alt="x"><p>hi</p><img src="/_next/image?url=file%3A%2F%2F%2Fetc%2Fsecret.png&amp;w=640">';
+  const { candidates } = collectImageCandidates(html, 'https://attacker.test/page');
+  assert.strictEqual(candidates.filter((c) => c.kind === 'file').length, 0);
+});
+
+test('collectImageCandidates allows file:// images for a local .html preview', () => {
+  const html = '<img src="banner.png" alt="배너 이미지입니다">';
+  const { candidates } = collectImageCandidates(html, 'file:///home/user/page.html');
+  assert.strictEqual(candidates.length, 1);
+  assert.strictEqual(candidates[0].kind, 'file');
+  assert.strictEqual(candidates[0].url, 'file:///home/user/banner.png');
+});
+
 test('collectImageCandidates caps by priority', () => {
   const html = [
     '<img src="/a/photo-1.jpg">',
@@ -53,6 +67,18 @@ test('collectImageCandidates caps by priority', () => {
   assert.ok(candidates[0].url.includes('thumbnail-koreatext'));
 });
 
+function bodyFor(text) {
+  const data = Buffer.from(text);
+  let sent = false;
+  return {
+    getReader() {
+      return {
+        read: async () => (sent ? { done: true } : (sent = true, { done: false, value: new Uint8Array(data) })),
+      };
+    },
+  };
+}
+
 test('stageOcrImages enforces size caps and stages files, urls, and data URIs', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'patina-ocr-test-'));
   const localImage = join(dir, 'local.png');
@@ -61,7 +87,7 @@ test('stageOcrImages enforces size caps and stages files, urls, and data URIs', 
   const fetchImpl = async (url) => ({
     ok: true,
     headers: { get: (name) => (name === 'content-length' && url.includes('huge') ? String(10 * 1024 * 1024) : null) },
-    arrayBuffer: async () => Buffer.from(url.includes('fail') ? '' : 'remote-bytes'),
+    body: bodyFor(url.includes('huge') ? 'x'.repeat(5 * 1024 * 1024) : 'remote-bytes'),
   });
 
   const candidates = [
@@ -81,6 +107,38 @@ test('stageOcrImages enforces size caps and stages files, urls, and data URIs', 
   } finally {
     rmSync(result.dir, { recursive: true, force: true });
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('stageOcrImages caps a stream that lies about (omits) Content-Length', async () => {
+  const fetchImpl = async () => ({
+    ok: true,
+    headers: { get: () => null }, // no content-length
+    body: bodyFor('y'.repeat(5 * 1024 * 1024)),
+  });
+  const result = await stageOcrImages(
+    [{ kind: 'url', url: 'https://evil.test/stream.png', ext: 'png' }],
+    { fetchImpl, maxBytes: 1024 },
+  );
+  try {
+    assert.strictEqual(result.staged.length, 0);
+    assert.strictEqual(result.skipped.length, 1);
+    assert.match(result.skipped[0].reason, /larger than/);
+  } finally {
+    rmSync(result.dir, { recursive: true, force: true });
+  }
+});
+
+test('stageOcrImages records skips for every candidate past the total budget', async () => {
+  const fetchImpl = async () => ({ ok: true, headers: { get: () => null }, body: bodyFor('z'.repeat(800)) });
+  const candidates = Array.from({ length: 4 }, (_, i) => ({ kind: 'url', url: `https://cdn.test/${i}.png`, ext: 'png' }));
+  const result = await stageOcrImages(candidates, { fetchImpl, totalBudget: 1000 });
+  try {
+    assert.strictEqual(result.staged.length, 1);
+    assert.strictEqual(result.skipped.length, 3);
+    assert.ok(result.skipped.every((s) => /budget/.test(s.reason)));
+  } finally {
+    rmSync(result.dir, { recursive: true, force: true });
   }
 });
 

--- a/tests/unit/ocr.test.js
+++ b/tests/unit/ocr.test.js
@@ -1,0 +1,122 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  collectImageCandidates,
+  stageOcrImages,
+  ocrStagedImages,
+  normalizeOcrText,
+  setOcrRuntimeForTests,
+  resetOcrRuntimeForTests,
+} from '../../src/ocr.js';
+import { stageCliImages } from '../../src/backends/contract.js';
+
+const BIG_DATA_URI = `data:image/jpeg;base64,${'A'.repeat(4000)}`;
+
+test('collectImageCandidates resolves sources, unwraps Next.js proxies, and dedupes', () => {
+  const html = [
+    '<img src="/img/banner-card.webp" alt="카드뉴스 배너">',
+    '<img src="/_next/image?url=https%3A%2F%2Fcdn.test%2Fthumbnail-a.webp&amp;w=3840&amp;q=75">',
+    '<img src="/img/banner-card.webp" alt="duplicate">',
+    '<img srcset="/img/sm.jpg 320w, /img/mid.jpg 640w, /img/huge.jpg 3840w">',
+    '<img src="/icons/logo.svg">',
+    `<img src="${BIG_DATA_URI}">`,
+    `<div style="background-image:url(${BIG_DATA_URI})"></div>`,
+    '<img src="data:image/png;base64,AAAA">',
+  ].join('\n');
+
+  const { candidates, truncated } = collectImageCandidates(html, 'https://example.test/page');
+  assert.strictEqual(truncated, false);
+  const urls = candidates.filter((c) => c.kind === 'url').map((c) => c.url);
+  assert.ok(urls.includes('https://example.test/img/banner-card.webp'));
+  assert.ok(urls.includes('https://cdn.test/thumbnail-a.webp'));
+  assert.ok(urls.includes('https://example.test/img/mid.jpg'));
+  assert.strictEqual(urls.filter((u) => u.includes('banner-card')).length, 1);
+  assert.ok(!urls.some((u) => u.endsWith('.svg')));
+  // The two identical big data URIs dedupe to one; the tiny placeholder is dropped.
+  assert.strictEqual(candidates.filter((c) => c.kind === 'data').length, 1);
+});
+
+test('collectImageCandidates caps by priority', () => {
+  const html = [
+    '<img src="/a/photo-1.jpg">',
+    '<img src="/b/thumbnail-koreatext.jpg" alt="한국어 텍스트가 들어있는 배너">',
+    '<img src="/c/photo-2.jpg">',
+  ].join('');
+  const { candidates, truncated } = collectImageCandidates(html, 'https://example.test/', { maxImages: 1 });
+  assert.strictEqual(truncated, true);
+  assert.strictEqual(candidates.length, 1);
+  assert.ok(candidates[0].url.includes('thumbnail-koreatext'));
+});
+
+test('stageOcrImages enforces size caps and stages files, urls, and data URIs', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'patina-ocr-test-'));
+  const localImage = join(dir, 'local.png');
+  writeFileSync(localImage, Buffer.from('local-bytes'));
+
+  const fetchImpl = async (url) => ({
+    ok: true,
+    headers: { get: (name) => (name === 'content-length' && url.includes('huge') ? String(10 * 1024 * 1024) : null) },
+    arrayBuffer: async () => Buffer.from(url.includes('fail') ? '' : 'remote-bytes'),
+  });
+
+  const candidates = [
+    { kind: 'url', url: 'https://cdn.test/ok.webp', ext: 'webp' },
+    { kind: 'url', url: 'https://cdn.test/huge.jpg', ext: 'jpg' },
+    { kind: 'file', url: pathToFileURL(localImage).href, ext: 'png' },
+    { kind: 'data', dataUri: `data:image/png;base64,${Buffer.from('data-bytes').toString('base64')}`, ext: 'png' },
+  ];
+
+  const result = await stageOcrImages(candidates, { fetchImpl });
+  try {
+    assert.strictEqual(result.staged.length, 3);
+    assert.strictEqual(result.skipped.length, 1);
+    assert.match(result.skipped[0].reason, /larger than/);
+    assert.strictEqual(readFileSync(result.staged.find((s) => s.kind === 'file').path, 'utf8'), 'local-bytes');
+    assert.strictEqual(readFileSync(result.staged.find((s) => s.kind === 'data').path, 'utf8'), 'data-bytes');
+  } finally {
+    rmSync(result.dir, { recursive: true, force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('normalizeOcrText filters NO_TEXT and flattens to one paragraph', () => {
+  assert.strictEqual(normalizeOcrText('NO_TEXT'), null);
+  assert.strictEqual(normalizeOcrText('  \n '), null);
+  assert.strictEqual(normalizeOcrText('카드뉴스\n딸깍\n\n이번 주 AI 뉴스'), '카드뉴스 / 딸깍 / 이번 주 AI 뉴스');
+});
+
+test('ocrStagedImages uses the injected runner and drops empty results', async () => {
+  setOcrRuntimeForTests({
+    runOcr: async (image) => (image.path.includes('texty') ? '이미지 속 한국어 문장입니다' : 'NO_TEXT'),
+  });
+  try {
+    const results = await ocrStagedImages(
+      [{ path: '/tmp/texty.png', kind: 'url', url: 'https://x.test/texty.png' }, { path: '/tmp/blank.png', kind: 'url', url: 'https://x.test/blank.png' }],
+      {},
+    );
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].text, '이미지 속 한국어 문장입니다');
+  } finally {
+    resetOcrRuntimeForTests();
+  }
+});
+
+test('stageCliImages copies attachments into the backend temp dir', () => {
+  const src = mkdtempSync(join(tmpdir(), 'patina-stage-src-'));
+  const dst = mkdtempSync(join(tmpdir(), 'patina-stage-dst-'));
+  try {
+    const imagePath = join(src, 'photo.webp');
+    writeFileSync(imagePath, Buffer.from('img'));
+    const staged = stageCliImages(dst, [imagePath]);
+    assert.deepStrictEqual(staged, ['ocr-image-0.webp']);
+    assert.ok(existsSync(join(dst, 'ocr-image-0.webp')));
+  } finally {
+    rmSync(src, { recursive: true, force: true });
+    rmSync(dst, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/preview.test.js
+++ b/tests/unit/preview.test.js
@@ -10,6 +10,7 @@ import {
   harvestStreamOps,
   resolveStreamedHtml,
   prepareSnapshotHtml,
+  inlineSrcdocIframes,
 } from '../../src/preview.js';
 
 const LONG_KO = '이 문장은 미리보기 추출 테스트를 위한 충분히 긴 한국어 단락입니다.';
@@ -216,6 +217,23 @@ test('resolveStreamedHtml keeps fallbacks whose segment never streamed', () => {
   const html = '<body><!--$?--><template id="B:0"></template><p>still loading fallback text here</p><!--/$--></body>';
   const out = resolveStreamedHtml(html, [{ kind: 'boundary', targetId: 'B:0', contentId: 'S:0' }]);
   assert.ok(out.includes('still loading fallback text here'));
+});
+
+test('inlineSrcdocIframes decodes srcdoc detail content into first-class DOM', () => {
+  const inner = '<section class="page"><h1>상세 페이지의 충분히 긴 제목 텍스트입니다 여기</h1>'
+    + '<p>이 문단은 충분히 긴 상세 설명 본문이라 추출 대상이 됩니다.</p>'
+    + '<script>track()</script><img src="data:image/png;base64,AAAA"></section>';
+  const escaped = inner.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  const html = `<body><h2>위 본문</h2><iframe title="상세" sandbox="allow-same-origin" srcdoc="${escaped}"></iframe></body>`;
+
+  const out = inlineSrcdocIframes(html);
+  assert.ok(!/<iframe/i.test(out));
+  assert.ok(out.includes('<div class="ptna-srcdoc">'));
+  assert.ok(out.includes('<section class="page">'));
+  assert.ok(!out.includes('track()')); // active content stripped inside srcdoc
+  const { blocks } = extractProseBlocks(out);
+  assert.ok(blocks.some((b) => b.text.includes('상세 설명 본문')));
+  assert.ok(blocks.some((b) => b.text.includes('충분히 긴 제목')));
 });
 
 test('prepareSnapshotHtml resolves a streamed page end to end', () => {


### PR DESCRIPTION
## What

`patina --preview --ocr <url>` extends detection to **text baked into images** — card-news, banners, marketing thumbnails — which DOM-text detection cannot see. On Korean skill-shop pages the most AI-sounding copy often lives in pixels, so this closes a real blind spot.

Stacked on #423.

## How (zero new deps — local CLIs as vision models)

- **Backend contract** gains an optional `images` param. `claude-cli`/`gemini-cli` stage attachments into their existing per-invocation temp cwd (preserving the empty-cwd prompt-injection containment; claude's in-cwd Read is auto-allowed in print mode, gemini uses `@`-includes); `codex-cli` attaches natively via `-i`. `kimi-cli` (tools hard-disabled by design) and `openai-http` reject images. The whole timeout/abort/concurrency-slot/fallback stack applies unchanged.
- **`src/ocr.js`** collects candidates from `<img>` src/srcset/lazy attrs (Next.js `/_next/image` wrappers unwrapped to the original asset) plus document-wide base64 data URIs — card-news ships as CSS `background-image` data URIs, not `<img>`. Caps: 8 images/page by priority, 2 MB/image (streamed, never trusts Content-Length), 10 MB total; SVG skipped.
- Extracted text rides the **same rewrite call** as extra blocks. Pixels can't be edited, so a changed finding renders as an annotation: dashed bronze outline + `I`-badge on the image, and a notes card with extracted text + suggested rewrite. stdout stays pipe-safe.

## Recon + review (multi-agent)

Two workflows backed this PR: a 4-way recon (backend invocation modes, empirical Korean-OCR quality across claude/gemini/codex/tesseract, image inventory of the test pages) and a 3-dimension adversarial review (correctness/security/integration) with per-finding verification.

The review's 9 confirmed findings are all fixed in the second commit:
- **HIGH** `file://` image SSRF (remote page reading local files) — file: candidates now require a local (file:) base.
- **HIGH** e2e test broke CI (gated on a real vision CLI) — test override now bypasses backend selection; production still requires one.
- **MEDIUM** image-only pages hard-failed before OCR; asymmetric score-chip scopes; unbounded download OOM.
- **LOW** file-budget accounting, Ctrl-C surfacing, silent-fallback warning (issue #88), doctor `images=yes`.

## Verification

- 603/603 tests pass; lint clean. OCR e2e re-verified green in a CLI-less `env -i` sandbox (CI condition).
- Live: `--preview --ocr` on a Korean card-news page — 8/8 images OCR'd verbatim via claude-cli, one finding flagged with a correct suggestion, before & after the security fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)