### PR TITLE
fix(structural-scoring): validate model dimension against the feature set at load time

### DIFF
--- a/src/features/structural-classifier.js
+++ b/src/features/structural-classifier.js
@@ -84,7 +84,13 @@ export function trainLogReg(X, y, { lr = 0.1, epochs = 2000, l2 = 0.01 } = {}) {
     b -= lr * (gradientB / Z.length);
   }
 
-  return { weights: w, bias: b, scaler, featureNames: STRUCTURAL_FEATURE_NAMES };
+  // Only stamp this patina version's feature names onto models actually
+  // trained at that width; a toy/experimental model must not masquerade as a
+  // STRUCTURAL_FEATURE_NAMES-compatible model (normalizeStructuralModel
+  // rejects non-matching widths at load time, issue #436).
+  return width === STRUCTURAL_FEATURE_NAMES.length
+    ? { weights: w, bias: b, scaler, featureNames: STRUCTURAL_FEATURE_NAMES }
+    : { weights: w, bias: b, scaler };
 }
 
 export function normalizeStructuralModel(model) {
@@ -102,6 +108,18 @@ export function normalizeStructuralModel(model) {
   }
   if (weights.length !== scaler.mu.length || weights.length !== scaler.sigma.length) {
     throw new TypeError('structural model dimensions must match scaler dimensions');
+  }
+  // Dimension must match THIS patina version's feature extractor, even when
+  // the optional featureNames field is absent (issue #436). Otherwise a
+  // self-consistent model trained against an older feature set loads cleanly
+  // and only explodes at predict time, deep inside analyzeText — past the
+  // call sites that handle load errors (audit aborts untyped; scoring.js
+  // silently zeroes the whole deterministic shadow score, including the
+  // markup-leakage floor).
+  if (weights.length !== STRUCTURAL_FEATURE_NAMES.length) {
+    throw new TypeError(
+      `structural model expects ${weights.length} features but this patina version extracts ${STRUCTURAL_FEATURE_NAMES.length} (${STRUCTURAL_FEATURE_NAMES.join(', ')}); retrain the model against the current feature set`,
+    );
   }
   if (weights.some((value) => !Number.isFinite(value)) || scaler.mu.some((value) => !Number.isFinite(value)) || scaler.sigma.some((value) => !Number.isFinite(value))) {
     throw new TypeError('structural model values must be finite numbers');

--- a/tests/unit/structural-classifier.test.js
+++ b/tests/unit/structural-classifier.test.js
@@ -7,6 +7,7 @@ import {
   extractStructuralFeatures,
   structuralFeatureRecord,
   structuralModelVerdict,
+  normalizeStructuralModel,
   trainLogReg,
   predictStructuralScore,
 } from '../../src/features/index.js';
@@ -71,10 +72,41 @@ test('structural model refuses the wrong language instead of scoring silently', 
 });
 
 test('logistic helper trains and scores a simple separable toy model', () => {
-  const X = [[0], [0.1], [1], [1.1]];
+  // Rows use the real feature width: predictStructuralScore normalizes the
+  // model, and normalizeStructuralModel rejects any other dimension (#436).
+  const row = (v) => [v, ...new Array(STRUCTURAL_FEATURE_NAMES.length - 1).fill(0)];
+  const X = [row(0), row(0.1), row(1), row(1.1)];
   const y = [0, 0, 1, 1];
   const model = trainLogReg(X, y, { lr: 0.2, epochs: 400, l2: 0 });
 
-  assert.ok(predictStructuralScore(model, [0]) < 0.5);
-  assert.ok(predictStructuralScore(model, [1.1]) > 0.5);
+  assert.deepEqual(model.featureNames, STRUCTURAL_FEATURE_NAMES);
+  assert.ok(predictStructuralScore(model, row(0)) < 0.5);
+  assert.ok(predictStructuralScore(model, row(1.1)) > 0.5);
+});
+
+test('trainLogReg does not stamp featureNames onto models of another width (#436)', () => {
+  const model = trainLogReg([[0], [1]], [0, 1], { lr: 0.2, epochs: 50, l2: 0 });
+  assert.equal('featureNames' in model, false);
+});
+
+test('normalizeStructuralModel rejects models not trained at this feature width (#436)', () => {
+  // Self-consistent (weights match scaler) but 8-wide and without the
+  // optional featureNames field — the exact shape of a stale model trained
+  // against an older feature set. Must fail at load time, not at predict
+  // time inside analyzeText.
+  const stale = {
+    lang: 'ko',
+    weights: new Array(8).fill(0.5),
+    bias: 0,
+    threshold: 0.5,
+    scaler: { mu: new Array(8).fill(0), sigma: new Array(8).fill(1) },
+  };
+  assert.throws(
+    () => normalizeStructuralModel(stale),
+    /expects 8 features but this patina version extracts 12/,
+  );
+  assert.throws(
+    () => structuralModelVerdict('오늘은 날씨가 좋았다. 점심을 먹었다.', { lang: 'ko', model: stale }),
+    /expects 8 features/,
+  );
 });

--- a/tests/unit/structural-model-loader.test.js
+++ b/tests/unit/structural-model-loader.test.js
@@ -58,6 +58,23 @@ test('loadStructuralModel loads private weights from an explicit path', () => {
   assert.deepEqual(model.featureNames, STRUCTURAL_FEATURE_NAMES);
 });
 
+test('loadStructuralModel rejects a stale model trained at another feature width (#436)', () => {
+  const dir = mkdtempSync(resolve(tmpdir(), 'patina-model-'));
+  const stale = {
+    lang: 'ko',
+    weights: new Array(8).fill(0.5),
+    bias: 0,
+    threshold: 0.5,
+    scaler: { mu: new Array(8).fill(0), sigma: new Array(8).fill(1) },
+  };
+  const path = writeModel(dir, stale);
+
+  assert.throws(
+    () => loadStructuralModel({ stylometry: { structural_model: { path } } }, { env: {}, cwd: dir, lang: 'ko' }),
+    /Invalid structural model at .*expects 8 features but this patina version extracts 12/,
+  );
+});
+
 test('configured private model lifts deterministic scoring without hosted service', () => {
   const dir = mkdtempSync(resolve(tmpdir(), 'patina-model-'));
   const path = writeModel(dir);


### PR DESCRIPTION
Fixes #436 (major — structural-scoring lane; tracking: #451).

## Problem (verified against the code)
`normalizeStructuralModel` (src/features/structural-classifier.js) validated `weights.length` only against `scaler.mu`/`scaler.sigma`; the `featureNames` cross-check is skipped when that optional field is absent. A self-consistent model trained against an older/narrower feature set loads cleanly, then throws `TypeError: scaler dimensions must match row dimensions` at predict time when `structuralModelVerdict` extracts the current 12-feature row:
- audit path (`src/output.js`): no try/catch → command aborts with a generic untyped exit-1
- `scoreDeterministicSignals` (src/scoring.js): outer catch converts it into `skipReason: 'deterministic-failure'`, **silently zeroing the entire deterministic shadow score — including the markup-leakage floor — with no warning** (unlike the handled load-failure branch)

Also found while verifying: `trainLogReg` stamped `featureNames: STRUCTURAL_FEATURE_NAMES` onto models of **any** width, so even the existing optional cross-check could be satisfied by a width-mismatched model.

## Fix
- `normalizeStructuralModel` now requires `weights.length === STRUCTURAL_FEATURE_NAMES.length`, throwing an actionable TypeError (expected vs actual width + feature list + retrain hint). Stale/corrupt models now fail at **load time**, where both call sites already handle and log errors (`loadStructuralModel` wraps it as `Invalid structural model at <path>: …`).
- `trainLogReg` stamps `featureNames` only when trained at the real feature width.

## Tests
- toy-model logistic test now trains at the real feature width (it previously relied on the unvalidated path)
- `trainLogReg` omits `featureNames` for other widths
- `normalizeStructuralModel` + `structuralModelVerdict` reject an 8-wide self-consistent model with the new message
- `loadStructuralModel` rejects the same stale model file at load time

`npm test` 633/633 pass, `npm run lint` clean.