### PR TITLE
fix(det-engine): CJK quote-aware sentence splitting + boundary-anchored lexicon matching (#441)

### DIFF
--- a/core/stylometry.md
+++ b/core/stylometry.md
@@ -225,13 +225,17 @@ Calibration note (2026-05-22): `npm run benchmark:katfish-ko -- --write --basena
 ## 6. Hot Decision Rule
 
 단락 수준 SUSPECT 판정은 단순한 OR 규칙으로 결정한다. v3.7 이후 lexicon density가
-세 번째 hot 신호로 추가되었다(상세 calibration은 §16).
+세 번째 hot 신호로, ko diagnostic composite가 네 번째 축으로 추가되었고, #334/#391
+이후 discourse-tell 두 종류(fake-candor opener, decorative thematic break)가
+문서 수준 density gate를 통과했을 때 추가 disjunct로 합류했다(상세 calibration은 §16).
 
 ```
 paragraph is SUSPECT iff
   burstiness_band == "low"  OR  MATTR_band == "low"  OR
   (lexicon_density > threshold AND lexicon_min_hits is satisfied)  OR
-  koDiagnostics.hot == true
+  koDiagnostics.hot == true  OR
+  (fakeCandor.doc_count >= 2 AND paragraph_candor_count >= 1)  OR
+  (thematicBreaks.doc_count >= 3 AND paragraph_break_count >= 1)
 ```
 
 ### 근거
@@ -244,6 +248,10 @@ paragraph is SUSPECT iff
   막기 위해 CJK 기본 `lexicon_min_hits`는 2다.
 - ko diagnostic signal은 내부에서 AND composite를 사용하므로 쉼표/조사 같은 단일 특징만으로는
   OR-rule에 들어오지 않는다
+- discourse-tell disjunct(fake-candor / thematic-break)는 단독 단락 특징이 아니라
+  문서 수준 density gate(candor opener ≥2, thematic break ≥3)를 먼저 통과해야 켜진다.
+  gate 통과 후 해당 tell을 실제로 1회 이상 보유한 단락만 hot으로 합류하므로, 단일
+  opener나 단일 divider가 문단을 단독으로 hot 처리하지 않는다(#334/#391).
 
 ### 임계값 재조정
 
@@ -681,7 +689,7 @@ paragraph is SUSPECT iff
   (lexicon_density > threshold AND min_hot_matches is satisfied)
 ```
 
-v3.7에서는 §6의 2-signal OR 규칙을 3-signal OR로 확장했다. burstiness/MATTR는 분포적 신호, lexicon은 어휘적 신호 — 다른 축이라 OR 결합 시 둘 다 합산 효과를 냈다. 현재 전체 규칙은 §6의 4-signal OR이며, ko diagnostic composite가 네 번째 축이다.
+v3.7에서는 §6의 2-signal OR 규칙을 3-signal OR로 확장했다. burstiness/MATTR는 분포적 신호, lexicon은 어휘적 신호 — 다른 축이라 OR 결합 시 둘 다 합산 효과를 냈다. 이후 ko diagnostic composite가 네 번째 축으로, #334/#391의 discourse-tell 두 종류가 문서 수준 density gate를 전제로 한 disjunct로 합류했다. 따라서 현재 전체 규칙은 §6의 4-signal OR에 discourse-tell 두 disjunct를 더한 형태다(stylometry 분포 신호 + lexicon 어휘 신호 + ko composite + discourse tell).
 
 ### 사전 파일
 

--- a/src/features/lexicon-core.js
+++ b/src/features/lexicon-core.js
@@ -36,12 +36,26 @@ export function parseLexiconBody(body, { skipUnderscore = false } = {}) {
 }
 
 // Phrases may include `~` as a wildcard standing in for up to 40 chars.
+// Inter-word whitespace becomes `\s+` and the wildcard becomes `[\s\S]{0,40}`
+// so a phrase hard-wrapped across a single newline inside a paragraph (which
+// only blank lines split) still matches instead of silently undercounting.
 export function phraseToRegex(phrase) {
   const escaped = phrase
     .toLowerCase()
-    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const withWildcard = escaped.replace(/~/g, '.{0,40}');
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\s+/g, '\\s+');
+  const withWildcard = escaped.replace(/~/g, '[\\s\\S]{0,40}');
   return new RegExp(withWildcard);
+}
+
+// Whole-word match for a multi-token non-CJK strict entry (contains a space,
+// hyphen, or apostrophe). Anchored on Unicode letter/digit boundaries so it
+// cannot hit inside a larger token, and whitespace tolerates soft line wraps.
+function strictEntryRegex(lowerEntry) {
+  const escaped = lowerEntry
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\s+/g, '\\s+');
+  return new RegExp(`(?<![\\p{L}\\p{N}])${escaped}(?![\\p{L}\\p{N}])`, 'u');
 }
 
 // Counts paragraph-level lexicon hits. Strict entries match whole-word
@@ -54,9 +68,12 @@ export function computeDensity(paragraphText, tokens, lexicon) {
 
   // §16: English strict entries match whole-word; CJK strict entries are
   // approximated by substring. Korean inflection and zh/ja character fallback
-  // mean `자리매김`, `可以说`, or `まとめると` may not survive as whole tokens.
-  // Punctuated entries always need substring fallback because tokenization
-  // strips edge punct.
+  // mean `자리매김`, `可以说`, or `まとめると` may not survive as whole tokens, so
+  // CJK keeps bare substring matching. A non-CJK strict entry that is not a
+  // single whole token (it carries a space/hyphen/apostrophe, so tokenization
+  // split or edge-stripped it) falls back to a whole-word boundary-anchored
+  // match — never bare substring, which would hit inside a larger token and
+  // break the documented whole-word contract (lexicon/ai-en.md).
   const cjkSubstring = ['ko', 'zh', 'ja'].includes(lexicon.lang);
   for (const entry of lexicon.strict) {
     const lowerEntry = entry.toLowerCase();
@@ -64,8 +81,10 @@ export function computeDensity(paragraphText, tokens, lexicon) {
       hits.push(entry);
       continue;
     }
-    const hasInternalPunct = /[^\p{L}\p{N}]/u.test(lowerEntry);
-    if ((cjkSubstring || hasInternalPunct) && lowerText.includes(lowerEntry)) {
+    const isMultiToken = /[^\p{L}\p{N}]/u.test(lowerEntry);
+    if (cjkSubstring) {
+      if (lowerText.includes(lowerEntry)) hits.push(entry);
+    } else if (isMultiToken && strictEntryRegex(lowerEntry).test(lowerText)) {
       hits.push(entry);
     }
   }

--- a/src/features/segment.js
+++ b/src/features/segment.js
@@ -6,8 +6,20 @@
 // so sentence-length and lexical-diversity signals are not collapsed to
 // "one token per sentence." Sentence splitting is regex-only and accepts known
 // false splits on abbreviations / decimals (documented limit).
-
-const SENTENCE_SPLIT_RE = /[.!?]+\s+|(?<=[。！？…])|\n+/u;
+//
+// A CJK sentence terminator (。！？) is treated as a boundary only when it is
+// NOT immediately followed by a closing quote/bracket, so quote-internal
+// terminators (彼は「やめろ。」と言った。) do not split mid-quote and a trailing
+// closer (…と言った。」) is never stranded as its own zero-token "sentence".
+// U+2026 (…) is intentionally NOT a hard terminator: in en/ko it is usually
+// intra-sentence ("Well… maybe not."), so splitting on it would perturb token
+// counts on exactly the human prose the tool must not flag. It is still
+// stripped from sentence ends below.
+const SENTENCE_CLOSERS = '」』】〕）》〉｝"\'”’';
+const SENTENCE_SPLIT_RE = new RegExp(
+  `[.!?]+\\s+|(?<=[。！？])(?![${SENTENCE_CLOSERS}])|\\n+`,
+  'u'
+);
 const PARAGRAPH_SPLIT_RE = /\n\s*\n/;
 const LIST_LINE_RE = /^\s*(?:[-*+]\s+|\d+[.)]\s+)/u;
 // \W in Unicode-aware mode. Strips edge punctuation but keeps internal

--- a/tests/unit/lexicon.test.js
+++ b/tests/unit/lexicon.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
-import { computeDensity, loadLexicon } from '../../src/features/lexicon.js';
+import { computeDensity, phraseToRegex, loadLexicon } from '../../src/features/lexicon.js';
 import { tokenize } from '../../src/features/segment.js';
 import { analyzeText } from '../../src/features/index.js';
 import { scoreDeterministicSignals } from '../../src/scoring.js';
@@ -106,4 +106,26 @@ test('scoreDeterministicSignals respects lexicon.languages gating', () => {
     repoRoot: REPO_ROOT,
   });
   assert.strictEqual(disabled.bands.lexicon.hot, 0);
+});
+
+test('non-CJK strict entries match whole-word, not inside a larger token (#441)', () => {
+  const lexicon = { lang: 'en', strict: ['cutting-edge', 'game changer'], phrases: [] };
+  // Whole-word hits land via the token set and the boundary-anchored fallback.
+  const hyphen = computeDensity('our cutting-edge approach', tokenize('our cutting-edge approach'), lexicon);
+  assert.ok(hyphen.hits.includes('cutting-edge'));
+  const multi = computeDensity('a real game changer here', tokenize('a real game changer here'), lexicon);
+  assert.ok(multi.hits.includes('game changer'));
+  // Boundary-anchored: no longer a bare substring inside a bigger token.
+  const inside = computeDensity('precutting-edged thing', tokenize('precutting-edged thing'), lexicon);
+  assert.equal(inside.hits.includes('cutting-edge'), false);
+  assert.equal(inside.matches, 0);
+});
+
+test('phrase regex matches across a soft line wrap and through the wildcard (#441)', () => {
+  // Inter-word whitespace tolerates a single newline inside a paragraph.
+  assert.ok(phraseToRegex('in the digital age').test('seen in the\ndigital age today'));
+  // `~` wildcard spans newlines too.
+  assert.ok(phraseToRegex('not only~but also').test('not only fast\nbut also cheap'));
+  // Still does not match when the words are absent.
+  assert.equal(phraseToRegex('in the digital age').test('in the analog era'), false);
 });

--- a/tests/unit/stylometry.test.js
+++ b/tests/unit/stylometry.test.js
@@ -23,6 +23,24 @@ test('splitSentences handles ., !, ?, 。, … and newlines', () => {
   assert.deepEqual(splitSentences('第一句。第二句！第三句？'), ['第一句', '第二句', '第三句']);
 });
 
+test('splitSentences keeps CJK terminators inside closing quotes attached (#441)', () => {
+  // Quote-internal 。 no longer splits mid-quote: this is one sentence.
+  assert.deepEqual(
+    splitSentences('彼は「やめろ。」と言った。'),
+    ['彼は「やめろ。」と言った']
+  );
+  // A trailing closing bracket after the terminator is never stranded as its
+  // own zero-token "sentence" (old behavior produced a lone 」).
+  assert.deepEqual(splitSentences('と言った。」'), ['と言った。」']);
+  // A real terminator followed by a non-closer still splits.
+  assert.deepEqual(splitSentences('そうだ。次の文。'), ['そうだ', '次の文']);
+});
+
+test('splitSentences does not split on intra-sentence ellipsis in en/ko (#441)', () => {
+  assert.deepEqual(splitSentences('Well… maybe not.'), ['Well… maybe not']);
+  assert.deepEqual(splitSentences('글쎄… 아닐지도.'), ['글쎄… 아닐지도']);
+});
+
 test('splitProseSentences excludes Markdown list blocks from prose rhythm samples', () => {
   const bulleted = `Here is what the tool does for you:
 - send hook events to external gateways


### PR DESCRIPTION
Closes #441 (review: det-engine lane from the 2026-06-13 full-repo architect review). Resolves the 4 minor + 1 nit findings. `src/features/*` stays deterministic and LLM-free; no new deps. The playground imports these modules directly, so both surfaces get the fixes.

## Findings addressed

**Minor**
- **CJK closing quotes after terminators strand fragments / zero-token sentences** (`segment.js`): a `。！？` boundary now fires only when the next char is not a closing quote/bracket (`」』】〕）》〉｝"'""`). `彼は「やめろ。」と言った。` is one sentence; `…と言った。」` no longer leaves a lone `」` that tokenizes to 0 tokens (which deflated the burstiness mean and inflated CV / sentence count on quote-heavy ja/zh prose).
- **Boundary-less substring fallback contradicts whole-word contract** (`lexicon-core.js`): non-CJK strict entries that are not whole tokens (space/hyphen/apostrophe) now use a Unicode-boundary-anchored regex instead of bare `includes`, so an entry can no longer hit inside a larger token (`cutting-edge` no longer matches inside `precutting-edged`). CJK keeps substring matching. Renamed `hasInternalPunct` → `isMultiToken`.
- **Phrase regexes can't match across soft line wraps** (`lexicon-core.js`): inter-word whitespace → `\s+` and the `~` wildcard → `[\s\S]{0,40}`, so a phrase hard-wrapped across a single newline inside a paragraph is still counted (was a silent false-negative).
- **Spec drift: hot rule ORs candor/thematic-break signals absent from the spec** (`core/stylometry.md`): §6 and §16 now document the two discourse-tell disjuncts and their document-level density gates (candor ≥2, breaks ≥3), which the implementation has ORed since #334/#391.

**Nit**
- **U+2026 ellipsis split en/ko mid-thought** (`segment.js`): `…` is no longer a hard sentence terminator (`Well… maybe not.` / `글쎄… 아닐지도.` stay one sentence); it is still stripped from sentence ends.

## Verification
- `node --test tests/unit/*.test.js tests/e2e/*.test.js` — 649 pass / 0 fail (adds segment closing-quote/ellipsis tests + lexicon boundary/soft-wrap tests; §10 EN/KO exact-count worked examples unchanged).
- `npm run lint` — green.
- `npm run benchmark` — 100% accuracy across en/ja/ko/zh, ROC-AUC/PR-AUC 1.000 (no detection regression).
- `npm run dogfood` — all tracked docs under the gate.