### PR TITLE
fix(ouroboros): check fidelity/MPS floors before declaring target met

### DIFF
--- a/src/ouroboros.js
+++ b/src/ouroboros.js
@@ -205,19 +205,24 @@ export async function runOuroboros({
     let shouldStop = false;
     let shouldRollback = false;
 
-    if (currentScore <= targetScore) {
-      reason = 'Target met';
-      shouldStop = true;
-    } else if (combinedDelta < 0) {
-      reason = `Regression (combined ${previousCombined} → ${combined})`;
-      shouldStop = true;
-      shouldRollback = true;
-    } else if (fidelity < fidelityFloor) {
+    // Floor checks MUST precede the target-met check (core/scoring.md "Ouroboros
+    // Loop Gating": both floors must pass for an iteration to be accepted).
+    // Deleting content is the easiest way to drop AI-likeness, so the iteration
+    // most likely to violate the floors is exactly the one that meets the target;
+    // checking the target first would accept it and promote gutted text to bestText.
+    if (fidelity < fidelityFloor) {
       reason = 'Fidelity floor violation';
       shouldStop = true;
       shouldRollback = true;
     } else if (mps === null || mps < mpsFloor) {
       reason = mps === null ? 'MPS scorer failure' : 'MPS floor violation';
+      shouldStop = true;
+      shouldRollback = true;
+    } else if (currentScore <= targetScore) {
+      reason = 'Target met';
+      shouldStop = true;
+    } else if (combinedDelta < 0) {
+      reason = `Regression (combined ${previousCombined} → ${combined})`;
       shouldStop = true;
       shouldRollback = true;
     } else if (delta <= plateauThreshold) {

--- a/tests/unit/ouroboros.test.js
+++ b/tests/unit/ouroboros.test.js
@@ -219,3 +219,71 @@ test('runOuroboros logs per-iteration score progress and latency', async () => {
   assert.equal(records[0].latency_ms, 500);
   assert.match(records[0].message, /\[ouroboros\] iter 1\/3 score 80 → 70 \(0\.5s\)/);
 });
+
+test('runOuroboros rolls back when target is met but fidelity floor is violated', async () => {
+  // Score 20 meets the default target (30), but fidelity grade 1 is below the
+  // 70 floor. Floors must win: the gutted rewrite is rejected, not returned.
+  const fixture = createLLMFixture({
+    scores: [80, 20],
+    rewrites: ['Gutted but target-meeting text.'],
+    mps: [100],
+    fidelityGrades: [1],
+  });
+
+  const result = await runWithFixture(fixture);
+
+  assert.equal(result.finalText, BASE_TEXT);
+  assert.equal(result.finalScore, 80);
+  assert.equal(result.iterations, 1);
+  assert.equal(result.reason, 'Fidelity floor violation');
+});
+
+test('runOuroboros rolls back when target is met but MPS floor is violated', async () => {
+  const fixture = createLLMFixture({
+    scores: [80, 20],
+    rewrites: ['Meaning-stripped target-meeting text.'],
+    mps: [50],
+    fidelityGrades: [3],
+  });
+
+  const result = await runWithFixture(fixture);
+
+  assert.equal(result.finalText, BASE_TEXT);
+  assert.equal(result.finalScore, 80);
+  assert.equal(result.iterations, 1);
+  assert.equal(result.reason, 'MPS floor violation');
+});
+
+test('runOuroboros rolls back when target is met but the MPS scorer fails', async () => {
+  // scoreMPS returns { mps: null } on schema failure; that must fail closed
+  // even when the AI-likeness target is met.
+  const fixture = createLLMFixture({
+    scores: [80, 20],
+    rewrites: ['Target-meeting text with unverifiable meaning.'],
+    mps: [null],
+    fidelityGrades: [3],
+  });
+
+  const result = await runWithFixture(fixture);
+
+  assert.equal(result.finalText, BASE_TEXT);
+  assert.equal(result.finalScore, 80);
+  assert.equal(result.iterations, 1);
+  assert.equal(result.reason, 'MPS scorer failure');
+});
+
+test('runOuroboros accepts a target-met iteration when both floors pass', async () => {
+  const fixture = createLLMFixture({
+    scores: [80, 20],
+    rewrites: ['Faithful target-meeting text.'],
+    mps: [95],
+    fidelityGrades: [3],
+  });
+
+  const result = await runWithFixture(fixture);
+
+  assert.equal(result.finalText, 'Faithful target-meeting text.');
+  assert.equal(result.finalScore, 20);
+  assert.equal(result.iterations, 1);
+  assert.equal(result.reason, 'Target met');
+});


### PR DESCRIPTION
Fixes #437 (BLOCK from the 2026-06-13 architect review, tracking: #451).

## Problem
`src/ouroboros.js` stop-condition chain checked `currentScore <= targetScore` **before** the fidelity floor, MPS floor, and MPS-scorer-failure checks. A target-met iteration therefore skipped the floors entirely: `shouldRollback` stayed false, the non-rollback branch promoted the gutted rewrite into `bestText`/`bestScore`, and it was returned as `finalText`.

This violates core/scoring.md §'Ouroboros Loop Gating' ("Both fidelity floor AND MPS floor must pass for an iteration to be accepted") and the function's own return-comment ("bestText is only ever updated on floor-passing iterations"). The failure mode is the likely one: deleting content is the easiest way to drop AI-likeness, so the iteration most likely to violate the floors is exactly the one that meets the target.

Verified against the code: the existing floor tests only passed because they lowered `target-score` to 5 to dodge the target-met branch — with the default target 30 and a score of 20, 'Target met' won.

## Fix
Ordering change only (both scorer results are already computed before the chain):

```
fidelity floor → MPS floor / scorer failure → target met → regression → plateau → max iterations
```

Floor-violating iterations now roll back even when the AI-likeness target is met. No behavior change for floor-passing iterations; the regression-vs-floor reorder only affects the reported `reason` string when both would fire (both roll back).

## Tests
4 new unit tests in `tests/unit/ouroboros.test.js` (all use the **default** target-score 30 so they exercise the previously-bypassing path):
- target met + fidelity floor violated → rollback, reason `Fidelity floor violation`
- target met + MPS floor violated → rollback, reason `MPS floor violation`
- target met + MPS scorer failure (`mps: null`) → fails closed, rollback
- target met + both floors passing → still accepted, reason `Target met`

`npm test` 634/634 pass, `npm run lint` clean.