### PR TITLE
fix(preview-surface): stream page-size cap, $-safe replacements, file-image confinement, numeric-entity srcdoc (#447)

### DIFF
--- a/src/ocr.js
+++ b/src/ocr.js
@@ -1,6 +1,6 @@
 import { mkdtempSync, writeFileSync, copyFileSync, readFileSync, statSync, chmodSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, dirname, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isSubresourceFetchAllowed } from './security.js';
 
@@ -46,6 +46,20 @@ function getRuntimeValue(options, key, fallback) {
 // document-wide base64 data URIs. Extension-less CDN URLs are kept and
 // magic-byte sniffed after download. SVG is skipped (vector text belongs to
 // the DOM extractor).
+// A file: image candidate is confined to the previewed file's own directory
+// subtree (#447): a malicious local .html must not reference absolute paths
+// like file:///home/user/passport.jpg and exfiltrate them to the OCR backend.
+function fileUrlWithinDir(fileUrl, dir) {
+  if (!dir) return false;
+  try {
+    const target = resolve(fileURLToPath(fileUrl));
+    const base = resolve(dir);
+    return target === base || target.startsWith(base + sep);
+  } catch {
+    return false;
+  }
+}
+
 export function collectImageCandidates(html, baseUrl, options = {}) {
   const maxImages = options.maxImages ?? DEFAULT_MAX_IMAGES;
   const source = String(html ?? '');
@@ -59,6 +73,11 @@ export function collectImageCandidates(html, baseUrl, options = {}) {
   // disclosure). This mirrors the empty-cwd CLI containment.
   const allowFileImages = String(baseUrl || '').startsWith('file:');
   const allowedProtocols = allowFileImages ? /^(https?|file):$/ : /^https?:$/;
+  // Confine local file: images to the previewed file's own directory subtree (#447).
+  let sourceDir = null;
+  if (allowFileImages) {
+    try { sourceDir = dirname(fileURLToPath(baseUrl)); } catch { sourceDir = null; }
+  }
 
   const pushUrlCandidate = (url, { anchor, alt, priority }) => {
     const ext = extensionOf(url);
@@ -66,6 +85,7 @@ export function collectImageCandidates(html, baseUrl, options = {}) {
     // extension-less URL is kept and sniffed from its bytes at staging time.
     if (ext && !ACCEPTED_EXTENSIONS.has(ext)) return;
     if (!ext && url.startsWith('file:')) return;
+    if (url.startsWith('file:') && !fileUrlWithinDir(url, sourceDir)) return;
     if (seen.has(url)) return;
     seen.add(url);
     candidates.push({
@@ -378,31 +398,43 @@ export async function fetchCappedBytes(fetchImpl, url, { signal, maxBytes, fetch
       response = await fetchImpl(url, { signal: controller.signal, redirect: 'follow' });
     }
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const declared = Number(response.headers.get('content-length'));
-    if (Number.isFinite(declared) && declared > maxBytes) throw new Error(tooBig);
-    if (!response.body || typeof response.body.getReader !== 'function') {
-      const buf = Buffer.from(await response.arrayBuffer());
-      if (buf.length > maxBytes) throw new Error(tooBig);
-      return buf;
-    }
-    const reader = response.body.getReader();
-    const chunks = [];
-    let total = 0;
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      total += value.length;
-      if (total > maxBytes) {
-        controller.abort(new Error(tooBig));
-        throw new Error(tooBig);
-      }
-      chunks.push(value);
-    }
-    return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+    return await readResponseBytesCapped(response, {
+      maxBytes,
+      tooBig,
+      onOverflow: () => controller.abort(new Error(tooBig)),
+    });
   } finally {
     clearTimeout(timer);
     signal?.removeEventListener?.('abort', onOuterAbort);
   }
+}
+
+// Read a response body chunk by chunk under a hard byte cap, so a chunked /
+// Content-Length-less response cannot buffer unbounded data into memory before
+// the size check. Shared by fetchCappedBytes and the preview page fetch (#447).
+export async function readResponseBytesCapped(response, { maxBytes, tooBig = 'response too large', onOverflow } = {}) {
+  const declared = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > maxBytes) throw new Error(tooBig);
+  if (!response.body || typeof response.body.getReader !== 'function') {
+    const buf = Buffer.from(await response.arrayBuffer());
+    if (buf.length > maxBytes) throw new Error(tooBig);
+    return buf;
+  }
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.length;
+    if (total > maxBytes) {
+      if (onOverflow) onOverflow();
+      else { try { await reader.cancel(); } catch {} }
+      throw new Error(tooBig);
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
 }
 
 export const OCR_PROMPT = [

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,5 +1,5 @@
 import { htmlEscape, diffBlockPairs } from './browser-diff.js';
-import { describeImage, fetchCappedBytes } from './ocr.js';
+import { describeImage, fetchCappedBytes, readResponseBytesCapped } from './ocr.js';
 import { isSubresourceFetchAllowed } from './security.js';
 
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
@@ -74,10 +74,15 @@ export async function fetchPreviewPage(url, options = {}) {
     if (contentType && !/html/i.test(contentType)) {
       throw new Error(`the page is ${contentType.split(';')[0]}, not HTML`);
     }
-    const html = await response.text();
-    if (html.length > maxBytes) {
-      throw new Error(`the page is larger than the ${Math.round(maxBytes / 1024 / 1024)}MB preview limit`);
-    }
+    // Stream the body under a true byte cap instead of buffering the whole
+    // response and checking UTF-16 code-unit length: a hostile/misconfigured
+    // server could otherwise stream hundreds of MB within the timeout, and
+    // `.length` undercounts multi-byte (e.g. Korean) pages (#447).
+    const buf = await readResponseBytesCapped(response, {
+      maxBytes,
+      tooBig: `the page is larger than the ${Math.round(maxBytes / 1024 / 1024)}MB preview limit`,
+    });
+    const html = buf.toString('utf-8');
     return { html, finalUrl: current };
   } finally {
     clearTimeout(timer);
@@ -273,7 +278,9 @@ export async function freezeSnapshotAssets(html, { baseUrl, signal, logger, fetc
       });
       css = embedded.css;
       fontCount += embedded.fontCount;
-      out = out.replace(sheet.tag, `<style data-ptna-frozen="${htmlEscape(sheet.url)}">${css}</style>`);
+      // Function replacement: page-controlled css must not have its `$&`/$`/$'
+      // sequences interpreted as replacement patterns (#447).
+      out = out.replace(sheet.tag, () => `<style data-ptna-frozen="${htmlEscape(sheet.url)}">${css}</style>`);
       sheetCount += 1;
     } catch (err) {
       if (signal?.aborted) break;
@@ -359,6 +366,12 @@ async function embedFontsAsDataUris(css, { origin, baseUrl, signal, fetchImpl, l
 
 function decodeHtmlEntities(value) {
   return String(value)
+    // Numeric character references (&#60; / &#x3c;) — browsers decode all of
+    // these in attribute values, so srcdoc inlining must too or numeric-entity
+    // markup renders as inert escaped text and its prose never reaches the
+    // extractor (#447).
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
     .replace(/&quot;/gi, '"')
@@ -1041,8 +1054,9 @@ function injectHead(html, sourceUrl) {
   // permissive CSP was already stripped by stripActiveContent).
   const csp = `<meta http-equiv="Content-Security-Policy" content="${PREVIEW_CSP}">`;
   const injection = `${csp}${baseTag}<style id="ptna-style">${PREVIEW_CSS}</style>`;
-  if (/<head\b[^>]*>/i.test(html)) return html.replace(/<head\b[^>]*>/i, `$&${injection}`);
-  if (/<html\b[^>]*>/i.test(html)) return html.replace(/<html\b[^>]*>/i, `$&<head>${injection}</head>`);
+  // Function replacements so `$`-sequences in the injected sourceUrl are literal (#447).
+  if (/<head\b[^>]*>/i.test(html)) return html.replace(/<head\b[^>]*>/i, (m) => `${m}${injection}`);
+  if (/<html\b[^>]*>/i.test(html)) return html.replace(/<html\b[^>]*>/i, (m) => `${m}<head>${injection}</head>`);
   return `<head>${injection}</head>${html}`;
 }
 
@@ -1083,9 +1097,11 @@ function injectChrome(html, { changedCount, totalCount, explanationHtml = '', sc
     + '</div>';
 
   let out = html;
-  if (/<body\b[^>]*>/i.test(out)) out = out.replace(/<body\b[^>]*>/i, `$&${inputs}`);
+  if (/<body\b[^>]*>/i.test(out)) out = out.replace(/<body\b[^>]*>/i, (m) => `${m}${inputs}`);
   else out = `${inputs}${out}`;
-  if (/<\/body\s*>/i.test(out)) return out.replace(/<\/body\s*>/i, `${notes}${bar}$&`);
+  // Function replacement so `$`-sequences in notes (LLM explanation + OCR'd image
+  // text) are not interpreted as replacement patterns (#447).
+  if (/<\/body\s*>/i.test(out)) return out.replace(/<\/body\s*>/i, (m) => `${notes}${bar}${m}`);
   return `${out}${notes}${bar}`;
 }
 

--- a/tests/unit/ocr.test.js
+++ b/tests/unit/ocr.test.js
@@ -269,3 +269,20 @@ test('stageCliImages copies attachments into the backend temp dir', () => {
     rmSync(dst, { recursive: true, force: true });
   }
 });
+
+test('file: image candidates are confined to the previewed file directory (#447)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'patina-ocr-confine-'));
+  try {
+    const baseUrl = pathToFileURL(join(dir, 'page.html')).href;
+    const insideUrl = pathToFileURL(join(dir, 'pic.png')).href;
+    const subdirUrl = pathToFileURL(join(dir, 'images', 'deep.png')).href;
+    const outsideUrl = pathToFileURL(join(tmpdir(), 'passport.png')).href; // parent dir, not under the source dir
+    const html = `<img src="${insideUrl}"><img src="${subdirUrl}"><img src="${outsideUrl}">`;
+    const urls = collectImageCandidates(html, baseUrl).candidates.map((c) => c.url);
+    assert.ok(urls.includes(insideUrl), 'same-dir image kept');
+    assert.ok(urls.includes(subdirUrl), 'subdirectory image kept');
+    assert.equal(urls.includes(outsideUrl), false, 'out-of-tree absolute path rejected');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/preview.test.js
+++ b/tests/unit/preview.test.js
@@ -640,6 +640,19 @@ test('prepareSnapshotHtml resolves a streamed page end to end', () => {
   assert.strictEqual(blocks.length, 1);
 });
 
+// Minimal ReadableStream-ish body so fetchPreviewPage's streaming byte cap
+// (readResponseBytesCapped) exercises its real reader path (#447).
+function streamBody(body) {
+  const bytes = Buffer.from(String(body));
+  let sent = false;
+  return {
+    getReader: () => ({
+      read: async () => (sent ? { done: true } : ((sent = true), { done: false, value: new Uint8Array(bytes) })),
+      cancel: async () => {},
+    }),
+  };
+}
+
 test('fetchPreviewPage validates status, content type, and size', async () => {
   const page = (body, init = {}) => Promise.resolve({
     ok: (init.status ?? 200) >= 200 && (init.status ?? 200) < 300,
@@ -647,6 +660,7 @@ test('fetchPreviewPage validates status, content type, and size', async () => {
     url: init.url ?? '',
     headers: { get: (name) => ({ 'content-type': 'text/html; charset=utf-8', ...init.headers })[name.toLowerCase()] ?? null },
     text: async () => body,
+    body: streamBody(body),
   });
 
   const ok = await fetchPreviewPage('https://example.test/', { fetchImpl: () => page('<p>hi</p>') });
@@ -686,6 +700,7 @@ test('fetchPreviewPage guards every redirect hop against private/internal target
     url: init.url ?? '',
     headers: { get: (name) => ({ 'content-type': 'text/html; charset=utf-8', ...init.headers })[name.toLowerCase()] ?? null },
     text: async () => init.body ?? '',
+    body: streamBody(init.body ?? ''),
   });
   const routed = (routes) => {
     const seen = [];
@@ -769,4 +784,27 @@ test('fetchPreviewPage guards every redirect hop against private/internal target
       /redirected too many times/,
     );
   }
+});
+
+test('inlineSrcdocIframes decodes numeric character references in srcdoc (#447)', () => {
+  const html = '<iframe srcdoc="&#60;p&#62;Numeric entity prose long enough to extract here.&#60;/p&#62;"></iframe>';
+  const out = inlineSrcdocIframes(html);
+  assert.match(out, /<p>Numeric entity prose long enough to extract here\.<\/p>/);
+});
+
+test('tainted $-sequences in preview injections are treated literally (#447)', () => {
+  const html = '<html><head></head><body><p>ORIGINAL_BODY_MARKER paragraph long enough here.</p></body></html>';
+  const { blocks } = extractProseBlocks(html);
+  const rewrites = blocks.map(() => 'Rewritten paragraph text here.');
+  const { html: out } = buildPreviewHtml({
+    html,
+    blocks,
+    rewrites,
+    sourceUrl: 'https://example.test/?x=$`$&',
+    explanationHtml: "<div class=\"explain-card\">tricky $` $& $' marker</div>",
+  });
+  // A `$`-sequence interpreted as a replacement pattern would expand to the
+  // document prefix and duplicate the body; the unique marker must appear once.
+  assert.equal(out.split('ORIGINAL_BODY_MARKER').length - 1, 1);
+  assert.ok(out.includes("tricky $` $& $' marker"));
 });


### PR DESCRIPTION
Closes #447 (review: preview-surface lane from the 2026-06-13 full-repo architect review). Resolves the 4 highest-value findings (including both security issues) and defers the 2 malformed-markup edge cases with a note. The lane's major finding (#439) already shipped in #453. No new deps.

## Findings addressed

**Minor**
- **Page-size cap enforced only after full buffering** (`preview.js`): `fetchPreviewPage` now reads the body under a true streaming byte cap (shared `readResponseBytesCapped`, extracted from `ocr.js` `fetchCappedBytes`) instead of `await response.text()` + `html.length`. A hostile/misconfigured server can no longer stream hundreds of MB within the timeout, and the limit is now byte-accurate for multi-byte (Korean) pages rather than UTF-16 code units.
- **Tainted `String.replace` replacement strings interpret `$`-patterns** (`preview.js`): the three callsites that put page/LLM/OCR-derived text in the replacement position (frozen stylesheet css, `injectHead`'s sourceUrl injection, `injectChrome`'s notes) now use **function** replacements, so a literal `` $` `` / `$'` / `$&` can no longer expand to the document prefix and duplicate the page inside the overlay.
- **file: image candidates not confined to the source directory** (`ocr.js`): a local `--preview --ocr` run now restricts file: image candidates to the previewed file's own directory subtree, so a malicious `.html` cannot reference `file:///home/user/passport.jpg` and exfiltrate it to the OCR backend.
- **`decodeHtmlEntities` skipped numeric character references** (`preview.js`): now decodes `&#60;` / `&#x3c;`, so srcdoc written with numeric entities inlines as real markup and its prose reaches `extractProseBlocks` instead of rendering as inert escaped text.

**Deferred (noted on the issue for a focused follow-up)**
- The stray-inline-close-tag escape in `hasOnlyInlineMarkup` and the unclosed-`srcdoc` content swallow in `inlineSrcdocIframes` are malformed/mis-nested-markup edge cases that need a balanced-tag checker / tag-token walk rather than the current loose regexes — higher-risk rewrites for low-frequency input, kept out of this security-focused PR.

## Verification
- `node --test tests/unit/*.test.js tests/e2e/*.test.js` — 650 pass / 0 fail (adds streaming-cap stream-body mocks, `$`-injection, file-confinement, and numeric-entity tests; `readResponseBytesCapped` shared with `fetchCappedBytes`, whose tests still pass).
- `npm run lint` — green.
- `npm run benchmark` — 100% accuracy, ROC-AUC/PR-AUC 1.000.
