### PR TITLE
release: 4.2.0

### DIFF
--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "4.1.0"
+version: "4.2.0"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,20 +12,26 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
-## Unreleased
+## 4.2.0 — 2026-06-12
+
+**In-place preview as the single review surface: file input, image-text OCR, full-page extraction coverage, live-design fidelity, and context-aware rewriting.**
+
+Semver rationale: minor — adds `--preview` file input, `--ocr`, the document-brief rewrite stage, and the extractor coverage rewrite; deprecates `--browser` behind a working alias (its stdout `--format` passthrough and any-extension input change under the deprecated flag, documented below rather than treated as breaking); the rest is preview-fidelity and sanitizer bug fixes. No API or schema removals.
 
 ### Added
+- `--preview` accepts local files, not just URLs (#423): `.html`/`.htm` runs through the same snapshot pipeline as a fetched page; `.md`/`.markdown`/`.txt` renders as a reading document. Both flows gain the diff page's remaining advantages — a collapsible "patina notes" explanation panel, a deterministic before/after score chip, and a three-state view toggle (rewritten / original / both, CSS-only). When the model merges or splits paragraphs, alignment falls back to LCS anchoring plus order-monotonic bigram-similarity pairing; unmatched blocks keep their original text instead of failing the run.
+- `--ocr` (#424): with `--preview` on URL/`.html` input, text baked into page images (card-news, banners, thumbnails) joins detection. Image-capable local CLI backends (`claude-cli`/`gemini-cli`/`codex-cli`) act as the vision layer — zero new dependencies, images staged into the backends' isolated temp dirs, the whole timeout/abort/fallback stack applies. Pixels can't be edited, so changed findings render as annotation cards embedding the exact OCR'd image, its text, and the suggested rewrite. Caps: 8 images/page by priority, 6MB/image (streamed), 16MB total; `file:` images only for local previews (SSRF guard).
+- URL extractor rewrite (#425): `extractProseBlocks` is now an attribute-aware single-pass tokenizer that recovers prose nested in rejected containers (`li>p`, wrapper divs), handles HTML5 optional end tags and React SSR empty-comment separators, and extracts leaf `div`/`section`/`article` copy. Measured visible-text coverage on real pages went from 16–55% to 73–84%.
 - Document-brief rewrite stage: rewrite prompts (minimal and strict, plus the SKILL.md pipeline as step 4.8) now derive a whole-document frame — document type, speaker/audience, dominant register, domain terms — before editing, and unify all rewritten sentences to the document's dominant register. For Korean input the dominant register is measured deterministically (`detectKoreanRegister`, sentence-ending distribution) and injected as a "document signals" section; `--preview` shows the measurement in a *document context* notes card. Addresses rewrites that stayed AI-flavored because blocks were paraphrased without global context.
 
 ### Fixed
+- `--preview` snapshot sanitizer is now a tag-aware walk (#425): neutralizes unclosed `<script>`, handlers hidden behind a `>` inside a quoted attribute, `/`- and quote-separated handler chains, and entity/control-encoded `javascript:` URLs; the page also carries a restrictive CSP (scripts/frames/objects blocked, passive assets allowed). `--ocr` image fetches from page content are SSRF-guarded — private/loopback/metadata addresses (including IPv4-mapped IPv6) refused unless same-host as the page, re-checked per redirect hop.
 - `--preview`: inlined `<iframe srcdoc>` detail content is no longer clipped by the host page's fixed-height `overflow:hidden` iframe wrapper — the adjacent sizing wrappers' inline height/overflow declarations are neutralized when the detail is inlined (#427).
 - `--preview`: inlined `<iframe srcdoc>` content now renders its viewport-relative CSS against the old iframe box instead of the window — the wrapper is a CSS container (`container-type:inline-size`) and the srcdoc's `vw` units and width-based `@media` queries are rewritten to container units/queries at inline time, so typography sizes and breakpoint layouts match the live page exactly (#430).
 - `--preview`: snapshots now freeze same-origin assets — stylesheets are inlined (relative `url()` absolutized against the stylesheet URL) and their same-origin fonts embedded as `data:` URIs — so pages render with their real CSS and web fonts even when the site blocks cross-site asset loads via Fetch Metadata, as Vercel-hosted sites do (#428).
 
 ### Deprecated
-- `--browser` is now an alias for `--preview` and prints a deprecation notice on stderr; the flag will be removed in 5.0. The in-place preview covers the old side-by-side diff page (the "both" view shows the rewrite next to the struck-through original) plus URL input, the score chip, and the notes panel. Behavior changes under the alias: stdout carries the rewritten prose only (the old byte-for-byte `--format` passthrough on stdout is gone), and input must match the preview contract (`.html`/`.md`/`.markdown`/`.txt`). The separate diff-page renderer was removed; `--serve` now documents against `--preview`.
-
-Semver rationale (for the next release): minor — the flag keeps working via the alias and warns; the stdout/extension contract change under a deprecated flag is called out here rather than treated as breaking.
+- `--browser` is now an alias for `--preview` and prints a deprecation notice on stderr; the flag will be removed in 5.0. The in-place preview covers the old side-by-side diff page (the "both" view shows the rewrite next to the struck-through original) plus URL input, the score chip, and the notes panel. Behavior changes under the alias: stdout carries the rewritten prose only (the old byte-for-byte `--format` passthrough on stdout is gone), and input must match the preview contract (`.html`/`.md`/`.markdown`/`.txt`). The separate diff-page renderer was removed; `--serve` now documents against `--preview` (#426).
 
 ## 4.1.0 — 2026-06-11
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 4.1.0" src="https://img.shields.io/badge/version-4.1.0-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 4.2.0" src="https://img.shields.io/badge/version-4.2.0-blue"></a>
 </p>
 
 <p align="center">
@@ -178,7 +178,7 @@ If meaning drifts, the change is retried or rolled back. Deterministic analysis 
 
 ```yaml
 # .patina.default.yaml
-version: "4.1.0"
+version: "4.2.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 4.1.0
+version: 4.2.0
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read

--- a/docs/API.md
+++ b/docs/API.md
@@ -163,7 +163,7 @@ and the model verdict is hot; absent model means baseline behavior.</p>
 <dt><a href="#runDefault">runDefault(parsed, logger)</a> ⇒ <code>Promise.&lt;void&gt;</code></dt>
 <dd><p>Run the default patina pipeline for an already-parsed CLI invocation:
 resolve config, provider, and backends, build prompts, then process each
-input job (rewrite/diff/audit/score/ouroboros, plus the browser-diff page).</p>
+input job (rewrite/diff/audit/score/ouroboros, plus the preview page).</p>
 </dd>
 <dt><a href="#createCancellationController">createCancellationController([options])</a> ⇒ <code>Object</code></dt>
 <dd><p>Create a SIGINT-aware cancellation controller for long-running CLI operations.</p>
@@ -334,6 +334,17 @@ single prompt can never carry two contradictory contracts (issue #397).</p>
 </dd>
 <dt><a href="#applyPrivateBaseURLOptIn">applyPrivateBaseURLOptIn([parsed])</a> ⇒ <code>void</code></dt>
 <dd><p>Persist CLI private-base-url opt-in into process.env for downstream calls.</p>
+</dd>
+<dt><a href="#isSubresourceFetchAllowed">isSubresourceFetchAllowed(rawUrl, [options])</a> ⇒ <code>Promise.&lt;boolean&gt;</code></dt>
+<dd><p>Decide whether a page-derived sub-resource (an <iframe src>, a CSS/<img>
+image URL) may be fetched. Unlike the user-typed preview URL — which is
+trusted and may point at localhost dev servers — these URLs come from page
+CONTENT, so a hostile page could aim them at cloud metadata (169.254.169.254)
+or internal RFC 1918 / loopback services (SSRF). The hostname is resolved
+(DNS rebinding aside, this catches names that map to private space) and any
+private/loopback/link-local result is refused UNLESS it shares the previewed
+page&#39;s host — a page may load its own internal assets, but an arbitrary
+public page may not reach into the local network.</p>
 </dd>
 </dl>
 
@@ -590,7 +601,7 @@ await main(['--help']);
 ## runDefault(parsed, logger) ⇒ <code>Promise.&lt;void&gt;</code>
 Run the default patina pipeline for an already-parsed CLI invocation:
 resolve config, provider, and backends, build prompts, then process each
-input job (rewrite/diff/audit/score/ouroboros, plus the browser-diff page).
+input job (rewrite/diff/audit/score/ouroboros, plus the preview page).
 
 **Kind**: global function
 **Returns**: <code>Promise.&lt;void&gt;</code> - Resolves after all job output is written.
@@ -1177,6 +1188,7 @@ Build the LLM prompt for rewrite, diff, audit, score, or ouroboros mode.
 | options.text | <code>string</code> |  | Input text. |
 | [options.mode] | <code>string</code> | <code>&quot;rewrite&quot;</code> | Output mode. |
 | [options.tone] | <code>object</code> \| <code>null</code> | <code></code> | Tone resolution metadata. |
+| [options.documentSignals] | <code>Array.&lt;string&gt;</code> \| <code>null</code> | <code></code> | Deterministic document   measurements (e.g. dominant Korean register) injected into rewrite prompts   as ground truth for the Phase 0 document brief. |
 
 **Example**
 ```js
@@ -1627,3 +1639,25 @@ Persist CLI private-base-url opt-in into process.env for downstream calls.
 ```js
 applyPrivateBaseURLOptIn({ allowPrivateBaseURL: true });
 ```
+<a name="isSubresourceFetchAllowed"></a>
+
+## isSubresourceFetchAllowed(rawUrl, [options]) ⇒ <code>Promise.&lt;boolean&gt;</code>
+Decide whether a page-derived sub-resource (an <iframe src>, a CSS/<img>
+image URL) may be fetched. Unlike the user-typed preview URL — which is
+trusted and may point at localhost dev servers — these URLs come from page
+CONTENT, so a hostile page could aim them at cloud metadata (169.254.169.254)
+or internal RFC 1918 / loopback services (SSRF). The hostname is resolved
+(DNS rebinding aside, this catches names that map to private space) and any
+private/loopback/link-local result is refused UNLESS it shares the previewed
+page's host — a page may load its own internal assets, but an arbitrary
+public page may not reach into the local network.
+
+**Kind**: global function
+**Returns**: <code>Promise.&lt;boolean&gt;</code> - True when the fetch is allowed.
+
+| Param | Type | Description |
+| --- | --- | --- |
+| rawUrl | <code>string</code> | Absolute http(s) sub-resource URL. |
+| [options] | <code>object</code> |  |
+| [options.baseUrl] | <code>string</code> | The previewed page's URL. |
+| [options.lookupImpl] | <code>function</code> | DNS resolver (injectable for tests);   defaults to node:dns/promises lookup with {all:true}. |

--- a/docs/benchmarks/latest.json
+++ b/docs/benchmarks/latest.json
@@ -7,7 +7,7 @@
   "schemaVersion": 3,
   "fixtureSchemaVersion": 1,
   "nodeVersion": "v22.17.1",
-  "generatedAt": "2026-06-10T11:56:24.875Z",
+  "generatedAt": "2026-06-12T09:36:23.679Z",
   "fixtureCount": 49,
   "overallAccuracy": 1,
   "overall": {

--- a/docs/benchmarks/latest.md
+++ b/docs/benchmarks/latest.md
@@ -7,7 +7,7 @@ This is the latest checked-in report for patina's deterministic suspect-zone ben
 ## Current result
 
 - Status: **passing**
-- Generated at: 2026-06-10T11:56:24.875Z
+- Generated at: 2026-06-12T09:36:23.679Z
 - Node: v22.17.1
 - Fixture schema: v1
 - Fixtures: 49

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "patina-cli",
-  "version": "4.0.1",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "patina-cli",
-      "version": "4.0.1",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "4.1.0"
+    "patina-cli": "4.2.0"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## 4.2.0 — 2026-06-12

**In-place preview as the single review surface: file input, image-text OCR, full-page extraction coverage, live-design fidelity, and context-aware rewriting.**

Semver: **minor** (full rationale in the CHANGELOG entry).

## Release prep in this PR

- CHANGELOG: Unreleased → 4.2.0 with title + rationale. Changelog-completeness audit of `v4.1.0..HEAD` (the 4.1.0 lesson) found **three merged-without-changelog features** — #423 preview file input, #424 `--ocr`, #425 extractor coverage + hardening — now documented.
- Version 4.2.0 across the five synchronized spots (package.json, patina-humanizer version + pin, SKILL.md, .patina.default.yaml, README badge + yaml) + lockfile.
- docs/API.md regenerated (new `isSubresourceFetchAllowed` export); benchmark report regenerated (timestamp-only drift, precision/recall unchanged); dogfood clean.

## Gates (local)

`release:check` OK · 630/630 tests · `benchmark:report` no metric drift · `dogfood` all under gate.

After merge: tag `v4.2.0` → release.yml verify + npm publish with provenance (patina-cli, patina-humanizer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)