### PR TITLE
fix(cli): keep failure-rate warm-up for explicit --max-failure-rate

### DIFF
--- a/src/cli/batch.js
+++ b/src/cli/batch.js
@@ -86,7 +86,12 @@ export function createBatchCircuitBreaker({ parsed, total }) {
       }
       if (
         Number.isFinite(maxFailureRate) &&
-        processed >= (parsed.maxFailureRate === undefined ? Math.min(total, 4) : 1) &&
+        // Warm-up applies to explicit --max-failure-rate too (#434): a ratio
+        // over a sample of 1 makes the first failed file 100% and turns any
+        // rate < 1.0 into stop-on-first-failure, contradicting the documented
+        // "stop when failure ratio exceeds r" semantics. Users who want
+        // stop-on-first-failure have --max-failures 1.
+        processed >= Math.min(total, 4) &&
         failures.length / processed > maxFailureRate
       ) {
         stopReason = `failure rate ${(failures.length / processed * 100).toFixed(1)}% exceeded ${(maxFailureRate * 100).toFixed(1)}%`;

--- a/tests/unit/batch.test.js
+++ b/tests/unit/batch.test.js
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { createBatchCircuitBreaker } from '../../src/cli/batch.js';
+
+function breaker({ total = 10, ...parsed } = {}) {
+  return createBatchCircuitBreaker({ parsed: { batch: true, ...parsed }, total });
+}
+
+const fail = (b, path = 'file.txt') => b.recordFailure({ path, err: new Error('boom') });
+
+test('explicit --max-failure-rate keeps the warm-up sample instead of stopping on the first failure (#434)', () => {
+  const b = breaker({ maxFailureRate: 0.5, maxFailures: Infinity });
+
+  // One failed file is a 100% ratio over a sample of 1 — must NOT trip an
+  // explicit 50% tolerance during warm-up (previously: stop-on-first-failure).
+  fail(b);
+  assert.equal(b.shouldStop(), false);
+
+  // 1/2 and 2/4 are exactly at the tolerance (not above) — keep going.
+  b.recordSuccess();
+  assert.equal(b.shouldStop(), false);
+  fail(b);
+  b.recordSuccess();
+  assert.equal(b.shouldStop(), false);
+
+  // 3/5 = 60% > 50% after warm-up — now the configured rate stops the batch.
+  fail(b);
+  assert.equal(b.shouldStop(), true);
+  assert.match(b.toError().message, /failure rate 60\.0% exceeded 50\.0%/);
+});
+
+test('explicit rate above the observed ratio lets the batch run past early failures', () => {
+  const b = breaker({ maxFailureRate: 0.8, maxFailures: Infinity });
+  fail(b);
+  fail(b);
+  b.recordSuccess();
+  b.recordSuccess();
+  // 2/4 = 50% <= 80% tolerance the user opted into.
+  assert.equal(b.shouldStop(), false);
+});
+
+test('default failure-rate path still uses the min(total, 4) warm-up', () => {
+  const b = breaker();
+
+  // Defaults: rate 0.25, warm-up min(10, 4) = 4.
+  fail(b);
+  assert.equal(b.shouldStop(), false, 'first failure is inside the warm-up window');
+  b.recordSuccess();
+  b.recordSuccess();
+  assert.equal(b.shouldStop(), false, 'still below the warm-up sample');
+  b.recordSuccess();
+  // 1/4 = 25% is not > 25% — boundary stays permissive.
+  assert.equal(b.shouldStop(), false);
+  fail(b);
+  // 2/5 = 40% > 25% after warm-up.
+  assert.equal(b.shouldStop(), true);
+});
+
+test('--max-failures 1 remains the stop-on-first-failure switch', () => {
+  const b = breaker({ maxFailures: 1, maxFailureRate: 0.5 });
+  fail(b);
+  assert.equal(b.shouldStop(), true);
+  assert.match(b.toError().message, /max failures reached \(1\/1\)/);
+});
+
+test('small batches engage the rate check only once fully sampled', () => {
+  // total 2 → warm-up min(2, 4) = 2.
+  const b = breaker({ total: 2, maxFailureRate: 0.5, maxFailures: Infinity });
+  fail(b);
+  assert.equal(b.shouldStop(), false);
+  fail(b);
+  // 2/2 = 100% > 50%.
+  assert.equal(b.shouldStop(), true);
+});


### PR DESCRIPTION
Fixes #434 (major — cli-core lane; tracking: #451).

## Problem (verified against the code)
`createBatchCircuitBreaker.shouldStop()` engaged the rate check once
`processed >= (parsed.maxFailureRate === undefined ? Math.min(total, 4) : 1)`.
With an explicit `--max-failure-rate`, the warm-up sample dropped to **1**: the first failed file yields ratio 1/1 = 100%, which exceeds any configured rate < 1.0 and stops the batch with `failure rate 100.0% exceeded N%`. Every explicit rate below 100% therefore behaved as stop-on-first-failure — the opposite of the tolerance the user opted into, and contradicting both the `--help` text ('Stop batch when failure ratio exceeds r') and CLI.md ('after a 25% failure rate **once enough files have run**').

## Fix
Apply the same `Math.min(total, 4)` warm-up to the explicit path. `--max-failures 1` remains the stop-on-first-failure switch. No doc changes needed — the code now matches what the docs already promise.

## Tests
New `tests/unit/batch.test.js` (first unit coverage for the circuit breaker):
- explicit rate 0.5 survives the first failure (previously stopped) and trips at 3/5 = 60% past warm-up — **verified to fail against the old code**
- at-tolerance boundary (2/4 = exactly 50%) stays permissive
- default path (0.25 / warm-up 4) unchanged
- `--max-failures 1` still stops on the first failure
- total=2 batches engage the rate check once fully sampled

`npm test` pass (incl. existing batch-breaker e2e), `npm run lint` clean.