### PR TITLE
feat(benchmark): low-FPR (TPR@1%/5%FPR) detection metrics

### DIFF
--- a/docs/benchmarks/latest.json
+++ b/docs/benchmarks/latest.json
@@ -7,7 +7,7 @@
   "schemaVersion": 3,
   "fixtureSchemaVersion": 1,
   "nodeVersion": "v22.17.1",
-  "generatedAt": "2026-06-12T09:36:23.679Z",
+  "generatedAt": "2026-06-13T17:47:23.201Z",
   "fixtureCount": 49,
   "overallAccuracy": 1,
   "overall": {
@@ -340,6 +340,26 @@
       },
       "roc_auc": 1,
       "pr_auc": 1,
+      "low_fpr": [
+        {
+          "target_fpr": 0.01,
+          "negatives": 23,
+          "positives": 26,
+          "max_false_positives": 0,
+          "actual_fpr": 0,
+          "tpr": 1,
+          "supported": true
+        },
+        {
+          "target_fpr": 0.05,
+          "negatives": 23,
+          "positives": 26,
+          "max_false_positives": 1,
+          "actual_fpr": 0,
+          "tpr": 1,
+          "supported": true
+        }
+      ],
       "bestF1": {
         "threshold": 3.846,
         "tp": 26,
@@ -618,6 +638,26 @@
         },
         "roc_auc": 1,
         "pr_auc": 1,
+        "low_fpr": [
+          {
+            "target_fpr": 0.01,
+            "negatives": 6,
+            "positives": 7,
+            "max_false_positives": 0,
+            "actual_fpr": 0,
+            "tpr": 1,
+            "supported": true
+          },
+          {
+            "target_fpr": 0.05,
+            "negatives": 6,
+            "positives": 7,
+            "max_false_positives": 0,
+            "actual_fpr": 0,
+            "tpr": 1,
+            "supported": true
+          }
+        ],
         "bestF1": {
           "threshold": 50,
           "tp": 7,
@@ -751,6 +791,26 @@
         },
         "roc_auc": 1,
         "pr_auc": 1,
+        "low_fpr": [
+          {
+            "target_fpr": 0.01,
+            "negatives": 6,
+            "positives": 6,
+            "max_false_positives": 0,
+            "actual_fpr": 0,
+            "tpr": 1,
+            "supported": true
+          },
+          {
+            "target_fpr": 0.05,
+            "negatives": 6,
+            "positives": 6,
+            "max_false_positives": 0,
+            "actual_fpr": 0,
+            "tpr": 1,
+            "supported": true
+          }
+        ],
         "bestF1": {
           "threshold": 23.167,
           "tp": 6,
@@ -848,6 +908,26 @@
         },
         "roc_auc": 1,
         "pr_auc": 1,
+        "low_fpr": [
+          {
+            "target_fpr": 0.01,
+            "negatives": 5,
+            "positives": 7,
+            "max_false_positives": 0,
+            "actual_fpr": 0,
+            "tpr": 1,
+            "supported": true
+          },
+          {
+            "target_fpr": 0.05,
+            "negatives": 5,
+            "positives": 7,
+            "max_false_positives": 0,
+            "actual_fpr": 0,
+            "tpr": 1,
+            "supported": true
+          }
+        ],
         "bestF1": {
           "threshold": 3.846,
           "tp": 7,
@@ -957,6 +1037,26 @@
         },
         "roc_auc": 1,
         "pr_auc": 1,
+        "low_fpr": [
+          {
+            "target_fpr": 0.01,
+            "negatives": 6,
+            "positives": 6,
+            "max_false_positives": 0,
+            "actual_fpr": 0,
+            "tpr": 1,
+            "supported": true
+          },
+          {
+            "target_fpr": 0.05,
+            "negatives": 6,
+            "positives": 6,
+            "max_false_positives": 0,
+            "actual_fpr": 0,
+            "tpr": 1,
+            "supported": true
+          }
+        ],
         "bestF1": {
           "threshold": 6.772,
           "tp": 6,

--- a/docs/benchmarks/latest.md
+++ b/docs/benchmarks/latest.md
@@ -7,7 +7,7 @@ This is the latest checked-in report for patina's deterministic suspect-zone ben
 ## Current result
 
 - Status: **passing**
-- Generated at: 2026-06-12T09:36:23.679Z
+- Generated at: 2026-06-13T17:47:23.201Z
 - Node: v22.17.1
 - Fixture schema: v1
 - Fixtures: 49
@@ -63,6 +63,26 @@ only on the checked-in fixture corpus and is not a broader model-era claim.
 | ja | 12 | 6 | 6 | 1 | 1 | 23.167 | 100.0% | 100.0% | 1 | 100.0% |
 | ko | 12 | 7 | 5 | 1 | 1 | 3.846 | 100.0% | 100.0% | 1 | 100.0% |
 | zh | 12 | 6 | 6 | 1 | 1 | 6.772 | 100.0% | 100.0% | 1 | 100.0% |
+
+## Low-FPR operating points
+
+TPR at a fixed false-positive budget. Aggregate AUROC/accuracy can hide
+deployment failure, so these report the strict operating point on the checked-in
+fixture corpus. `n/a` marks a slice without enough negatives (or positives) to
+support the target; `max FP` of 0 is a strict zero-false-positive point.
+
+| scope | target FPR | negatives | max FP | actual FPR | TPR |
+|---|---:|---:|---:|---:|---:|
+| overall | 1.0% | 23 | 0 | 0.0% | 100.0% |
+| overall | 5.0% | 23 | 1 | 0.0% | 100.0% |
+| en | 1.0% | 6 | 0 | 0.0% | 100.0% |
+| en | 5.0% | 6 | 0 | 0.0% | 100.0% |
+| ja | 1.0% | 6 | 0 | 0.0% | 100.0% |
+| ja | 5.0% | 6 | 0 | 0.0% | 100.0% |
+| ko | 1.0% | 5 | 0 | 0.0% | 100.0% |
+| ko | 5.0% | 5 | 0 | 0.0% | 100.0% |
+| zh | 1.0% | 6 | 0 | 0.0% | 100.0% |
+| zh | 5.0% | 6 | 0 | 0.0% | 100.0% |
 
 ## Sample sizes
 

--- a/scripts/benchmark-report.mjs
+++ b/scripts/benchmark-report.mjs
@@ -52,6 +52,7 @@ function validateResultsSchema(results) {
   if (!isNumberOrNull(results?.ranking?.overall?.roc_auc)) missing.push('ranking.overall.roc_auc');
   if (!isNumberOrNull(results?.ranking?.overall?.pr_auc)) missing.push('ranking.overall.pr_auc');
   if (!results?.ranking?.overall?.bestF1) missing.push('ranking.overall.bestF1');
+  if (!Array.isArray(results?.ranking?.overall?.low_fpr)) missing.push('ranking.overall.low_fpr');
   for (const [lang, summary] of Object.entries(results?.perLanguage || {})) {
     for (const detector of ['burstiness', 'koDiagnostics', 'mattr', 'lexicon']) {
       if (!summary.byDetector?.[detector]) missing.push(`perLanguage.${lang}.byDetector.${detector}`);
@@ -128,6 +129,23 @@ function rankingRows(ranking = {}) {
     const best = summary.bestF1 || {};
     return `| ${cell(scope)} | ${summary.n} | ${summary.positives} | ${summary.negatives} | ${optionalNum(summary.roc_auc)} | ${optionalNum(summary.pr_auc)} | ${optionalNum(best.threshold)} | ${optionalPct(best.precision)} | ${optionalPct(best.recall)} | ${optionalNum(best.f1, 2)} | ${optionalPct(best.accuracy)} |`;
   });
+}
+
+function lowFprRows(ranking = {}) {
+  const scopes = [];
+  if (ranking.overall) scopes.push(['overall', ranking.overall]);
+  for (const [lang, summary] of Object.entries(ranking.perLanguage || {}).sort(([a], [b]) => a.localeCompare(b))) {
+    scopes.push([lang, summary]);
+  }
+  const rows = [];
+  for (const [scope, summary] of scopes) {
+    for (const m of summary.low_fpr || []) {
+      const tpr = m.tpr == null ? `n/a (${m.reason || 'unsupported'})` : optionalPct(m.tpr);
+      const actual = m.actual_fpr == null ? 'n/a' : optionalPct(m.actual_fpr);
+      rows.push(`| ${cell(scope)} | ${optionalPct(m.target_fpr)} | ${m.negatives} | ${m.max_false_positives} | ${actual} | ${tpr} |`);
+    }
+  }
+  return rows;
 }
 
 function classRows(fixtures = []) {
@@ -234,6 +252,17 @@ only on the checked-in fixture corpus and is not a broader model-era claim.
 | scope | fixtures | positives | negatives | ROC-AUC | PR-AUC | best threshold | precision | recall | best F1 | accuracy |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 ${rankingRows(results.ranking).join('\n')}
+
+## Low-FPR operating points
+
+TPR at a fixed false-positive budget. Aggregate AUROC/accuracy can hide
+deployment failure, so these report the strict operating point on the checked-in
+fixture corpus. \`n/a\` marks a slice without enough negatives (or positives) to
+support the target; \`max FP\` of 0 is a strict zero-false-positive point.
+
+| scope | target FPR | negatives | max FP | actual FPR | TPR |
+|---|---:|---:|---:|---:|---:|
+${lowFprRows(results.ranking).join('\n')}
 
 ## Sample sizes
 

--- a/tests/quality/ranking-metrics.mjs
+++ b/tests/quality/ranking-metrics.mjs
@@ -18,8 +18,73 @@ export function summarizeRanking(records = []) {
     scoreRange: scoreRange(normalized),
     roc_auc: round(rocAuc(normalized)),
     pr_auc: round(averagePrecision(normalized)),
+    low_fpr: lowFprSummaries(normalized),
     bestF1: best,
     sweep,
+  };
+}
+
+// Default low-FPR operating points reported alongside AUROC/PR-AUC.
+export const DEFAULT_LOW_FPR_TARGETS = [0.01, 0.05];
+
+// Low-FPR operating-point metrics: at a target false-positive rate, what TPR can
+// the signal reach without exceeding the FP budget? Aggregate AUROC/accuracy can
+// hide deployment failure, so these surface the strict operating point.
+// Diagnostics: no negatives -> unsupported (no_negatives); no positives ->
+// tpr null (no_positives); floor(target*negatives)==0 keeps a strict zero-FP
+// operating point (max_false_positives: 0) rather than failing.
+export function lowFprSummaries(records = [], targets = DEFAULT_LOW_FPR_TARGETS) {
+  return targets.map((target) => lowFprMetric(records, target));
+}
+
+export function lowFprMetric(records = [], targetFpr = 0.01) {
+  const normalized = records
+    .map((record) => ({ score: Number(record.score), expected: Boolean(record.expected) }))
+    .filter((record) => Number.isFinite(record.score));
+  const positives = normalized.filter((record) => record.expected).length;
+  const negatives = normalized.length - positives;
+  const maxFalsePositives = Math.floor(targetFpr * negatives);
+  const base = { target_fpr: targetFpr, negatives, positives, max_false_positives: maxFalsePositives };
+
+  if (negatives === 0) {
+    return { ...base, actual_fpr: null, tpr: null, supported: false, reason: 'no_negatives' };
+  }
+
+  // Pick the threshold that maximizes true positives while keeping the false
+  // positive count within budget. Deterministic tie-break: fewer false
+  // positives, then the higher (more conservative) threshold.
+  let best = null;
+  for (const threshold of thresholdCandidates(normalized)) {
+    let tp = 0;
+    let fp = 0;
+    for (const record of normalized) {
+      if (record.score >= threshold) {
+        if (record.expected) tp += 1;
+        else fp += 1;
+      }
+    }
+    if (fp > maxFalsePositives) continue;
+    const candidate = { tp, fp, threshold, actualFpr: fp / negatives };
+    if (
+      !best ||
+      candidate.tp > best.tp ||
+      (candidate.tp === best.tp && candidate.actualFpr < best.actualFpr) ||
+      (candidate.tp === best.tp && candidate.actualFpr === best.actualFpr && candidate.threshold > best.threshold)
+    ) {
+      best = candidate;
+    }
+  }
+  // `best` always exists: the highest sentinel threshold predicts nothing, so
+  // fp = 0 <= maxFalsePositives.
+
+  if (positives === 0) {
+    return { ...base, actual_fpr: round(best.actualFpr), tpr: null, supported: false, reason: 'no_positives' };
+  }
+  return {
+    ...base,
+    actual_fpr: round(best.actualFpr),
+    tpr: round(best.tp / positives),
+    supported: true,
   };
 }
 

--- a/tests/unit/ranking-metrics.test.js
+++ b/tests/unit/ranking-metrics.test.js
@@ -4,6 +4,8 @@ import { strict as assert } from 'node:assert';
 import {
   averagePrecision,
   bestF1Threshold,
+  lowFprMetric,
+  lowFprSummaries,
   rocAuc,
   summarizeRanking,
   thresholdSweep,
@@ -50,4 +52,55 @@ test('threshold sweep includes all-cold candidate and deterministic best-F1 tie 
 
   assert.ok(rows.some((row) => row.threshold === 101 && row.recall === 0));
   assert.equal(bestF1Threshold(rows).threshold, 100);
+});
+
+test('lowFprMetric reaches full TPR within the 1% FP budget on separable signal', () => {
+  const records = [];
+  for (let i = 0; i < 10; i++) records.push({ score: 90, expected: true });
+  records.push({ score: 95, expected: false }); // one risky negative
+  for (let i = 0; i < 99; i++) records.push({ score: 0, expected: false }); // 100 negatives total
+  const m = lowFprMetric(records, 0.01);
+  assert.equal(m.negatives, 100);
+  assert.equal(m.max_false_positives, 1); // floor(0.01 * 100)
+  assert.equal(m.tpr, 1);
+  assert.equal(m.actual_fpr, 0.01);
+  assert.equal(m.supported, true);
+});
+
+test('lowFprMetric keeps a strict zero-FP operating point when the budget floors to 0', () => {
+  const records = [{ score: 90, expected: true }, { score: 80, expected: false }];
+  for (let i = 0; i < 19; i++) records.push({ score: 0, expected: false }); // 20 negatives
+  const m = lowFprMetric(records, 0.01); // floor(0.01 * 20) = 0
+  assert.equal(m.max_false_positives, 0);
+  assert.equal(m.tpr, 1); // a threshold above 80 catches the positive with zero FP
+  assert.equal(m.actual_fpr, 0);
+  assert.equal(m.supported, true);
+});
+
+test('lowFprMetric is unsupported with no negatives and tpr-null with no positives', () => {
+  const noNeg = lowFprMetric([{ score: 80, expected: true }, { score: 90, expected: true }], 0.01);
+  assert.equal(noNeg.supported, false);
+  assert.equal(noNeg.reason, 'no_negatives');
+  assert.equal(noNeg.actual_fpr, null);
+  assert.equal(noNeg.tpr, null);
+
+  const noPos = lowFprMetric([{ score: 10, expected: false }, { score: 0, expected: false }], 0.05);
+  assert.equal(noPos.supported, false);
+  assert.equal(noPos.reason, 'no_positives');
+  assert.equal(noPos.tpr, null);
+});
+
+test('summarizeRanking includes low_fpr at the default 1% and 5% targets', () => {
+  const summary = summarizeRanking([
+    { score: 90, expected: true },
+    { score: 70, expected: true },
+    { score: 10, expected: false },
+    { score: 0, expected: false },
+  ]);
+  assert.equal(Array.isArray(summary.low_fpr), true);
+  assert.deepEqual(summary.low_fpr.map((m) => m.target_fpr), [0.01, 0.05]);
+  for (const m of summary.low_fpr) {
+    for (const k of ['target_fpr', 'negatives', 'max_false_positives']) assert.ok(k in m);
+  }
+  assert.equal(lowFprSummaries([]).length, 2);
 });


### PR DESCRIPTION
Wave 0 (B1) of the approved ralplan plan (run 2026-06-03-1359-33c4). Adds strict low-false-positive operating points to the ranking diagnostics — aggregate AUROC/accuracy can hide deployment failure.

- `ranking-metrics.mjs`: `lowFprMetric`/`lowFprSummaries` (defaults 1%/5%) wired into `summarizeRanking.low_fpr`. Schema: target_fpr, negatives, positives, max_false_positives=floor(target*negatives), actual_fpr, tpr, supported, reason. Threshold maximizes TP within budget; deterministic tie-break (lower actual FPR → higher threshold). Diagnostics: no_negatives / no_positives / strict zero-FP when floor==0.
- `ranking-metrics.test.js`: separable-signal 1% budget, strict zero-FP, no-negative/no-positive diagnostics, summarizeRanking integration.
- `benchmark-report.mjs`: "Low-FPR operating points" section + `validateResultsSchema` now requires `ranking.overall.low_fpr`.
- `docs/benchmarks/latest.{md,json}`: regenerated. ROC-AUC/PR-AUC/accuracy/precision/recall/F1 unchanged; benchmark still 100%.

`src/features/*` untouched; no new dep. Gate: architect CLEAR×3/APPROVE, executor QA passed (algorithm+CLI). Verify: `node --test tests/unit/ranking-metrics.test.js` (8), full suite **704 pass**, lint green, benchmark **100%**, dogfood OK.