### PR TITLE
docs(backends): document single-owner retry contract + invariant tests (#C3)

### DIFF
--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -1,3 +1,24 @@
+// Backend resilience contract — single owner per concern (C3).
+//
+// To avoid duplicated or compounding retries, each resilience concern has
+// exactly ONE owner:
+//
+//   * Transport retry (same provider, same request) — src/api.js `callLLM`.
+//     Retries up to `maxRetries` times on retryable HTTP/network errors with
+//     exponential backoff + jitter, bounded by the deadline. CLI backends pass
+//     maxRetries=0 (see BACKEND_SAFETY_DEFAULTS) so they never transport-retry.
+//   * Backend fallback (different backend) — src/backends/index.js
+//     `invokeBackendChain`. On a retryable error it advances to the NEXT backend
+//     in the chain; it NEVER re-invokes the same backend (that is transport
+//     retry's job). `isRetryableBackendError` (here) is the shared predicate.
+//   * Schema retry (re-ask for valid JSON) — src/scoring.js `callAndParseJson`.
+//     Exactly one extra attempt at temperature 0 on a JSON-parse/schema failure.
+//   * Timeout & concurrency — this module: `DEFAULT_BACKEND_TIMEOUT_MS`,
+//     `resolveBackendMaxConcurrency`, `withBackendConcurrencySlot`,
+//     `resolveBackendMaxRetries`.
+//
+// Defaults are intentionally stable; changing a retry path means changing its
+// single owner here or in the file named above, never adding a parallel one.
 import { spawn } from 'node:child_process';
 import { copyFileSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir, userInfo } from 'node:os';

--- a/tests/e2e/backends.test.js
+++ b/tests/e2e/backends.test.js
@@ -199,6 +199,37 @@ describe('Backend Fallback Chain', () => {
     assert.match(events[0].message, /first failed with HTTP 429; falling back to second/);
   });
 
+  it('invokes each backend at most once and never transport-retries the same backend (#C3)', async () => {
+    const counts = { first: 0, second: 0 };
+    const result = await invokeBackendChain({
+      backends: [
+        {
+          name: 'first',
+          invoke: async () => {
+            counts.first += 1;
+            const err = new Error('rate limited');
+            err.status = 429;
+            throw err;
+          },
+        },
+        {
+          name: 'second',
+          invoke: async () => {
+            counts.second += 1;
+            return 'ok';
+          },
+        },
+      ],
+      prompt: 'rewrite this',
+      logger: { warn() {} },
+    });
+    assert.strictEqual(result, 'ok');
+    // Fallback advances to the next backend; it never re-invokes the same one
+    // (transport retry of a single backend is callLLM's job, not the chain's).
+    assert.strictEqual(counts.first, 1);
+    assert.strictEqual(counts.second, 1);
+  });
+
   it('does not fall through non-retryable backend errors', async () => {
     let secondCalled = false;
     await assert.rejects(

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -320,3 +320,22 @@ test('callLLM sends response_format only when responseFormat is provided (#C2)',
     globalThis.fetch = originalFetch;
   }
 });
+
+test('callLLM makes exactly maxRetries+1 transport attempts on a persistent retryable error (#C3)', async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return { ok: false, status: 503, text: async () => 'unavailable', headers: { get: () => null } };
+  };
+  try {
+    await assert.rejects(
+      callLLM({ prompt: 'x', apiKey: 'k', maxRetries: 2, sleep: async () => {} }),
+      (err) => err.status === 503,
+    );
+    // Transport retry is owned by callLLM: 1 initial attempt + 2 retries.
+    assert.equal(calls, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/unit/scoring.test.js
+++ b/tests/unit/scoring.test.js
@@ -440,3 +440,21 @@ test('scoreText omits responseFormat when the opt-in is unset (#C2)', async () =
   assert.equal(calls.length, 1);
   assert.equal(calls[0].responseFormat, undefined);
 });
+
+test('scoreText runs exactly two LLM attempts then yields a schema-failure result on persistent bad JSON (#C3)', async () => {
+  let calls = 0;
+  const result = await scoreText({
+    text: 'draft to score',
+    config: loadConfig(),
+    patterns: [],
+    callLLM: async () => {
+      calls += 1;
+      return 'definitely not json';
+    },
+    logger: { warn() {} },
+  });
+  // Schema retry is owned by callAndParseJson: exactly 1 attempt + 1 temp-0 retry.
+  assert.equal(calls, 2);
+  assert.equal(result.overall, null);
+  assert.equal(result.error, 'schema-failure');
+});


### PR DESCRIPTION
## What
Wave 2 / C3 (after C2). Documents one owner per backend resilience concern and locks the invariants with tests. **No behavior change** — there was no duplicate/compounding retry path to remove.

## Ownership (doc in src/backends/contract.js)
- **Transport retry** → `src/api.js` `callLLM` (maxRetries+1 attempts, backoff+jitter, deadline-bounded; CLI backends maxRetries=0).
- **Backend fallback** → `src/backends/index.js` `invokeBackendChain` (advances to the next backend; never re-invokes the same one).
- **Schema retry** → `src/scoring.js` `callAndParseJson` (one temperature-0 re-ask).
- **Timeout & concurrency** → `src/backends/contract.js`.

## Tests (invariants)
- `callLLM` makes exactly maxRetries+1 transport attempts on a persistent 503.
- `scoreText` makes exactly 2 LLM attempts then returns a schema-failure result.
- `invokeBackendChain` invokes each backend at most once (no same-backend retry).

## Gate
- Architect: **CLEAR / APPROVE** (doc verified line-by-line against api.js/index.js/scoring.js/contract.js; no duplicate path).
- Executor QA: 16 red-team + 71 focused tests, **0 failed**.
- Full suite 729 pass; lint green; dogfood OK.