### PR TITLE
perf(prompt): cache-friendly prompt layout + surface provider cache tokens (#C1)

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -45,6 +45,23 @@ function truncate(text, max = 256) {
   return text.length > max ? `${text.slice(0, max)}…` : text;
 }
 
+// Surface provider prompt-cache token counts when present, normalized across
+// OpenAI-compatible (usage.prompt_tokens_details.cached_tokens) and Anthropic-
+// style (usage.cache_read_input_tokens / cache_creation_input_tokens) shapes.
+// Absent-safe: returns null when the provider exposes no cache usage, so the
+// cache-friendly prompt layout (C1) can be observed without breaking providers
+// that omit these fields.
+function extractCacheTokens(usage) {
+  if (!usage || typeof usage !== 'object') return null;
+  const cachedRead = usage.prompt_tokens_details?.cached_tokens ?? usage.cache_read_input_tokens ?? null;
+  const cacheCreation = usage.cache_creation_input_tokens ?? null;
+  if (cachedRead == null && cacheCreation == null) return null;
+  return {
+    cachedReadTokens: cachedRead ?? null,
+    cacheCreationTokens: cacheCreation ?? null,
+  };
+}
+
 function abortError(message = 'The operation was aborted') {
   const err = new Error(message);
   err.name = 'AbortError';
@@ -254,6 +271,7 @@ export async function callLLM({
         temperature,
         seed: seed ?? null,
         usage: data.usage ?? null,
+        cacheTokens: extractCacheTokens(data.usage),
         rawResponse: data,
         content,
       };

--- a/src/prompt-builder.js
+++ b/src/prompt-builder.js
@@ -207,12 +207,6 @@ export function buildPrompt(options) {
     }
   }
 
-  if (mode === 'rewrite' && Array.isArray(documentSignals) && documentSignals.length > 0) {
-    prompt += `## Document Signals (deterministic measurements)\n\n`;
-    prompt += documentSignals.map((signal) => `- ${signal}`).join('\n');
-    prompt += `\n\nTreat these as ground truth when forming the Phase 0 document brief.\n\n`;
-  }
-
   prompt += `## Instructions\n\n`;
   prompt += `Process the following text according to the output mode "${mode}".\n\n`;
 
@@ -226,6 +220,17 @@ export function buildPrompt(options) {
     prompt += buildScoreInstructions(config, lang, text, activePatterns);
   } else if (mode === 'ouroboros') {
     prompt += buildOuroborosInstructions(config, structurePacks, lexicalPacks);
+  }
+
+  // Per-document deterministic measurements sit adjacent to the input, after
+  // the stable instruction prefix, so the large pattern-pack/profile/voice/
+  // instruction prefix stays byte-identical across documents in a batch and
+  // maximizes provider prompt-cache hits. Only these signals and the fenced
+  // input below vary per document.
+  if (mode === 'rewrite' && Array.isArray(documentSignals) && documentSignals.length > 0) {
+    prompt += `## Document Signals (deterministic measurements)\n\n`;
+    prompt += documentSignals.map((signal) => `- ${signal}`).join('\n');
+    prompt += `\n\nTreat these as ground truth when forming the Phase 0 document brief.\n\n`;
   }
 
   prompt += `\n## Input Text\n\n`;

--- a/tests/fixtures/prompt-snapshots/rewrite-signals.md
+++ b/tests/fixtures/prompt-snapshots/rewrite-signals.md
@@ -1,0 +1,126 @@
+You are an editor who detects and removes AI writing patterns from text, rewriting it into natural, human-written prose.
+
+## Tone Resolution (v3.10)
+
+- resolved_tone: null
+- tone_source: profile_only
+- tone_evidence: []
+- tone_confidence: null
+
+No tone specified — profile-only mode (regression-safe path). Phase 4.5b is skipped. Emit Phase 6 YAML footer with tone: null and tone_source: profile_only.
+
+## Configuration
+
+- Language: en
+- Profile: default
+- Output mode: rewrite
+- Blocklist: never say pivotal
+- Allowlist: OpenClaw
+
+## Pattern Packs
+
+### Pack: en-structure
+
+### 1. Metronomic Paragraph Rhythm
+**Watch words:** firstly, secondly, in conclusion
+**Fire condition:** adjacent paragraphs share the same sentence count.
+
+### Pack: en-content
+
+### 4. Promotional Adjectives
+**Watch words:** transformative, robust, scalable, pivotal
+**Fire condition:** praise words replace concrete evidence.
+
+## Profile
+
+voice-overrides:
+  specificity: amplify
+  hype: reduce
+
+## Voice Guidelines
+
+- Prefer concrete nouns over broad abstractions.
+- Keep claims, polarity, causation, and numbers intact.
+
+## Instructions
+
+Process the following text according to the output mode "rewrite".
+
+Follow the 3-Phase pipeline:
+
+### Phase 0: Document Brief (internal — never output)
+
+Before any edit, read the whole input and fix in your head: what this document is (landing page / blog post / notice / documentation), who is speaking to whom, the document's dominant register and tone, and its recurring domain terms. Keep that frame for every edit below. Unify all rewritten sentences to the document's dominant register — register mixing across sentences is itself an AI tell. Reuse the document's own domain terms instead of generic synonyms.
+
+### Phase 1: Structure Scan
+
+Apply the structure patterns to fix document-level issues:
+- en-structure
+
+1. Scan paragraph layout, repetition, translationese, passive patterns
+2. Correct structural issues — diversify paragraph structure
+3. Verify core claims and logical flow survive structural changes
+4. Intentionally vary paragraph length and sentence count (burstiness)
+
+**Skip if**: text is ≤2 paragraphs OR no structure packs loaded.
+
+### Phase 2: Sentence/Lexical Rewrite
+
+Apply all remaining pattern packs (content, language, style, communication, filler):
+- en-content
+
+1. Scan all patterns for AI tells
+2. Rewrite AI-sounding expressions into natural alternatives
+3. Preserve core meaning, claims, polarity, causation, numbers
+4. Match profile tone
+5. Inject personality per voice guidelines
+6. Respect blocklist/allowlist and pattern overrides
+
+### Phase 3: Self-Audit
+
+1. Scan for remaining AI tells
+2. Verify no polarity inversions (negation → positive or vice versa)
+3. Ensure Phase 1 corrections were not reverted in Phase 2
+4. Final check: meaning preserved?
+
+### Output format (STRICT — v3.11)
+
+Produce output in this exact order, with no other text outside the tagged blocks:
+
+1. The rewritten text wrapped in `[BODY]`/`[/BODY]` tags. The body block must contain ONLY the user-facing rewrite — no headings, no Phase labels, no preamble like "잔여 AI 티" or "최종 결과물".
+2. Self-audit notes wrapped in `[SELF_AUDIT]`/`[/SELF_AUDIT]` tags (brief: what still looks AI-written, which patterns were applied). This block is for downstream review — patina strips it before showing the user.
+3. The Phase 6 YAML footer if tone resolution requires it.
+
+Example shape (uses [BODY]/[/BODY]):
+
+```
+[BODY]
+<rewritten text>
+[/BODY]
+
+[SELF_AUDIT]
+- residual signals: ...
+- patterns applied: ...
+[/SELF_AUDIT]
+
+---
+tone: ...
+tone_source: ...
+tone_evidence: [...]
+tone_confidence: ...
+---
+```
+## Document Signals (deterministic measurements)
+
+- burstiness CV 0.18 (low)
+- MATTR 0.52 (low)
+- lexicon density 3.1/1k (high)
+
+Treat these as ground truth when forming the Phase 0 document brief.
+
+
+## Input Text
+
+<INPUT REDACTED>
+
+## Output

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -207,6 +207,8 @@ test('callLLM reports usage metadata without changing string return value', asyn
       cost_usd: 0.001,
     });
     assert.equal(seen[0].content, 'hello');
+    // No provider cache fields in this usage payload -> absent-safe null.
+    assert.equal(seen[0].cacheTokens, null);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -267,6 +269,36 @@ test('a throw from onResponse does not re-issue the paid request (#444)', async 
       /callback boom/,
     );
     assert.equal(calls, 1, 'fetch must run exactly once despite the onResponse throw');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('callLLM surfaces provider prompt-cache token counts when present', async () => {
+  const originalFetch = globalThis.fetch;
+  const cases = [
+    // OpenAI-compatible shape.
+    {
+      usage: { prompt_tokens: 100, completion_tokens: 5, prompt_tokens_details: { cached_tokens: 80 } },
+      expected: { cachedReadTokens: 80, cacheCreationTokens: null },
+    },
+    // Anthropic-style shape.
+    {
+      usage: { input_tokens: 100, cache_read_input_tokens: 64, cache_creation_input_tokens: 12 },
+      expected: { cachedReadTokens: 64, cacheCreationTokens: 12 },
+    },
+  ];
+  try {
+    for (const { usage, expected } of cases) {
+      const seen = [];
+      globalThis.fetch = async () => ({
+        ok: true,
+        json: async () => ({ model: 'm', choices: [{ message: { content: 'ok' } }], usage }),
+      });
+      const content = await callLLM({ prompt: 'x', apiKey: 'k', model: 'm', onResponse: (m) => seen.push(m) });
+      assert.equal(content, 'ok');
+      assert.deepEqual(seen[0].cacheTokens, expected);
+    }
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/unit/document-signals.test.js
+++ b/tests/unit/document-signals.test.js
@@ -21,8 +21,11 @@ test('strict rewrite prompt renders document signals as ground truth for the Pha
   assert.ok(prompt.includes('## Document Signals (deterministic measurements)'));
   assert.ok(prompt.includes(SIGNALS[0]));
   assert.ok(prompt.includes('Phase 0: Document Brief'));
-  // Signals section precedes the instructions that consume it.
-  assert.ok(prompt.indexOf('Document Signals') < prompt.indexOf('## Instructions'));
+  // C1 cache-friendly layout: the per-document signals sit AFTER the stable
+  // instruction prefix and immediately before the input, so the large
+  // pattern-pack/profile/voice/instruction prefix stays cacheable across a batch.
+  assert.ok(prompt.indexOf('Document Signals') > prompt.indexOf('## Instructions'));
+  assert.ok(prompt.indexOf('Document Signals') < prompt.indexOf('## Input Text'));
 });
 
 test('minimal rewrite prompt carries the brief and the signals section', () => {

--- a/tests/unit/prompt-builder.snapshot.test.js
+++ b/tests/unit/prompt-builder.snapshot.test.js
@@ -13,6 +13,7 @@ const UPDATE_SNAPSHOTS = process.env.UPDATE_PROMPT_SNAPSHOTS === '1';
 const CASES = [
   { name: 'rewrite strict', file: 'rewrite-strict.md', mode: 'rewrite', promptMode: 'strict' },
   { name: 'rewrite minimal', file: 'rewrite-minimal.md', mode: 'rewrite', promptMode: 'minimal' },
+  { name: 'rewrite with signals', file: 'rewrite-signals.md', mode: 'rewrite', promptMode: 'strict', documentSignals: ['burstiness CV 0.18 (low)', 'MATTR 0.52 (low)', 'lexicon density 3.1/1k (high)'] },
   { name: 'diff', file: 'diff.md', mode: 'diff', promptMode: 'strict' },
   { name: 'audit', file: 'audit.md', mode: 'audit', promptMode: 'strict' },
   { name: 'score', file: 'score.md', mode: 'score', promptMode: 'strict' },
@@ -134,7 +135,7 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function buildSnapshot({ mode, promptMode }) {
+function buildSnapshot({ mode, promptMode, documentSignals = null }) {
   const prompt = buildPrompt({
     config,
     patterns,
@@ -145,6 +146,7 @@ function buildSnapshot({ mode, promptMode }) {
     mode,
     tone,
     promptMode,
+    documentSignals,
   });
   return `${redactInputSection(prompt).trim()}\n`;
 }


### PR DESCRIPTION
## What
Wave 2 / C1 (must precede C2/C3). Improves provider prompt-cache hit rates without changing prompt semantics.

## Changes
- **Prompt layout** (`src/prompt-builder.js`): the per-document `## Document Signals` block (rewrite mode) moves verbatim from mid-prompt to immediately **before** `## Input Text`, after the stable instruction prefix. The big pattern-pack/profile/voice/instruction prefix (plus batch-stable tone/config) is now byte-identical across documents in a batch — only the signals + input vary per document. Tone block left at top (batch-stable; design comment).
- **Cache-token metadata** (`src/api.js`): `callLLM` response metadata now carries `cacheTokens`, normalizing OpenAI (`prompt_tokens_details.cached_tokens`) and Anthropic (`cache_read_input_tokens`/`cache_creation_input_tokens`) shapes; absent-safe (null when unexposed).

## Equivalence
Existing golden snapshots (rewrite-strict/minimal, diff, audit, score, ouroboros) are **unchanged** — proves zero drift for signal-less prompts. New `rewrite-signals` snapshot locks the new ordering. No detector/engine change (`src/features/*` untouched).

## Gate
- Architect: **CLEAR / APPROVE**.
- Executor QA: **71 assertions, 0 failed** — snapshot stability + only rewrite-signals added; ordering (signals after Instructions, before Input); cache-token shapes incl. absent-safe null; `npm run benchmark` 100% / ROC·PR-AUC 1.000; dogfood OK.
- Full suite 722 pass; lint green.