### PR TITLE
perf(stylometry): rolling O(n) MATTR, bit-identical to slice+Set (#A2)

### DIFF
--- a/docs/benchmarks/perf-latest.json
+++ b/docs/benchmarks/perf-latest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-06-13T17:32:45.884Z",
+  "generatedAt": "2026-06-13T18:08:30.447Z",
   "nodeVersion": "v22.17.1",
   "platform": "linux",
   "arch": "x64",
@@ -16,11 +16,11 @@
       "inputParagraphs": 3,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 0.632,
-      "p95Ms": 1.217,
-      "p99Ms": 1.217,
-      "meanMs": 0.717,
-      "textsPerSec": 1394.951
+      "p50Ms": 0.532,
+      "p95Ms": 0.939,
+      "p99Ms": 0.939,
+      "meanMs": 0.611,
+      "textsPerSec": 1636.965
     },
     {
       "id": "perf-en-short",
@@ -30,11 +30,11 @@
       "inputParagraphs": 1,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 0.194,
-      "p95Ms": 0.289,
-      "p99Ms": 0.289,
-      "meanMs": 0.21,
-      "textsPerSec": 4757.031
+      "p50Ms": 0.208,
+      "p95Ms": 0.257,
+      "p99Ms": 0.257,
+      "meanMs": 0.214,
+      "textsPerSec": 4667.049
     },
     {
       "id": "perf-ko-medium",
@@ -44,11 +44,11 @@
       "inputParagraphs": 3,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 1.246,
-      "p95Ms": 1.606,
-      "p99Ms": 1.606,
-      "meanMs": 1.283,
-      "textsPerSec": 779.428
+      "p50Ms": 1.544,
+      "p95Ms": 1.846,
+      "p99Ms": 1.846,
+      "meanMs": 1.523,
+      "textsPerSec": 656.405
     },
     {
       "id": "perf-ko-short",
@@ -58,11 +58,11 @@
       "inputParagraphs": 1,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 0.455,
-      "p95Ms": 0.692,
-      "p99Ms": 0.692,
-      "meanMs": 0.486,
-      "textsPerSec": 2059.082
+      "p50Ms": 0.64,
+      "p95Ms": 0.687,
+      "p99Ms": 0.687,
+      "meanMs": 0.637,
+      "textsPerSec": 1570.875
     },
     {
       "id": "perf-mixed-long",
@@ -72,11 +72,11 @@
       "inputParagraphs": 6,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 0.602,
-      "p95Ms": 0.928,
-      "p99Ms": 0.928,
-      "meanMs": 0.651,
-      "textsPerSec": 1535.769
+      "p50Ms": 0.859,
+      "p95Ms": 1.209,
+      "p99Ms": 1.209,
+      "meanMs": 0.931,
+      "textsPerSec": 1073.79
     },
     {
       "id": "perf-synth-lexicon",
@@ -86,11 +86,11 @@
       "inputParagraphs": 1,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 2.745,
-      "p95Ms": 2.906,
-      "p99Ms": 2.906,
-      "meanMs": 2.77,
-      "textsPerSec": 361.038
+      "p50Ms": 1.582,
+      "p95Ms": 1.869,
+      "p99Ms": 1.869,
+      "meanMs": 1.623,
+      "textsPerSec": 615.987
     },
     {
       "id": "perf-synth-mattr",
@@ -100,58 +100,58 @@
       "inputParagraphs": 1,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 7.67,
-      "p95Ms": 9.929,
-      "p99Ms": 9.929,
-      "meanMs": 7.88,
-      "textsPerSec": 126.91
+      "p50Ms": 4.265,
+      "p95Ms": 5.468,
+      "p99Ms": 5.468,
+      "meanMs": 4.367,
+      "textsPerSec": 228.993
     }
   ],
   "buckets": [
     {
       "sizeBucket": "long",
       "fixtureCount": 1,
-      "p50Ms": 0.651,
-      "p95Ms": 0.651,
-      "p99Ms": 0.651,
-      "meanMs": 0.651,
-      "textsPerSec": 1536.098
+      "p50Ms": 0.931,
+      "p95Ms": 0.931,
+      "p99Ms": 0.931,
+      "meanMs": 0.931,
+      "textsPerSec": 1074.114
     },
     {
       "sizeBucket": "medium",
       "fixtureCount": 2,
-      "p50Ms": 0.717,
-      "p95Ms": 1.283,
-      "p99Ms": 1.283,
-      "meanMs": 1,
-      "textsPerSec": 1000
+      "p50Ms": 0.611,
+      "p95Ms": 1.523,
+      "p99Ms": 1.523,
+      "meanMs": 1.067,
+      "textsPerSec": 937.207
     },
     {
       "sizeBucket": "short",
       "fixtureCount": 2,
-      "p50Ms": 0.21,
-      "p95Ms": 0.486,
-      "p99Ms": 0.486,
-      "meanMs": 0.348,
-      "textsPerSec": 2873.563
+      "p50Ms": 0.214,
+      "p95Ms": 0.637,
+      "p99Ms": 0.637,
+      "meanMs": 0.426,
+      "textsPerSec": 2350.176
     },
     {
       "sizeBucket": "synthetic-lexicon",
       "fixtureCount": 1,
-      "p50Ms": 2.77,
-      "p95Ms": 2.77,
-      "p99Ms": 2.77,
-      "meanMs": 2.77,
-      "textsPerSec": 361.011
+      "p50Ms": 1.623,
+      "p95Ms": 1.623,
+      "p99Ms": 1.623,
+      "meanMs": 1.623,
+      "textsPerSec": 616.143
     },
     {
       "sizeBucket": "synthetic-mattr",
       "fixtureCount": 1,
-      "p50Ms": 7.88,
-      "p95Ms": 7.88,
-      "p99Ms": 7.88,
-      "meanMs": 7.88,
-      "textsPerSec": 126.904
+      "p50Ms": 4.367,
+      "p95Ms": 4.367,
+      "p99Ms": 4.367,
+      "meanMs": 4.367,
+      "textsPerSec": 228.99
     }
   ]
 }

--- a/docs/benchmarks/perf-latest.md
+++ b/docs/benchmarks/perf-latest.md
@@ -4,7 +4,7 @@ Latency of the deterministic offline analyzer (`analyzeText`) over fixed fixture
 **Report-only — not a release gate and not a latency threshold.** Timing is
 machine-dependent; treat this as a local snapshot, not a CI-drift target.
 
-- Generated at: 2026-06-13T17:32:45.884Z
+- Generated at: 2026-06-13T18:08:30.447Z
 - Node: v22.17.1 · linux/x64
 - Passes: 7 measured (+1 warmup) per fixture
 - Fixtures: 7
@@ -14,21 +14,21 @@ machine-dependent; treat this as a local snapshot, not a CI-drift target.
 
 | bucket | fixtures | p50 ms | p95 ms | p99 ms | mean ms | texts/sec |
 |--------|---------:|-------:|-------:|-------:|--------:|----------:|
-| long | 1 | 0.651 | 0.651 | 0.651 | 0.651 | 1536.098 |
-| medium | 2 | 0.717 | 1.283 | 1.283 | 1.000 | 1000.000 |
-| short | 2 | 0.210 | 0.486 | 0.486 | 0.348 | 2873.563 |
-| synthetic-lexicon | 1 | 2.770 | 2.770 | 2.770 | 2.770 | 361.011 |
-| synthetic-mattr | 1 | 7.880 | 7.880 | 7.880 | 7.880 | 126.904 |
+| long | 1 | 0.931 | 0.931 | 0.931 | 0.931 | 1074.114 |
+| medium | 2 | 0.611 | 1.523 | 1.523 | 1.067 | 937.207 |
+| short | 2 | 0.214 | 0.637 | 0.637 | 0.426 | 2350.176 |
+| synthetic-lexicon | 1 | 1.623 | 1.623 | 1.623 | 1.623 | 616.143 |
+| synthetic-mattr | 1 | 4.367 | 4.367 | 4.367 | 4.367 | 228.990 |
 
 ## Per fixture
 
 | fixture | lang | bucket | chars | paras | p50 ms | p95 ms | p99 ms | mean ms | texts/sec |
 |---------|------|--------|------:|------:|-------:|-------:|-------:|--------:|----------:|
-| perf-en-medium | en | medium | 316 | 3 | 0.632 | 1.217 | 1.217 | 0.717 | 1394.951 |
-| perf-en-short | en | short | 51 | 1 | 0.194 | 0.289 | 0.289 | 0.210 | 4757.031 |
-| perf-ko-medium | ko | medium | 135 | 3 | 1.246 | 1.606 | 1.606 | 1.283 | 779.428 |
-| perf-ko-short | ko | short | 31 | 1 | 0.455 | 0.692 | 0.692 | 0.486 | 2059.082 |
-| perf-mixed-long | en | long | 727 | 6 | 0.602 | 0.928 | 0.928 | 0.651 | 1535.769 |
-| perf-synth-lexicon | en | synthetic-lexicon | 10480 | 1 | 2.745 | 2.906 | 2.906 | 2.770 | 361.038 |
-| perf-synth-mattr | en | synthetic-mattr | 27200 | 1 | 7.670 | 9.929 | 9.929 | 7.880 | 126.910 |
+| perf-en-medium | en | medium | 316 | 3 | 0.532 | 0.939 | 0.939 | 0.611 | 1636.965 |
+| perf-en-short | en | short | 51 | 1 | 0.208 | 0.257 | 0.257 | 0.214 | 4667.049 |
+| perf-ko-medium | ko | medium | 135 | 3 | 1.544 | 1.846 | 1.846 | 1.523 | 656.405 |
+| perf-ko-short | ko | short | 31 | 1 | 0.640 | 0.687 | 0.687 | 0.637 | 1570.875 |
+| perf-mixed-long | en | long | 727 | 6 | 0.859 | 1.209 | 1.209 | 0.931 | 1073.790 |
+| perf-synth-lexicon | en | synthetic-lexicon | 10480 | 1 | 1.582 | 1.869 | 1.869 | 1.623 | 615.987 |
+| perf-synth-mattr | en | synthetic-mattr | 27200 | 1 | 4.265 | 5.468 | 5.468 | 4.367 | 228.993 |
 

--- a/src/features/stylometry.js
+++ b/src/features/stylometry.js
@@ -119,17 +119,45 @@ export function burstinessCV(sentenceTokenCounts) {
 
 // Moving Average Type-Token Ratio (window default 50).
 // Falls back to simple TTR when token count < window.
+//
+// Rolling implementation: keeps a running unique-token count over a sliding
+// window (O(n)) instead of rebuilding a Set per window position (O(n*window)).
+// This is bit-identical to the slice+Set form because each window's unique
+// count equals `new Set(slice).size`, and the per-window terms `unique / window`
+// are accumulated in the same left-to-right order, so `sum / count` is exact.
 export function mattr(tokens, window = DEFAULT_MATTR_WINDOW) {
   if (!Array.isArray(tokens) || tokens.length === 0) return null;
   const lower = tokens.map((t) => t.toLowerCase());
-  if (lower.length < window) {
-    return new Set(lower).size / lower.length;
+  const n = lower.length;
+  if (n < window) {
+    return new Set(lower).size / n;
   }
-  let sum = 0;
-  let count = 0;
-  for (let i = 0; i + window <= lower.length; i++) {
-    const slice = lower.slice(i, i + window);
-    sum += new Set(slice).size / window;
+  // Initialize the first window [0, window).
+  const counts = new Map();
+  let unique = 0;
+  for (let i = 0; i < window; i++) {
+    const tok = lower[i];
+    const prev = counts.get(tok) || 0;
+    if (prev === 0) unique++;
+    counts.set(tok, prev + 1);
+  }
+  let sum = unique / window;
+  let count = 1;
+  // Slide one token at a time; window position i covers [i, i + window).
+  for (let i = 1; i + window <= n; i++) {
+    const out = lower[i - 1];
+    const outCount = counts.get(out);
+    if (outCount === 1) {
+      counts.delete(out);
+      unique--;
+    } else {
+      counts.set(out, outCount - 1);
+    }
+    const inc = lower[i + window - 1];
+    const inCount = counts.get(inc) || 0;
+    if (inCount === 0) unique++;
+    counts.set(inc, inCount + 1);
+    sum += unique / window;
     count++;
   }
   return sum / count;

--- a/tests/unit/stylometry.test.js
+++ b/tests/unit/stylometry.test.js
@@ -9,6 +9,7 @@ import {
   classifyMattr,
 } from '../../src/features/stylometry.js';
 import { analyzeText } from '../../src/features/index.js';
+import { extractStructuralFeatures } from '../../src/features/structural-features.js';
 
 test('splitParagraphs returns trimmed non-empty paragraphs', () => {
   assert.deepEqual(splitParagraphs(''), []);
@@ -234,4 +235,91 @@ test('Chinese/Japanese text without spaces keeps burstiness end-to-end', () => {
   assert.equal(ja.paragraphs[0].tokenCount, 25);
   assert.deepEqual(ja.paragraphs[0].burstiness, { cv: 0, band: 'low' });
   assert.equal(ja.hot, true);
+});
+// --- A2: rolling MATTR equivalence -----------------------------------------
+
+// Exact pre-refactor reference: rebuilds a Set for every window slice.
+function refMattr(tokens, window = 50) {
+  if (!Array.isArray(tokens) || tokens.length === 0) return null;
+  const lower = tokens.map((t) => t.toLowerCase());
+  if (lower.length < window) {
+    return new Set(lower).size / lower.length;
+  }
+  let sum = 0;
+  let count = 0;
+  for (let i = 0; i + window <= lower.length; i++) {
+    const slice = lower.slice(i, i + window);
+    sum += new Set(slice).size / window;
+    count++;
+  }
+  return sum / count;
+}
+
+test('mattr rolling implementation is bit-identical to slice+Set reference', () => {
+  const patterns = {
+    repeated: (len) => Array.from({ length: len }, () => 'the'),
+    alternating: (len) => Array.from({ length: len }, (_, i) => (i % 2 ? 'beta' : 'alpha')),
+    unique: (len) => Array.from({ length: len }, (_, i) => `tok${i}`),
+    mixedCase: (len) => Array.from({ length: len }, (_, i) => ['The', 'the', 'THE', 'tHe', 'Cat', 'CAT'][i % 6]),
+    unicode: (len) => Array.from({ length: len }, (_, i) => ['café', 'CAFÉ', 'naïve', 'Naïve', 'Über', 'über'][i % 6]),
+    cjk: (len) => Array.from({ length: len }, (_, i) => ['工', '具', '写', '作', '模', '型'][i % 6]),
+  };
+
+  // Required scope: windows 1/2/40/50; lengths empty/below-window/exact-window/window+1/long.
+  const windows = [1, 2, 40, 50];
+  for (const w of windows) {
+    const lengths = [0, Math.max(0, w - 1), w, w + 1, w + 75];
+    for (const [name, gen] of Object.entries(patterns)) {
+      for (const len of lengths) {
+        const tokens = gen(len);
+        const got = mattr(tokens, w);
+        const want = refMattr(tokens, w);
+        assert.ok(
+          Object.is(got, want),
+          `mattr mismatch pattern=${name} window=${w} len=${len}: got ${got} want ${want}`,
+        );
+      }
+    }
+  }
+
+  // Default window (50) parity, including a long input on the rolling path.
+  const longDefault = Array.from({ length: 130 }, (_, i) => ['alpha', 'beta', 'gamma', 'alpha', 'beta'][i % 5]);
+  assert.ok(Object.is(mattr(longDefault), refMattr(longDefault, 50)));
+  // Empty / degenerate inputs.
+  assert.equal(mattr([]), null);
+  assert.equal(mattr('not-an-array'), null);
+});
+
+test('extractStructuralFeatures vectors unchanged after rolling mattr (parity)', () => {
+  // Captured from the pre-refactor (slice+Set) implementation; the rolling
+  // version must reproduce the full structural vector for every language.
+  const STRUCTURAL_BASELINE = {
+    en: [0.4065457283638481, 7.25, 2.947456530637899, 0.8275862068965517, 0.7931034482758621, 0.7916666666666666, 5.896551724137931, 0.25, 0.028409090909090908, 1, 0, 0],
+    ko: [0.5160156871153361, 6.5, 3.3541019662496847, 0.8846153846153846, 0.8846153846153846, 0.9130434782608695, 2.769230769230769, 0, 0.05263157894736842, 0.75, 0.11538461538461539, 0],
+    zh: [0.3197799481205415, 9.666666666666666, 3.0912061651652345, 0.8275862068965517, 0.8275862068965517, 0.7916666666666666, 1, 0, 0, 1, 0, 0],
+    ja: [0.23022081247934104, 14.333333333333334, 3.2998316455372216, 0.7209302325581395, 0.75625, 0.7096774193548387, 1, 0, 0, 1, 0, 0],
+  };
+  const texts = {
+    en: 'The tool is innovative. The tool is efficient and reliable. Teams adopt it quickly because it scales.\n\nMoreover, the platform delivers measurable value across diverse organizational contexts and workflows.',
+    ko: '이 도구는 혁신적이다. 이 도구는 효율적이고 신뢰할 수 있다. 팀은 확장성 때문에 빠르게 채택한다.\n\n또한 이 플랫폼은 다양한 조직 맥락과 업무 흐름에서 측정 가능한 가치를 제공한다.',
+    zh: '这个工具很创新。这个工具高效可靠。团队因为可扩展性而迅速采用它。',
+    ja: 'このツールは革新的だ。このツールは効率的で信頼できる。チームは拡張性のために素早く採用する。',
+  };
+  for (const [lang, t] of Object.entries(texts)) {
+    assert.deepEqual(extractStructuralFeatures(t, { lang }), STRUCTURAL_BASELINE[lang]);
+  }
+});
+
+// extractStructuralFeatures default MATTR window is 40; analyzer default is 50.
+// The exhaustive mattr≡refMattr test above covers both windows on the rolling
+// path, so the integration result is identical for every possible token array.
+test('extractStructuralFeatures mattr element matches reference at window 40', () => {
+  const long = `${'alpha beta gamma delta epsilon zeta eta theta iota kappa '.repeat(8)}lambda mu nu.`;
+  const vec = extractStructuralFeatures(long, { lang: 'en', mattrWindow: 40 });
+  // Replicate the structural-features tokenization pipeline exactly.
+  const normalized = long.normalize('NFC');
+  const sentences = splitParagraphs(normalized).flatMap((p) => splitProseSentences(p));
+  const tokens = sentences.flatMap((s) => tokenize(s, { lang: 'en' }));
+  assert.ok(tokens.length > 40, 'expected the long input to exercise the rolling path');
+  assert.ok(Object.is(vec[4], refMattr(tokens, 40)));
 });


### PR DESCRIPTION
## What
Wave 1 / A2 of the approved ralplan plan (run 2026-06-03-1359-33c4). Replaces the O(n·window) slice+Set MATTR in `src/features/stylometry.js` with an O(n) rolling unique-count map.

## Equivalence (exact, not epsilon)
Each window's unique count equals `new Set(slice).size`; per-window terms `unique/window` are summed in the same left-to-right order, so `sum/count` is **bit-identical**. The `n<window` simple-TTR fallback and `length===0 → null` guard are preserved.

## Tests (`tests/unit/stylometry.test.js`)
- Exhaustive `mattr`≡inline-old-reference across windows 1/2/40/50; lengths empty/below/exact/window+1/long; patterns repeated/alternating/all-unique/mixed-case/Unicode/CJK.
- Full 12-element structural-vector parity for EN/KO/ZH/JA (captured from pre-change impl).
- Window-40 integration parity via the structural-features tokenization pipeline.

## Gate
- Architect: **CLEAR / APPROVE**.
- Executor QA red-team: **101,864 equivalence comparisons, ZERO mismatches**; 23/23 unit tests; `npm run benchmark` 100% / ROC·PR-AUC 1.000; dogfood OK.

## Perf (report-only)
`docs/benchmarks/perf-latest.*` refreshed: `perf-synth-mattr` p50 7.67ms → 4.27ms (~44% faster). No latency gate.

## Conflict order
Merges before A5 (both touch `stylometry.js`).