### PR TITLE
feat(api): opt-in OpenAI structured output for the HTTP scorer (#C2)

### DIFF
--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -7,6 +7,12 @@ language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
 profile: default
 output: rewrite           # rewrite | diff | audit | score
 
+# Opt-in: request OpenAI-compatible structured output (response_format
+# json_object) for ouroboros LLM scoring. Default false; only the openai-http
+# backend forwards it (never sent to local CLI backends). Some OpenAI-compatible
+# endpoints reject response_format — leave false unless your endpoint supports it.
+structured-output: false
+
 # Tone categorization (v3.10): named voice axis. Six v1 tones for ko/en.
 # Resolution: explicit --tone > config tone > config profile.
 # auto = heuristic single-tone detection at SKILL.md Phase 4.5b.

--- a/src/api.js
+++ b/src/api.js
@@ -169,6 +169,7 @@ export function computeBackoffMs(attempt, retryAfter, opts = {}) {
  * @param {string} [options.model] Model id to request. Defaults to gpt-5.5.
  * @param {number} [options.temperature=DEFAULT_TEMPERATURE] Sampling temperature.
  * @param {number|string} [options.seed] Optional deterministic seed forwarded to the provider.
+ * @param {object} [options.responseFormat] Optional OpenAI-compatible structured-output request field (sent as response_format) when provided.
  * @param {number} [options.timeout=120000] Per-attempt timeout in milliseconds.
  * @param {number} [options.maxRetries=2] Retry count after the first attempt.
  * @param {number} [options.deadline] Absolute epoch-millisecond deadline for all attempts.
@@ -190,6 +191,10 @@ export async function callLLM({
   model = DEFAULT_BEST_MODELS.openai,
   temperature = DEFAULT_TEMPERATURE,
   seed,
+  // Optional OpenAI-compatible structured-output request field, e.g.
+  // { type: 'json_object' } or a json_schema spec. Opt-in: when omitted, no
+  // response_format is sent so endpoints that reject the field are unaffected.
+  responseFormat,
   timeout = DEFAULT_TIMEOUT,
   maxRetries = DEFAULT_MAX_RETRIES,
   deadline,
@@ -208,6 +213,7 @@ export async function callLLM({
     temperature,
   };
   if (seed !== undefined && seed !== null) body.seed = seed;
+  if (responseFormat) body.response_format = responseFormat;
 
 
   let lastError;

--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -13,30 +13,37 @@ export const BACKEND_SAFETY_DEFAULTS = Object.freeze({
     maxRetries: DEFAULT_HTTP_MAX_RETRIES,
     promptMode: 'strict',
     agentRuntime: false,
+    // Only the OpenAI-compatible HTTP backend builds a chat-completions body,
+    // so structured-output request fields (response_format) apply here alone.
+    supportsStructuredOutput: true,
   },
   'codex-cli': {
     maxConcurrency: 2,
     maxRetries: 0,
     promptMode: 'minimal',
     agentRuntime: true,
+    supportsStructuredOutput: false,
   },
   'claude-cli': {
     maxConcurrency: 1,
     maxRetries: 0,
     promptMode: 'minimal',
     agentRuntime: true,
+    supportsStructuredOutput: false,
   },
   'gemini-cli': {
     maxConcurrency: 2,
     maxRetries: 0,
     promptMode: 'minimal',
     agentRuntime: true,
+    supportsStructuredOutput: false,
   },
   'kimi-cli': {
     maxConcurrency: 1,
     maxRetries: 0,
     promptMode: 'minimal',
     agentRuntime: true,
+    supportsStructuredOutput: false,
   },
 });
 
@@ -45,10 +52,18 @@ const UNKNOWN_BACKEND_SAFETY = Object.freeze({
   maxRetries: 0,
   promptMode: 'strict',
   agentRuntime: false,
+  supportsStructuredOutput: false,
 });
 
 export function getBackendSafety(backendName) {
   return BACKEND_SAFETY_DEFAULTS[backendName] || UNKNOWN_BACKEND_SAFETY;
+}
+
+// True only for backends whose request path can carry an OpenAI-compatible
+// structured-output field (response_format). CLI backends spawn an agent and
+// never receive it, so structured output is never sent to a local CLI.
+export function backendSupportsStructuredOutput(backendName) {
+  return getBackendSafety(backendName).supportsStructuredOutput === true;
 }
 
 export function resolveBackendMaxConcurrency(backendName, override) {

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -29,7 +29,7 @@ import { applyScoreGate, extractScoreOverall } from './score-gate.js';
 import { loadInputs } from './input.js';
 import { PatinaCliError, runtimeError } from '../errors.js';
 import { providerHttpKeyEnvVars, resolveHttpApiKey } from '../auth.js';
-import { DEFAULT_BACKEND_TIMEOUT_MS, getBackendSafety } from '../backends/contract.js';
+import { DEFAULT_BACKEND_TIMEOUT_MS, getBackendSafety, backendSupportsStructuredOutput } from '../backends/contract.js';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -237,6 +237,8 @@ export async function runDefault(parsed, logger) {
             timeout: timeoutMs,
             signal: cancellation.signal,
             logger,
+            // Opt-in structured output for the openai-http scorer; default off.
+            structuredOutput: config['structured-output'] === true && backendSupportsStructuredOutput('openai-http'),
           });
         } else {
           result = await invokeBackendChain({

--- a/src/ouroboros.js
+++ b/src/ouroboros.js
@@ -46,6 +46,10 @@ export async function runOuroboros({
   signal,
   timeout,
   logger = createLogger(),
+  // Opt-in: when true, ouroboros scoring/MPS/fidelity calls request OpenAI
+  // structured output (response_format json_object). Default false; only the
+  // openai-http scorer forwards it (callLLM here is always the HTTP client).
+  structuredOutput = false,
 }) {
   const ouroborosConfig = config.ouroboros || {};
   const targetScore = ouroborosConfig['target-score'] ?? 30;
@@ -53,6 +57,8 @@ export async function runOuroboros({
   const plateauThreshold = ouroborosConfig['plateau-threshold'] ?? 10;
   const fidelityFloor = ouroborosConfig['fidelity-floor'] ?? 70;
   const mpsFloor = ouroborosConfig['mps-floor'] ?? 70;
+
+  const scoringResponseFormat = structuredOutput ? { type: 'json_object' } : undefined;
 
   const iterationLog = [];
 
@@ -69,6 +75,7 @@ export async function runOuroboros({
     signal,
     timeout,
     logger,
+    responseFormat: scoringResponseFormat,
   });
 
   const initialScore = initialScoreResult?.overall ?? 100;
@@ -151,6 +158,7 @@ export async function runOuroboros({
       signal,
       timeout,
       logger,
+      responseFormat: scoringResponseFormat,
     });
 
     let currentScore = scoreResult?.overall ?? 100;
@@ -175,6 +183,7 @@ export async function runOuroboros({
         signal,
         timeout,
         logger,
+        responseFormat: scoringResponseFormat,
       }),
       scoreFidelity({
         original: text,
@@ -188,6 +197,7 @@ export async function runOuroboros({
         signal,
         timeout,
         logger,
+        responseFormat: scoringResponseFormat,
       }),
     ]);
 

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -92,6 +92,10 @@ async function callAndParseJson({
   logger = createLogger(),
   now,
   sleep,
+  // Opt-in OpenAI-compatible structured-output request field (e.g.
+  // { type: 'json_object' }). Forwarded to callLLM on every attempt; the strict
+  // JSON parse + temperature-0 retry below remains the fallback regardless.
+  responseFormat,
 }) {
   let lastError;
   for (let attempt = 0; attempt < 2; attempt++) {
@@ -107,6 +111,7 @@ async function callAndParseJson({
       timeout,
       now,
       sleep,
+      responseFormat,
     });
     try {
       return { parsed: parseStrictJson(result), raw: result };
@@ -139,6 +144,7 @@ async function callAndParseJson({
  * @param {object} [options.logger] patina logger.
  * @param {Function} [options.now] Clock returning epoch milliseconds.
  * @param {Function} [options.sleep] Sleep helper for tests.
+ * @param {object} [options.responseFormat] Opt-in OpenAI-compatible structured-output request field forwarded to callLLM.
  * @returns {Promise<object>} Score payload with overall, interpretation, llmScore, and deterministicScore.
  * @throws {Error} When the operation is aborted.
  * @example
@@ -158,6 +164,8 @@ export async function scoreText({
   logger = createLogger(),
   now,
   sleep,
+  // Opt-in structured-output request field; defaults off (undefined).
+  responseFormat,
 }) {
   const lang = config.language || 'ko';
   const deterministicScore = scoreDeterministicSignals({ text, config, logger });
@@ -206,6 +214,7 @@ ${text}
       logger,
       now,
       sleep,
+      responseFormat,
     });
     return withShadowScore(parsed, { deterministicScore, config, logger });
   } catch (e) {
@@ -479,6 +488,7 @@ export function reconcileScoreOverall({
  * @param {object} [options.logger] patina logger.
  * @param {Function} [options.now] Clock returning epoch milliseconds.
  * @param {Function} [options.sleep] Sleep helper for tests.
+ * @param {object} [options.responseFormat] Opt-in OpenAI-compatible structured-output request field forwarded to callLLM.
  * @returns {Promise<Object>} MPS result.
  * @throws {Error} When the operation is aborted.
  * @example
@@ -497,6 +507,8 @@ export async function scoreMPS({
   logger = createLogger(),
   now,
   sleep,
+  // Opt-in structured-output request field; defaults off (undefined).
+  responseFormat,
 }) {
   const prompt = `You are a Meaning Preservation evaluator. Compare the ORIGINAL text with the REWRITTEN text.
 
@@ -542,6 +554,7 @@ ${rewritten}
       logger,
       now,
       sleep,
+      responseFormat,
     });
     return parsed;
   } catch (e) {
@@ -604,6 +617,7 @@ export function lengthRatioPoints(original, rewritten) {
  * @param {object} [options.logger] patina logger.
  * @param {Function} [options.now] Clock returning epoch milliseconds.
  * @param {Function} [options.sleep] Sleep helper for tests.
+ * @param {object} [options.responseFormat] Opt-in OpenAI-compatible structured-output request field forwarded to callLLM.
  * @returns {Promise<Object>} Fidelity result.
  * @throws {Error} When the operation is aborted.
  * @example
@@ -622,6 +636,8 @@ export async function scoreFidelity({
   logger = createLogger(),
   now,
   sleep,
+  // Opt-in structured-output request field; defaults off (undefined).
+  responseFormat,
 }) {
   // Length is deterministic; only ask LLM for the three judgment criteria.
   const lengthPoints = lengthRatioPoints(original, rewritten);
@@ -669,6 +685,7 @@ ${rewritten}
       logger,
       now,
       sleep,
+      responseFormat,
     });
     parsed = result.parsed;
   } catch (e) {

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -303,3 +303,20 @@ test('callLLM surfaces provider prompt-cache token counts when present', async (
     globalThis.fetch = originalFetch;
   }
 });
+test('callLLM sends response_format only when responseFormat is provided (#C2)', async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    let body;
+    globalThis.fetch = async (_url, opts) => {
+      body = JSON.parse(opts.body);
+      return { ok: true, json: async () => ({ model: 'm', choices: [{ message: { content: 'ok' } }] }) };
+    };
+    await callLLM({ prompt: 'x', apiKey: 'k', model: 'm', responseFormat: { type: 'json_object' } });
+    assert.deepEqual(body.response_format, { type: 'json_object' });
+    // Omitted by default so endpoints that reject the field are unaffected.
+    await callLLM({ prompt: 'x', apiKey: 'k', model: 'm' });
+    assert.equal('response_format' in body, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/unit/backend-contract.test.js
+++ b/tests/unit/backend-contract.test.js
@@ -8,6 +8,7 @@ import {
   resolveBackendMaxConcurrency,
   isRetryableBackendError,
   withBackendConcurrencySlot,
+  backendSupportsStructuredOutput,
 } from '../../src/backends/contract.js';
 
 test('resolveBackendMaxConcurrency fails closed on an invalid override (#445)', () => {
@@ -20,6 +21,15 @@ test('resolveBackendMaxConcurrency fails closed on an invalid override (#445)', 
   // valid override applies; unset uses the backend default.
   assert.equal(resolveBackendMaxConcurrency('claude-cli', 2), 2);
   assert.equal(resolveBackendMaxConcurrency('claude-cli'), 1);
+});
+
+test('backendSupportsStructuredOutput is true only for openai-http (#C2)', () => {
+  assert.equal(backendSupportsStructuredOutput('openai-http'), true);
+  for (const cli of ['codex-cli', 'claude-cli', 'gemini-cli', 'kimi-cli']) {
+    assert.equal(backendSupportsStructuredOutput(cli), false);
+  }
+  // Unknown backends fail closed: structured output is never sent.
+  assert.equal(backendSupportsStructuredOutput('mystery-backend'), false);
 });
 
 test('isRetryableBackendError honors message status even when err.status is null (#445)', () => {

--- a/tests/unit/scoring.test.js
+++ b/tests/unit/scoring.test.js
@@ -405,3 +405,38 @@ test('deterministic skipped and failure payloads pin signalScore to zero', () =>
   assert.strictEqual(failed.skipped, true);
   assert.strictEqual(failed.signalScore, 0);
 });
+// --- C2: opt-in structured output ------------------------------------------
+
+test('scoreText forwards responseFormat to callLLM on both attempts and keeps strict-JSON fallback (#C2)', async () => {
+  const calls = [];
+  const callLLM = async (args) => {
+    calls.push(args);
+    // First attempt returns non-JSON to force the temperature-0 retry.
+    return calls.length === 1
+      ? 'sorry, here is the answer'
+      : '{ "categories": {}, "overall": 20, "interpretation": "mostly human" }';
+  };
+  const result = await scoreText({
+    text: 'A sample draft to score.',
+    config: loadConfig(),
+    patterns: [],
+    responseFormat: { type: 'json_object' },
+    callLLM,
+  });
+  assert.equal(calls.length, 2); // garbage -> retry preserves the fallback
+  assert.deepEqual(calls[0].responseFormat, { type: 'json_object' });
+  assert.deepEqual(calls[1].responseFormat, { type: 'json_object' });
+  assert.equal(calls[1].temperature, 0); // retry runs at temperature 0
+  assert.ok(result.overall != null);
+});
+
+test('scoreText omits responseFormat when the opt-in is unset (#C2)', async () => {
+  const calls = [];
+  const callLLM = async (args) => {
+    calls.push(args);
+    return '{ "categories": {}, "overall": 10, "interpretation": "human" }';
+  };
+  await scoreText({ text: 'x', config: loadConfig(), patterns: [], callLLM });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].responseFormat, undefined);
+});


### PR DESCRIPTION
## What
Wave 2 / C2 (after C1, before C3). Adds an opt-in OpenAI-compatible structured-output (`response_format`) request field for the HTTP scorer.

## Changes
- `src/api.js`: `callLLM` accepts optional `responseFormat` → `body.response_format`; omitted otherwise.
- `src/backends/contract.js`: `supportsStructuredOutput` capability (openai-http: true; all CLI + unknown: false) + `backendSupportsStructuredOutput()`.
- `src/scoring.js`: `callAndParseJson` + scoreText/scoreMPS/scoreFidelity thread `responseFormat` on **both** attempts; strict-JSON parse + temperature-0 retry fallback unchanged.
- `src/ouroboros.js`: `structuredOutput` option (default false) → `{ type: 'json_object' }`.
- `src/cli/run.js`: gate `config['structured-output'] === true && backendSupportsStructuredOutput('openai-http')` (default off; ouroboros always uses the HTTP callLLM).
- `.patina.default.yaml`: documented `structured-output: false`.

## Guarantees
- **Opt-in / default off** — endpoints that reject `response_format` are unaffected unless explicitly enabled.
- **Never sent to local CLI backends** — CLI adapters build no chat-completions body and reference no `response_format`; capability flag false for all CLI.
- **Strict-JSON fallback preserved** on every attempt.
- Deterministic engine + prompt text unchanged (benchmark 100%/AUC 1.000; no snapshot regen). Version-sync gate passes.

## Gate
- Architect: **CLEAR / APPROVE**.
- Executor QA: **30 assertions, 0 failed** — body emission, threading+fallback, never-to-CLI gate, unit tests, benchmark, snapshot stability. Full suite 726 pass; lint green.