### PR TITLE
perf(lexicon): cache phrase/strict regexes per lexicon (#A3)

### DIFF
--- a/docs/benchmarks/perf-latest.json
+++ b/docs/benchmarks/perf-latest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-06-13T18:08:30.447Z",
+  "generatedAt": "2026-06-13T18:19:14.885Z",
   "nodeVersion": "v22.17.1",
   "platform": "linux",
   "arch": "x64",
@@ -16,11 +16,11 @@
       "inputParagraphs": 3,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 0.532,
-      "p95Ms": 0.939,
-      "p99Ms": 0.939,
-      "meanMs": 0.611,
-      "textsPerSec": 1636.965
+      "p50Ms": 0.398,
+      "p95Ms": 1.559,
+      "p99Ms": 1.559,
+      "meanMs": 0.622,
+      "textsPerSec": 1608.104
     },
     {
       "id": "perf-en-short",
@@ -30,11 +30,11 @@
       "inputParagraphs": 1,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 0.208,
-      "p95Ms": 0.257,
-      "p99Ms": 0.257,
-      "meanMs": 0.214,
-      "textsPerSec": 4667.049
+      "p50Ms": 0.241,
+      "p95Ms": 0.302,
+      "p99Ms": 0.302,
+      "meanMs": 0.245,
+      "textsPerSec": 4073.498
     },
     {
       "id": "perf-ko-medium",
@@ -44,11 +44,11 @@
       "inputParagraphs": 3,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 1.544,
-      "p95Ms": 1.846,
-      "p99Ms": 1.846,
-      "meanMs": 1.523,
-      "textsPerSec": 656.405
+      "p50Ms": 1.257,
+      "p95Ms": 1.438,
+      "p99Ms": 1.438,
+      "meanMs": 1.218,
+      "textsPerSec": 820.682
     },
     {
       "id": "perf-ko-short",
@@ -58,11 +58,11 @@
       "inputParagraphs": 1,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 0.64,
-      "p95Ms": 0.687,
-      "p99Ms": 0.687,
-      "meanMs": 0.637,
-      "textsPerSec": 1570.875
+      "p50Ms": 0.489,
+      "p95Ms": 0.618,
+      "p99Ms": 0.618,
+      "meanMs": 0.49,
+      "textsPerSec": 2041.142
     },
     {
       "id": "perf-mixed-long",
@@ -72,11 +72,11 @@
       "inputParagraphs": 6,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 0.859,
-      "p95Ms": 1.209,
-      "p99Ms": 1.209,
-      "meanMs": 0.931,
-      "textsPerSec": 1073.79
+      "p50Ms": 0.445,
+      "p95Ms": 0.886,
+      "p99Ms": 0.886,
+      "meanMs": 0.518,
+      "textsPerSec": 1928.951
     },
     {
       "id": "perf-synth-lexicon",
@@ -86,11 +86,11 @@
       "inputParagraphs": 1,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 1.582,
-      "p95Ms": 1.869,
-      "p99Ms": 1.869,
-      "meanMs": 1.623,
-      "textsPerSec": 615.987
+      "p50Ms": 1.117,
+      "p95Ms": 1.478,
+      "p99Ms": 1.478,
+      "meanMs": 1.216,
+      "textsPerSec": 822.696
     },
     {
       "id": "perf-synth-mattr",
@@ -100,58 +100,58 @@
       "inputParagraphs": 1,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 4.265,
-      "p95Ms": 5.468,
-      "p99Ms": 5.468,
-      "meanMs": 4.367,
-      "textsPerSec": 228.993
+      "p50Ms": 3.394,
+      "p95Ms": 4.341,
+      "p99Ms": 4.341,
+      "meanMs": 3.347,
+      "textsPerSec": 298.82
     }
   ],
   "buckets": [
     {
       "sizeBucket": "long",
       "fixtureCount": 1,
-      "p50Ms": 0.931,
-      "p95Ms": 0.931,
-      "p99Ms": 0.931,
-      "meanMs": 0.931,
-      "textsPerSec": 1074.114
+      "p50Ms": 0.518,
+      "p95Ms": 0.518,
+      "p99Ms": 0.518,
+      "meanMs": 0.518,
+      "textsPerSec": 1930.502
     },
     {
       "sizeBucket": "medium",
       "fixtureCount": 2,
-      "p50Ms": 0.611,
-      "p95Ms": 1.523,
-      "p99Ms": 1.523,
-      "meanMs": 1.067,
-      "textsPerSec": 937.207
+      "p50Ms": 0.622,
+      "p95Ms": 1.218,
+      "p99Ms": 1.218,
+      "meanMs": 0.92,
+      "textsPerSec": 1086.957
     },
     {
       "sizeBucket": "short",
       "fixtureCount": 2,
-      "p50Ms": 0.214,
-      "p95Ms": 0.637,
-      "p99Ms": 0.637,
-      "meanMs": 0.426,
-      "textsPerSec": 2350.176
+      "p50Ms": 0.245,
+      "p95Ms": 0.49,
+      "p99Ms": 0.49,
+      "meanMs": 0.368,
+      "textsPerSec": 2721.088
     },
     {
       "sizeBucket": "synthetic-lexicon",
       "fixtureCount": 1,
-      "p50Ms": 1.623,
-      "p95Ms": 1.623,
-      "p99Ms": 1.623,
-      "meanMs": 1.623,
-      "textsPerSec": 616.143
+      "p50Ms": 1.216,
+      "p95Ms": 1.216,
+      "p99Ms": 1.216,
+      "meanMs": 1.216,
+      "textsPerSec": 822.368
     },
     {
       "sizeBucket": "synthetic-mattr",
       "fixtureCount": 1,
-      "p50Ms": 4.367,
-      "p95Ms": 4.367,
-      "p99Ms": 4.367,
-      "meanMs": 4.367,
-      "textsPerSec": 228.99
+      "p50Ms": 3.347,
+      "p95Ms": 3.347,
+      "p99Ms": 3.347,
+      "meanMs": 3.347,
+      "textsPerSec": 298.775
     }
   ]
 }

--- a/docs/benchmarks/perf-latest.md
+++ b/docs/benchmarks/perf-latest.md
@@ -4,7 +4,7 @@ Latency of the deterministic offline analyzer (`analyzeText`) over fixed fixture
 **Report-only — not a release gate and not a latency threshold.** Timing is
 machine-dependent; treat this as a local snapshot, not a CI-drift target.
 
-- Generated at: 2026-06-13T18:08:30.447Z
+- Generated at: 2026-06-13T18:19:14.885Z
 - Node: v22.17.1 · linux/x64
 - Passes: 7 measured (+1 warmup) per fixture
 - Fixtures: 7
@@ -14,21 +14,21 @@ machine-dependent; treat this as a local snapshot, not a CI-drift target.
 
 | bucket | fixtures | p50 ms | p95 ms | p99 ms | mean ms | texts/sec |
 |--------|---------:|-------:|-------:|-------:|--------:|----------:|
-| long | 1 | 0.931 | 0.931 | 0.931 | 0.931 | 1074.114 |
-| medium | 2 | 0.611 | 1.523 | 1.523 | 1.067 | 937.207 |
-| short | 2 | 0.214 | 0.637 | 0.637 | 0.426 | 2350.176 |
-| synthetic-lexicon | 1 | 1.623 | 1.623 | 1.623 | 1.623 | 616.143 |
-| synthetic-mattr | 1 | 4.367 | 4.367 | 4.367 | 4.367 | 228.990 |
+| long | 1 | 0.518 | 0.518 | 0.518 | 0.518 | 1930.502 |
+| medium | 2 | 0.622 | 1.218 | 1.218 | 0.920 | 1086.957 |
+| short | 2 | 0.245 | 0.490 | 0.490 | 0.368 | 2721.088 |
+| synthetic-lexicon | 1 | 1.216 | 1.216 | 1.216 | 1.216 | 822.368 |
+| synthetic-mattr | 1 | 3.347 | 3.347 | 3.347 | 3.347 | 298.775 |
 
 ## Per fixture
 
 | fixture | lang | bucket | chars | paras | p50 ms | p95 ms | p99 ms | mean ms | texts/sec |
 |---------|------|--------|------:|------:|-------:|-------:|-------:|--------:|----------:|
-| perf-en-medium | en | medium | 316 | 3 | 0.532 | 0.939 | 0.939 | 0.611 | 1636.965 |
-| perf-en-short | en | short | 51 | 1 | 0.208 | 0.257 | 0.257 | 0.214 | 4667.049 |
-| perf-ko-medium | ko | medium | 135 | 3 | 1.544 | 1.846 | 1.846 | 1.523 | 656.405 |
-| perf-ko-short | ko | short | 31 | 1 | 0.640 | 0.687 | 0.687 | 0.637 | 1570.875 |
-| perf-mixed-long | en | long | 727 | 6 | 0.859 | 1.209 | 1.209 | 0.931 | 1073.790 |
-| perf-synth-lexicon | en | synthetic-lexicon | 10480 | 1 | 1.582 | 1.869 | 1.869 | 1.623 | 615.987 |
-| perf-synth-mattr | en | synthetic-mattr | 27200 | 1 | 4.265 | 5.468 | 5.468 | 4.367 | 228.993 |
+| perf-en-medium | en | medium | 316 | 3 | 0.398 | 1.559 | 1.559 | 0.622 | 1608.104 |
+| perf-en-short | en | short | 51 | 1 | 0.241 | 0.302 | 0.302 | 0.245 | 4073.498 |
+| perf-ko-medium | ko | medium | 135 | 3 | 1.257 | 1.438 | 1.438 | 1.218 | 820.682 |
+| perf-ko-short | ko | short | 31 | 1 | 0.489 | 0.618 | 0.618 | 0.490 | 2041.142 |
+| perf-mixed-long | en | long | 727 | 6 | 0.445 | 0.886 | 0.886 | 0.518 | 1928.951 |
+| perf-synth-lexicon | en | synthetic-lexicon | 10480 | 1 | 1.117 | 1.478 | 1.478 | 1.216 | 822.696 |
+| perf-synth-mattr | en | synthetic-mattr | 27200 | 1 | 3.394 | 4.341 | 4.341 | 3.347 | 298.820 |
 

--- a/src/features/lexicon-core.js
+++ b/src/features/lexicon-core.js
@@ -58,6 +58,32 @@ function strictEntryRegex(lowerEntry) {
   return new RegExp(`(?<![\\p{L}\\p{N}])${escaped}(?![\\p{L}\\p{N}])`, 'u');
 }
 
+// Per-lexicon regex caches keyed by the lexicon object identity. Phrase and
+// strict-entry regexes depend only on the lexicon's entry text, never on the
+// paragraph under test, so they are compiled once per (lexicon, entry) pair
+// and reused across every computeDensity() call. WeakMaps keep the cache OFF
+// the lexicon object — Object.keys(lexicon) and JSON.stringify(lexicon) are
+// unchanged, and a lexicon's cache is garbage-collected with it. The compiled
+// regexes are non-global and non-sticky (no /g or /y flags), so repeated
+// .test() calls carry no lastIndex state and are safe to share. Entries are
+// keyed by string, so any later-added phrase/entry is compiled lazily.
+const phraseRegexCache = new WeakMap();
+const strictEntryRegexCache = new WeakMap();
+
+function memoizedRegex(cache, lexicon, key, build) {
+  let byKey = cache.get(lexicon);
+  if (!byKey) {
+    byKey = new Map();
+    cache.set(lexicon, byKey);
+  }
+  let regex = byKey.get(key);
+  if (!regex) {
+    regex = build(key);
+    byKey.set(key, regex);
+  }
+  return regex;
+}
+
 // Counts paragraph-level lexicon hits. Strict entries match whole-word
 // (Unicode-aware boundaries via \p{L}\p{N}); phrases match as substrings
 // with `~` wildcard support. Each entry counts at most once per paragraph.
@@ -84,12 +110,12 @@ export function computeDensity(paragraphText, tokens, lexicon) {
     const isMultiToken = /[^\p{L}\p{N}]/u.test(lowerEntry);
     if (cjkSubstring) {
       if (lowerText.includes(lowerEntry)) hits.push(entry);
-    } else if (isMultiToken && strictEntryRegex(lowerEntry).test(lowerText)) {
+    } else if (isMultiToken && memoizedRegex(strictEntryRegexCache, lexicon, lowerEntry, strictEntryRegex).test(lowerText)) {
       hits.push(entry);
     }
   }
   for (const phrase of lexicon.phrases) {
-    if (phraseToRegex(phrase).test(lowerText)) hits.push(phrase);
+    if (memoizedRegex(phraseRegexCache, lexicon, phrase, phraseToRegex).test(lowerText)) hits.push(phrase);
   }
 
   const density = tokens.length > 0 ? (hits.length / tokens.length) * 1000 : 0;

--- a/tests/unit/lexicon.test.js
+++ b/tests/unit/lexicon.test.js
@@ -129,3 +129,86 @@ test('phrase regex matches across a soft line wrap and through the wildcard (#44
   // Still does not match when the words are absent.
   assert.equal(phraseToRegex('in the digital age').test('in the analog era'), false);
 });
+// --- A3: per-lexicon regex cache --------------------------------------------
+
+test('computeDensity is stable across repeated calls (cache consistency)', () => {
+  const lexicon = {
+    lang: 'en',
+    strict: ['cutting-edge', 'game changer', 'delve'],
+    phrases: ['in the digital age', 'not only~but also'],
+  };
+  const text = 'We delve into a cutting-edge, real game changer in the digital age; not only fast but also cheap.';
+  const tokens = tokenize(text);
+  const first = computeDensity(text, tokens, lexicon);
+  // Functional correctness on the first (cache-populating) call.
+  assert.deepEqual(
+    [...first.hits].sort(),
+    ['cutting-edge', 'delve', 'game changer', 'in the digital age', 'not only~but also'].sort(),
+  );
+  assert.equal(first.matches, 5);
+  // 50 further calls must return byte-identical results (no cache drift).
+  for (let i = 0; i < 50; i++) {
+    const again = computeDensity(text, tokens, lexicon);
+    assert.deepEqual(again, first);
+  }
+  // A non-matching paragraph through the same (now warm) lexicon stays correct.
+  const cold = computeDensity('nothing to see here', tokenize('nothing to see here'), lexicon);
+  assert.deepEqual(cold.hits, []);
+  assert.equal(cold.matches, 0);
+});
+
+test('cached phrase/strict regexes are non-global and non-sticky', () => {
+  // The cache reuses these regex objects, so /g or /y would corrupt lastIndex
+  // across repeated .test() calls.
+  const re = phraseToRegex('in the digital age');
+  assert.equal(re.global, false);
+  assert.equal(re.sticky, false);
+  // Behavioral proof: a matching phrase keeps matching on every repeat.
+  const lexicon = { lang: 'en', strict: [], phrases: ['delve into'] };
+  for (let i = 0; i < 10; i++) {
+    assert.equal(computeDensity('we delve into it', tokenize('we delve into it'), lexicon).matches, 1);
+  }
+});
+
+test('computeDensity does not mutate lexicon object shape (WeakMap cache)', () => {
+  const lexicon = { lang: 'en', strict: ['game changer'], phrases: ['in the digital age'] };
+  const keysBefore = Object.keys(lexicon);
+  const jsonBefore = JSON.stringify(lexicon);
+  for (let i = 0; i < 5; i++) {
+    computeDensity('a real game changer in the digital age', tokenize('a real game changer in the digital age'), lexicon);
+  }
+  assert.deepEqual(Object.keys(lexicon), keysBefore);
+  assert.equal(JSON.stringify(lexicon), jsonBefore);
+  // Cache internals are not enumerable on the lexicon.
+  assert.deepEqual(Object.keys(lexicon), ['lang', 'strict', 'phrases']);
+});
+
+test('regex cache is keyed per lexicon object (no cross-contamination)', () => {
+  const a = { lang: 'en', strict: [], phrases: ['alpha signal'] };
+  const b = { lang: 'en', strict: [], phrases: ['beta signal'] };
+  const text = 'this beta signal only';
+  const tokens = tokenize(text);
+  assert.deepEqual(computeDensity(text, tokens, a).hits, []);
+  assert.deepEqual(computeDensity(text, tokens, b).hits, ['beta signal']);
+  // Re-querying a must still see only its own phrase, not b's.
+  assert.deepEqual(computeDensity(text, tokens, a).hits, []);
+});
+
+test('cache preserves language-aware strict semantics (EN whole-word vs CJK substring)', () => {
+  // EN multi-token strict entry is boundary-anchored, never a bare substring.
+  const en = { lang: 'en', strict: ['cutting-edge'], phrases: [] };
+  assert.equal(computeDensity('precutting-edged thing', tokenize('precutting-edged thing'), en).matches, 0);
+  assert.ok(computeDensity('a cutting-edge idea', tokenize('a cutting-edge idea'), en).hits.includes('cutting-edge'));
+  // CJK strict entries keep substring matching (inflection/character fallback).
+  for (const [lang, entry, text] of [
+    ['ko', '자리매김', '시장에서 자리매김했다'],
+    ['zh', '可以说', '可以说这很重要'],
+    ['ja', 'まとめると', 'まとめるとこうなる'],
+  ]) {
+    const lex = { lang, strict: [entry], phrases: [] };
+    const hot = computeDensity(text, tokenize(text, { lang }), lex);
+    assert.ok(hot.hits.includes(entry), `${lang} substring entry should hit`);
+    // Repeated call identical through the warm cache.
+    assert.deepEqual(computeDensity(text, tokenize(text, { lang }), lex), hot);
+  }
+});


### PR DESCRIPTION
## What
Wave 1 / A3 of the approved ralplan plan (run 2026-06-03-1359-33c4). Memoizes `phraseToRegex`/`strictEntryRegex` results in module-local WeakMaps keyed by the lexicon object, so `computeDensity()` compiles each entry's regex once instead of recompiling per paragraph.

## Behavior-preserving
- Same regex source; **non-global / non-sticky** (no /g or /y) so repeated `.test()` carries no lastIndex state.
- Language-aware: CJK (ko/zh/ja) strict entries still use `lowerText.includes` substring matching; only non-CJK multi-token strict entries use the boundary regex.
- WeakMap keeps the cache **off** the lexicon object: `Object.keys(lexicon)` and `JSON.stringify(lexicon)` are byte-identical before/after.

## Tests (`tests/unit/lexicon.test.js`, +5)
Repeated-call identity (50/100 iterations), non-global/non-sticky assertion, object-shape preservation, per-lexicon isolation, EN-whole-word vs CJK-substring semantics, wildcard.

## Gate
- Architect: **CLEAR / APPROVE**.
- Executor QA red-team: cached vs inline uncached reference, **212 comparisons, ZERO mismatches** (cold+warm, EN/KO/ZH/JA, wildcards, soft wraps, shape/leak, regex-state drift); 14/14 lexicon tests; `npm run benchmark` 100% / ROC·PR-AUC 1.000; dogfood OK.

## Perf (report-only)
`perf-synth-lexicon` p50 1.58ms → 1.12ms (~29% faster). No latency gate.