### PR TITLE
fix(infra): typed user-input errors, JSON-safe diff, stream-honoring logger, exit-code hardening (#449)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,7 @@ import { resolve, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
+import { inputError } from './errors.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -26,7 +27,11 @@ export function loadConfig(path = resolve(REPO_ROOT, '.patina.default.yaml'), { 
   const raw = readFileSync(path, 'utf8');
   const parsed = yaml.load(raw);
   if (!isPlainObject(parsed)) {
-    throw new Error(`Config at ${path} did not parse to a YAML mapping (got ${typeof parsed})`);
+    throw inputError(
+      'config did not parse to a YAML mapping',
+      `${path}: got ${Array.isArray(parsed) ? 'array' : typeof parsed}`,
+      'A patina config must be a YAML mapping (key: value pairs), not a list or scalar.'
+    );
   }
   const config = parsed;
 
@@ -45,11 +50,24 @@ export function loadConfig(path = resolve(REPO_ROOT, '.patina.default.yaml'), { 
 }
 
 function mergeYamlMapping(config, filePath, label) {
-  const raw = readFileSync(filePath, 'utf8');
+  let raw;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (err) {
+    throw inputError(
+      `${label.toLowerCase()} file could not be read`,
+      `${filePath}: ${err.message}`,
+      'Check the --config path (or the ~/.patina.yaml / ./.patina.yaml location).'
+    );
+  }
   const parsed = yaml.load(raw);
   if (parsed === null || parsed === undefined) return; // empty file
   if (!isPlainObject(parsed)) {
-    throw new Error(`${label} at ${filePath} must be a YAML mapping (got ${Array.isArray(parsed) ? 'array' : typeof parsed})`);
+    throw inputError(
+      `${label.toLowerCase()} is not a YAML mapping`,
+      `${filePath}: got ${Array.isArray(parsed) ? 'array' : typeof parsed}`,
+      'A patina config must be a YAML mapping (key: value pairs).'
+    );
   }
   deepMerge(config, parsed);
 }
@@ -112,15 +130,19 @@ const VALID_TONES = ['casual', 'professional', 'academic', 'narrative', 'marketi
 export function resolveTone({ cliTone, configTone, lang }) {
   if (cliTone !== undefined && cliTone !== null) {
     if (!VALID_TONES.includes(cliTone)) {
-      throw new Error(
-        `Unknown tone '${cliTone}'. Valid tones: ${VALID_TONES.join(', ')}`
+      throw inputError(
+        `unknown tone '${cliTone}'`,
+        `--tone must be one of: ${VALID_TONES.join(', ')}.`,
+        'Pass a supported tone, or omit --tone for profile-only mode.'
       );
     }
   }
   if (configTone !== undefined && configTone !== null && configTone !== '') {
     if (!VALID_TONES.includes(configTone)) {
-      throw new Error(
-        `Invalid tone '${configTone}' in config. Valid tones: ${VALID_TONES.join(', ')}`
+      throw inputError(
+        `invalid tone '${configTone}' in config`,
+        `The config 'tone' must be one of: ${VALID_TONES.join(', ')}.`,
+        'Fix the tone value in your .patina.yaml (or remove it).'
       );
     }
   }

--- a/src/errors.js
+++ b/src/errors.js
@@ -76,7 +76,9 @@ export function renderCliError(err) {
  */
 export function getExitCode(err, fallback = 1) {
   const n = Number(err ? /** @type {any} */ (err).exitCode : undefined);
-  return Number.isInteger(n) && n >= 0 ? n : fallback;
+  // Reject exitCode 0 on a thrown error: a fatal catch must never exit 0 after
+  // printing an error. Only a positive integer overrides the fallback (#449).
+  return Number.isInteger(n) && n >= 1 ? n : fallback;
 }
 
 function normalizeError(err) {

--- a/src/loader.js
+++ b/src/loader.js
@@ -2,6 +2,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { resolve, sep } from 'node:path';
 import yaml from 'js-yaml';
 import { validateProfileName } from './security.js';
+import { inputError, runtimeError } from './errors.js';
 
 /**
  * Read a UTF-8 text file.
@@ -52,7 +53,7 @@ export function loadPatterns(repoRoot, lang, skipPatterns = []) {
   const files = readdirSync(patternsDir)
     .filter((f) => f.startsWith(`${lang}-`) && f.endsWith('.md'))
     .filter((f) => {
-      const packName = f.replace('.md', '');
+      const packName = f.slice(0, -3);
       return !skipPatterns.includes(packName);
     })
     .sort();
@@ -87,7 +88,13 @@ export function loadProfile(repoRoot, profileName) {
   const profilesDir = resolve(repoRoot, 'profiles');
   const profilePath = resolve(profilesDir, `${profileName}.md`);
   if (!profilePath.startsWith(profilesDir + sep)) {
-    throw new Error(`Profile path escaped profiles/: ${profilePath}`);
+    // Defense-in-depth after validateProfileName; an escape here is an internal
+    // invariant breach, not user input — keep it a typed runtime error (#449).
+    throw runtimeError(
+      'profile path escaped the profiles directory',
+      `${profilePath} is outside ${profilesDir}.`,
+      'This is an internal guard; report it if you see it with a normal --profile value.'
+    );
   }
   const content = loadFile(profilePath);
   return splitFrontmatter(content);
@@ -139,7 +146,11 @@ export function loadVoiceSample(path) {
     .filter(Boolean);
 
   if (paragraphs.length === 0) {
-    throw new Error(`Voice sample is empty: ${path}`);
+    throw inputError(
+      'voice sample is empty',
+      `${path} has no non-empty paragraphs.`,
+      'Provide a --voice-sample file with at least one paragraph of the target writing style.'
+    );
   }
 
   const selected = paragraphs.slice(0, 3);

--- a/src/logger.js
+++ b/src/logger.js
@@ -29,7 +29,13 @@ export function createLogger({
   const emit = (levelName, event, fields = {}) => {
     if (LEVELS[levelName] < threshold) return;
     closeProgress();
-    if (fields.message) console.error(fields.message);
+    if (!fields.message) return;
+    // Honor an injected custom stream (tests, child loggers) like progress/
+    // closeProgress already do, instead of always hardcoding stderr (#449). The
+    // default process.stderr stays on console.error so the common path keeps a
+    // single write API on that fd.
+    if (stream && stream !== process.stderr) stream.write(`${fields.message}\n`);
+    else console.error(fields.message);
   };
 
   const progress = (_event, fields = {}) => {

--- a/src/output.js
+++ b/src/output.js
@@ -47,7 +47,9 @@ function renderFormattedBody(result, mode, parsed = {}, opts = {}) {
   if (mode === 'rewrite' || mode === 'ouroboros') {
     body = stripSelfAudit(body, { logger: opts.logger });
   }
-  if (mode === 'diff') {
+  if (mode === 'diff' && (parsed.format || 'markdown') !== 'json') {
+    // Skip ANSI colorization for JSON output, otherwise raw escape codes get
+    // embedded inside the JSON `output` string field on a TTY (#449).
     body = colorizeDiff(body, { parsed, env: opts.env, stdout: opts.stdout });
   }
   return body;

--- a/tests/unit/logger.test.js
+++ b/tests/unit/logger.test.js
@@ -3,29 +3,22 @@ import { strict as assert } from 'node:assert';
 
 import { createLogger } from '../../src/logger.js';
 
-function captureConsoleError(fn) {
-  const original = console.error;
+function captureStream() {
   const lines = [];
-  console.error = (message) => lines.push(String(message));
-  try {
-    fn();
-  } finally {
-    console.error = original;
-  }
-  return lines;
+  const stream = { write: (chunk) => lines.push(String(chunk).replace(/\n$/, '')) };
+  return { stream, lines };
 }
 
 test('logger respects quiet and PATINA_LOG_LEVEL', () => {
   const previous = process.env.PATINA_LOG_LEVEL;
   process.env.PATINA_LOG_LEVEL = 'warn';
   try {
-    const lines = captureConsoleError(() => {
-      const logger = createLogger();
-      logger.info('hidden', { message: '[patina] hidden' });
-      logger.warn('shown', { message: '[patina] shown' });
-      createLogger({ quiet: true }).error('also_hidden', { message: '[patina] hidden error' });
-    });
-    assert.deepEqual(lines, ['[patina] shown']);
+    const cap = captureStream();
+    const logger = createLogger({ stream: cap.stream });
+    logger.info('hidden', { message: '[patina] hidden' });
+    logger.warn('shown', { message: '[patina] shown' });
+    createLogger({ quiet: true, stream: cap.stream }).error('also_hidden', { message: '[patina] hidden error' });
+    assert.deepEqual(cap.lines, ['[patina] shown']);
   } finally {
     if (previous === undefined) delete process.env.PATINA_LOG_LEVEL;
     else process.env.PATINA_LOG_LEVEL = previous;

--- a/tests/unit/tone.test.js
+++ b/tests/unit/tone.test.js
@@ -54,14 +54,14 @@ test('resolveTone: ja + auto → unsupported_language_fallback', () => {
 test('resolveTone: invalid cliTone throws', () => {
   assert.throws(
     () => resolveTone({ cliTone: 'bogus', lang: 'ko' }),
-    /Unknown tone 'bogus'/
+    /unknown tone 'bogus'/
   );
 });
 
 test('resolveTone: invalid configTone throws', () => {
   assert.throws(
     () => resolveTone({ cliTone: undefined, configTone: 'nope', lang: 'ko' }),
-    /Invalid tone 'nope' in config/
+    /invalid tone 'nope' in config/
   );
 });
 
@@ -116,6 +116,14 @@ test('formatOutput: colorizes labeled diff output on TTY', () => {
   assert.ok(out.includes('\x1b[1mPattern: 1. Generic polish\x1b[0m'));
   assert.ok(out.includes('\x1b[31mRemoved: old phrasing\x1b[0m'));
   assert.ok(out.includes('\x1b[32mAdded: sharper phrasing\x1b[0m'));
+});
+
+test('formatOutput: does not embed ANSI in --diff --format json on a TTY (#449)', () => {
+  const raw = 'Pattern: 1. Generic polish\nRemoved: old phrasing\nAdded: sharper phrasing';
+  const out = formatOutput(raw, 'diff', { format: 'json' }, { env: {}, stdout: { isTTY: true } });
+  // The JSON payload's `output` field must carry the plain diff, no escape codes.
+  assert.equal(out.includes('\x1b['), false);
+  assert.equal(JSON.parse(out).output, raw);
 });
 
 test('formatOutput: disables diff colors for NO_COLOR, --no-color, and non-TTY', () => {


### PR DESCRIPTION
Closes #449 (review: infra lane from the 2026-06-13 full-repo architect review). Resolves the 4 minor + 2 of 3 nits. No new deps.

## Findings addressed

**Minor**
- **User-input validation threw plain `Error` (exit 1, should be 2)** (`config.js`): invalid base/user/`--config` YAML (non-mapping) and unknown CLI/config tones now throw typed `inputError` (exit 2); a missing/unreadable `--config` (or `~/.patina.yaml`) path now surfaces as a typed `inputError` instead of a raw fs `ENOENT`.
- **Empty voice sample threw plain `Error`** (`loader.js`): `loadVoiceSample` now throws `inputError` (exit 2); the post-validation profile-escape guard throws a typed `runtimeError`.
- **Diff ANSI colorization applied before the JSON branch** (`output.js`): colorization is skipped when `--format json`, so `--diff --format json` on a TTY no longer embeds raw escape codes inside the JSON `output` string.
- **Logger `emit` ignored the injected stream** (`logger.js`): `emit` now honors a custom injected stream (tests / child loggers) like `progress`/`closeProgress` already do; the default `process.stderr` stays on `console.error` so the common path keeps a single write API per fd.

**Nit**
- **Pack name via first-occurrence `.md` replace** (`loader.js`): uses `f.slice(0, -3)` so a filename with `.md` mid-name can't yield a wrong pack name and silently break skip-patterns matching.
- **`getExitCode` accepted exitCode 0 on a thrown error** (`errors.js`): now requires `>= 1`, so a fatal catch can never `process.exit(0)` after printing an error.

## Not changed (noted)
- The lang-prefix glob co-loading a future hyphenated language pack (e.g. `zh-tw`) has no live bug with the current `ko/en/zh/ja` packs and needs a language registry to distinguish the language segment from the pack name — left as a documented future item.

## Verification
- `node --test tests/unit/*.test.js tests/e2e/*.test.js` — 646 pass / 0 fail (adds an injected-stream logger test and a diff+json no-ANSI test; tone tests updated for the typed-error messages).
- `npm run lint` — green.
- `npm run benchmark` — 100% accuracy (unchanged; no detection-layer change).
