### PR TITLE
release: 4.3.0

### DIFF
--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "4.2.0"
+version: "4.3.0"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
+## 4.3.0 — 2026-06-13
+
+**Reliability, security, and false-positive hardening from the 2026-06-13 full-repo architect review.**
+
+Semver rationale: minor — adds the `--no-stop-on-retryable-storm` batch flag and `--name=value` / `--` argument syntax, and changes several user-observable CLI behaviors (config/voice-sample input errors now exit 2; retryable-storm stopping is restricted to EX_TEMPFAIL/timeout; per-attempt timeouts surface as `TimeoutError`; the ouroboros loop drops its per-iteration self-audit; document input is data-fenced in prompts). The rest is security, correctness, and false-positive bug fixes across the deterministic engine, the LLM/backend layers, preview, and the playground. No API or schema removals.
+
+### Security
+- Refuse token-leaking plaintext HTTP: `isLoopbackHost` exempts only real IPv4 loopback literals, so `http://127.attacker.example/` is no longer treated as loopback and the Bearer token is not sent in cleartext to a non-loopback host (#448).
+- `--preview --ocr` confines local `file:` image candidates to the previewed file's own directory subtree, so a malicious local `.html` can no longer reference an absolute path (e.g. `file:///home/you/passport.jpg`) and exfiltrate it to the OCR backend (#447).
+- Preview injection hardening: page/LLM/OCR-derived text placed in `String.replace` replacement positions is applied via function replacements, so a literal `$`-sequence can no longer expand to the document prefix and duplicate the page; the fetched page body is read under a true streaming byte cap instead of being fully buffered; document input is wrapped in a sentinel data-fence so adversarial third-party text under `--batch`/`--gate`/ouroboros cannot pose as the prompt's own `## Output`/`[BODY]`/`[SELF_AUDIT]` sections (#447, #444).
+- Every page-fetch redirect hop is SSRF-guarded against private/internal targets (#439).
+
+### Fixed — detection accuracy & false positives
+- CJK sentence splitting keeps terminators inside closing quotes attached and no longer strands zero-token "sentences"; `…` is no longer a hard terminator in en/ko; AI-lexicon strict entries match on whole-word boundaries and phrases match across soft line wraps (#441).
+- `navlist` only counts as model-output leakage with a corroborating tool token; CommonMark setext H2 underlines and YAML frontmatter no longer count as decorative dividers; the `당신` direct-address rule gains Hangul boundary guards; `c11-connective-comma` excludes common 고-final nouns (#442).
+- Self-identification leakage no longer false-positives on human bio/ML prose (#435).
+- Structural classifier: corrupt/non-object model files fail loud, zero/negative sigma is rejected, the max-FPR threshold uses `ceil`, the audit path degrades to a warning, and a model trained at the wrong feature width is rejected at load (#443, #436).
+
+### Fixed — reliability
+- LLM client / ouroboros: a per-attempt timeout that exhausts retries surfaces as `TimeoutError` (not `AbortError`), so `scoreMPS`/`scoreFidelity` take the fail-closed rollback instead of crashing the run; a throw from the `onResponse` callback no longer re-issues the already-paid request; the loop fails closed on a missing fidelity and stops paying for a self-audit block it immediately strips; fidelity/MPS floors are checked before declaring the target met (#444, #437).
+- Backends: an explicit `status: null` no longer skips retry detection; the concurrency cap fails closed on an invalid override; a crashed run's slot is reclaimed by pid-liveness instead of blocking a cap-1 backend for ~30 min, and slot roots are per-user; a flag-sourced foreign-family model is dropped per fallback leg; codex stdout is discarded to avoid a pipe-buffer deadlock (#445, #438).
+- CLI adapters: codex stderr decodes as UTF-8; image-staging failures clean up the temp dir and surface a typed error; a stdin error kills the child before its cwd is removed; signal death is reported instead of "exited with code null"; gemini/kimi banner stripping is tightened to avoid eating real response lines (#446).
+- CLI: output-routing flags (`--in-place`/`--suffix`/`--outdir`) are batch-only and mutually exclusive with `--outdir` collision detection; blank numeric option values are rejected instead of coercing to 0; the interactive stdin prompt writes to stderr so it shows under `--quiet`; Ctrl-C during batch is a run-level stop, not a per-file failure; explicit `--max-failure-rate` keeps its warm-up sample (#440, #434).
+- Infra: config/tone/voice-sample input validation throws typed errors (exit 2); `--diff --format json` no longer embeds ANSI escape codes; the logger honors an injected stream; `getExitCode` rejects exit 0 on a thrown error; hosted-response span offsets validate against the returned text length (#449, #445).
+- Playground: text-presentation symbols (™/©/®) no longer count as emoji; lexicon highlighting falls back to plain escaping when case folding changes string length; per-keystroke re-analysis is debounced (#450).
+
+### Added
+- `--no-stop-on-retryable-storm` to opt out of batch retryable-storm stopping (on by default in batch mode); `--name=value` argument syntax and a `--` end-of-options separator so dash-prefixed file names are usable (#440).
+
 ## 4.2.0 — 2026-06-12
 
 **In-place preview as the single review surface: file input, image-text OCR, full-page extraction coverage, live-design fidelity, and context-aware rewriting.**

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 4.2.0" src="https://img.shields.io/badge/version-4.2.0-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 4.3.0" src="https://img.shields.io/badge/version-4.3.0-blue"></a>
 </p>
 
 <p align="center">
@@ -178,7 +178,7 @@ If meaning drifts, the change is retried or rolled back. Deterministic analysis 
 
 ```yaml
 # .patina.default.yaml
-version: "4.2.0"
+version: "4.3.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 4.2.0
+version: 4.3.0
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "4.2.0"
+    "patina-cli": "4.3.0"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## 4.3.0 — minor release

Version bump + CHANGELOG for the **17 post-4.2.0 fix lanes** from the 2026-06-13 full-repo architect review. This PR is **version-sync + CHANGELOG only** — no code changes (those already merged via #452–#468).

### Why minor
- New `--no-stop-on-retryable-storm` batch flag + `--name=value` / `--` argument syntax (additive).
- User-observable CLI behavior changes: config/voice-sample input errors now exit 2; retryable-storm stopping restricted to EX_TEMPFAIL/timeout; per-attempt timeouts surface as `TimeoutError`; ouroboros drops its per-iteration self-audit; document input is data-fenced in prompts.
- Everything else is security / correctness / false-positive bug fixes. No API or schema removals.

### Headline fixes (security)
- Plaintext-HTTP token leak via `127.*` DNS names refused (#448)
- `--preview --ocr` local `file:` image exfiltration confined to the source dir (#447)
- Preview `$`-pattern replacement injection + prompt input data-fencing (#447, #444)

### Version-sync (verified by `release:check`)
`package.json` · `SKILL.md` · `.patina.default.yaml` · `README.md` (badge + config example) · `packages/patina-humanizer/package.json` (version + `patina-cli` dep) · `CHANGELOG.md` (4.3.0 heading).

### Gate (run locally, mirrors `release.yml` verify)
- `npm run release:check` → OK for 4.3.0
- `npm test` → 693 pass / 0 fail
- `npm run lint` → green
- `npm run dogfood` → all tracked docs under the gate
- `npm run benchmark` → 100% accuracy, ROC-AUC/PR-AUC 1.000 (no meaningful `docs/benchmarks` drift)
- `npm run check:no-private-assets` → 0 forbidden paths
- `npm pack --dry-run` → `patina-cli-4.3.0.tgz` (280 files) + `patina-humanizer-4.3.0.tgz`

### Publish — deferred to maintainer
Merging this PR does **not** publish. Per `release.yml`, npm publish (patina-cli + patina-humanizer, with provenance) is triggered by pushing the **`v4.3.0` tag** (or `workflow_dispatch` with `publish=true`). Tag push intentionally left to you.
