### PR TITLE
perf(playground): run analysis in a Web Worker with same-thread fallback (#A4)

### DIFF
--- a/playground/analysis-dispatch.js
+++ b/playground/analysis-dispatch.js
@@ -1,0 +1,125 @@
+// Pure analysis-dispatch protocol for the playground.
+//
+// This module has NO DOM and NO Worker globals, so it is safe to unit-test in
+// node. `app.js` wires the real Worker + render(); `analyzer-worker.js` wires
+// handleAnalysisRequest. Keeping the monotonic-request-id, stale-rejection, and
+// worker-fallback logic here makes that protocol testable without a browser.
+
+// Worker side: turn an analysis request message into a response. Pure.
+// Exchanges only structured-clone-safe data: requestId, text, lang, result.
+export function handleAnalysisRequest(message, analyze) {
+  const { requestId, text, lang } = message ?? {};
+  return { requestId, analysis: analyze(text ?? '', { lang }) };
+}
+
+// Main-thread controller. Dependencies are injected so this is fully testable:
+//   analyze(text, { lang })  -> synchronous deterministic analysis (fallback).
+//   createWorker()           -> a Worker-like object, or null; may throw.
+//   onResult(analysis, id)   -> apply the freshest analysis to the UI.
+//   onError(error)           -> optional notification when the worker dies.
+//
+// Guarantees:
+//   * request ids are monotonic increasing;
+//   * only the latest request id is applied (stale worker responses dropped);
+//   * any worker construction / postMessage / runtime error permanently falls
+//     back to synchronous same-thread analysis (no lost or duplicated render).
+export function createAnalysisController({ analyze, createWorker, onResult, onError } = {}) {
+  if (typeof analyze !== 'function') {
+    throw new TypeError('createAnalysisController requires an analyze() function');
+  }
+
+  let worker = null;
+  let workerDisabled = false;
+  let counter = 0;
+  let latestId = 0;
+  let lastRequest = null;
+  let pendingId = 0; // latest request awaiting a worker response (0 = none).
+
+  function disableWorker(error) {
+    workerDisabled = true;
+    const dead = worker;
+    worker = null;
+    if (dead && typeof dead.terminate === 'function') {
+      try {
+        dead.terminate();
+      } catch {
+        // A worker that throws on terminate is already gone; ignore.
+      }
+    }
+    if (error !== undefined) onError?.(error);
+  }
+
+  function ensureWorker() {
+    if (workerDisabled) return null;
+    if (worker) return worker;
+    if (typeof createWorker !== 'function') {
+      workerDisabled = true;
+      return null;
+    }
+    let created;
+    try {
+      created = createWorker();
+    } catch (error) {
+      disableWorker(error);
+      return null;
+    }
+    if (!created) {
+      workerDisabled = true;
+      return null;
+    }
+    created.onmessage = (event) => {
+      const data = event && typeof event === 'object' && 'data' in event ? event.data : event;
+      // Drop stale or unrecognized responses; only the latest request renders.
+      if (!data || data.requestId !== latestId) return;
+      pendingId = 0; // latest request is now fulfilled by the worker.
+      onResult?.(data.analysis, data.requestId);
+    };
+    created.onerror = (error) => {
+      disableWorker(error);
+      // Recover ONLY a still-in-flight latest request, so a worker that dies
+      // after already answering the latest request can never render twice.
+      if (pendingId !== 0 && pendingId === latestId && lastRequest && lastRequest.requestId === pendingId) {
+        runSameThread(lastRequest.text, lastRequest.lang, lastRequest.requestId);
+      }
+    };
+    worker = created;
+    return worker;
+  }
+
+  function runSameThread(text, lang, requestId) {
+    const analysis = analyze(text, { lang });
+    if (requestId === latestId) {
+      pendingId = 0; // this request is fully resolved on the main thread.
+      onResult?.(analysis, requestId);
+    }
+    return { requestId, mode: 'sync', analysis };
+  }
+
+  function request(text, lang) {
+    counter += 1;
+    const requestId = counter;
+    latestId = requestId;
+    lastRequest = { text, lang, requestId };
+    const active = ensureWorker();
+    if (!active) return runSameThread(text, lang, requestId);
+    try {
+      active.postMessage({ requestId, text, lang });
+    } catch (error) {
+      disableWorker(error);
+      return runSameThread(text, lang, requestId);
+    }
+    pendingId = requestId; // worker accepted the post; await its response.
+    return { requestId, mode: 'worker' };
+  }
+
+  return {
+    request,
+    isStale: (id) => id !== latestId,
+    get latestId() {
+      return latestId;
+    },
+    get usingWorker() {
+      return Boolean(worker) && !workerDisabled;
+    },
+  };
+}

--- a/playground/analyzer-worker.js
+++ b/playground/analyzer-worker.js
@@ -1,0 +1,12 @@
+// Web Worker entry: runs the deterministic playground analysis off the main
+// thread so a long paste never blocks UI rendering. app.js loads this via
+// `new URL('./analyzer-worker.js', import.meta.url)` so the path stays relative
+// and works under static hosting (patina.vibetip.help). Browser-pure: no node:
+// imports, no detector behavior — just the shared analyzer + dispatch glue.
+import { analyzePlaygroundText } from './analyzer.js';
+import { handleAnalysisRequest } from './analysis-dispatch.js';
+
+globalThis.onmessage = (event) => {
+  const response = handleAnalysisRequest(event.data, analyzePlaygroundText);
+  globalThis.postMessage(response);
+};

--- a/playground/app.js
+++ b/playground/app.js
@@ -8,6 +8,7 @@ import {
   renderAuditDiff,
   renderKoreanAdvisory,
 } from './analyzer.js';
+import { createAnalysisController } from './analysis-dispatch.js';
 
 const doc = globalThis.document;
 const state = {
@@ -95,10 +96,29 @@ function render() {
   nodes.cliPreview.textContent = buildCliCommand(state.text, state.lang);
 }
 
+// Analysis runs in a Web Worker so a long paste never blocks rendering. The
+// worker is loaded by relative URL for static hosting; if Worker is missing or
+// the worker errors, the controller transparently falls back to same-thread
+// analysis. Only the latest request id is rendered, so stale worker responses
+// from earlier keystrokes can never overwrite newer input (#450 follow-up).
+function createAnalysisWorker() {
+  const WorkerCtor = globalThis.Worker;
+  if (typeof WorkerCtor !== 'function') return null;
+  return new WorkerCtor(new URL('./analyzer-worker.js', import.meta.url), { type: 'module' });
+}
+
+const analysisController = createAnalysisController({
+  analyze: analyzePlaygroundText,
+  createWorker: createAnalysisWorker,
+  onResult: (analysis) => {
+    state.analysis = analysis;
+    render();
+  },
+});
+
 function runAnalysis() {
   state.text = nodes.input.value;
-  state.analysis = analyzePlaygroundText(state.text, { lang: state.lang });
-  render();
+  analysisController.request(state.text, state.lang);
 }
 
 async function copyText(text) {

--- a/tests/unit/playground.test.js
+++ b/tests/unit/playground.test.js
@@ -39,6 +39,10 @@ import {
   koreanPosDiversityProxy as nodeKoreanPosDiversityProxy,
   koreanSpacingFeatures as nodeKoreanSpacingFeatures,
 } from '../../src/features/stylometry.js';
+import {
+  createAnalysisController,
+  handleAnalysisRequest,
+} from '../../playground/analysis-dispatch.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../..');
@@ -859,4 +863,144 @@ test('highlightLexiconHits falls back to plain escaping when lowercasing changes
   assert.equal(highlightLexiconHits('\u0130stanbul tool', ['tool']).includes('<mark>'), false);
   // A same-length string still highlights the hit.
   assert.ok(highlightLexiconHits('great tool here', ['tool']).includes('<mark>tool</mark>'));
+});
+// --- A4: playground analysis worker dispatch --------------------------------
+
+function makeFakeWorker() {
+  return {
+    posted: [],
+    onmessage: null,
+    onerror: null,
+    terminated: false,
+    postMessage(message) { this.posted.push(message); },
+    terminate() { this.terminated = true; },
+    respond(requestId, analysis) { this.onmessage?.({ data: { requestId, analysis } }); },
+    fail(error) { this.onerror?.(error ?? new Error('worker boom')); },
+  };
+}
+
+const fakeAnalyze = (text, { lang } = {}) => ({ text, lang, source: 'analyze' });
+
+test('handleAnalysisRequest echoes the request id and analyzes text+lang', () => {
+  const out = handleAnalysisRequest({ requestId: 7, text: 'hi', lang: 'en' }, fakeAnalyze);
+  assert.deepEqual(out, { requestId: 7, analysis: { text: 'hi', lang: 'en', source: 'analyze' } });
+  // Missing fields coerce safely (structured-clone-safe, no throw).
+  const empty = handleAnalysisRequest(undefined, fakeAnalyze);
+  assert.equal(empty.requestId, undefined);
+  assert.deepEqual(empty.analysis, { text: '', lang: undefined, source: 'analyze' });
+});
+
+test('controller falls back to same-thread analysis when no worker is available', () => {
+  const results = [];
+  const controller = createAnalysisController({
+    analyze: fakeAnalyze,
+    createWorker: () => null,
+    onResult: (analysis, id) => results.push([id, analysis]),
+  });
+  const r = controller.request('alpha', 'en');
+  assert.equal(r.mode, 'sync');
+  assert.equal(controller.usingWorker, false);
+  assert.deepEqual(results, [[1, { text: 'alpha', lang: 'en', source: 'analyze' }]]);
+});
+
+test('controller uses the worker and applies only the latest (non-stale) response', () => {
+  const worker = makeFakeWorker();
+  const results = [];
+  const controller = createAnalysisController({
+    analyze: fakeAnalyze,
+    createWorker: () => worker,
+    onResult: (analysis, id) => results.push([id, analysis]),
+  });
+  assert.equal(controller.request('first', 'en').mode, 'worker');
+  assert.equal(controller.request('second', 'ko').mode, 'worker');
+  assert.equal(controller.usingWorker, true);
+  assert.deepEqual(worker.posted, [
+    { requestId: 1, text: 'first', lang: 'en' },
+    { requestId: 2, text: 'second', lang: 'ko' },
+  ]);
+  // A stale response for the superseded request id is dropped.
+  worker.respond(1, { stale: true });
+  assert.deepEqual(results, []);
+  assert.equal(controller.isStale(1), true);
+  // The latest response renders.
+  worker.respond(2, { fresh: true });
+  assert.deepEqual(results, [[2, { fresh: true }]]);
+});
+
+test('controller falls back to same-thread when worker construction throws', () => {
+  const results = [];
+  const controller = createAnalysisController({
+    analyze: fakeAnalyze,
+    createWorker: () => { throw new Error('no worker'); },
+    onResult: (analysis) => results.push(analysis),
+  });
+  assert.equal(controller.request('x', 'en').mode, 'sync');
+  assert.deepEqual(results, [{ text: 'x', lang: 'en', source: 'analyze' }]);
+});
+
+test('controller falls back and terminates the worker when postMessage throws', () => {
+  const worker = makeFakeWorker();
+  worker.postMessage = () => { throw new Error('detached'); };
+  const results = [];
+  const controller = createAnalysisController({
+    analyze: fakeAnalyze,
+    createWorker: () => worker,
+    onResult: (analysis) => results.push(analysis),
+  });
+  assert.equal(controller.request('y', 'ko').mode, 'sync');
+  assert.equal(worker.terminated, true);
+  assert.deepEqual(results, [{ text: 'y', lang: 'ko', source: 'analyze' }]);
+});
+
+test('controller recovers the in-flight request and falls back after a worker runtime error', () => {
+  const worker = makeFakeWorker();
+  const errors = [];
+  const results = [];
+  const controller = createAnalysisController({
+    analyze: fakeAnalyze,
+    createWorker: () => worker,
+    onResult: (analysis, id) => results.push([id, analysis]),
+    onError: (e) => errors.push(e),
+  });
+  controller.request('one', 'en'); // worker path, id 1
+  worker.fail(new Error('crash')); // worker dies -> recover id 1 same-thread
+  assert.equal(errors.length, 1);
+  assert.equal(controller.usingWorker, false);
+  assert.deepEqual(results, [[1, { text: 'one', lang: 'en', source: 'analyze' }]]);
+  // Subsequent requests stay on the main thread.
+  assert.equal(controller.request('two', 'en').mode, 'sync');
+  assert.deepEqual(results, [
+    [1, { text: 'one', lang: 'en', source: 'analyze' }],
+    [2, { text: 'two', lang: 'en', source: 'analyze' }],
+  ]);
+});
+
+test('controller does not re-render after a worker error following a completed response', () => {
+  const worker = makeFakeWorker();
+  const results = [];
+  const controller = createAnalysisController({
+    analyze: fakeAnalyze,
+    createWorker: () => worker,
+    onResult: (analysis, id) => results.push([id, analysis]),
+  });
+  controller.request('one', 'en'); // id 1, worker path
+  worker.respond(1, { done: true }); // accepted -> rendered exactly once
+  assert.deepEqual(results, [[1, { done: true }]]);
+  // A late worker crash must NOT re-run the already-completed latest request.
+  worker.fail(new Error('late crash'));
+  assert.deepEqual(results, [[1, { done: true }]]);
+  assert.equal(controller.usingWorker, false);
+});
+
+test('playground worker module graph stays browser-pure and loads by relative URL', () => {
+  const { seen, violations } = collectStaticImports('playground/analyzer-worker.js');
+  assert.deepEqual(violations, []);
+  assert.ok([...seen].some((file) => file.endsWith('/playground/analysis-dispatch.js')));
+  const workerSrc = readFileSync(resolve(REPO_ROOT, 'playground/analyzer-worker.js'), 'utf8');
+  assert.match(workerSrc, /from '\.\/analyzer\.js'/);
+  assert.match(workerSrc, /globalThis\.onmessage/);
+  assert.match(workerSrc, /globalThis\.postMessage/);
+  // app.js must load the worker by relative URL so static hosting keeps working.
+  const appSrc = readFileSync(resolve(REPO_ROOT, 'playground/app.js'), 'utf8');
+  assert.match(appSrc, /new URL\('\.\/analyzer-worker\.js', import\.meta\.url\)/);
 });


### PR DESCRIPTION
## What
Wave 2 / A4 of the approved ralplan plan. Moves playground analysis off the main thread so a long paste never blocks UI rendering.

## Design
- NEW `playground/analysis-dispatch.js` (browser-pure, no DOM/Worker globals): `createAnalysisController({analyze, createWorker, onResult, onError})` + `handleAnalysisRequest()`. Monotonic request ids; only the latest id renders (stale worker responses dropped); transparent **same-thread fallback** on missing Worker / construction throw / postMessage throw / worker `onerror`, with in-flight recovery tracked by `pendingId` (no duplicate or lost render).
- NEW `playground/analyzer-worker.js`: worker entry, loaded via `new URL('./analyzer-worker.js', import.meta.url)` so it stays relative for static hosting and out of the static module graph.
- `playground/app.js`: builds the controller; `runAnalysis()` delegates to `controller.request()`; worker via guarded `globalThis.Worker`.
- No detector behavior change — `analyzer.js` untouched; same input+lang yields identical observable analysis.

## Gate
- Architect: round 1 **BLOCK** (duplicate render if the worker errored *after* answering the latest request) → fixed with `pendingId` tracking + regression test → re-review **CLEAR / APPROVE**.
- Executor QA: 44 protocol/equivalence/static assertions pass; observable analysis deep-equals direct `analyzePlaygroundText` across ko/en/zh/ja; deterministic engine untouched.
- 50 playground tests; full suite 720 pass; lint green; `npm run playground:data` in sync.

## Manual QA (per A4 acceptance)
1. Open the playground; paste a long EN document — UI stays responsive; final audit reflects the pasted text (no stale partial).
2. Change language mid-analysis — the latest language's analysis wins (no stale overwrite).
3. Click **Run audit** twice quickly — stays immediate (not debounced); latest render wins.
4. Simulate no/failed Worker (e.g. `delete window.Worker` before load, or block the worker URL) — analysis still runs on the main thread, identical output.