### PR TITLE
fix(det-signals): drop navlist leakage FP, exclude setext/frontmatter & noun calques (#442)

### DIFF
--- a/src/features/catalog/ko-interference.js
+++ b/src/features/catalog/ko-interference.js
@@ -68,7 +68,11 @@ export const KO_INTERFERENCE_TRANSLATIONESE_RULES = [
     label: '연결어미 뒤 쉼표 (-고,/-며,/-지만,)',
     strong: false,
     minCount: 2,
-    re: () => /(?:고|며|지만|면서|아서|어서)\s*,/g,
+    // The 고 arm excludes common 고-final nouns (참고/광고/사고/경고/공고/원고/최고/
+    // 중고/창고/재고…) so plain noun lists do not feed the evidence gate (#442);
+    // 보다(보고) and similar verb stems stay matchable. 며/지만/면서/아서/어서 are
+    // unambiguous connective endings and need no guard.
+    re: () => /(?:며|지만|면서|아서|어서)\s*,|(?<![참광사신경충권예공원최중창재])고\s*,/g,
     example: { before: '그는 자료를 검토하고, 결과를 정리하며, 보고서를 작성했다.', after: '그는 자료를 검토하고 결과를 정리한 뒤 보고서를 작성했다.' },
   },
 ];

--- a/src/features/discourse-tells.js
+++ b/src/features/discourse-tells.js
@@ -24,6 +24,42 @@ const THEMATIC_BREAK_MIN = 3;
 // A markdown thematic break: a line that is only ---, ***, or ___ (3+), optionally spaced.
 const THEMATIC_BREAK_LINE = /^[ \t]*(?:-[ \t]*){3,}$|^[ \t]*(?:\*[ \t]*){3,}$|^[ \t]*(?:_[ \t]*){3,}$/;
 const HEADING_LINE = /^[ \t]*#{1,6}[ \t]+\S/;
+// Only the dash variant of a thematic break can also be a CommonMark setext
+// H2 underline; *** / ___ are always thematic breaks.
+const SETEXT_UNDERLINE_CANDIDATE = /^[ \t]*(?:-[ \t]*){3,}$/;
+// A line that, when it sits directly above a dash-only line, makes that dash
+// line a setext underline rather than a divider: anything that is not blank,
+// not a heading, not itself a break, and not a list/blockquote marker.
+const NON_SETEXT_PARENT = /^[ \t]*(?:[-*+][ \t]|\d+[.)][ \t]|>)/;
+
+// A dash-only line is a setext H2 underline (not a decorative divider) when the
+// immediately preceding line is plain prose (#442).
+function isSetextUnderline(lines, i) {
+  if (!SETEXT_UNDERLINE_CANDIDATE.test(lines[i])) return false;
+  const prev = i > 0 ? lines[i - 1] : '';
+  if (prev.trim() === '') return false;
+  if (HEADING_LINE.test(prev)) return false;
+  if (THEMATIC_BREAK_LINE.test(prev)) return false;
+  if (NON_SETEXT_PARENT.test(prev)) return false;
+  return true;
+}
+
+// Index of the closing fence of a leading YAML frontmatter block, or -1. The two
+// `---` lines a real frontmatter block contributes at file start are not
+// dividers. To avoid mistaking a document that merely opens with a `---`
+// divider for frontmatter, the line right after the opening fence must look
+// like YAML (a `key:` line or a `- ` list item) — never a markdown heading or
+// prose (#442).
+function frontmatterEndIndex(lines) {
+  if (lines[0] === undefined || !/^---[ \t]*$/.test(lines[0])) return -1;
+  if (lines[1] === undefined || !/^[ \t]*(?:[\w.$-]+[ \t]*:(?:\s|$)|- )/.test(lines[1])) {
+    return -1;
+  }
+  for (let j = 2; j < lines.length; j++) {
+    if (/^(?:---|\.\.\.)[ \t]*$/.test(lines[j])) return j;
+  }
+  return -1;
+}
 
 export function detectFakeCandor(text) {
   const str = typeof text === 'string' ? text : '';
@@ -41,10 +77,13 @@ export function detectFakeCandor(text) {
 
 export function detectThematicBreaks(text) {
   const lines = (typeof text === 'string' ? text : '').split(/\r?\n/);
+  const frontmatterEnd = frontmatterEndIndex(lines);
   let count = 0;
   let adjacentToHeading = 0;
   for (let i = 0; i < lines.length; i++) {
+    if (i <= frontmatterEnd) continue;
     if (!THEMATIC_BREAK_LINE.test(lines[i])) continue;
+    if (isSetextUnderline(lines, i)) continue;
     count++;
     // "adjacent to a heading" = the next non-empty line is a heading.
     for (let j = i + 1; j < lines.length; j++) {

--- a/src/features/markup-leakage.js
+++ b/src/features/markup-leakage.js
@@ -41,7 +41,7 @@ const MARKUP_RULES = [
   {
     id: 'model-tool-token',
     label: 'Model tool token',
-    build: () => /\bturn\d+(?:search|view|news|image|forecast|finance|fetch)\d*\b|\bnavlist\b|\bgrok_card\b/gi,
+    build: () => /\bturn\d+(?:search|view|news|image|forecast|finance|fetch)\d*\b|\bgrok_card\b/gi,
   },
   {
     id: 'object-replacement-char',
@@ -71,6 +71,16 @@ const MARKUP_RULES = [
     //   real refusal boilerplate uses.
     build: () => /\bas an? (?:AI|artificial intelligence) language model\b|\bas a large language model\b|\bas a language model,? I\b|\bas an AI assistant\b|\bI(?: am|'?m) an AI(?:\s+(?:assistant|chatbot|language model|model))?(?:\s+(?:created|developed|trained|designed|built|made)\s+by\b|(?![-/]|\s+\w))/gi,
   },
+  {
+    // `navlist` alone is a plausible human identifier (CSS class/id, variable
+    // name) in frontend docs/code, so it is NOT near-proof on its own (#442).
+    // It only counts as leakage when an independent near-proof token in the
+    // same text corroborates that this is pasted model output.
+    id: 'model-nav-token',
+    label: 'Model navlist token',
+    corroborated: true,
+    build: () => /\bnavlist\b/gi,
+  },
 ];
 
 /**
@@ -83,17 +93,28 @@ export function detectMarkupLeakage(text) {
   const hits = [];
   if (!str) return { leaked: false, hits };
 
+  const corroborated = [];
+  let hasIndependentHit = false;
   for (const rule of MARKUP_RULES) {
     const matches = str.match(rule.build());
-    if (matches && matches.length > 0) {
-      hits.push({
-        id: rule.id,
-        label: rule.label,
-        count: matches.length,
-        samples: [...new Set(matches.map((m) => m.trim()).filter(Boolean))].slice(0, 3),
-      });
+    if (!matches || matches.length === 0) continue;
+    const hit = {
+      id: rule.id,
+      label: rule.label,
+      count: matches.length,
+      samples: [...new Set(matches.map((m) => m.trim()).filter(Boolean))].slice(0, 3),
+    };
+    if (rule.corroborated) {
+      corroborated.push(hit);
+    } else {
+      hits.push(hit);
+      hasIndependentHit = true;
     }
   }
+  // Corroboration-required tokens (navlist) only escalate to leakage when an
+  // independent near-proof token also fired; otherwise they are dropped so a
+  // human identifier cannot force the LEAKAGE_SCORE_FLOOR on its own (#442).
+  if (hasIndependentHit) hits.push(...corroborated);
   return { leaked: hits.length > 0, hits };
 }
 

--- a/src/features/translationese.js
+++ b/src/features/translationese.js
@@ -39,7 +39,9 @@ const RULES = [
     id: 'direct-address-you',
     label: '"당신" 직접 호칭 (English "you")',
     strong: true,
-    re: () => /당신(?:은|이|의|에게|을|를|께서|께)?/g,
+    // Hangul boundary guards (matching a16-pronoun-literal) keep 당신 out of
+    // unspaced compounds like 해당신청 / 사당신축 (#442).
+    re: () => /(?<![가-힣])당신(?:은|이|의|에게|을|를|께서|께)?(?![가-힣])/g,
     example: { before: '당신은 이것을 설정할 수 있습니다.', after: '이건 설정할 수 있다.' },
   },
   getKoInterferenceRule('a16-pronoun-literal'),

--- a/tests/unit/discourse-tells.test.js
+++ b/tests/unit/discourse-tells.test.js
@@ -50,6 +50,21 @@ test('thematic break does not fire on normal markdown with one rule', () => {
   assert.equal(detectThematicBreaks(md).hot, false);
 });
 
+test('setext H2 underlines and YAML frontmatter are not counted as dividers (#442)', () => {
+  // Three setext H2 underlines (--- directly under a prose line) must NOT trip
+  // the divider gate.
+  const setext = 'Intro line\n---\n\nbody\n\nSection one\n---\n\nmore\n\nSection two\n---\n';
+  assert.equal(detectThematicBreaks(setext).count, 0);
+  assert.equal(detectThematicBreaks(setext).hot, false);
+  // Real YAML frontmatter plus a single genuine divider stays below the gate.
+  const fm = '---\ntitle: Post\ntags: [a, b]\n---\n\n# Heading\n\nbody\n\n---\n\nfooter';
+  assert.equal(detectThematicBreaks(fm).count, 1);
+  assert.equal(detectThematicBreaks(fm).hot, false);
+  // A divider preceded by a blank line is still a real divider.
+  const real = 'A\n\n---\n\nB\n\n---\n\nC\n\n---\n\nD';
+  assert.equal(detectThematicBreaks(real).count, 3);
+});
+
 test('detectDiscourseTells aggregates both', () => {
   const r = detectDiscourseTells("Here's the thing. The truth is, this works.\n\n---\n\nmore");
   assert.equal(r.fakeCandor.hot, true);

--- a/tests/unit/markup-leakage.test.js
+++ b/tests/unit/markup-leakage.test.js
@@ -10,10 +10,21 @@ test('detects OpenAI citation markup', () => {
   assert.ok(r.hits.some((h) => h.id === 'oai-citation-markup'));
 });
 
-test('detects model tool tokens (turn0search, navlist, grok_card)', () => {
-  for (const s of ['see turn0search1 for', 'rendered navlist here', 'a grok_card block']) {
+test('detects model tool tokens (turn0search, grok_card)', () => {
+  for (const s of ['see turn0search1 for', 'a grok_card block']) {
     assert.equal(detectMarkupLeakage(s).leaked, true, s);
   }
+});
+
+test('navlist only counts as leakage with corroborating tool-token context (#442)', () => {
+  // Standalone navlist (a plausible human CSS class / identifier) is NOT
+  // near-proof on its own.
+  assert.equal(detectMarkupLeakage('rendered navlist here').leaked, false);
+  assert.equal(detectMarkupLeakage('<ul class="navlist">').leaked, false);
+  // With an independent near-proof token present, it escalates to leakage.
+  const r = detectMarkupLeakage('turn0search1 then navlist follows');
+  assert.equal(r.leaked, true);
+  assert.ok(r.hits.some((h) => h.id === 'model-nav-token'));
 });
 
 test('detects object-replacement character', () => {

--- a/tests/unit/translationese.test.js
+++ b/tests/unit/translationese.test.js
@@ -201,6 +201,26 @@ test('ko translationese pronoun literal catches stacked-particle calques from sh
   }
 });
 
+test('direct-address-you respects Hangul boundaries (#442)', () => {
+  const rule = TRANSLATIONESE_RULES.find((r) => r.id === 'direct-address-you');
+  const countYou = (text) => (text.match(rule.re()) || []).length;
+  // 당신 inside unspaced compounds must not match.
+  assert.equal(countYou('해당신청을 처리했다.'), 0);
+  assert.equal(countYou('사당신축 공사가 끝났다.'), 0);
+  // Genuine second-person 당신 still matches.
+  assert.equal(countYou('당신은 이것을 설정할 수 있습니다.'), 1);
+  assert.equal(countYou('당신의 의견을 존중한다.'), 1);
+});
+
+test('c11-connective-comma skips common 고-final nouns (#442)', () => {
+  const count = (text) =>
+    (text.match(getKoInterferenceRule('c11-connective-comma').re()) || []).length;
+  // Plain noun lists ending in 고 are no longer counted as connective evidence.
+  assert.equal(count('참고, 광고, 경고, 공고, 원고, 최고, 중고, 창고, 재고, 충고, 권고,'), 0);
+  // Real connective endings before a comma still match (verb stem 하고, etc.).
+  assert.ok(count('검토하고, 정리하며, 마쳤다.') >= 2);
+});
+
 test('ko post-editese pronoun literal still excludes bound nouns and word-internal 그', () => {
   const pronounLiteralCount = (text) =>
     koreanPostEditeseFeatures(text, { lang: 'ko' }).metrics.interference.pronounLiteralCount;


### PR DESCRIPTION
Closes #442 (review: det-signals lane from the 2026-06-13 full-repo architect review). Resolves the 3 minor + 1 nit findings. The lane's major finding (#435) already shipped in #454. `src/features/*` stays deterministic and LLM-free; no new deps.

## Findings addressed

**Minor**
- **`\bnavlist\b` /i triggered near-proof leakage on human frontend docs** (`markup-leakage.js`): `navlist` (a realistic human CSS class / identifier) is no longer near-proof on its own. It is split into a `corroborated` rule that only escalates to leakage — and forces `LEAKAGE_SCORE_FLOOR=90` — when an independent high-specificity token (turn-search / contentReference / grok_card / oaicite / chatgpt tracking param) is also present. Standalone `navlist` (`<ul class="navlist">`) no longer fires.
- **Setext underlines & YAML frontmatter counted as decorative dividers** (`discourse-tells.js`): `detectThematicBreaks` now skips a `---` line that is a CommonMark setext H2 underline (directly under a prose line) and a leading YAML frontmatter block, so a human markdown doc with setext headings / frontmatter no longer flips `thematicBreaks.hot` and inflates the score's hot ratio. Frontmatter detection is strict (requires a YAML-like line after the opening fence) so a doc that merely opens with a `---` divider is unaffected.
- **`direct-address-you` (당신) lacked Hangul boundary guards** (`translationese.js`): now uses the same `(?<![가-힣]) … (?![가-힣])` discipline as `a16-pronoun-literal`, so it no longer fires inside unspaced compounds (`해당신청`, `사당신축`).

**Nit**
- **`c11-connective-comma` matched nouns ending in 고** (`catalog/ko-interference.js`): the 고 arm now excludes common 고-final nouns (`참고/광고/경고/공고/원고/최고/중고/창고/재고/충고/권고`…), so plain noun lists no longer feed the translationese independent-evidence gate; verb stems (`보고` etc.) stay matchable. `며/지만/면서/아서/어서` need no guard.

## Verification
- `node --test tests/unit/*.test.js tests/e2e/*.test.js` — 653 pass / 0 fail (adds navlist-corroboration, setext/frontmatter, 당신-boundary, and c11-noun tests).
- `npm run lint` — green.
- `npm run benchmark` — 100% accuracy across en/ja/ko/zh, ROC-AUC/PR-AUC 1.000 (no detection regression).
- `npm run dogfood` — tracked docs unchanged, all under the gate.