### PR TITLE
fix(det-signals): stop self-identification leakage FPs on human bio/ML prose

### DIFF
--- a/src/features/markup-leakage.js
+++ b/src/features/markup-leakage.js
@@ -56,7 +56,20 @@ const MARKUP_RULES = [
   {
     id: 'explicit-self-identification',
     label: 'Explicit AI self-identification',
-    build: () => /\bas an? (?:AI|artificial intelligence) language model\b|\bas a large language model\b|\bas a language model\b|\bas an AI assistant\b|\bI am an AI\b|\bI'?m an AI\b/gi,
+    // Near-proof-grade, so precision beats recall (issue #435): a single hit
+    // forces LEAKAGE_SCORE_FLOOR. Human bio/ML prose must not fire:
+    // - "I am an AI researcher" / "I'm an AI safety engineer": \b alone sits
+    //   between "AI" and the next noun, so the bare phrase needs a guard. The
+    //   "I am/I'm an AI" alternant (optionally with an AI-role noun:
+    //   assistant/chatbot/model) only matches when the phrase ends the clause
+    //   (punctuation/EOL) or continues with refusal-boilerplate provenance
+    //   ("created/trained/developed ... by"), and never before "-"/"/"
+    //   compounds like "AI-powered" or "AI/ML". Human job titles such as
+    //   "AI assistant manager" stay cold.
+    // - "BERT functions as a language model": the bare alternant now requires
+    //   the first-person continuation ("as a language model, I ...") that
+    //   real refusal boilerplate uses.
+    build: () => /\bas an? (?:AI|artificial intelligence) language model\b|\bas a large language model\b|\bas a language model,? I\b|\bas an AI assistant\b|\bI(?: am|'?m) an AI(?:\s+(?:assistant|chatbot|language model|model))?(?:\s+(?:created|developed|trained|designed|built|made)\s+by\b|(?![-/]|\s+\w))/gi,
   },
 ];
 

--- a/tests/unit/markup-leakage.test.js
+++ b/tests/unit/markup-leakage.test.js
@@ -25,8 +25,36 @@ test('detects AI tracking params in URLs', () => {
 });
 
 test('detects explicit AI self-identification', () => {
-  for (const s of ['As an AI language model, I cannot', "I'm an AI, so", 'as a large language model']) {
+  const positives = [
+    'As an AI language model, I cannot',
+    "I'm an AI, so",
+    'as a large language model',
+    'As a language model, I cannot help with that.',
+    'as a language model I am unable to',
+    'I am an AI.',
+    'I am an AI',
+    'I am an AI assistant created by',
+    "I'm an AI chatbot.",
+    'I am an AI trained by a large lab.',
+  ];
+  for (const s of positives) {
     assert.equal(detectMarkupLeakage(s).leaked, true, s);
+  }
+});
+
+test('self-identification rule does NOT fire on human bio/ML prose (issue #435)', () => {
+  const negatives = [
+    'I am an AI researcher at a mid-sized lab.',
+    "I'm an AI safety engineer working on evals.",
+    'I am an AI ethics consultant and writer.',
+    'BERT functions as a language model for downstream tasks.',
+    'We benchmark it as a language model baseline.',
+    'I am an AI-powered-tools skeptic, honestly.',
+    "I'm an AI/ML engineer by trade.",
+    'I am an AI assistant manager at the store.',
+  ];
+  for (const s of negatives) {
+    assert.equal(detectMarkupLeakage(s).leaked, false, s);
   }
 });
 


### PR DESCRIPTION
Fixes #435 (major, false-positive — det-signals lane; tracking: #451).

## Problem (verified against the code)
`explicit-self-identification` in `src/features/markup-leakage.js` matched human prose:
- `\bI am an AI\b` / `\bI'?m an AI\b` — the trailing `\b` sits between "AI" and the next word, so **"I am an AI researcher"** and **"I'm an AI safety engineer"** fired. Same for hyphen/slash compounds ("AI-powered", "AI/ML"), which `\b` also accepts.
- bare `\bas a language model\b` — **"BERT functions as a language model"** fired.

markup-leakage is near-proof-grade: one hit → `leaked=true` → document `hot` (src/features/index.js) → `Math.max(hotRatio, LEAKAGE_SCORE_FLOOR=90)` in src/scoring.js. A single human-plausible phrase forced the 'heavily AI' band.

## Fix (deterministic, src/features stays LLM-free, no new deps)
- "I am/I'm an AI" (optionally followed by an AI-role noun: assistant/chatbot/model/language model) matches only when the phrase **ends the clause** (punctuation/EOL) or continues with the refusal-boilerplate provenance tail **"created/trained/developed/designed/built/made … by"**. It never matches before `-`/`/`. Human job titles ("AI assistant manager") stay cold.
- bare "as a language model" now requires the first-person continuation `,? I` ("As a language model, I cannot…"), per the issue's suggested anchor. The `as an AI language model` / `as a large language model` / `as an AI assistant` alternants are unchanged.

Playground is unaffected drift-wise: `playground/analyzer.js` imports this module directly.

## Tests
`tests/unit/markup-leakage.test.js`: positives extended (clause-final "I am an AI.", "I'm an AI chatbot.", "I am an AI assistant created by", "I am an AI trained by a large lab.", "As a language model, I cannot…", "as a language model I am unable to") and a new issue-#435 negative block (AI researcher / AI safety engineer / AI ethics consultant / BERT-as-a-language-model / language-model baseline / AI-powered / AI/ML / AI assistant manager).

`npm test` 631/631 pass, `npm run lint` clean.