### PR TITLE
fix(backends-core): fail-closed concurrency, null-status retry, slot pid liveness, per-leg model (#445)

### DIFF
--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
-import { copyFileSync, mkdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { copyFileSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir, userInfo } from 'node:os';
 import { join } from 'node:path';
 
 export const DEFAULT_BACKEND_TIMEOUT_MS = 600_000;
@@ -52,10 +52,13 @@ export function getBackendSafety(backendName) {
 }
 
 export function resolveBackendMaxConcurrency(backendName, override) {
-  const n = override === undefined || override === null
-    ? getBackendSafety(backendName).maxConcurrency
-    : Number(override);
-  return Number.isFinite(n) && n > 0 ? Math.floor(n) : Infinity;
+  const fallback = getBackendSafety(backendName).maxConcurrency;
+  if (override === undefined || override === null) return fallback;
+  const n = Number(override);
+  // Fail closed: an invalid override (0, negative, NaN) must not silently
+  // disable the cross-process cap. Fall back to the backend's own default
+  // rather than Infinity — the cap exists to bound agent-CLI fan-out (#445).
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
 }
 
 export function resolveBackendMaxRetries(backendName, override) {
@@ -98,8 +101,12 @@ export function describeBackendError(err) {
 }
 
 function extractStatus(err) {
-  const direct = Number(err?.status);
-  if (Number.isFinite(direct)) return direct;
+  // `Number(null) === 0` is finite, so an explicit `status: null` would short
+  // out the HTTP 429/503 message fallback and look non-retryable (#445).
+  if (err?.status != null) {
+    const direct = Number(err.status);
+    if (Number.isFinite(direct)) return direct;
+  }
   const match = String(err?.message || '').match(/\bHTTP\s+(429|503)\b/);
   return match ? Number(match[1]) : null;
 }
@@ -153,7 +160,10 @@ async function acquireBackendSlot({
 }) {
   throwIfAborted(signal, `${backendName || 'backend'}: aborted while waiting for concurrency slot`);
   const startedAt = Date.now();
-  const root = join(tmpdir(), 'patina-backend-slots', safePathSegment(backendName || 'backend'));
+  // Per-user slot root: the slot dirs are real locks, and a world-shared
+  // tmpdir path means another user's slot dir cannot be removed (EACCES) and
+  // would permanently consume a cap slot on a multi-user host (#445).
+  const root = join(tmpdir(), `patina-backend-slots-${userSlotSegment()}`, safePathSegment(backendName || 'backend'));
   mkdirSync(root, { recursive: true });
 
   for (;;) {
@@ -183,9 +193,47 @@ async function acquireBackendSlot({
 
 function cleanupStaleSlot(slot, staleMs) {
   try {
+    // A crashed owner (its pid no longer alive) must release the slot
+    // immediately, not after staleMs — otherwise a cap-1 backend (claude/kimi)
+    // is blocked for up to 30 minutes by a dead run (#445).
+    if (!isSlotOwnerAlive(slot)) {
+      rmSync(slot, { recursive: true, force: true });
+      return;
+    }
     const ageMs = Date.now() - statSync(slot).mtimeMs;
     if (ageMs > staleMs) rmSync(slot, { recursive: true, force: true });
   } catch {}
+}
+
+// True unless the slot's recorded owner pid is provably dead. Unreadable/absent
+// owner records return true so mtime staleness still governs and a just-created
+// slot (owner.json not yet written) is never yanked from under its owner.
+function isSlotOwnerAlive(slot) {
+  let pid;
+  try {
+    pid = Number(JSON.parse(readFileSync(join(slot, 'owner.json'), 'utf8'))?.pid);
+  } catch {
+    return true;
+  }
+  if (!Number.isInteger(pid) || pid <= 0) return true;
+  try {
+    process.kill(pid, 0); // signal 0 is a liveness probe, not an actual signal
+    return true;
+  } catch (err) {
+    // ESRCH → no such process (dead); EPERM → exists but not ours (alive).
+    return err?.code === 'EPERM';
+  }
+}
+
+// A filesystem-safe per-user segment so slot roots are owned by, and removable
+// by, the current user. uid on POSIX; falls back to the username elsewhere.
+function userSlotSegment() {
+  try {
+    const { uid, username } = userInfo();
+    return Number.isInteger(uid) && uid >= 0 ? `uid-${uid}` : safePathSegment(username || 'user');
+  } catch {
+    return 'user';
+  }
 }
 
 function releaseBackendSlot(slot) {

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -183,7 +183,7 @@ export function selectOcrBackends(selectedBackends = [], { logger } = {}) {
     // image-capable CLI the user did not name. Surface it at warn level
     // (issue #88: agent-CLI use should be visible) — only --quiet hides it.
     logger?.warn?.('ocr.backend_fallback', {
-      message: `[patina] --ocr is using ${fallback[0].name} for image text (the selected backend cannot read images).`,
+      message: `[patina] --ocr will try ${fallback.map((b) => b.name).join(' → ')} for image text (the selected backend cannot read images).`,
     });
   }
   return fallback;

--- a/src/backends/patina-hosted-schema.js
+++ b/src/backends/patina-hosted-schema.js
@@ -106,7 +106,11 @@ export function parseHostedResponse(body) {
   assertText(body.text, 'text');
   if (!Array.isArray(body.spans)) fail('spans must be an array');
 
-  const textLength = body.text.normalize('NFC').length;
+  // Validate offsets against the exact string returned to the caller (#445):
+  // normalizing to NFC here while returning the raw text made valid end-spans
+  // on non-NFC (e.g. NFD Korean) text falsely fail and left accepted offsets
+  // ambiguous about which normalization they index.
+  const textLength = body.text.length;
   const spans = body.spans.map((span, index) => {
     assertPlainObject(span, `spans[${index}]`);
     for (const key of Object.keys(span)) {

--- a/src/model-defaults.js
+++ b/src/model-defaults.js
@@ -27,6 +27,16 @@ const BACKEND_SELECTOR_ALIASES = Object.freeze({
   'kimi-cli': 'kimi',
 });
 
+// Family prefix per local backend, mirroring the selectBackend model heuristic
+// in backends/index.js. Used to drop a flag-sourced model that belongs to a
+// different leg of an explicit fallback chain (#445).
+const BACKEND_MODEL_FAMILY = Object.freeze({
+  'codex-cli': /^codex(-|$)/i,
+  'claude-cli': /^claude(-|$)/i,
+  'gemini-cli': /^gemini(-|$)/i,
+  'kimi-cli': /^kimi(-|$)/i,
+});
+
 /**
  * Resolve the model id a local CLI backend should receive.
  *
@@ -50,6 +60,16 @@ export function resolveLocalCliModel({ backendName, model, modelSource }) {
 
   const alias = BACKEND_SELECTOR_ALIASES[backendName];
   if (alias && String(model).toLowerCase() === alias) return defaultModel;
+
+  // A flag-sourced model whose family does not match this backend belongs to a
+  // different leg of an explicit fallback chain (e.g.
+  // `--backend openai-http,claude-cli --model gpt-5.5`). Forwarding the foreign
+  // id would fail this leg on an unknown model; use the backend's own default
+  // so the user-configured fallback actually works (#445).
+  const family = BACKEND_MODEL_FAMILY[backendName];
+  if (modelSource === 'flag' && family && !family.test(String(model))) {
+    return defaultModel;
+  }
 
   return model;
 }

--- a/tests/unit/backend-contract.test.js
+++ b/tests/unit/backend-contract.test.js
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir, userInfo } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  resolveBackendMaxConcurrency,
+  isRetryableBackendError,
+  withBackendConcurrencySlot,
+} from '../../src/backends/contract.js';
+
+test('resolveBackendMaxConcurrency fails closed on an invalid override (#445)', () => {
+  // claude-cli's default cap is 1; an invalid override must not disable it.
+  assert.equal(resolveBackendMaxConcurrency('claude-cli', 0), 1);
+  assert.equal(resolveBackendMaxConcurrency('claude-cli', -3), 1);
+  assert.equal(resolveBackendMaxConcurrency('claude-cli', NaN), 1);
+  // openai-http default cap is 4.
+  assert.equal(resolveBackendMaxConcurrency('openai-http', 0), 4);
+  // valid override applies; unset uses the backend default.
+  assert.equal(resolveBackendMaxConcurrency('claude-cli', 2), 2);
+  assert.equal(resolveBackendMaxConcurrency('claude-cli'), 1);
+});
+
+test('isRetryableBackendError honors message status even when err.status is null (#445)', () => {
+  assert.equal(isRetryableBackendError({ status: null, message: 'HTTP 429 rate limited' }, { attemptIndex: 0 }), true);
+  assert.equal(isRetryableBackendError({ status: null, message: 'HTTP 503 unavailable' }, { attemptIndex: 5 }), true);
+  // a generic error with no rate-limit signal stays non-retryable.
+  assert.equal(isRetryableBackendError({ status: null, message: 'bad request' }, { attemptIndex: 0 }), false);
+});
+
+function userSlotSegment() {
+  try {
+    const { uid, username } = userInfo();
+    return Number.isInteger(uid) && uid >= 0
+      ? `uid-${uid}`
+      : String(username || 'user').replace(/[^a-z0-9._-]+/gi, '_');
+  } catch {
+    return 'user';
+  }
+}
+
+test('a concurrency slot held by a dead pid is reclaimed immediately (#445)', async () => {
+  const backendName = `test-fixture-${process.pid}-${Date.now()}`;
+  const root = join(tmpdir(), `patina-backend-slots-${userSlotSegment()}`, backendName);
+  mkdirSync(join(root, 'slot-0'), { recursive: true });
+  // Owner pid that is provably dead (no such process) — must be reclaimed
+  // without waiting for the staleMs window.
+  writeFileSync(join(root, 'slot-0', 'owner.json'), JSON.stringify({ pid: 999_999_999, backendName }), 'utf8');
+
+  try {
+    let ran = false;
+    const result = await withBackendConcurrencySlot({
+      backendName,
+      maxConcurrency: 1,
+      timeout: 3000,
+      pollMs: 25,
+      staleMs: 60 * 60_000, // long, so only the pid-liveness path can reclaim
+      fn: async () => { ran = true; return 'ok'; },
+    });
+    assert.equal(ran, true);
+    assert.equal(result, 'ok');
+  } finally {
+    rmSync(join(tmpdir(), `patina-backend-slots-${userSlotSegment()}`, backendName), { recursive: true, force: true });
+  }
+});

--- a/tests/unit/backend-model-defaults.test.js
+++ b/tests/unit/backend-model-defaults.test.js
@@ -74,6 +74,29 @@ test('local CLI model resolver uses best-known defaults and preserves explicit i
   );
 });
 
+test('drops a foreign-family flag model per fallback leg (#445)', () => {
+  // `--backend openai-http,claude-cli --model gpt-5.5`: the claude-cli leg must
+  // fall back to its own default instead of forwarding the foreign id.
+  assert.strictEqual(
+    resolveLocalCliModel({ backendName: 'claude-cli', model: 'gpt-5.5', modelSource: 'flag' }),
+    DEFAULT_BEST_MODELS.claudeCli
+  );
+  assert.strictEqual(
+    resolveLocalCliModel({ backendName: 'gemini-cli', model: 'gpt-5.5', modelSource: 'flag' }),
+    DEFAULT_BEST_MODELS.geminiCli
+  );
+  // A matching-family flag model is still honored.
+  assert.strictEqual(
+    resolveLocalCliModel({ backendName: 'claude-cli', model: 'claude-opus-custom', modelSource: 'flag' }),
+    'claude-opus-custom'
+  );
+  // openai-http is not a local CLI; it still receives the model verbatim.
+  assert.strictEqual(
+    resolveLocalCliModel({ backendName: 'openai-http', model: 'gpt-5.5', modelSource: 'flag' }),
+    'gpt-5.5'
+  );
+});
+
 test('local CLI backends pass default best-model flags to child processes', async () => {
   await withFakeCli(async () => {
     const codex = JSON.parse(await codexCli.invoke({ prompt: 'rewrite this', modelSource: 'default' }));

--- a/tests/unit/patina-hosted-schema.test.js
+++ b/tests/unit/patina-hosted-schema.test.js
@@ -83,3 +83,25 @@ test('every general category is accepted', () => {
     assert.equal(spans[0].category, category);
   }
 });
+
+test('offsets validate against the returned (raw) text, not an NFC copy (#445)', () => {
+  // 가 in NFD = U+1100 U+1161 (length 2 in JS) vs NFC U+AC00 (length 1). A span
+  // ending at the raw length must be accepted and the raw text returned.
+  const nfd = '\u1100\u1161';
+  const { spans, text } = parseHostedResponse({
+    schemaVersion: HOSTED_SCHEMA_VERSION,
+    text: nfd,
+    spans: [{ start: 0, end: 2, score: 0.5, category: 'other' }],
+  });
+  assert.equal(text, nfd);
+  assert.equal(spans[0].end, 2);
+  // An offset past the raw length still fails loud.
+  assert.throws(
+    () => parseHostedResponse({
+      schemaVersion: HOSTED_SCHEMA_VERSION,
+      text: nfd,
+      spans: [{ start: 0, end: 3, score: 0.5, category: 'other' }],
+    }),
+    HostedSchemaError,
+  );
+});


### PR DESCRIPTION
Closes #445 (review: backends-core lane from the 2026-06-13 full-repo architect review). Resolves the 5 minor findings + 1 of 2 nits. No new deps.

## Findings addressed

**Minor**
- **`extractStatus` treated `err.status=null` as status 0** (`contract.js`): an explicit `status: null` now skips the `Number()` coercion and runs the HTTP 429/503 message fallback, so a rate-limit error shaped that way is retryable and the explicit fallback chain engages.
- **`resolveBackendMaxConcurrency` failed open to `Infinity`** (`contract.js`): an invalid override (0/negative/NaN) now falls back to the backend's default cap instead of `Infinity`, so the cross-process agent-CLI fan-out cap can't be silently disabled.
- **Stale slot cleanup ignored owner pid** (`contract.js`): `cleanupStaleSlot` now reclaims a slot whose owner pid is provably dead (`process.kill(pid, 0)` -> `ESRCH`) immediately, instead of blocking a cap-1 backend for up to 30 min after a crash. The slot root is now per-user (`patina-backend-slots-<uid>`), so another user's slot dir can't trigger swallowed `EACCES` and permanently consume slots on multi-user hosts. Unreadable/just-created owner records keep mtime-staleness semantics.
- **Span offsets validated against an NFC copy but raw text returned** (`patina-hosted-schema.js`): offsets now validate against `body.text.length` (the returned string), so non-NFC (NFD Korean) responses no longer falsely reject valid end-spans, and accepted offsets unambiguously index the returned text.
- **Fallback legs received the first backend's flag model verbatim** (`model-defaults.js`): `resolveLocalCliModel` drops a flag-sourced model whose family doesn't match a local-CLI leg of an explicit chain (`--backend openai-http,claude-cli --model gpt-5.5`), using the leg's own default so the user-configured fallback works.

**Nit**
- **OCR fallback warning named only the first backend** (`index.js`): now names the full capable chain it will try.

## Not changed here (cross-referenced)
- The "chain-level retryable set narrower than openai-http's own" nit is documented design (`docs/CLI.md`), and #444 already adds a `TimeoutError` comment to `isRetryableBackendError`. This lane leaves that function untouched to avoid a merge conflict with #444 / PR #462.

## Verification
- `node --test tests/unit/*.test.js tests/e2e/*.test.js` — 650 pass / 0 fail (adds `backend-contract.test.js`: fail-closed concurrency, null-status retry, dead-pid slot reclaim; plus foreign-family model and NFD-offset tests).
- `npm run lint` — green.
- `npm run benchmark` — 100% accuracy, ROC-AUC/PR-AUC 1.000.
