### PR TITLE
test(benchmark): fix red main — add low_fpr to benchmarkResults helper

### DIFF
--- a/tests/unit/benchmark-report.test.js
+++ b/tests/unit/benchmark-report.test.js
@@ -60,6 +60,10 @@ function benchmarkResults(overrides = {}) {
           f1: 1,
           accuracy: 1,
         },
+        low_fpr: [
+          { target_fpr: 0.01, negatives: 0, max_false_positives: 0, actual_fpr: null, tpr: null, supported: false, reason: 'no_negatives' },
+          { target_fpr: 0.05, negatives: 0, max_false_positives: 0, actual_fpr: null, tpr: null, supported: false, reason: 'no_negatives' },
+        ],
       },
       perLanguage: {},
     },


### PR DESCRIPTION
## Problem
PR #472 (B1 low-FPR metrics) added a `validateResultsSchema` guard requiring `ranking.overall.low_fpr` (an array), but did not update the `benchmarkResults()` test fixture in `tests/unit/benchmark-report.test.js`. The admin squash-merge bypassed the CI wait, so `main` has been failing the test `benchmark report renders undefined ranking metrics as unavailable, not zero` (1 failing test).

## Fix
Add the realistic `no_negatives` low-FPR diagnostics (negatives:0) to the `benchmarkResults()` helper's `ranking.overall` so the schema guard passes. Test-only change; no runtime/behavior impact.

## Verify
- `node --test tests/unit/benchmark-report.test.js` → 2/2 pass
- Full suite: 704 pass / 0 fail
- `npm run lint` green