### PR TITLE
fix(playground): emoji-presentation tell, fold-safe highlight, lexicon-flag parity, input debounce (#450)

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -11,15 +11,28 @@ Static, audit-only web playground for `patina.vibetip.help`.
 
 ## Local preview
 
-Serve the repository root so `vercel.json`-style root paths can resolve brand and social assets:
+The static entry (`index.html`) loads `/app.js`, `/styles.css`, and `/analytics.js`
+via root-absolute paths that resolve through the `vercel.json` rewrites
+(`/app.js` → `/playground/app.js`). A plain static server rooted at the repo
+serves the page at `/playground/` where those `/app.js` URLs 404, so use a
+rewrite-aware dev server:
 
 ```bash
-npx http-server .
-# or
-python3 -m http.server 8080
+npx vercel dev
 ```
 
-Then open `http://localhost:8080/playground/`.
+Then open the URL it prints (the root route rewrites to the playground entry). A
+plain `npx http-server .` will render the page shell but not its JS/CSS.
+
+## Parity with the CLI
+
+The playground hot-paragraph ratio is intentionally a *superset* of the CLI's
+deterministic `--score`: it adds playground-only formatting tells (em dash /
+bold / emoji overuse) and per-paragraph markup leakage that canonical
+`analyzeText` omits (the CLI adds the optional structural classifier instead).
+So the playground can mark more paragraphs hot than `npx patina-cli --score` for
+the same text; shared signals (stylometry, lexicon, the leakage floor) stay
+pinned in parity by `tests/unit/playground.test.js`.
 
 ## Data refresh
 

--- a/playground/analyzer.js
+++ b/playground/analyzer.js
@@ -120,7 +120,12 @@ function zeroKoPostEditeseMetrics() {
   return koreanPostEditeseFeatures('', { lang: 'ko' }).metrics;
 }
 
-const EMOJI_BASE_RE = '\\p{Extended_Pictographic}(?:\\uFE0F|\\uFE0E)?(?:\\p{Emoji_Modifier})?';
+// Require emoji presentation, not bare Extended_Pictographic: ©/®/™ are
+// Extended_Pictographic with default TEXT presentation and would otherwise count
+// as emoji at the any-occurrence threshold (#450). A pictograph counts only when
+// it has emoji presentation by default (Emoji_Presentation) or is forced to it
+// with U+FE0F.
+const EMOJI_BASE_RE = '(?:\\p{Emoji_Presentation}\\uFE0F?|\\p{Extended_Pictographic}\\uFE0F)(?:\\p{Emoji_Modifier})?';
 const EMOJI_CLUSTER_PATTERN = `(?:\\p{Regional_Indicator}{2}|[#*0-9]\\uFE0F?\\u20E3|${EMOJI_BASE_RE}(?:\\u200D${EMOJI_BASE_RE})*)`;
 const EMOJI_CLUSTER_RE = new RegExp(EMOJI_CLUSTER_PATTERN, 'u');
 const EMOJI_CLUSTER_RE_GLOBAL = new RegExp(EMOJI_CLUSTER_PATTERN, 'gu');
@@ -428,6 +433,10 @@ function collectHitRanges(text, hits) {
 }
 
 export function highlightLexiconHits(text, hits) {
+  // collectHitRanges indexes against text.toLowerCase(); if case folding changes
+  // length (e.g. 'İ' U+0130 → 2 UTF-16 units) every range would shift and mark
+  // the wrong substring. Fall back to plain escaped text in that case (#450).
+  if (text.toLowerCase().length !== text.length) return escapeHtml(text);
   const ranges = collectHitRanges(text, hits);
   if (ranges.length === 0) return escapeHtml(text);
   let html = '';

--- a/playground/app.js
+++ b/playground/app.js
@@ -140,6 +140,17 @@ function reportFalsePositive() {
     : 'Pop-up blocked. Allow pop-ups, or open an issue from the GitHub link in the header.';
 }
 
+// Re-analysis runs detectTranslationese + per-paragraph stylometry + three
+// innerHTML re-renders; debounce keystrokes so a long paste does not block the
+// main thread on every character. The 'Run audit' button stays immediate (#450).
+function debounce(fn, ms) {
+  let timer = null;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), ms);
+  };
+}
+
 function bind() {
   nodes.lang.value = state.lang;
   nodes.input.value = state.text;
@@ -148,7 +159,7 @@ function bind() {
     updateQuery();
     runAnalysis();
   });
-  nodes.input.addEventListener('input', runAnalysis);
+  nodes.input.addEventListener('input', debounce(runAnalysis, 200));
   nodes.analyze.addEventListener('click', runAnalysis);
   nodes.sample.addEventListener('click', setSample);
   nodes.copyCli.addEventListener('click', copyCli);

--- a/scripts/generate-playground-data.mjs
+++ b/scripts/generate-playground-data.mjs
@@ -30,7 +30,9 @@ for (const lang of LANGS) {
   const source = `lexicon/ai-${lang}.md`;
   const raw = readFileSync(resolve(REPO_ROOT, source), 'utf8');
   const { meta, body } = parseFrontmatter(raw);
-  const parsed = parseLexiconBody(body, { skipUnderscore: true });
+  // Match the CLI loader (src/features/lexicon.js parseLexiconBody(body)) so an
+  // underscore-prefixed entry can't count in the CLI yet vanish from the bundle (#450).
+  const parsed = parseLexiconBody(body);
   lexicons[lang] = {
     lang,
     source,

--- a/tests/unit/playground.test.js
+++ b/tests/unit/playground.test.js
@@ -16,6 +16,7 @@ import {
   SUPPORTED_LANGS,
   splitProseSentences,
   countFormatting,
+  highlightLexiconHits,
   TRANSLATIONESE_RULES as PLAYGROUND_TRANSLATIONESE_RULES,
   TRANSLATIONESE_ABS_MIN,
   TRANSLATIONESE_DENSITY_MIN,
@@ -842,4 +843,20 @@ test('generated playground lexicon bundle is in sync with markdown lexicons', ()
     encoding: 'utf8',
   });
   assert.equal(result.status, 0, result.stderr || result.stdout);
+});
+
+test('playground emoji tell ignores text-presentation symbols ™/©/® (#450)', () => {
+  assert.equal(countFormatting('Acme\u2122 \u00a9 2026 \u00ae', { segmenter: null }).emoji, 0);
+  // A default-emoji-presentation pictograph still counts.
+  assert.equal(countFormatting('Ship it \u{1F680}', { segmenter: null }).emoji, 1);
+  // A text-default pictograph forced to emoji presentation with U+FE0F counts.
+  assert.equal(countFormatting('mark \u2122\uFE0F', { segmenter: null }).emoji, 1);
+});
+
+test('highlightLexiconHits falls back to plain escaping when lowercasing changes length (#450)', () => {
+  // 'İ' (U+0130) lowercases to 2 UTF-16 units, so index math against the
+  // lowercased copy would drift and mark the wrong substring.
+  assert.equal(highlightLexiconHits('\u0130stanbul tool', ['tool']).includes('<mark>'), false);
+  // A same-length string still highlights the hit.
+  assert.ok(highlightLexiconHits('great tool here', ['tool']).includes('<mark>tool</mark>'));
 });


### PR DESCRIPTION
Closes #450 (review: playground lane from the 2026-06-13 full-repo architect review). Resolves the 3 minor + 3 nit findings. No new deps; `src/features/*` untouched.

## Findings addressed

**Minor**
- **Emoji tell counted text-presentation symbols ™/©/®** (`analyzer.js`): `EMOJI_BASE_RE` now requires emoji presentation (`Emoji_Presentation`, or `Extended_Pictographic` + `U+FE0F`) instead of bare `Extended_Pictographic`, so `Acme™` / `© 2026` no longer mark a paragraph hot at the any-occurrence threshold. (Playground-only — `src/` has no `Extended_Pictographic` usage.)
- **`collectHitRanges` offsets drifted when `toLowerCase` changed length** (`analyzer.js`): `highlightLexiconHits` now falls back to plain escaped text when `text.toLowerCase().length !== text.length` (e.g. `İ` → 2 UTF-16 units), instead of slicing the original string with lowercased indices and marking the wrong substring. (No XSS — still escaped — but visibly wrong.)
- **Lexicon generator used `skipUnderscore:true` while the CLI does not** (`generate-playground-data.mjs`): now `parseLexiconBody(body)` to match `src/features/lexicon.js`, closing the latent parity gap (an underscore-prefixed entry would count in the CLI but vanish from the bundle). No live change — no underscore entries exist today, and the committed bundle is byte-identical (staleness test still passes).

**Nit**
- **No debounce on per-keystroke re-analysis** (`app.js`): the `input` handler is debounced 200 ms; the *Run audit* button stays immediate, so long pastes no longer block the main thread per character.
- **Documented local preview broke on root-absolute asset paths** (`README.md`): local-preview docs now point at a rewrite-aware dev server (`vercel dev`), since `/app.js` etc. 404 under a plain static server at `/playground/`.
- **Playground hot-rule superset vs CLI** (`README.md`): added a user-facing "Parity with the CLI" note explaining the playground hot-ratio is an intentional superset of `--score` (it adds formatting/leakage tells the CLI omits).

## Verification
- `node --test tests/unit/*.test.js tests/e2e/*.test.js` — 647 pass / 0 fail (adds emoji-presentation and fold-safe-highlight tests; the playground bundle staleness check still passes).
- `npm run lint` — green.
- `npm run benchmark` — 100% accuracy.
