### PR TITLE
fix(backends): discard codex stdout to prevent pipe-buffer deadlock

### DIFF
--- a/src/backends/codex-cli.js
+++ b/src/backends/codex-cli.js
@@ -70,7 +70,11 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       '--model', cliModel,
       '--output-last-message', outFile,
       ...imageArgs,
-    ], { stdio: ['pipe', 'pipe', 'pipe'], cwd: dir });
+      // stdout is discarded, not piped: `codex exec` streams session/progress
+      // output there, and a piped-but-undrained stdout deadlocks the child
+      // once the ~64KB OS pipe buffer fills (#438). The final answer comes
+      // from --output-last-message, so nothing on stdout is needed.
+    ], { stdio: ['pipe', 'ignore', 'pipe'], cwd: dir });
 
     let stderr = '';
     proc.stderr.on('data', (chunk) => { stderr += chunk; });

--- a/tests/unit/backend-cancellation.test.js
+++ b/tests/unit/backend-cancellation.test.js
@@ -53,3 +53,47 @@ test('CLI backends reject AbortSignal cancellation and kill their child process'
     rmSync(binDir, { recursive: true, force: true });
   }
 });
+
+test('codex-cli does not deadlock when the child floods stdout (#438)', async () => {
+  const binDir = mkdtempSync(join(tmpdir(), 'patina-fake-cli-'));
+  const oldPath = process.env.PATH;
+
+  try {
+    // Fake `codex exec`: stream 8MB of session/progress noise to stdout —
+    // waiting for 'drain' like a real blocked writer — and only then write
+    // the --output-last-message file and exit. With a piped-but-undrained
+    // stdout the OS pipe buffer (~64KB) fills, 'drain' never fires, the
+    // child never exits, and invoke() hangs until its timeout.
+    const path = join(binDir, 'codex');
+    writeFileSync(path, [
+      '#!/usr/bin/env node',
+      "const fs = require('node:fs');",
+      'process.stdin.resume();',
+      'const args = process.argv.slice(2);',
+      "const outFile = args[args.indexOf('--output-last-message') + 1];",
+      'let written = 0;',
+      "const chunk = 'x'.repeat(65536);",
+      'function pump() {',
+      '  while (written < 8 * 1024 * 1024) {',
+      '    written += chunk.length;',
+      '    if (!process.stdout.write(chunk)) {',
+      "      process.stdout.once('drain', pump);",
+      '      return;',
+      '    }',
+      '  }',
+      "  fs.writeFileSync(outFile, 'final answer');",
+      '  process.exit(0);',
+      '}',
+      'pump();',
+      '',
+    ].join('\n'));
+    chmodSync(path, 0o755);
+    process.env.PATH = `${binDir}:${oldPath || ''}`;
+
+    const result = await codexCli.invoke({ prompt: 'rewrite this', timeout: 5000 });
+    assert.equal(result, 'final answer');
+  } finally {
+    process.env.PATH = oldPath;
+    rmSync(binDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #438 (major — backend-adapters lane; tracking: #451).

## Problem (verified against the code)
`src/backends/codex-cli.js` spawned `codex exec` with `stdio: ['pipe', 'pipe', 'pipe']` but only `stderr` got a data handler — no stdout listener, no `resume()`. `codex exec` streams session/progress output to stdout; once the ~64KB OS pipe buffer fills, the child's writes block and the invocation hangs until the (default 600s) timeout SIGKILLs it. The final answer is read from `--output-last-message`, so stdout is entirely unused. The other three adapters (claude/gemini/kimi) drain stdout — cross-adapter inconsistency.

## Fix
`stdio: ['pipe', 'ignore', 'pipe']` — progress output goes to /dev/null, the child can always exit. stdin (prompt) and stderr (error reporting on non-zero exit) are unchanged.

## Test
New regression test in `tests/unit/backend-cancellation.test.js` using the existing fake-CLI-on-PATH harness: the fake `codex` pumps **8MB** to stdout, waiting on `'drain'` like a real blocked writer, and only then writes the `--output-last-message` file and exits 0.

Verified both directions:
- against the old code: test fails with `codex-cli backend: timed out after 5000ms` (the exact deadlock)
- with the fix: resolves `'final answer'` in <200ms

`npm test` 632/632 pass, `npm run lint` clean.