### PR TITLE
fix(structural-scoring): fail loud on corrupt models, FPR ceil, guard audit path (#443)

### DIFF
--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -265,7 +265,7 @@ export async function runDefault(parsed, logger) {
         }
         const auditBackstop =
           mode === 'audit' && (parsed.format ?? 'markdown') !== 'json' && !parsed.batch
-            ? buildDeterministicAuditBackstop(text, { lang, repoRoot, config })
+            ? buildDeterministicAuditBackstop(text, { lang, repoRoot, config, logger })
             : '';
         let output;
         let scoreValidationOutput = null;

--- a/src/features/structural-classifier.js
+++ b/src/features/structural-classifier.js
@@ -124,6 +124,12 @@ export function normalizeStructuralModel(model) {
   if (weights.some((value) => !Number.isFinite(value)) || scaler.mu.some((value) => !Number.isFinite(value)) || scaler.sigma.some((value) => !Number.isFinite(value))) {
     throw new TypeError('structural model values must be finite numbers');
   }
+  // Sigma must be strictly positive: a hand-written or truncated model with a
+  // zero/negative sigma passes the finite check but makes applyScaler emit
+  // NaN/±Infinity, which sigmoid turns into a silent NaN verdict (#443).
+  if (scaler.sigma.some((value) => !(value > 0))) {
+    throw new TypeError('structural model scaler sigma values must be positive');
+  }
   if (Array.isArray(model.featureNames) && model.featureNames.join('\0') !== STRUCTURAL_FEATURE_NAMES.join('\0')) {
     throw new TypeError('structural model featureNames do not match this patina version');
   }
@@ -158,14 +164,20 @@ export function thresholdForMaxFpr(model, Xtrain, ytrain, maxFpr = 0.1) {
     .map((row) => predictStructuralScore(normalized, row))
     .sort((a, b) => a - b);
   if (negativeScores.length === 0) return DEFAULT_STRUCTURAL_THRESHOLD;
-  const index = Math.min(negativeScores.length - 1, Math.floor((1 - maxFpr) * negativeScores.length));
+  // ceil (not floor) so the realized FPR never exceeds maxFpr: floor would keep
+  // an extra negative above the threshold (#443).
+  const index = Math.min(negativeScores.length - 1, Math.ceil((1 - maxFpr) * negativeScores.length));
   return Math.max(DEFAULT_STRUCTURAL_THRESHOLD, negativeScores[index]);
 }
 
 export function structuralModelVerdict(text, { lang = 'ko', model = null } = {}) {
   if (!model) return { available: false, hot: null, score: null };
   const normalized = normalizeStructuralModel(model);
-  if (normalized.lang && normalized.lang !== lang) return { available: false, hot: null, score: null };
+  // A truthy non-object model normalizes to null; treat as unavailable rather
+  // than null-derefing normalized.lang (#443).
+  if (!normalized || (normalized.lang && normalized.lang !== lang)) {
+    return { available: false, hot: null, score: null };
+  }
   const row = extractStructuralFeatures(text, { lang });
   const score = predictStructuralScore(normalized, row);
   return {

--- a/src/features/structural-model-loader.js
+++ b/src/features/structural-model-loader.js
@@ -108,7 +108,17 @@ export function loadStructuralModel(config = {}, opts = {}) {
   }
 
   try {
-    return normalizeStructuralModel(parsed);
+    const model = normalizeStructuralModel(parsed);
+    // normalizeStructuralModel returns null (not throws) for non-object JSON
+    // (null/number/boolean/string) — reachable via truncation/corruption. The
+    // file exists, so this is an invalid model, not "no model installed";
+    // failing here keeps the loader's contract that a resolved file is a model
+    // (#443).
+    if (!model) {
+      const kind = parsed === null ? 'null' : Array.isArray(parsed) ? 'array' : typeof parsed;
+      throw new Error(`expected a model object but got ${kind}`);
+    }
+    return model;
   } catch (err) {
     throw new Error(`Invalid structural model at ${resolved.path}: ${err.message}`);
   }

--- a/src/output.js
+++ b/src/output.js
@@ -512,6 +512,8 @@ function normalizeFooterTail(lines) {
  * @param {string} [opts.lang]
  * @param {string} [opts.repoRoot]
  * @param {object} [opts.config]
+ * @param {{ warn?: Function }} [opts.logger] Optional logger; the structural
+ *   model load degrades to a warning here instead of aborting the audit (#443).
  * @returns {string} Markdown section (empty string when nothing fired).
  */
 export function buildDeterministicAuditBackstop(text, opts = {}) {
@@ -541,7 +543,17 @@ export function buildDeterministicAuditBackstop(text, opts = {}) {
   }
 
   // markup leakage (near-proof) + density-gated discourse tells — language-agnostic.
-  const structuralModel = loadStructuralModel(opts.config ?? {}, { lang });
+  // The structural classifier is an advisory backstop: a configured-but-missing
+  // or corrupt model must degrade to a warning here, exactly as the --score path
+  // does (scoring.js), instead of aborting `patina --audit` (#443).
+  let structuralModel = null;
+  try {
+    structuralModel = loadStructuralModel(opts.config ?? {}, { lang });
+  } catch (err) {
+    opts.logger?.warn?.('audit.structural_model_load_failure', {
+      message: `[patina] structural model load failed; continuing without structural classifier: ${err?.message || err}`,
+    });
+  }
   const a = analyzeText(str, { lang, repoRoot: opts.repoRoot, structuralModel });
   for (const h of a.markupLeakage?.hits ?? []) {
     rows.push({ signal: 'markup-leakage', label: h.label, severity: 'HIGH', location: (h.samples ?? []).join(', ') });

--- a/tests/unit/structural-classifier.test.js
+++ b/tests/unit/structural-classifier.test.js
@@ -10,6 +10,7 @@ import {
   normalizeStructuralModel,
   trainLogReg,
   predictStructuralScore,
+  thresholdForMaxFpr,
 } from '../../src/features/index.js';
 
 function constantModel({ bias = 10, threshold = 0.5, lang = 'ko' } = {}) {
@@ -109,4 +110,45 @@ test('normalizeStructuralModel rejects models not trained at this feature width 
     () => structuralModelVerdict('오늘은 날씨가 좋았다. 점심을 먹었다.', { lang: 'ko', model: stale }),
     /expects 8 features/,
   );
+});
+
+test('normalizeStructuralModel rejects non-positive sigma (#443)', () => {
+  const zero = constantModel();
+  zero.scaler.sigma = new Array(STRUCTURAL_FEATURE_NAMES.length).fill(1);
+  zero.scaler.sigma[0] = 0;
+  assert.throws(() => normalizeStructuralModel(zero), /sigma values must be positive/);
+  const negative = constantModel();
+  negative.scaler.sigma = new Array(STRUCTURAL_FEATURE_NAMES.length).fill(1);
+  negative.scaler.sigma[0] = -2;
+  assert.throws(() => normalizeStructuralModel(negative), /sigma values must be positive/);
+});
+
+test('structuralModelVerdict treats a truthy non-object model as unavailable (#443)', () => {
+  assert.deepEqual(
+    structuralModelVerdict('오늘은 날씨가 좋았다. 점심을 먹었다.', { lang: 'ko', model: 'not-a-model' }),
+    { available: false, hot: null, score: null },
+  );
+});
+
+test('thresholdForMaxFpr keeps the realized FPR within maxFpr (ceil, #443)', () => {
+  const feat0 = (v) => [v, ...new Array(STRUCTURAL_FEATURE_NAMES.length - 1).fill(0)];
+  const model = {
+    lang: 'ko',
+    weights: [1, ...new Array(STRUCTURAL_FEATURE_NAMES.length - 1).fill(0)],
+    bias: 0,
+    threshold: 0.5,
+    scaler: {
+      mu: new Array(STRUCTURAL_FEATURE_NAMES.length).fill(0),
+      sigma: new Array(STRUCTURAL_FEATURE_NAMES.length).fill(1),
+    },
+    featureNames: STRUCTURAL_FEATURE_NAMES,
+  };
+  // 15 negatives with strictly increasing scores (the finding's worked case
+  // where floor() let realized FPR reach 13.3% > 10%).
+  const X = [];
+  const y = [];
+  for (let v = -7; v <= 7; v++) { X.push(feat0(v)); y.push(0); }
+  const threshold = thresholdForMaxFpr(model, X, y, 0.1);
+  const flagged = X.filter((row) => predictStructuralScore(model, row) >= threshold).length;
+  assert.ok(flagged / X.length <= 0.1, `realized FPR ${flagged}/${X.length} exceeds 0.1`);
 });

--- a/tests/unit/structural-model-loader.test.js
+++ b/tests/unit/structural-model-loader.test.js
@@ -114,3 +114,32 @@ test('audit backstop surfaces a hot private structural model verdict', () => {
   assert.match(md, /structural-classifier/);
   assert.match(md, /문서 단위 구조 분류기/);
 });
+
+test('loadStructuralModel rejects a configured model file that is valid JSON but not an object (#443)', () => {
+  const dir = mkdtempSync(resolve(tmpdir(), 'patina-model-'));
+  const path = resolve(dir, 'model-ko.json');
+  for (const raw of ['null', '42', 'true', '"x"']) {
+    writeFileSync(path, raw, 'utf8');
+    assert.throws(
+      () => loadStructuralModel({ stylometry: { structural_model: { path } } }, { env: {}, cwd: dir, lang: 'ko' }),
+      /Invalid structural model at[\s\S]*expected a model object but got/,
+      raw,
+    );
+  }
+});
+
+test('audit backstop degrades to a warning when the configured model is corrupt (#443)', () => {
+  const dir = mkdtempSync(resolve(tmpdir(), 'patina-model-'));
+  const path = resolve(dir, 'model-ko.json');
+  writeFileSync(path, '42', 'utf8');
+  const warnings = [];
+  const logger = { warn: (code) => warnings.push(code) };
+  // Must not throw — the advisory backstop continues without the classifier.
+  const md = buildDeterministicAuditBackstop('오늘은 날씨가 좋았다. 점심을 먹었다.', {
+    lang: 'ko',
+    config: { stylometry: { structural_model: { path } } },
+    logger,
+  });
+  assert.equal(typeof md, 'string');
+  assert.ok(warnings.includes('audit.structural_model_load_failure'));
+});


### PR DESCRIPTION
Closes #443 (review: structural-scoring lane from the 2026-06-13 full-repo architect review). Resolves the 4 minor findings + 2 nits; the lane's major finding (#436) already shipped in #455. `src/features/*` stays deterministic and LLM-free; no new deps.

## Findings addressed

**Minor**
- **Corrupt non-object JSON silently disabled a required model** (`structural-model-loader.js`): `normalizeStructuralModel` returns `null` (not throws) for `null`/number/boolean/string — reachable via truncation. The loader now throws `Invalid structural model … expected a model object but got <kind>` since the file exists, honoring the "explicit paths are required" contract.
- **Zero/negative sigma yielded silent NaN scores** (`structural-classifier.js`): `normalizeStructuralModel` now rejects non-positive sigma (it previously only checked finiteness; `sigma=0` → `applyScaler` NaN/±Inf → sigmoid NaN → `score: NaN`, serialized to `null`).
- **`thresholdForMaxFpr` off-by-one** (`structural-classifier.js`): `Math.floor((1-maxFpr)*n)` let the realized FPR exceed `maxFpr` (n=15, maxFpr=0.1 → 13.3%); now `Math.ceil(…)` capped at `n-1`.
- **Audit path called `loadStructuralModel` uncaught** (`output.js` / `cli/run.js`): a configured-but-missing/corrupt model aborted `patina --audit` while `--score` degraded to a warning. The audit backstop now catch-and-warns (advisory) and threads the logger through, matching the score path.

**Nit**
- **`structuralModelVerdict` null-deref on truthy non-object model** (`structural-classifier.js`): added the `if (!normalized)` guard → returns unavailable instead of throwing on `normalized.lang`.

## Not changed here (cross-referenced)
- The score-gate untyped-`Error` nit from this lane is fixed in #440 / **PR #458** (score-gate now throws a typed `runtimeError`).
- The deterministic-gate-exclusion finding is a verification note ("holds; placement drift, no import-time side effects") — no code change required.

## Verification
- `node --test tests/unit/*.test.js tests/e2e/*.test.js` — 654 pass / 0 fail (adds sigma-rejection, null-model-guard, FPR-ceil, corrupt-file, and audit-warn tests).
- `npm run lint` — green (added `opts.logger` to the JSDoc).
- `npm run benchmark` — 100% accuracy, ROC-AUC/PR-AUC 1.000 (these are defensive load/validation paths; no shipped model, so scoring is unchanged).