### PR TITLE
fix(auth-security): scope loopback exemption to IPv4 literals, bound doctor probe (#448)

### DIFF
--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -156,7 +156,9 @@ function parseDoctorArgs(args) {
 
 function checkCommand(cmd, args) {
   try {
-    const result = spawnSync(cmd, args, { encoding: 'utf8' });
+    // timeout so a hung shim on PATH (e.g. a wedged `tmux`) can't block
+    // `patina doctor` indefinitely; fixed argv + no shell means no injection (#448).
+    const result = spawnSync(cmd, args, { encoding: 'utf8', timeout: 5000 });
     return {
       ok: result.status === 0,
       stdout: result.stdout || '',

--- a/src/security.js
+++ b/src/security.js
@@ -40,7 +40,11 @@ export function validateProfileName(name) {
 export function isLoopbackHost(hostname) {
   if (!hostname) return false;
   if (hostname === 'localhost') return true;
-  if (hostname === '127.0.0.1' || hostname.startsWith('127.')) return true;
+  // 127/8 is loopback, but only for real IPv4 literals — a DNS name like
+  // '127.attacker.example' starts with '127.' yet must NOT be exempted from
+  // the plaintext-HTTP guard (it would leak the Bearer token in cleartext to a
+  // non-loopback host, #448).
+  if (isIP(hostname) === 4 && hostname.startsWith('127.')) return true;
   if (hostname === '::1' || hostname === '[::1]') return true;
   return false;
 }

--- a/tests/unit/security.test.js
+++ b/tests/unit/security.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   applyPrivateBaseURLOptIn,
+  isLoopbackHost,
   isPrivateOrSpecialIP,
   isSubresourceFetchAllowed,
   shouldAllowPrivateBaseURL,
@@ -71,6 +72,26 @@ test('validateBaseURL rejects private literal IPs unless private URL opt-in is s
   });
 });
 
+
+test('isLoopbackHost only exempts real IPv4 loopback literals, not 127.* DNS names (#448)', () => {
+  assert.equal(isLoopbackHost('127.0.0.1'), true);
+  assert.equal(isLoopbackHost('127.5.6.7'), true);
+  assert.equal(isLoopbackHost('localhost'), true);
+  assert.equal(isLoopbackHost('::1'), true);
+  // A DNS name that merely starts with '127.' must NOT be treated as loopback.
+  assert.equal(isLoopbackHost('127.attacker.example'), false);
+  assert.equal(isLoopbackHost('127.0.0.1.evil.com'), false);
+});
+
+test('validateBaseURL refuses plaintext HTTP to a 127.* DNS name but allows real loopback (#448)', () => {
+  withEnv({ PATINA_ALLOW_INSECURE_BASE_URL: undefined, PATINA_ALLOW_PRIVATE_BASE_URL: undefined }, () => {
+    assert.throws(
+      () => validateBaseURL('http://127.attacker.example/v1'),
+      /refusing plaintext HTTP/,
+    );
+    assert.doesNotThrow(() => validateBaseURL('http://127.0.0.1/v1'));
+  });
+});
 test('shouldAllowPrivateBaseURL and applyPrivateBaseURLOptIn honor flag and env opt-in', () => {
   withEnv({ PATINA_ALLOW_PRIVATE_BASE_URL: undefined }, () => {
     assert.equal(shouldAllowPrivateBaseURL(), false);


### PR DESCRIPTION
Closes #448 (review: auth-security lane from the 2026-06-13 full-repo architect review). Fixes the exploitable minor + the clean robustness nit; defers the DNS-rebinding TOCTOU and the optional permission-warning nit with technical notes (a security lane should not rush an architectural change). No new deps.

## Findings addressed

**Minor**
- **`isLoopbackHost` prefix-matched DNS names like `127.attacker.example`** (`security.js`): the 127/8 exemption now applies only to real IPv4 literals (`isIP(hostname) === 4`). Previously `'127.attacker.example'.startsWith('127.')` was true, so `validateBaseURL` waved `http://127.attacker.example/` past the plaintext-HTTP guard and the Bearer token went out in cleartext to a non-loopback host. `localhost` / `::1` / real `127.x.x.x` literals stay exempt.

**Nit**
- **`checkCommand` `spawnSync` had no timeout** (`doctor.js`): now `{ timeout: 5000 }`, so a hung shim on PATH (e.g. a wedged `tmux -V`) cannot block `patina doctor` indefinitely. Fixed argv + no shell → no injection risk.

## Deferred (noted for focused follow-up)
- **Sub-resource SSRF resolve-then-fetch TOCTOU (DNS rebinding)** — a defense-in-depth gap already acknowledged in the guard's doc comment; redirects are re-guarded via `guardHop`. Closing it requires pinning the resolved IP via a custom fetch dispatcher/connect hook, which would touch the injectable-fetch abstraction and its tests — disproportionate and risky for this lane.
- **World-readable API-key-file permission warning** — optional, POSIX-only; would thread a new warning channel through `readApiKeyFile` → `doctor`. Left out to keep this security PR focused and low-risk.

## Verification
- `node --test tests/unit/*.test.js tests/e2e/*.test.js` — 647 pass / 0 fail (adds `isLoopbackHost` + plaintext-HTTP-guard tests).
- `npm run lint` — green.
- `npm run benchmark` — 100% accuracy (unchanged; no detection-layer change).
