### PR TITLE
fix(cli): harden arg parsing, output routing, and batch failure classification (#440)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -175,14 +175,16 @@ patina --batch --backend kimi-cli --max-concurrency 1 --max-retries 0 docs/*.md
 Circuit breakers stop batch mode after repeated failure instead of burning quota:
 
 ```bash
-patina --batch --max-failures 5 --max-failure-rate 0.25 --stop-on-retryable-storm docs/*.md
+patina --batch --max-failures 5 --max-failure-rate 0.25 docs/*.md
 patina --batch --timeout-ms 600000 docs/*.md
 ```
 
 `--max-failure-rate` accepts either a ratio (`0.25`) or a percent (`25`). By
 default, batch mode stops after a small failure budget, after a 25% failure rate
 once enough files have run, or after repeated retryable storms such as HTTP 429,
-timeouts, empty local-CLI responses, or repeated Kimi/Claude process exits.
+timeouts, empty local-CLI responses, or repeated temporary-failure exits
+(exit code 75). Storm stopping is on by default; pass
+`--no-stop-on-retryable-storm` to keep the batch running through storms.
 
 MDX/frontmatter note: patina does not parse MDX or rewrite YAML frontmatter
 schemas. For `.mdx` batches, run your site's MDX/build validator after patina

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
 import { getRepoRoot } from './config.js';
 import { runDoctor } from './commands/doctor.js';
 import { handleAuth, printBackendStatus } from './commands/auth.js';
-import { parseArgs, validateModeExclusivity, validateServeRequest, validatePreviewRequest, printHelp } from './cli/args.js';
+import { parseArgs, validateModeExclusivity, validateServeRequest, validatePreviewRequest, validateOutputRouting, printHelp } from './cli/args.js';
 import { runDefault } from './cli/run.js';
 import { inputError, renderCliError, getExitCode } from './errors.js';
 import { createLogger } from './logger.js';
@@ -87,6 +87,7 @@ export async function main(args) {
   validateModeExclusivity(parsed);
   validatePreviewRequest(parsed);
   validateServeRequest(parsed);
+  validateOutputRouting(parsed);
 
   return runDefault(parsed, logger);
 }

--- a/src/cli/args.js
+++ b/src/cli/args.js
@@ -1,14 +1,74 @@
 import { listBackendNames } from '../backends/index.js';
 import { inputError } from '../errors.js';
+import { basename } from 'node:path';
 
-export function parseArgs(args) {
+// Options that consume the next token as their value. Drives --name=value
+// expansion and the --suffix flag-collision backstop (#440).
+const VALUE_OPTIONS = new Set([
+  '--lang', '--profile', '--tone', '--voice-sample', '--format', '--exit-on',
+  '--suffix', '--outdir', '--model', '--api-key-file', '--base-url',
+  '--backend', '--timeout-ms', '--max-concurrency', '--max-retries',
+  '--max-failures', '--max-failure-rate', '--provider', '--config',
+]);
+
+// Boolean switches. Used to reject `--quiet=1`-style values explicitly and to
+// catch a flag name swallowed as another option's value.
+const FLAG_OPTIONS = new Set([
+  '--help', '-h', '--version', '-v', '--browser', '--preview', '--ocr',
+  '--serve', '--diff', '--no-color', '--audit', '--score', '--quiet',
+  '--ouroboros', '--batch', '--in-place', '--allow-private-base-url',
+  '--stop-on-retryable-storm', '--no-stop-on-retryable-storm',
+  '--list-backends', '--allow-insecure-base-url', '--no-interactive',
+]);
+
+// Expand `--name=value` into two tokens for known value-taking options and
+// reject `=value` on boolean switches. Tokens after a `--` end-of-options
+// separator pass through untouched so dash-prefixed file names stay usable.
+function expandArgs(args) {
+  const expanded = [];
+  let afterSeparator = false;
+  for (const token of args) {
+    if (afterSeparator || token === '--') {
+      if (token === '--') afterSeparator = true;
+      expanded.push(token);
+      continue;
+    }
+    const eq = token.startsWith('--') ? token.indexOf('=') : -1;
+    if (eq > 2) {
+      const name = token.slice(0, eq);
+      if (VALUE_OPTIONS.has(name)) {
+        expanded.push(name, token.slice(eq + 1));
+        continue;
+      }
+      if (FLAG_OPTIONS.has(name)) {
+        throw inputError(
+          `${name} does not take a value`,
+          `Received "${token}", but ${name} is an on/off switch.`,
+          `Pass ${name} by itself.`
+        );
+      }
+      // Unknown --x=y falls through to the unknown-option error below.
+    }
+    expanded.push(token);
+  }
+  return expanded;
+}
+
+export function parseArgs(rawArgs) {
   const parsed = {
     files: [],
     format: 'markdown',
   };
+  const args = expandArgs(rawArgs);
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
+    if (arg === '--') {
+      // End-of-options separator: everything after it is a file path, even
+      // when it starts with '-' (#440).
+      parsed.files.push(...args.slice(i + 1));
+      break;
+    }
     switch (arg) {
       case '--help':
       case '-h':
@@ -87,7 +147,7 @@ export function parseArgs(args) {
       case '--exit-on': {
         const value = readOptionValue(args, i, arg, { allowFlagLike: true });
         i++;
-        const n = Number(value);
+        const n = numericOptionValue(value);
         if (!Number.isFinite(n) || n < 0 || n > 100) {
           throw inputError(
             '--exit-on expects a number from 0 to 100',
@@ -107,10 +167,22 @@ export function parseArgs(args) {
       case '--in-place':
         parsed.inPlace = true;
         break;
-      case '--suffix':
-        parsed.suffix = readOptionValue(args, i, arg, { allowFlagLike: true });
+      case '--suffix': {
+        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
         i++;
+        // allowFlagLike keeps `-humanized` usable, but a KNOWN flag name here
+        // means the value was omitted and the next option got swallowed
+        // (`--suffix --batch` would silently disable batch mode, #440).
+        if (VALUE_OPTIONS.has(value) || FLAG_OPTIONS.has(value) || value === '--') {
+          throw inputError(
+            '--suffix requires a value',
+            `"${value}" is a patina flag, so the suffix value was probably omitted.`,
+            'Use `patina --batch --suffix -humanized <files>` (the suffix may start with "-").'
+          );
+        }
+        parsed.suffix = value;
         break;
+      }
       case '--outdir':
         parsed.outdir = readOptionValue(args, i, arg);
         i++;
@@ -166,6 +238,12 @@ export function parseArgs(args) {
       }
       case '--stop-on-retryable-storm':
         parsed.stopOnRetryableStorm = true;
+        break;
+      case '--no-stop-on-retryable-storm':
+        // Storm stopping is ON by default in batch mode; this is the only
+        // way to turn it off (#440 — the positive flag alone was a no-op
+        // presented as opt-in).
+        parsed.stopOnRetryableStorm = false;
         break;
       case '--list-backends':
         parsed.listBackends = true;
@@ -267,6 +345,48 @@ export function validateServeRequest(parsed) {
   }
 }
 
+// Output routing flags are batch-only and mutually exclusive. Without this,
+// `patina --in-place draft.md` silently prints to stdout (never overwriting),
+// combined destinations apply hidden precedence, and --outdir can collapse
+// distinct inputs onto one output file (#440).
+export function validateOutputRouting(parsed) {
+  const destinations = [
+    parsed.inPlace ? '--in-place' : null,
+    parsed.suffix !== undefined ? '--suffix' : null,
+    parsed.outdir !== undefined ? '--outdir' : null,
+  ].filter(Boolean);
+  if (destinations.length === 0) return;
+  if (!parsed.batch) {
+    throw inputError(
+      `${destinations[0]} requires --batch`,
+      'Output routing flags only apply to batch mode; without --batch the result goes to stdout.',
+      `Run \`patina --batch ${destinations[0]}${destinations[0] === '--in-place' ? '' : ' <value>'} <files>\`.`
+    );
+  }
+  if (destinations.length > 1) {
+    throw inputError(
+      `${destinations[0]} and ${destinations[1]} cannot be combined`,
+      'Each batch run writes to exactly one destination; combining them would silently pick one.',
+      'Pick one of --in-place, --suffix, or --outdir.'
+    );
+  }
+  if (parsed.outdir !== undefined) {
+    const seen = new Map();
+    for (const file of parsed.files) {
+      const base = basename(file);
+      const prior = seen.get(base);
+      if (prior !== undefined && prior !== file) {
+        throw inputError(
+          `--outdir would overwrite ${base}`,
+          `Both "${prior}" and "${file}" map to the same output file in ${parsed.outdir}.`,
+          'Rename the inputs, or use --suffix / --in-place to keep outputs beside their sources.'
+        );
+      }
+      seen.set(base, file);
+    }
+  }
+}
+
 function readOptionValue(args, index, option, { allowFlagLike = false } = {}) {
   const value = args[index + 1];
   if (value === undefined || (!allowFlagLike && value.startsWith('-'))) {
@@ -279,8 +399,15 @@ function readOptionValue(args, index, option, { allowFlagLike = false } = {}) {
   return value;
 }
 
+// Number('') === 0 and Number('  ') === 0, so a shell-quoting mistake like
+// `--max-retries ""` would silently become 0 (#440). Blank values are NaN.
+function numericOptionValue(value) {
+  if (value === undefined || String(value).trim() === '') return NaN;
+  return Number(value);
+}
+
 function parsePositiveIntegerOption(value, option) {
-  const n = Number(value);
+  const n = numericOptionValue(value);
   if (!Number.isInteger(n) || n <= 0) {
     throw inputError(
       `${option} expects a positive integer`,
@@ -292,7 +419,7 @@ function parsePositiveIntegerOption(value, option) {
 }
 
 function parseNonNegativeIntegerOption(value, option) {
-  const n = Number(value);
+  const n = numericOptionValue(value);
   if (!Number.isInteger(n) || n < 0) {
     throw inputError(
       `${option} expects a non-negative integer`,
@@ -304,7 +431,7 @@ function parseNonNegativeIntegerOption(value, option) {
 }
 
 function parseFailureRateOption(value, option) {
-  const n = Number(value);
+  const n = numericOptionValue(value);
   if (!Number.isFinite(n) || n < 0) {
     throw inputError(
       `${option} expects a ratio or percent`,
@@ -356,13 +483,14 @@ OUTPUT & BATCH
   --format <fmt>          Stdout format: markdown (default), text, json
   --quiet                 Suppress patina status/warning logs on stderr
   --batch                 Process multiple files
-  --in-place              Overwrite original files (with --batch)
-  --suffix <ext>          Save as {name}{ext}{extname}
-  --outdir <dir>          Save results to directory
+  --in-place              Overwrite original files (requires --batch)
+  --suffix <ext>          Save as {name}{ext}{extname} (requires --batch)
+  --outdir <dir>          Save results to directory (requires --batch)
   --max-failures <n>      Stop batch after n failed files
   --max-failure-rate <r>  Stop batch when failure ratio exceeds r (0.25 or 25)
-  --stop-on-retryable-storm
-                          Stop batch after repeated 429/timeouts/empty local-CLI exits
+  --no-stop-on-retryable-storm
+                          Keep going through repeated 429/timeout/temporary-exit
+                          storms (storm stopping is on by default in batch mode)
   --no-interactive        Do not wait for TTY stdin; exit 2 when no input is given
 
 LANGUAGE & PROFILE

--- a/src/cli/batch.js
+++ b/src/cli/batch.js
@@ -134,8 +134,11 @@ function classifyRetryableStorm(err) {
   if (/\bHTTP\s+503\b/i.test(message) || err?.status === 503) return 'HTTP 503';
   if (/Provider stream timed out/i.test(message)) return 'provider stream timeout';
   if (/timed out/i.test(message) || err?.name === 'AbortError') return 'timeout';
-  const exit = message.match(/\bexited with code\s+(75|1)\b/i);
-  if (exit) return `exit ${exit[1]}`;
+  // Only EX_TEMPFAIL (75) counts as a retryable exit. Exit 1 is the generic
+  // failure code for nearly every local-CLI error (auth, bad flags,
+  // deterministic rejections) — three unrelated failures must not be labeled
+  // a 'retryable storm' (#440); they stop the run via the failure budget.
+  if (/\bexited with code\s+75\b/i.test(message)) return 'exit 75';
   if (/no final response body|empty response|final-message-only/i.test(message)) return 'empty response';
   return null;
 }

--- a/src/cli/input.js
+++ b/src/cli/input.js
@@ -1,8 +1,10 @@
 import { loadInputText } from '../loader.js';
 import { inputError } from '../errors.js';
-import { createLogger } from '../logger.js';
 
-export async function loadInputs(parsed, logger = createLogger()) {
+// The second parameter used to be a logger for the stdin prompt; the prompt
+// now writes straight to stderr (#440). Kept as `_logger` so existing callers
+// passing a logger stay source-compatible.
+export async function loadInputs(parsed, _logger) {
   if (parsed.files.length === 0) {
     if (process.stdin.isTTY) {
       if (parsed.noInteractive) {
@@ -12,7 +14,10 @@ export async function loadInputs(parsed, logger = createLogger()) {
           'Pass a file path, pipe text via stdin, or omit --no-interactive to paste text and press Ctrl-D.'
         );
       }
-      logger.info('stdin.prompt', { message: '[patina] Paste text, then press Ctrl-D to run (Ctrl-C to cancel).' });
+      // Interaction-critical UI, not a status log: --quiet silences the
+      // logger, which would leave a TTY user blocked on Ctrl-D with zero
+      // indication (#440). Write straight to stderr.
+      process.stderr.write('[patina] Paste text, then press Ctrl-D to run (Ctrl-C to cancel).\n');
     }
     const stdin = await readStdin({ interactive: Boolean(process.stdin.isTTY) });
     if (!stdin.trim()) {

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -302,6 +302,11 @@ export async function runDefault(parsed, logger) {
         batchState.recordSuccess();
       } catch (err) {
         if (!shouldHandleBatchFailure(parsed, jobs.length)) throw err;
+        // Ctrl-C is a run-level stop, not a per-file failure: after the abort,
+        // every remaining iteration's throwIfCanceled() would otherwise be
+        // recorded and logged as a spurious 'batch.file_failed' for files that
+        // were never attempted (#440). The outer catch maps this to exit 130.
+        if (cancellation.signal.aborted || err?.exitCode === 130) throw err;
         batchState.recordFailure({ path, err });
         logger.warn('batch.file_failed', {
           message: `[patina] batch file failed: ${path} (${batchState.failures.length}/${batchState.maxFailures} failures): ${err.message}`,

--- a/src/cli/score-gate.js
+++ b/src/cli/score-gate.js
@@ -1,10 +1,15 @@
 import { extractOverallScore } from '../output.js';
+import { runtimeError } from '../errors.js';
 import { createLogger } from '../logger.js';
 
 export function applyScoreGate(result, output, gate, logger = createLogger()) {
   const overall = extractScoreOverall(result, output);
   if (overall === null) {
-    throw new Error('score gate could not find a numeric `overall` value in --score output.');
+    throw runtimeError(
+      'score gate could not find a numeric overall value',
+      'The --score output carried no parseable `overall` number, so the --exit-on gate cannot be applied.',
+      'Rerun with `--format json` to inspect the score payload, or drop --exit-on if the backend cannot produce strict score output.'
+    );
   }
   if (overall > gate) {
     logger.warn('score.gate_failed', { message: `[patina] score gate failed: overall ${overall} > ${gate}` });

--- a/tests/unit/batch.test.js
+++ b/tests/unit/batch.test.js
@@ -73,3 +73,30 @@ test('small batches engage the rate check only once fully sampled', () => {
   // 2/2 = 100% > 50%.
   assert.equal(b.shouldStop(), true);
 });
+
+test('generic exit-1 failures no longer count as a retryable storm (#440)', () => {
+  const b = breaker({ maxFailures: Infinity, maxFailureRate: 1 });
+  for (let i = 0; i < 3; i++) {
+    b.recordFailure({ path: `f${i}.md`, err: new Error('claude-cli backend: claude exited with code 1\nauth expired') });
+  }
+  // rate 3/3 = 100% is not > 1.0, budget is Infinity — only the storm rule
+  // could stop here, and exit 1 must not feed it.
+  assert.equal(b.shouldStop(), false);
+});
+
+test('EX_TEMPFAIL exits still trip the retryable-storm breaker', () => {
+  const b = breaker({ maxFailures: Infinity, maxFailureRate: 1 });
+  for (let i = 0; i < 3; i++) {
+    b.recordFailure({ path: `f${i}.md`, err: new Error('kimi-cli backend: kimi exited with code 75') });
+  }
+  assert.equal(b.shouldStop(), true);
+  assert.match(b.toError().message, /retryable storm detected \(3 × exit 75\)/);
+});
+
+test('--no-stop-on-retryable-storm disables the storm rule (#440)', () => {
+  const b = breaker({ maxFailures: Infinity, maxFailureRate: 1, stopOnRetryableStorm: false });
+  for (let i = 0; i < 5; i++) {
+    b.recordFailure({ path: `f${i}.md`, err: new Error('HTTP 429 too many requests') });
+  }
+  assert.equal(b.shouldStop(), false);
+});

--- a/tests/unit/cli-args.test.js
+++ b/tests/unit/cli-args.test.js
@@ -1,0 +1,106 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { parseArgs, validateOutputRouting } from '../../src/cli/args.js';
+import { applyScoreGate } from '../../src/cli/score-gate.js';
+import { PatinaCliError } from '../../src/errors.js';
+
+test('output routing flags require --batch (#440)', () => {
+  assert.throws(
+    () => validateOutputRouting(parseArgs(['--in-place', 'draft.md'])),
+    /--in-place requires --batch/,
+  );
+  assert.throws(
+    () => validateOutputRouting(parseArgs(['--suffix', '-humanized', 'draft.md'])),
+    /--suffix requires --batch/,
+  );
+  assert.throws(
+    () => validateOutputRouting(parseArgs(['--outdir', 'out', 'draft.md'])),
+    /--outdir requires --batch/,
+  );
+  // With --batch each destination is valid on its own.
+  for (const flags of [['--in-place'], ['--suffix', '-x'], ['--outdir', 'out']]) {
+    validateOutputRouting(parseArgs(['--batch', ...flags, 'a.md', 'b.md']));
+  }
+});
+
+test('output destinations are mutually exclusive (#440)', () => {
+  assert.throws(
+    () => validateOutputRouting(parseArgs(['--batch', '--in-place', '--outdir', 'out', 'a.md'])),
+    /--in-place and --outdir cannot be combined/,
+  );
+  assert.throws(
+    () => validateOutputRouting(parseArgs(['--batch', '--suffix', '-x', '--outdir', 'out', 'a.md'])),
+    /--suffix and --outdir cannot be combined/,
+  );
+});
+
+test('--outdir rejects input basename collisions instead of silently overwriting (#440)', () => {
+  assert.throws(
+    () => validateOutputRouting(parseArgs(['--batch', '--outdir', 'out', 'a/readme.md', 'b/readme.md'])),
+    /--outdir would overwrite readme\.md/,
+  );
+  // Distinct basenames and a repeated identical path are fine.
+  validateOutputRouting(parseArgs(['--batch', '--outdir', 'out', 'a/one.md', 'b/two.md']));
+  validateOutputRouting(parseArgs(['--batch', '--outdir', 'out', 'a/one.md', 'a/one.md']));
+});
+
+test('--suffix keeps hyphen values but rejects swallowed flag names (#440)', () => {
+  assert.equal(parseArgs(['--batch', '--suffix', '-humanized', 'a.md']).suffix, '-humanized');
+  assert.throws(
+    () => parseArgs(['--suffix', '--batch', 'a.md']),
+    /--suffix requires a value/,
+  );
+  assert.throws(
+    () => parseArgs(['--suffix', '--outdir', 'a.md']),
+    /--suffix requires a value/,
+  );
+});
+
+test('--no-stop-on-retryable-storm turns storm stopping off (#440)', () => {
+  assert.equal(parseArgs(['--batch']).stopOnRetryableStorm, undefined);
+  assert.equal(parseArgs(['--batch', '--stop-on-retryable-storm']).stopOnRetryableStorm, true);
+  assert.equal(parseArgs(['--batch', '--no-stop-on-retryable-storm']).stopOnRetryableStorm, false);
+});
+
+test('blank numeric values are rejected instead of coercing to 0 (#440)', () => {
+  assert.throws(() => parseArgs(['--exit-on', '']), /--exit-on expects a number/);
+  assert.throws(() => parseArgs(['--exit-on', '   ']), /--exit-on expects a number/);
+  assert.throws(() => parseArgs(['--max-retries', '']), /--max-retries expects a non-negative integer/);
+  assert.throws(() => parseArgs(['--max-failure-rate', '']), /--max-failure-rate expects a ratio or percent/);
+  // Explicit zeros remain valid.
+  assert.equal(parseArgs(['--exit-on', '0']).gate, 0);
+  assert.equal(parseArgs(['--max-retries', '0']).maxRetries, 0);
+});
+
+test('--flag=value works for value-taking options (#440)', () => {
+  const parsed = parseArgs(['--lang=en', '--max-retries=2', '--suffix=-humanized', 'a.md']);
+  assert.equal(parsed.lang, 'en');
+  assert.equal(parsed.maxRetries, 2);
+  assert.equal(parsed.suffix, '-humanized');
+  assert.deepEqual(parsed.files, ['a.md']);
+});
+
+test('=value on boolean switches and unknown options stays an error (#440)', () => {
+  assert.throws(() => parseArgs(['--quiet=1']), /--quiet does not take a value/);
+  assert.throws(() => parseArgs(['--unknown=x']), /unknown option --unknown=x/);
+});
+
+test('-- ends option parsing so dash-prefixed files are usable (#440)', () => {
+  const parsed = parseArgs(['--lang', 'en', '--', '-draft.md', '--not-a-flag.md']);
+  assert.equal(parsed.lang, 'en');
+  assert.deepEqual(parsed.files, ['-draft.md', '--not-a-flag.md']);
+});
+
+test('applyScoreGate throws a typed runtime error when overall is missing (#440)', () => {
+  let err;
+  try {
+    applyScoreGate('no score here', 'no score here', 30, { warn() {} });
+  } catch (e) {
+    err = e;
+  }
+  assert.ok(err instanceof PatinaCliError);
+  assert.equal(err.exitCode, 1);
+  assert.match(err.what, /score gate could not find a numeric overall value/);
+  assert.match(err.action, /--format json/);
+});


### PR DESCRIPTION
Closes #440 (review: cli-core lane from the 2026-06-13 full-repo architect review). The major finding from this lane (#434) already shipped in #457; this PR resolves the remaining 5 minor + 5 nit findings.

## Findings addressed

**Minor**
- **Ctrl-C during batch logged as per-file failures** (`run.js`): rethrow when `cancellation.signal.aborted` / `err.exitCode === 130` so never-attempted files are not recorded/logged as `batch.file_failed`; outer catch still maps to exit 130.
- **`--stop-on-retryable-storm` was a no-op** (`batch.js`/`args.js`): storm stopping is on by default in batch mode; added `--no-stop-on-retryable-storm` as the real off switch and corrected the help text.
- **`--outdir` silently overwrote outputs on basename collisions** (`args.js`): `validateOutputRouting` rejects two inputs mapping to the same `--outdir` file.
- **`--in-place`/`--suffix`/`--outdir` ignored without `--batch` and shadowing each other** (`args.js`): new `validateOutputRouting` makes them batch-only and mutually exclusive.
- **`applyScoreGate` threw bare `Error`** (`score-gate.js`): now `runtimeError(what, why, action)` (exit 1) with `--format json` guidance.

**Nit**
- **Generic `exited with code 1` fed the storm breaker** (`batch.js`): only `EX_TEMPFAIL` (exit 75) counts; exit-1 failures stop via the failure budget instead.
- **`--suffix` swallowed a following flag** (`args.js`): rejects known flag names as the suffix value while keeping `-humanized`.
- **Empty-string numeric values coerced to 0** (`args.js`): `numericOptionValue` returns NaN for blank `--exit-on`/`--max-retries`/etc.
- **No `--flag=value` syntax / no `--` separator** (`args.js`): `expandArgs` splits `--name=value` for value-taking options, rejects `=value` on switches, and `--` ends option parsing for dash-prefixed file names.
- **`--quiet` suppressed the interactive stdin prompt** (`input.js`): the TTY paste prompt now writes straight to stderr.

## Verification
- `node --test tests/unit/*.test.js tests/e2e/*.test.js` — 658 pass / 0 fail (adds `tests/unit/cli-args.test.js`, 18 cases, + 3 batch storm-classification tests).
- `npm run lint` (syntax + eslint + tsc + cspell) — green.
- End-to-end binary smoke: all new validation paths emit typed three-line errors and exit 2.

Docs/help text (`docs/CLI.md`, `printHelp`) updated. No new runtime deps; `src/features/*` untouched.