### PR TITLE
fix(preview): guard every page-fetch redirect hop against SSRF

### DIFF
--- a/src/preview.js
+++ b/src/preview.js
@@ -21,10 +21,13 @@ const PROSE_TAGS = 'p|h1|h2|h3|h4|h5|h6|li|blockquote|figcaption|dt|dd|summary|d
 // control labels — never body copy.
 const EXCLUDED_CONTAINERS = 'head|script|style|noscript|template|textarea|svg|iframe|select|option|code|pre|nav|button';
 
+const MAX_PAGE_REDIRECTS = 5;
+
 export async function fetchPreviewPage(url, options = {}) {
   const fetchImpl = options.fetchImpl ?? fetch;
   const timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+  const lookupImpl = options.lookupImpl;
   const outerSignal = options.signal;
 
   const controller = new AbortController();
@@ -36,11 +39,34 @@ export async function fetchPreviewPage(url, options = {}) {
   }
 
   try {
-    const response = await fetchImpl(url, {
-      signal: controller.signal,
-      redirect: 'follow',
-      headers: { accept: 'text/html,application/xhtml+xml' },
-    });
+    // Follow redirects manually so every hop is SSRF-guarded. The user-typed
+    // URL is trusted (it may legitimately point at a localhost dev server),
+    // but redirect Location headers are server-controlled content: a hostile
+    // public page must not be able to 30x the preview into cloud metadata or
+    // an internal host — especially since the final hop becomes baseUrl,
+    // which the subresource guard then treats as "the page's own host"
+    // (same containment rule as fetchCappedBytes in ocr.js).
+    let current = url;
+    let response;
+    for (let hop = 0; ; hop++) {
+      response = await fetchImpl(current, {
+        signal: controller.signal,
+        redirect: 'manual',
+        headers: { accept: 'text/html,application/xhtml+xml' },
+      });
+      const location = response.status >= 300 && response.status < 400
+        ? response.headers.get('location')
+        : null;
+      if (!location) break;
+      if (hop >= MAX_PAGE_REDIRECTS) {
+        throw new Error('the page redirected too many times');
+      }
+      const next = new URL(location, current).href;
+      if (!(await isSubresourceFetchAllowed(next, { baseUrl: url, lookupImpl }))) {
+        throw new Error('the page redirected to a private/internal address');
+      }
+      current = next;
+    }
     if (!response.ok) {
       throw new Error(`the page returned HTTP ${response.status}`);
     }
@@ -52,7 +78,7 @@ export async function fetchPreviewPage(url, options = {}) {
     if (html.length > maxBytes) {
       throw new Error(`the page is larger than the ${Math.round(maxBytes / 1024 / 1024)}MB preview limit`);
     }
-    return { html, finalUrl: response.url || url };
+    return { html, finalUrl: current };
   } finally {
     clearTimeout(timer);
     outerSignal?.removeEventListener?.('abort', onOuterAbort);

--- a/tests/unit/preview.test.js
+++ b/tests/unit/preview.test.js
@@ -678,3 +678,95 @@ test('fetchPreviewPage aborts on timeout', async () => {
     /timed out/,
   );
 });
+
+test('fetchPreviewPage guards every redirect hop against private/internal targets (#439)', async () => {
+  const respond = (init = {}) => ({
+    ok: (init.status ?? 200) >= 200 && (init.status ?? 200) < 300,
+    status: init.status ?? 200,
+    url: init.url ?? '',
+    headers: { get: (name) => ({ 'content-type': 'text/html; charset=utf-8', ...init.headers })[name.toLowerCase()] ?? null },
+    text: async () => init.body ?? '',
+  });
+  const routed = (routes) => {
+    const seen = [];
+    const fetchImpl = async (url, opts) => {
+      seen.push({ url, redirect: opts.redirect });
+      const route = routes[url];
+      assert.ok(route, `unexpected fetch: ${url}`);
+      return respond(route);
+    };
+    return { fetchImpl, seen };
+  };
+
+  // A hostile public page must not 30x the preview into private space:
+  // the final hop becomes baseUrl, which would wave through every
+  // same-host subresource fetch afterwards.
+  for (const target of ['http://192.168.1.10/', 'http://169.254.169.254/latest/meta-data/', 'http://127.0.0.1:8080/']) {
+    const { fetchImpl, seen } = routed({
+      'https://evil.test/': { status: 302, headers: { location: target } },
+    });
+    await assert.rejects(
+      () => fetchPreviewPage('https://evil.test/', { fetchImpl }),
+      /private\/internal address/,
+    );
+    // The private target itself is never fetched.
+    assert.deepStrictEqual(seen.map((s) => s.url), ['https://evil.test/']);
+  }
+
+  // Hostnames that RESOLVE private are blocked too (lookupImpl injectable).
+  {
+    const { fetchImpl } = routed({
+      'https://evil.test/': { status: 301, headers: { location: 'https://rebind.test/' } },
+    });
+    await assert.rejects(
+      () => fetchPreviewPage('https://evil.test/', {
+        fetchImpl,
+        lookupImpl: async () => [{ address: '10.0.0.5', family: 4 }],
+      }),
+      /private\/internal address/,
+    );
+  }
+
+  // Public-to-public redirects still work; finalUrl is the last hop and
+  // every hop uses redirect: 'manual'.
+  {
+    const { fetchImpl, seen } = routed({
+      'https://example.test/': { status: 302, headers: { location: '/moved' } },
+      'https://example.test/moved': { status: 301, headers: { location: 'https://other.test/page' } },
+      'https://other.test/page': { body: '<p>final</p>' },
+    });
+    const result = await fetchPreviewPage('https://example.test/', {
+      fetchImpl,
+      lookupImpl: async () => [{ address: '93.184.216.34', family: 4 }],
+    });
+    assert.strictEqual(result.html, '<p>final</p>');
+    assert.strictEqual(result.finalUrl, 'https://other.test/page');
+    assert.ok(seen.every((s) => s.redirect === 'manual'));
+  }
+
+  // A user-typed private URL may redirect within its own host (localhost
+  // dev servers stay usable), mirroring the subresource same-host rule.
+  {
+    const { fetchImpl } = routed({
+      'http://127.0.0.1:3000/': { status: 302, headers: { location: '/app' } },
+      'http://127.0.0.1:3000/app': { body: '<p>dev</p>' },
+    });
+    const result = await fetchPreviewPage('http://127.0.0.1:3000/', { fetchImpl });
+    assert.strictEqual(result.html, '<p>dev</p>');
+    assert.strictEqual(result.finalUrl, 'http://127.0.0.1:3000/app');
+  }
+
+  // Redirect loops are cut off instead of spinning forever.
+  {
+    const { fetchImpl } = routed({
+      'https://loop.test/': { status: 302, headers: { location: 'https://loop.test/' } },
+    });
+    await assert.rejects(
+      () => fetchPreviewPage('https://loop.test/', {
+        fetchImpl,
+        lookupImpl: async () => [{ address: '93.184.216.34', family: 4 }],
+      }),
+      /redirected too many times/,
+    );
+  }
+});


### PR DESCRIPTION
Fixes #439 (major, security — preview-surface lane; tracking: #451).

## Problem (verified against the code)
`fetchPreviewPage` (src/preview.js) used `redirect: 'follow'` with no per-hop guard and returned `response.url` as `finalUrl`. `src/cli/run.js` adopts that `finalUrl` as `sourceUrl`/`baseUrl`, which anchors every later subresource SSRF check. Since `isSubresourceFetchAllowed` intentionally allows private/loopback targets that share the page's host (`sameHostAsPage`), a hostile public page that 30x's to `http://192.168.x.x/` or loopback gets:
1. its internal content rendered and rewritten by patina, and
2. **all same-host subresource fetches waved through the guard** (freezeSnapshotAssets stylesheets/fonts, `--ocr` image staging),

contradicting the project's own threat model — `fetchCappedBytes` in `src/ocr.js` already manually re-guards every redirect hop for subresources.

## Fix
Manual redirect loop mirroring the existing `guardHop` pattern:
- first request = trusted user-typed URL (localhost dev servers stay usable)
- every `Location` hop is resolved against the current URL and checked with `isSubresourceFetchAllowed(next, { baseUrl: <original user-typed URL> })` — private hops are allowed only within the user-typed host
- blocked targets are **never fetched**; hop cap of 5; `finalUrl` = last guarded hop
- new `lookupImpl` option for test-injectable DNS, same as the subresource guard

## Tests
New unit test in `tests/unit/preview.test.js` covering: literal private/metadata/loopback redirect targets (blocked pre-fetch, asserted via fetch-call log), DNS-resolving-private hostnames, public→public chains (finalUrl + `redirect: 'manual'` on every hop), same-host private redirect allowed for user-typed `127.0.0.1`, and redirect-loop cutoff.

`npm test` 631/631 pass, `npm run lint` clean.