### PR TITLE
perf(ko): single-pass Korean diagnostics, tokenize eojeols once (#A5)

### DIFF
--- a/docs/benchmarks/perf-latest.json
+++ b/docs/benchmarks/perf-latest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-06-13T18:19:14.885Z",
+  "generatedAt": "2026-06-13T19:25:18.992Z",
   "nodeVersion": "v22.17.1",
   "platform": "linux",
   "arch": "x64",
@@ -16,11 +16,11 @@
       "inputParagraphs": 3,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 0.398,
-      "p95Ms": 1.559,
-      "p99Ms": 1.559,
-      "meanMs": 0.622,
-      "textsPerSec": 1608.104
+      "p50Ms": 0.374,
+      "p95Ms": 1.445,
+      "p99Ms": 1.445,
+      "meanMs": 0.592,
+      "textsPerSec": 1688.793
     },
     {
       "id": "perf-en-short",
@@ -30,11 +30,11 @@
       "inputParagraphs": 1,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 0.241,
-      "p95Ms": 0.302,
-      "p99Ms": 0.302,
-      "meanMs": 0.245,
-      "textsPerSec": 4073.498
+      "p50Ms": 0.206,
+      "p95Ms": 0.263,
+      "p99Ms": 0.263,
+      "meanMs": 0.214,
+      "textsPerSec": 4680.85
     },
     {
       "id": "perf-ko-medium",
@@ -44,11 +44,11 @@
       "inputParagraphs": 3,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 1.257,
-      "p95Ms": 1.438,
-      "p99Ms": 1.438,
-      "meanMs": 1.218,
-      "textsPerSec": 820.682
+      "p50Ms": 1.053,
+      "p95Ms": 1.347,
+      "p99Ms": 1.347,
+      "meanMs": 1.113,
+      "textsPerSec": 898.417
     },
     {
       "id": "perf-ko-short",
@@ -58,11 +58,11 @@
       "inputParagraphs": 1,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 0.489,
-      "p95Ms": 0.618,
-      "p99Ms": 0.618,
-      "meanMs": 0.49,
-      "textsPerSec": 2041.142
+      "p50Ms": 0.415,
+      "p95Ms": 0.641,
+      "p99Ms": 0.641,
+      "meanMs": 0.451,
+      "textsPerSec": 2218.921
     },
     {
       "id": "perf-mixed-long",
@@ -72,11 +72,11 @@
       "inputParagraphs": 6,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 0.445,
-      "p95Ms": 0.886,
-      "p99Ms": 0.886,
-      "meanMs": 0.518,
-      "textsPerSec": 1928.951
+      "p50Ms": 0.44,
+      "p95Ms": 0.783,
+      "p99Ms": 0.783,
+      "meanMs": 0.489,
+      "textsPerSec": 2043.645
     },
     {
       "id": "perf-synth-lexicon",
@@ -86,11 +86,11 @@
       "inputParagraphs": 1,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 1.117,
-      "p95Ms": 1.478,
-      "p99Ms": 1.478,
-      "meanMs": 1.216,
-      "textsPerSec": 822.696
+      "p50Ms": 1.11,
+      "p95Ms": 1.768,
+      "p99Ms": 1.768,
+      "meanMs": 1.241,
+      "textsPerSec": 805.666
     },
     {
       "id": "perf-synth-mattr",
@@ -100,58 +100,58 @@
       "inputParagraphs": 1,
       "passes": 7,
       "warmupPasses": 1,
-      "p50Ms": 3.394,
-      "p95Ms": 4.341,
-      "p99Ms": 4.341,
-      "meanMs": 3.347,
-      "textsPerSec": 298.82
+      "p50Ms": 3.241,
+      "p95Ms": 3.64,
+      "p99Ms": 3.64,
+      "meanMs": 3.146,
+      "textsPerSec": 317.883
     }
   ],
   "buckets": [
     {
       "sizeBucket": "long",
       "fixtureCount": 1,
-      "p50Ms": 0.518,
-      "p95Ms": 0.518,
-      "p99Ms": 0.518,
-      "meanMs": 0.518,
-      "textsPerSec": 1930.502
+      "p50Ms": 0.489,
+      "p95Ms": 0.489,
+      "p99Ms": 0.489,
+      "meanMs": 0.489,
+      "textsPerSec": 2044.99
     },
     {
       "sizeBucket": "medium",
       "fixtureCount": 2,
-      "p50Ms": 0.622,
-      "p95Ms": 1.218,
-      "p99Ms": 1.218,
-      "meanMs": 0.92,
-      "textsPerSec": 1086.957
+      "p50Ms": 0.592,
+      "p95Ms": 1.113,
+      "p99Ms": 1.113,
+      "meanMs": 0.853,
+      "textsPerSec": 1173.021
     },
     {
       "sizeBucket": "short",
       "fixtureCount": 2,
-      "p50Ms": 0.245,
-      "p95Ms": 0.49,
-      "p99Ms": 0.49,
-      "meanMs": 0.368,
-      "textsPerSec": 2721.088
+      "p50Ms": 0.214,
+      "p95Ms": 0.451,
+      "p99Ms": 0.451,
+      "meanMs": 0.333,
+      "textsPerSec": 3007.519
     },
     {
       "sizeBucket": "synthetic-lexicon",
       "fixtureCount": 1,
-      "p50Ms": 1.216,
-      "p95Ms": 1.216,
-      "p99Ms": 1.216,
-      "meanMs": 1.216,
-      "textsPerSec": 822.368
+      "p50Ms": 1.241,
+      "p95Ms": 1.241,
+      "p99Ms": 1.241,
+      "meanMs": 1.241,
+      "textsPerSec": 805.802
     },
     {
       "sizeBucket": "synthetic-mattr",
       "fixtureCount": 1,
-      "p50Ms": 3.347,
-      "p95Ms": 3.347,
-      "p99Ms": 3.347,
-      "meanMs": 3.347,
-      "textsPerSec": 298.775
+      "p50Ms": 3.146,
+      "p95Ms": 3.146,
+      "p99Ms": 3.146,
+      "meanMs": 3.146,
+      "textsPerSec": 317.864
     }
   ]
 }

--- a/docs/benchmarks/perf-latest.md
+++ b/docs/benchmarks/perf-latest.md
@@ -4,7 +4,7 @@ Latency of the deterministic offline analyzer (`analyzeText`) over fixed fixture
 **Report-only — not a release gate and not a latency threshold.** Timing is
 machine-dependent; treat this as a local snapshot, not a CI-drift target.
 
-- Generated at: 2026-06-13T18:19:14.885Z
+- Generated at: 2026-06-13T19:25:18.992Z
 - Node: v22.17.1 · linux/x64
 - Passes: 7 measured (+1 warmup) per fixture
 - Fixtures: 7
@@ -14,21 +14,21 @@ machine-dependent; treat this as a local snapshot, not a CI-drift target.
 
 | bucket | fixtures | p50 ms | p95 ms | p99 ms | mean ms | texts/sec |
 |--------|---------:|-------:|-------:|-------:|--------:|----------:|
-| long | 1 | 0.518 | 0.518 | 0.518 | 0.518 | 1930.502 |
-| medium | 2 | 0.622 | 1.218 | 1.218 | 0.920 | 1086.957 |
-| short | 2 | 0.245 | 0.490 | 0.490 | 0.368 | 2721.088 |
-| synthetic-lexicon | 1 | 1.216 | 1.216 | 1.216 | 1.216 | 822.368 |
-| synthetic-mattr | 1 | 3.347 | 3.347 | 3.347 | 3.347 | 298.775 |
+| long | 1 | 0.489 | 0.489 | 0.489 | 0.489 | 2044.990 |
+| medium | 2 | 0.592 | 1.113 | 1.113 | 0.853 | 1173.021 |
+| short | 2 | 0.214 | 0.451 | 0.451 | 0.333 | 3007.519 |
+| synthetic-lexicon | 1 | 1.241 | 1.241 | 1.241 | 1.241 | 805.802 |
+| synthetic-mattr | 1 | 3.146 | 3.146 | 3.146 | 3.146 | 317.864 |
 
 ## Per fixture
 
 | fixture | lang | bucket | chars | paras | p50 ms | p95 ms | p99 ms | mean ms | texts/sec |
 |---------|------|--------|------:|------:|-------:|-------:|-------:|--------:|----------:|
-| perf-en-medium | en | medium | 316 | 3 | 0.398 | 1.559 | 1.559 | 0.622 | 1608.104 |
-| perf-en-short | en | short | 51 | 1 | 0.241 | 0.302 | 0.302 | 0.245 | 4073.498 |
-| perf-ko-medium | ko | medium | 135 | 3 | 1.257 | 1.438 | 1.438 | 1.218 | 820.682 |
-| perf-ko-short | ko | short | 31 | 1 | 0.489 | 0.618 | 0.618 | 0.490 | 2041.142 |
-| perf-mixed-long | en | long | 727 | 6 | 0.445 | 0.886 | 0.886 | 0.518 | 1928.951 |
-| perf-synth-lexicon | en | synthetic-lexicon | 10480 | 1 | 1.117 | 1.478 | 1.478 | 1.216 | 822.696 |
-| perf-synth-mattr | en | synthetic-mattr | 27200 | 1 | 3.394 | 4.341 | 4.341 | 3.347 | 298.820 |
+| perf-en-medium | en | medium | 316 | 3 | 0.374 | 1.445 | 1.445 | 0.592 | 1688.793 |
+| perf-en-short | en | short | 51 | 1 | 0.206 | 0.263 | 0.263 | 0.214 | 4680.850 |
+| perf-ko-medium | ko | medium | 135 | 3 | 1.053 | 1.347 | 1.347 | 1.113 | 898.417 |
+| perf-ko-short | ko | short | 31 | 1 | 0.415 | 0.641 | 0.641 | 0.451 | 2218.921 |
+| perf-mixed-long | en | long | 727 | 6 | 0.440 | 0.783 | 0.783 | 0.489 | 2043.645 |
+| perf-synth-lexicon | en | synthetic-lexicon | 10480 | 1 | 1.110 | 1.768 | 1.768 | 1.241 | 805.666 |
+| perf-synth-mattr | en | synthetic-mattr | 27200 | 1 | 3.241 | 3.640 | 3.640 | 3.146 | 317.883 |
 

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -10,6 +10,7 @@ import {
   classifyBurstiness,
   classifyMattr,
   classifyKoreanDiagnostics,
+  koreanDiagnostics,
   commaDensity,
   koreanPosDiversityProxy,
   koreanSpacingFeatures,
@@ -118,7 +119,7 @@ export function analyzeText(text, opts = {}) {
     const mattrBand = classifyMattr(mattrValue, mattrBands);
     const lex = computeDensity(paragraph, allTokens, lexicon);
     const koSignals = lang === 'ko'
-      ? buildKoreanSignals(paragraph, sentences.length, {
+      ? koreanDiagnostics(paragraph, sentences.length, {
           enabled: koDiagnosticsEnabled,
           bands: koDiagnosticBands,
         })
@@ -189,6 +190,7 @@ export {
   classifyBurstiness,
   classifyMattr,
   classifyKoreanDiagnostics,
+  koreanDiagnostics,
   commaDensity,
   koreanPosDiversityProxy,
   koreanSpacingFeatures,
@@ -209,23 +211,4 @@ export {
   resolveStructuralModelPath,
 };
 
-function buildKoreanSignals(paragraph, sentenceCount, { enabled, bands }) {
-  const spacing = koreanSpacingFeatures(paragraph);
-  const comma = commaDensity(paragraph, sentenceCount);
-  const posDiversity = koreanPosDiversityProxy(paragraph);
-  const koDiagnostics = enabled
-    ? classifyKoreanDiagnostics({
-        sentenceCount,
-        spacing,
-        comma,
-        posDiversity,
-      }, bands)
-    : { hot: false, strength: 0, reasons: [], thresholds: bands };
 
-  return {
-    spacing,
-    comma,
-    posDiversity,
-    koDiagnostics,
-  };
-}

--- a/src/features/stylometry.js
+++ b/src/features/stylometry.js
@@ -439,8 +439,7 @@ export function detectKoreanRegister(text) {
   };
 }
 
-export function koreanSpacingFeatures(paragraph) {
-  const eojeols = koreanEojeols(paragraph);
+export function koreanSpacingFeatures(paragraph, eojeols = koreanEojeols(paragraph)) {
   const lengths = eojeols.map(koreanLength).filter((length) => length > 0);
   const eojeolCount = lengths.length;
 
@@ -466,8 +465,7 @@ export function commaDensity(paragraph, sentenceCount = null) {
   };
 }
 
-export function koreanPosDiversityProxy(paragraph) {
-  const eojeols = koreanEojeols(paragraph);
+export function koreanPosDiversityProxy(paragraph, eojeols = koreanEojeols(paragraph)) {
   const matches = [];
 
   for (const token of eojeols) {
@@ -547,6 +545,26 @@ export function classifyKoreanDiagnostics({
     reasons: hot ? reasons : [],
     thresholds,
   };
+}
+
+// Single-pass Korean per-paragraph diagnostics: tokenize eojeols ONCE and reuse
+// them for the spacing and POS-diversity proxies (previously each recomputed
+// koreanEojeols), then derive comma density and the composite classification.
+// Output is identical to calling koreanSpacingFeatures/commaDensity/
+// koreanPosDiversityProxy/classifyKoreanDiagnostics separately.
+export function koreanDiagnostics(
+  paragraph,
+  sentenceCount,
+  { enabled = true, bands = DEFAULT_KO_DIAGNOSTIC_BANDS } = {}
+) {
+  const eojeols = koreanEojeols(paragraph);
+  const spacing = koreanSpacingFeatures(paragraph, eojeols);
+  const comma = commaDensity(paragraph, sentenceCount);
+  const posDiversity = koreanPosDiversityProxy(paragraph, eojeols);
+  const koDiagnostics = enabled
+    ? classifyKoreanDiagnostics({ sentenceCount, spacing, comma, posDiversity }, bands)
+    : { hot: false, strength: 0, reasons: [], thresholds: bands };
+  return { spacing, comma, posDiversity, koDiagnostics };
 }
 
 export function classifyBurstiness(cv, bands = DEFAULT_BURSTINESS_BANDS) {

--- a/tests/unit/stylometry-ko.test.js
+++ b/tests/unit/stylometry-ko.test.js
@@ -3,6 +3,8 @@ import { strict as assert } from 'node:assert';
 
 import { analyzeText } from '../../src/features/index.js';
 import {
+  koreanDiagnostics,
+  DEFAULT_KO_DIAGNOSTIC_BANDS,
   classifyKoreanDiagnostics,
   commaDensity,
   koreanPosDiversityProxy,
@@ -132,4 +134,90 @@ test('detectKoreanRegister reports mixed registers and refuses thin samples', as
   // Fewer than three classified endings is noise, not a register.
   assert.equal(detectKoreanRegister('짧다.'), null);
   assert.equal(detectKoreanRegister('Hello world. This is English text only.'), null);
+});
+// --- A5: KO single-pass diagnostics equivalence -----------------------------
+
+import { splitProseSentences } from '../../src/features/segment.js';
+
+// Reference assembly identical to the pre-A5 buildKoreanSignals: each proxy
+// recomputes its own eojeols. koreanDiagnostics must match it exactly while
+// tokenizing eojeols only once.
+function referenceKoreanSignals(paragraph, sentenceCount, { enabled = true, bands = DEFAULT_KO_DIAGNOSTIC_BANDS } = {}) {
+  const spacing = koreanSpacingFeatures(paragraph);
+  const comma = commaDensity(paragraph, sentenceCount);
+  const posDiversity = koreanPosDiversityProxy(paragraph);
+  const koDiagnostics = enabled
+    ? classifyKoreanDiagnostics({ sentenceCount, spacing, comma, posDiversity }, bands)
+    : { hot: false, strength: 0, reasons: [], thresholds: bands };
+  return { spacing, comma, posDiversity, koDiagnostics };
+}
+
+test('koreanDiagnostics single-pass output matches separate spacing/comma/posDiversity/classify calls', () => {
+  const cases = [
+    '이 도구는 혁신적이다. 이 도구는 효율적이고 신뢰할 수 있다. 팀은 확장성 때문에 빠르게 채택한다. 또한 측정 가능한 가치를 제공한다.',
+    '어제 친구랑 카페 갔는데, 거기 커피가 진짜 맛있더라. 너도 한번 가봐! 분위기도 좋고, 가격도 안 비싸.',
+    KO_COMPOSITE_TEXT,
+    '', // empty paragraph
+    '단문.', // single short sentence
+  ];
+  for (const paragraph of cases) {
+    const sentenceCount = splitProseSentences(paragraph).length;
+    for (const enabled of [true, false]) {
+      assert.deepEqual(
+        koreanDiagnostics(paragraph, sentenceCount, { enabled }),
+        referenceKoreanSignals(paragraph, sentenceCount, { enabled }),
+        `mismatch for "${paragraph.slice(0, 12)}" enabled=${enabled}`,
+      );
+    }
+  }
+});
+
+test('koreanDiagnostics disabled branch returns the inert composite', () => {
+  const bands = DEFAULT_KO_DIAGNOSTIC_BANDS;
+  const out = koreanDiagnostics('이 도구는 혁신적이다. 빠르게 채택한다.', 2, { enabled: false });
+  assert.deepEqual(out.koDiagnostics, { hot: false, strength: 0, reasons: [], thresholds: bands });
+});
+
+test('koreanSpacingFeatures/koreanPosDiversityProxy honor a pre-computed eojeols argument', () => {
+  // Passing an explicit eojeols array bypasses internal tokenization.
+  assert.equal(koreanSpacingFeatures('이 도구는 결과를 보여준다', []).eojeolCount, 0);
+  assert.equal(koreanPosDiversityProxy('이 도구는 결과를 보여준다', []).eojeolCount, 0);
+  // A custom three-token array is used verbatim.
+  const spacing = koreanSpacingFeatures('ignored', ['가나다', '라마', '바']);
+  assert.equal(spacing.eojeolCount, 3);
+});
+
+test('analyzeText KO per-paragraph diagnostics are unchanged after the single-pass refactor (parity)', () => {
+  const ai = analyzeText('이 도구는 혁신적이다. 이 도구는 효율적이고 신뢰할 수 있다. 팀은 확장성 때문에 빠르게 채택한다. 또한 측정 가능한 가치를 제공한다.', { lang: 'ko' }).paragraphs[0];
+  assert.deepEqual(ai.spacing, {
+    eojeolCount: 19,
+    meanEojeolLength: 2.789473684210526,
+    eojeolLengthCV: 0.41251341715236683,
+    singleSyllableRatio: 0.15789473684210525,
+    longEojeolRatio: 0,
+  });
+  assert.deepEqual(ai.posDiversity, {
+    proxy: 'suffix',
+    eojeolCount: 19,
+    matchedCount: 8,
+    coverage: 0.42105263157894735,
+    distinctClassCount: 4,
+    classDiversity: 0.5,
+    distinctSuffixCount: 6,
+    suffixDiversity: 0.75,
+    classes: ['declarative_ending', 'location', 'object', 'topic'],
+  });
+  assert.equal(ai.koDiagnostics.hot, false);
+  assert.equal(ai.hot, true);
+
+  const natural = analyzeText('어제 친구랑 카페 갔는데, 거기 커피가 진짜 맛있더라. 너도 한번 가봐! 분위기도 좋고, 가격도 안 비싸.', { lang: 'ko' }).paragraphs[0];
+  assert.deepEqual(natural.spacing, {
+    eojeolCount: 16,
+    meanEojeolLength: 2.4375,
+    eojeolLengthCV: 0.32332103110047417,
+    singleSyllableRatio: 0.0625,
+    longEojeolRatio: 0,
+  });
+  assert.equal(natural.posDiversity.matchedCount, 5);
+  assert.equal(natural.hot, false);
 });


### PR DESCRIPTION
## What
Wave 3 / A5 (after A2; justified by A1/A2/A3 perf evidence). Eliminates duplicate Korean eojeol tokenization in the per-paragraph diagnostics.

## Change
New `koreanDiagnostics(paragraph, sentenceCount, { enabled, bands })` tokenizes a paragraph's eojeols **once** and reuses them for the spacing and POS-diversity proxies (each previously recomputed `koreanEojeols`), then derives comma density + the composite classification. `koreanSpacingFeatures`/`koreanPosDiversityProxy` gained an optional pre-computed `eojeols` arg (default = `koreanEojeols(paragraph)`, so standalone callers are unchanged). `analyzeText`'s `buildKoreanSignals` is replaced by `koreanDiagnostics`.

## Equivalence (exact)
Output is byte-identical. `structural-features.js` left unchanged (off the default benchmark hot path; perf doesn't justify the equivalence risk).

## Gate
- Architect: **CLEAR / APPROVE** (required before A5).
- Executor QA: **328 equivalence comparisons, 0 mismatches**; KO/stylometry/playground-parity tests pass; benchmark 100% / ROC·PR-AUC 1.000.
- Full suite 733 pass; lint green; dogfood OK.

## Perf (report-only)
`perf-ko-medium` p50 1.26→1.05ms (~16%), `perf-ko-short` 0.49→0.42ms (~15%).