### PR TITLE
fix(backend-adapters): UTF-8 stderr, image-stage cleanup, signal-aware close, kill-on-stdin-error, tighter noise strip (#446)

### DIFF
--- a/src/backends/claude-cli.js
+++ b/src/backends/claude-cli.js
@@ -58,8 +58,15 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
   // permission-denied (and granting them would weaken the containment above).
   let effectivePrompt = prompt;
   if (Array.isArray(images) && images.length > 0) {
-    const staged = stageCliImages(dir, images);
-    effectivePrompt = `${prompt}\n\nAttached image file(s) in the working directory: ${staged.map((f) => `./${f}`).join(', ')} — read them before answering.`;
+    try {
+      const staged = stageCliImages(dir, images);
+      effectivePrompt = `${prompt}\n\nAttached image file(s) in the working directory: ${staged.map((f) => `./${f}`).join(', ')} — read them before answering.`;
+    } catch (err) {
+      // Runs before the Promise's cleanup; remove the temp dir and surface a
+      // backend-shaped error instead of leaking it and escaping a raw fs error (#446).
+      try { rmSync(dir, { recursive: true, force: true }); } catch {}
+      throw new Error(`claude-cli backend: failed to stage image input (${err.message})`);
+    }
   }
 
   return new Promise((resolve, reject) => {
@@ -93,10 +100,12 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       }
     });
 
-    proc.on('close', (code) => {
+    proc.on('close', (code, sig) => {
       if (settled) return;
       if (code !== 0) {
-        finishReject(new Error(`claude-cli backend: claude exited with code ${code}\n${stderr}`));
+        // Signal death (OOM kill, external SIGTERM) yields code===null (#446).
+        const how = code === null && sig ? `terminated by ${sig}` : `exited with code ${code}`;
+        finishReject(new Error(`claude-cli backend: claude ${how}\n${stderr}`));
         return;
       }
       finishResolve(stdout);
@@ -108,7 +117,7 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
     // surfaces the real exit code + stderr); reject on anything else.
     proc.stdin.on('error', (err) => {
       if (err && err.code !== 'EPIPE') {
-        finishReject(new Error(`claude-cli backend: stdin error (${err.message})`));
+        finishReject(new Error(`claude-cli backend: stdin error (${err.message})`), { kill: true });
       }
     });
     proc.stdin.write(effectivePrompt);
@@ -123,6 +132,8 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       settled = true;
       clearTimeout(timer);
       cleanupSignal();
+      // SIGKILL reaches only the direct child; grandchildren (workers/ripgrep/MCP)
+      // are not in a killable group and may briefly outlive it — accepted leak (#446).
       if (kill) proc.kill('SIGKILL');
       cleanup();
       reject(err);

--- a/src/backends/codex-cli.js
+++ b/src/backends/codex-cli.js
@@ -56,8 +56,16 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
   // into the temp cwd keeps the read-only sandbox + empty-cwd containment.
   const imageArgs = [];
   if (Array.isArray(images) && images.length > 0) {
-    for (const staged of stageCliImages(dir, images)) {
-      imageArgs.push('-i', join(dir, staged));
+    try {
+      for (const staged of stageCliImages(dir, images)) {
+        imageArgs.push('-i', join(dir, staged));
+      }
+    } catch (err) {
+      // stageCliImages runs before the Promise, so its own try/finally cleanup
+      // does not cover it — clean up the temp dir and surface a backend-shaped
+      // error instead of leaking the dir and escaping a raw fs error (#446).
+      try { rmSync(dir, { recursive: true, force: true }); } catch {}
+      throw new Error(`codex-cli backend: failed to stage image input (${err.message})`);
     }
   }
 
@@ -77,6 +85,7 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
     ], { stdio: ['pipe', 'ignore', 'pipe'], cwd: dir });
 
     let stderr = '';
+    proc.stderr.setEncoding('utf8'); // decode as streaming UTF-8 so multibyte CJK is not corrupted at chunk boundaries (#446)
     proc.stderr.on('data', (chunk) => { stderr += chunk; });
 
     let settled = false;
@@ -98,10 +107,13 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       }
     });
 
-    proc.on('close', (code) => {
+    proc.on('close', (code, sig) => {
       if (settled) return;
       if (code !== 0) {
-        finishReject(new Error(`codex-cli backend: codex exited with code ${code}\n${stderr}`));
+        // Signal death (OOM kill, external SIGTERM) yields code===null; report
+        // the signal instead of "exited with code null" (#446).
+        const how = code === null && sig ? `terminated by ${sig}` : `exited with code ${code}`;
+        finishReject(new Error(`codex-cli backend: codex ${how}\n${stderr}`));
         return;
       }
 
@@ -119,7 +131,7 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
     // surfaces the real exit code + stderr); reject on anything else.
     proc.stdin.on('error', (err) => {
       if (err && err.code !== 'EPIPE') {
-        finishReject(new Error(`codex-cli backend: stdin error (${err.message})`));
+        finishReject(new Error(`codex-cli backend: stdin error (${err.message})`), { kill: true });
       }
     });
     proc.stdin.write(prompt);
@@ -134,6 +146,9 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       settled = true;
       clearTimeout(timer);
       cleanupSignal();
+      // SIGKILL reaches only the direct child; these agent CLIs are not spawned
+      // detached, so forked grandchildren (workers/ripgrep/MCP) can outlive the
+      // kill and briefly hold the now-removed temp cwd — an accepted leak (#446).
       if (kill) proc.kill('SIGKILL');
       cleanup();
       reject(err);

--- a/src/backends/gemini-cli.js
+++ b/src/backends/gemini-cli.js
@@ -64,8 +64,15 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
   // images are staged into the temp cwd and referenced as @<filename>.
   let effectivePrompt = prompt;
   if (Array.isArray(images) && images.length > 0) {
-    const staged = stageCliImages(dir, images);
-    effectivePrompt = `${staged.map((f) => `@${f}`).join(' ')}\n${prompt}`;
+    try {
+      const staged = stageCliImages(dir, images);
+      effectivePrompt = `${staged.map((f) => `@${f}`).join(' ')}\n${prompt}`;
+    } catch (err) {
+      // Runs before the Promise's cleanup; remove the temp dir and surface a
+      // backend-shaped error instead of leaking it and escaping a raw fs error (#446).
+      try { rmSync(dir, { recursive: true, force: true }); } catch {}
+      throw new Error(`gemini-cli backend: failed to stage image input (${err.message})`);
+    }
   }
 
   return new Promise((resolve, reject) => {
@@ -99,10 +106,12 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       }
     });
 
-    proc.on('close', (code) => {
+    proc.on('close', (code, sig) => {
       if (settled) return;
       if (code !== 0) {
-        finishReject(new Error(`gemini-cli backend: gemini exited with code ${code}\n${stderr}`));
+        // Signal death (OOM kill, external SIGTERM) yields code===null (#446).
+        const how = code === null && sig ? `terminated by ${sig}` : `exited with code ${code}`;
+        finishReject(new Error(`gemini-cli backend: gemini ${how}\n${stderr}`));
         return;
       }
       finishResolve(stripGeminiNoise(stdout));
@@ -114,7 +123,7 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
     // surfaces the real exit code + stderr); reject on anything else.
     proc.stdin.on('error', (err) => {
       if (err && err.code !== 'EPIPE') {
-        finishReject(new Error(`gemini-cli backend: stdin error (${err.message})`));
+        finishReject(new Error(`gemini-cli backend: stdin error (${err.message})`), { kill: true });
       }
     });
     proc.stdin.write(effectivePrompt);
@@ -129,6 +138,8 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       settled = true;
       clearTimeout(timer);
       cleanupSignal();
+      // SIGKILL reaches only the direct child; grandchildren (workers/ripgrep/MCP)
+      // are not in a killable group and may briefly outlive it — accepted leak (#446).
       if (kill) proc.kill('SIGKILL');
       cleanup();
       reject(err);
@@ -159,9 +170,12 @@ function throwIfAborted(signal) {
 // available. Falling back to GrepTool.", "MCP issues detected..."). They
 // aren't part of the model's response, so strip leading lines that match
 // known noise patterns before returning.
-function stripGeminiNoise(text) {
+export function stripGeminiNoise(text) {
   const lines = text.split(/\r?\n/);
-  const noiseRe = /^(Warning:|Ripgrep is not available|MCP issues detected|Loaded cached credentials)/i;
+  // Anchor to the exact known gemini stdout banners, not a broad `Warning:`
+  // prefix — a model response that legitimately begins with "Warning: ..."
+  // must not be truncated (#446).
+  const noiseRe = /^(?:Ripgrep is not available\b|MCP issues detected\b|Loaded cached credentials\b)/i;
   let i = 0;
   while (i < lines.length && (noiseRe.test(lines[i]) || lines[i].trim() === '')) {
     i++;

--- a/src/backends/kimi-cli.js
+++ b/src/backends/kimi-cli.js
@@ -108,10 +108,12 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       }
     });
 
-    proc.on('close', (code) => {
+    proc.on('close', (code, sig) => {
       if (settled) return;
       if (code !== 0) {
-        finishReject(new Error(`kimi-cli backend: kimi exited with code ${code}\n${stderr}`));
+        // Signal death (OOM kill, external SIGTERM) yields code===null (#446).
+        const how = code === null && sig ? `terminated by ${sig}` : `exited with code ${code}`;
+        finishReject(new Error(`kimi-cli backend: kimi ${how}\n${stderr}`));
         return;
       }
       finishResolve(stripKimiNoise(stdout));
@@ -123,7 +125,7 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
     // surfaces the real exit code + stderr); reject on anything else.
     proc.stdin.on('error', (err) => {
       if (err && err.code !== 'EPIPE') {
-        finishReject(new Error(`kimi-cli backend: stdin error (${err.message})`));
+        finishReject(new Error(`kimi-cli backend: stdin error (${err.message})`), { kill: true });
       }
     });
     proc.stdin.write(prompt);
@@ -138,6 +140,8 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       settled = true;
       clearTimeout(timer);
       cleanupSignal();
+      // SIGKILL reaches only the direct child; grandchildren (workers/MCP) are
+      // not in a killable group and may briefly outlive it — accepted leak (#446).
       if (kill) proc.kill('SIGKILL');
       cleanup();
       reject(err);
@@ -164,12 +168,19 @@ function throwIfAborted(signal) {
   if (signal?.aborted) throw abortError('kimi-cli backend: aborted');
 }
 
-function stripKimiNoise(text) {
-  return text
-    .split(/\r?\n/)
-    .filter((line) => !/^To resume this session:\s*kimi\s+-r\s+/i.test(line.trim()))
-    .join('\n')
-    .trimStart();
+export function stripKimiNoise(text) {
+  const lines = text.split(/\r?\n/);
+  const bannerRe = /^To resume this session:\s*kimi\s+-r\s+/i;
+  // The resume banner is a trailing footer; strip it only from the end so a
+  // mid-response line that legitimately quotes the same text survives (#446).
+  let last = lines.length - 1;
+  while (last >= 0 && lines[last].trim() === '') last--;
+  if (last >= 0 && bannerRe.test(lines[last].trim())) {
+    let end = last;
+    while (end > 0 && lines[end - 1].trim() === '') end--;
+    return lines.slice(0, end).join('\n').trimStart();
+  }
+  return lines.join('\n').trimStart();
 }
 
 function kimiDataDir() {

--- a/tests/unit/backend-adapter-noise.test.js
+++ b/tests/unit/backend-adapter-noise.test.js
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { stripGeminiNoise } from '../../src/backends/gemini-cli.js';
+import { stripKimiNoise } from '../../src/backends/kimi-cli.js';
+
+test('stripGeminiNoise strips known leading banners but keeps a "Warning:" response (#446)', () => {
+  const noisy = 'Loaded cached credentials\nRipgrep is not available. Falling back to GrepTool.\n\nThe real rewritten text.';
+  assert.equal(stripGeminiNoise(noisy), 'The real rewritten text.');
+  // A model response that legitimately begins with "Warning:" must NOT be truncated.
+  const warning = 'Warning: this approach has a tradeoff.\n\nUse it carefully.';
+  assert.equal(stripGeminiNoise(warning), warning);
+  // MCP banner is still stripped.
+  assert.equal(stripGeminiNoise('MCP issues detected: foo\nBody here.'), 'Body here.');
+});
+
+test('stripKimiNoise strips only the trailing resume banner (#446)', () => {
+  const trailing = 'Rewritten body line one.\nLine two.\n\nTo resume this session: kimi -r abc123';
+  assert.equal(stripKimiNoise(trailing), 'Rewritten body line one.\nLine two.');
+  // A banner-shaped line mid-body (with real content as the trailing line) is
+  // preserved — the old filter removed it anywhere in the body and lost content.
+  const midBanner = 'To resume this session: kimi -r quoted-in-body\nBut the actual answer continues here.';
+  assert.equal(stripKimiNoise(midBanner), midBanner);
+  // No banner → unchanged aside from leading trim.
+  assert.equal(stripKimiNoise('just a response'), 'just a response');
+});


### PR DESCRIPTION
Closes #446 (review: backend-adapters lane from the 2026-06-13 full-repo architect review). Resolves the 5 minor + 2 nit findings, applied consistently across the claude/codex/gemini/kimi CLI adapters. The lane's major finding (#438) already shipped in #456. No new deps.

## Findings addressed

**Minor**
- **codex stderr lacked `setEncoding('utf8')`** — multibyte CJK error text could corrupt into U+FFFD at chunk boundaries. Now matches the other three adapters.
- **Temp dir leak + raw fs error when `stageCliImages` throws** (codex/claude/gemini) — staging runs before the Promise's cleanup, so a bad image path leaked the temp dir and escaped a raw error. Now wrapped to remove the temp dir and throw the `<backend> backend: ...`-shaped error.
- **stdin non-EPIPE error rejected without `{ kill: true }`** (all four) — left an orphaned CLI with no timeout bound while its temp cwd was removed underneath it. Now kills the child first.
- **`'close'` handler ignored the signal arg** (all four) — signal death (OOM kill / external SIGTERM) reported `exited with code null`; now reports `terminated by <signal>`.
- **SIGKILL killed only the direct child** (all four) — documented the accepted grandchild leak at the kill site (the agent CLIs fork non-detached subprocesses).

**Nit**
- **`stripGeminiNoise` could delete a legitimate `Warning:` response** — now anchors to the exact known stdout banners (Ripgrep / MCP / Loaded credentials) instead of a broad `Warning:` prefix.
- **`stripKimiNoise` filtered matching lines anywhere** — now strips the resume banner only from the trailing footer position, preserving a mid-response line that quotes the same text.

## Verification
- `node --test tests/unit/*.test.js tests/e2e/*.test.js` — 652 pass / 0 fail (adds `backend-adapter-noise.test.js`; `stripGeminiNoise`/`stripKimiNoise` exported for testability).
- `npm run lint` — green.
- `npm run benchmark` — 100% accuracy, ROC-AUC/PR-AUC 1.000.
