### PR TITLE
feat(benchmark): additive slice metrics scaffold (#B2)

### DIFF
--- a/docs/benchmarks/latest.json
+++ b/docs/benchmarks/latest.json
@@ -7,7 +7,7 @@
   "schemaVersion": 3,
   "fixtureSchemaVersion": 1,
   "nodeVersion": "v22.17.1",
-  "generatedAt": "2026-06-13T17:47:23.201Z",
+  "generatedAt": "2026-06-13T19:36:48.740Z",
   "fixtureCount": 49,
   "overallAccuracy": 1,
   "overall": {
@@ -1146,6 +1146,212 @@
       }
     }
   },
+  "slices": {
+    "language": {
+      "minCount": 5,
+      "values": {
+        "en": {
+          "n": 13,
+          "tp": 7,
+          "fp": 0,
+          "fn": 0,
+          "tn": 6,
+          "accuracy": 1,
+          "precision": 1,
+          "recall": 1,
+          "f1": 1,
+          "supported": true,
+          "reason": null
+        },
+        "ja": {
+          "n": 12,
+          "tp": 6,
+          "fp": 0,
+          "fn": 0,
+          "tn": 6,
+          "accuracy": 1,
+          "precision": 1,
+          "recall": 1,
+          "f1": 1,
+          "supported": true,
+          "reason": null
+        },
+        "ko": {
+          "n": 12,
+          "tp": 7,
+          "fp": 0,
+          "fn": 0,
+          "tn": 5,
+          "accuracy": 1,
+          "precision": 1,
+          "recall": 1,
+          "f1": 1,
+          "supported": true,
+          "reason": null
+        },
+        "zh": {
+          "n": 12,
+          "tp": 6,
+          "fp": 0,
+          "fn": 0,
+          "tn": 6,
+          "accuracy": 1,
+          "precision": 1,
+          "recall": 1,
+          "f1": 1,
+          "supported": true,
+          "reason": null
+        }
+      }
+    },
+    "class": {
+      "minCount": 5,
+      "values": {
+        "ai": {
+          "n": 26,
+          "tp": 26,
+          "fp": 0,
+          "fn": 0,
+          "tn": 0,
+          "accuracy": 1,
+          "precision": 1,
+          "recall": 1,
+          "f1": 1,
+          "supported": true,
+          "reason": null
+        },
+        "natural": {
+          "n": 23,
+          "tp": 0,
+          "fp": 0,
+          "fn": 0,
+          "tn": 23,
+          "accuracy": 1,
+          "precision": null,
+          "recall": null,
+          "f1": null,
+          "supported": true,
+          "reason": null
+        }
+      }
+    },
+    "lengthBucket": {
+      "minCount": 5,
+      "values": {
+        "medium": {
+          "n": 12,
+          "tp": 6,
+          "fp": 0,
+          "fn": 0,
+          "tn": 6,
+          "accuracy": 1,
+          "precision": 1,
+          "recall": 1,
+          "f1": 1,
+          "supported": true,
+          "reason": null
+        },
+        "short": {
+          "n": 37,
+          "tp": 20,
+          "fp": 0,
+          "fn": 0,
+          "tn": 17,
+          "accuracy": 1,
+          "precision": 1,
+          "recall": 1,
+          "f1": 1,
+          "supported": true,
+          "reason": null
+        }
+      }
+    },
+    "domain": {
+      "minCount": 5,
+      "values": {
+        "unspecified": {
+          "n": 49,
+          "tp": 26,
+          "fp": 0,
+          "fn": 0,
+          "tn": 23,
+          "accuracy": 1,
+          "precision": 1,
+          "recall": 1,
+          "f1": 1,
+          "supported": true,
+          "reason": null
+        }
+      }
+    },
+    "register": {
+      "minCount": 5,
+      "values": {
+        "unspecified": {
+          "n": 48,
+          "tp": 25,
+          "fp": 0,
+          "fn": 0,
+          "tn": 23,
+          "accuracy": 1,
+          "precision": 1,
+          "recall": 1,
+          "f1": 1,
+          "supported": true,
+          "reason": null
+        },
+        "workplace-summary": {
+          "n": 1,
+          "tp": 1,
+          "fp": 0,
+          "fn": 0,
+          "tn": 0,
+          "accuracy": null,
+          "precision": null,
+          "recall": null,
+          "f1": null,
+          "supported": false,
+          "reason": "insufficient_data"
+        }
+      }
+    },
+    "generator": {
+      "minCount": 5,
+      "values": {
+        "unspecified": {
+          "n": 49,
+          "tp": 26,
+          "fp": 0,
+          "fn": 0,
+          "tn": 23,
+          "accuracy": 1,
+          "precision": 1,
+          "recall": 1,
+          "f1": 1,
+          "supported": true,
+          "reason": null
+        }
+      }
+    },
+    "edited": {
+      "minCount": 5,
+      "values": {
+        "unspecified": {
+          "n": 49,
+          "tp": 26,
+          "fp": 0,
+          "fn": 0,
+          "tn": 23,
+          "accuracy": 1,
+          "precision": 1,
+          "recall": 1,
+          "f1": 1,
+          "supported": true,
+          "reason": null
+        }
+      }
+    }
+  },
   "fixtures": [
     {
       "fixture_id": "en-ai-01",
@@ -1171,7 +1377,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 80.512,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "medium",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "en-ai-02",
@@ -1197,7 +1408,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 69.883,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "medium",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "en-ai-03",
@@ -1223,7 +1439,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 78.495,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "medium",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "en-ai-04",
@@ -1249,7 +1470,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 76.717,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "medium",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "en-ai-05",
@@ -1275,7 +1501,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 68.994,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "medium",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "en-ai-06-chat-register",
@@ -1306,7 +1537,12 @@
         "mattr_band": "high",
         "lexicon_density_min": 0,
         "lexicon_density_max": 80
-      }
+      },
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "en-ai-07-discourse-candor",
@@ -1341,7 +1577,12 @@
           "mattr": false,
           "lexicon": false
         }
-      }
+      },
+      "length_bucket": "medium",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "en-nat-01",
@@ -1367,7 +1608,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "medium",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "en-nat-02",
@@ -1393,7 +1639,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "medium",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "en-nat-03",
@@ -1419,7 +1670,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "medium",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "en-nat-04",
@@ -1445,7 +1701,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "medium",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "en-nat-05",
@@ -1471,7 +1732,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "medium",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "en-nat-06-single-opener",
@@ -1500,7 +1766,12 @@
       "expected_metrics": {
         "predicted_hot": false,
         "hot_paragraphs": 0
-      }
+      },
+      "length_bucket": "medium",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ja-ai-01",
@@ -1526,7 +1797,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 84.959,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ja-ai-02",
@@ -1552,7 +1828,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 23.167,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ja-ai-03",
@@ -1578,7 +1859,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 79.067,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ja-ai-04-lexicon",
@@ -1614,7 +1900,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 100,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ja-ai-05-formulaic-summary",
@@ -1651,7 +1942,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 100,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ja-ai-06-broad-tech",
@@ -1687,7 +1983,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 100,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ja-nat-01",
@@ -1713,7 +2014,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ja-nat-02",
@@ -1739,7 +2045,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ja-nat-03",
@@ -1765,7 +2076,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ja-nat-04-lexicon-cold",
@@ -1791,7 +2107,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ja-nat-05-station-note",
@@ -1817,7 +2138,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ja-nat-06-maintenance-log",
@@ -1843,7 +2169,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ko-ai-01",
@@ -1871,7 +2202,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 68.992,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ko-ai-02",
@@ -1897,7 +2233,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 75.545,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ko-ai-03",
@@ -1925,7 +2266,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 75.545,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ko-ai-04",
@@ -1951,7 +2297,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 67.314,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ko-ai-05",
@@ -1981,7 +2332,12 @@
       "ko_diagnostics_strength": 0.285,
       "signal_score": 67.314,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ko-ai-06-chat-register",
@@ -2012,7 +2368,12 @@
         "mattr_band": "high",
         "lexicon_density_min": 0,
         "lexicon_density_max": 80
-      }
+      },
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ko-ai-07-ko-diagnostic",
@@ -2042,7 +2403,12 @@
       "ko_diagnostics_strength": 3.846,
       "signal_score": 3.846,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "workplace-summary",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ko-nat-01",
@@ -2068,7 +2434,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ko-nat-02",
@@ -2094,7 +2465,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ko-nat-03",
@@ -2120,7 +2496,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ko-nat-04",
@@ -2146,7 +2527,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "ko-nat-05",
@@ -2172,7 +2558,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "zh-ai-01",
@@ -2198,7 +2589,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 79.272,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "zh-ai-02",
@@ -2224,7 +2620,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 6.772,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "zh-ai-03",
@@ -2250,7 +2651,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 72.43,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "zh-ai-04-lexicon",
@@ -2287,7 +2693,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 100,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "zh-ai-05-formulaic-summary",
@@ -2326,7 +2737,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 100,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "zh-ai-06-broad-tech",
@@ -2363,7 +2779,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 100,
       "hot_paragraphs": 1,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "zh-nat-01",
@@ -2389,7 +2810,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "zh-nat-02",
@@ -2415,7 +2841,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "zh-nat-03",
@@ -2441,7 +2872,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "zh-nat-04-lexicon-cold",
@@ -2467,7 +2903,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "zh-nat-05-market-note",
@@ -2493,7 +2934,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     },
     {
       "fixture_id": "zh-nat-06-maintenance-log",
@@ -2519,7 +2965,12 @@
       "ko_diagnostics_strength": 0,
       "signal_score": 0,
       "hot_paragraphs": 0,
-      "expected_metrics": null
+      "expected_metrics": null,
+      "length_bucket": "short",
+      "domain": "unspecified",
+      "register": "unspecified",
+      "generator": "unspecified",
+      "edited": "unspecified"
     }
   ],
   "sampleSizes": {

--- a/docs/benchmarks/latest.md
+++ b/docs/benchmarks/latest.md
@@ -7,7 +7,7 @@ This is the latest checked-in report for patina's deterministic suspect-zone ben
 ## Current result
 
 - Status: **passing**
-- Generated at: 2026-06-13T17:47:23.201Z
+- Generated at: 2026-06-13T19:36:48.740Z
 - Node: v22.17.1
 - Fixture schema: v1
 - Fixtures: 49
@@ -83,6 +83,62 @@ support the target; `max FP` of 0 is a strict zero-false-positive point.
 | ko | 5.0% | 5 | 0 | 0.0% | 100.0% |
 | zh | 1.0% | 6 | 0 | 0.0% | 100.0% |
 | zh | 5.0% | 6 | 0 | 0.0% | 100.0% |
+
+## Slice metrics
+
+Report-only confusion metrics grouped by metadata dimension. `language`,
+`class`, and `lengthBucket` are derived from current fixtures; `domain`,
+`register`, `generator`, and `edited` collapse to `unspecified` until the
+corpus carries that metadata. Slices below the per-dimension minimum count are
+reported as `insufficient data` (counts only). No detector thresholds change.
+
+### language (min 5)
+
+| value | n | accuracy | precision | recall | f1 | state |
+|---|---:|---:|---:|---:|---:|---|
+| en | 13 | 100.0% | 100.0% | 100.0% | 1 | ok |
+| ja | 12 | 100.0% | 100.0% | 100.0% | 1 | ok |
+| ko | 12 | 100.0% | 100.0% | 100.0% | 1 | ok |
+| zh | 12 | 100.0% | 100.0% | 100.0% | 1 | ok |
+
+### class (min 5)
+
+| value | n | accuracy | precision | recall | f1 | state |
+|---|---:|---:|---:|---:|---:|---|
+| ai | 26 | 100.0% | 100.0% | 100.0% | 1 | ok |
+| natural | 23 | 100.0% | — | — | — | ok |
+
+### lengthBucket (min 5)
+
+| value | n | accuracy | precision | recall | f1 | state |
+|---|---:|---:|---:|---:|---:|---|
+| medium | 12 | 100.0% | 100.0% | 100.0% | 1 | ok |
+| short | 37 | 100.0% | 100.0% | 100.0% | 1 | ok |
+
+### domain (min 5)
+
+| value | n | accuracy | precision | recall | f1 | state |
+|---|---:|---:|---:|---:|---:|---|
+| unspecified | 49 | 100.0% | 100.0% | 100.0% | 1 | ok |
+
+### register (min 5)
+
+| value | n | accuracy | precision | recall | f1 | state |
+|---|---:|---:|---:|---:|---:|---|
+| unspecified | 48 | 100.0% | 100.0% | 100.0% | 1 | ok |
+| workplace-summary | 1 | — | — | — | — | insufficient_data |
+
+### generator (min 5)
+
+| value | n | accuracy | precision | recall | f1 | state |
+|---|---:|---:|---:|---:|---:|---|
+| unspecified | 49 | 100.0% | 100.0% | 100.0% | 1 | ok |
+
+### edited (min 5)
+
+| value | n | accuracy | precision | recall | f1 | state |
+|---|---:|---:|---:|---:|---:|---|
+| unspecified | 49 | 100.0% | 100.0% | 100.0% | 1 | ok |
 
 ## Sample sizes
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "scripts/lint.mjs",
     "tests/quality/benchmark.mjs",
     "tests/quality/ranking-metrics.mjs",
+    "tests/quality/slice-metrics.mjs",
     "tests/quality/README.md",
     "tests/fixtures/suspect-zones/",
     "README.md",

--- a/scripts/benchmark-report.mjs
+++ b/scripts/benchmark-report.mjs
@@ -53,6 +53,7 @@ function validateResultsSchema(results) {
   if (!isNumberOrNull(results?.ranking?.overall?.pr_auc)) missing.push('ranking.overall.pr_auc');
   if (!results?.ranking?.overall?.bestF1) missing.push('ranking.overall.bestF1');
   if (!Array.isArray(results?.ranking?.overall?.low_fpr)) missing.push('ranking.overall.low_fpr');
+  if (!results?.slices || typeof results.slices !== 'object') missing.push('slices');
   for (const [lang, summary] of Object.entries(results?.perLanguage || {})) {
     for (const detector of ['burstiness', 'koDiagnostics', 'mattr', 'lexicon']) {
       if (!summary.byDetector?.[detector]) missing.push(`perLanguage.${lang}.byDetector.${detector}`);
@@ -195,6 +196,31 @@ function misclassificationSection(fixtures = []) {
   ].join('\n');
 }
 
+// Render the report-only slice tables (B2). One sub-table per metadata
+// dimension; below-minimum slices show counts with an `insufficient data`
+// state; absent dimensions collapse to a single `unspecified` value.
+function sliceSection(slices = {}) {
+  const order = ['language', 'class', 'lengthBucket', 'domain', 'register', 'generator', 'edited'];
+  const dims = order.filter((d) => slices[d]);
+  for (const d of Object.keys(slices)) if (!dims.includes(d)) dims.push(d);
+  const blocks = [];
+  for (const dim of dims) {
+    const { minCount, values } = slices[dim];
+    const rows = Object.entries(values).map(([value, m]) => {
+      const state = m.supported ? 'ok' : (m.reason || 'unsupported');
+      return `| ${cell(value)} | ${m.n} | ${optionalPct(m.accuracy)} | ${optionalPct(m.precision)} | ${optionalPct(m.recall)} | ${optionalNum(m.f1)} | ${state} |`;
+    });
+    blocks.push([
+      `### ${cell(dim)} (min ${minCount})`,
+      '',
+      '| value | n | accuracy | precision | recall | f1 | state |',
+      '|---|---:|---:|---:|---:|---:|---|',
+      rows.join('\n') || '| _(none)_ | 0 | — | — | — | — | — |',
+    ].join('\n'));
+  }
+  return blocks.join('\n\n');
+}
+
 function renderMarkdown(results, benchmarkStatus) {
   const generatedAt = results.generatedAt || new Date().toISOString();
   const languages = Object.keys(results.perLanguage || {}).sort();
@@ -263,6 +289,16 @@ support the target; \`max FP\` of 0 is a strict zero-false-positive point.
 | scope | target FPR | negatives | max FP | actual FPR | TPR |
 |---|---:|---:|---:|---:|---:|
 ${lowFprRows(results.ranking).join('\n')}
+
+## Slice metrics
+
+Report-only confusion metrics grouped by metadata dimension. \`language\`,
+\`class\`, and \`lengthBucket\` are derived from current fixtures; \`domain\`,
+\`register\`, \`generator\`, and \`edited\` collapse to \`unspecified\` until the
+corpus carries that metadata. Slices below the per-dimension minimum count are
+reported as \`insufficient data\` (counts only). No detector thresholds change.
+
+${sliceSection(results.slices)}
 
 ## Sample sizes
 

--- a/tests/quality/benchmark.mjs
+++ b/tests/quality/benchmark.mjs
@@ -18,6 +18,7 @@ import { analyzeText } from '../../src/features/index.js';
 import { loadLexicon } from '../../src/features/lexicon.js';
 import { summarizeSignalStrength } from '../../src/features/signal-strength.js';
 import { summarizeRanking } from './ranking-metrics.mjs';
+import { summarizeSlices, lengthBucket, UNSPECIFIED } from './slice-metrics.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../..');
@@ -276,6 +277,14 @@ function main() {
       detectors,
       ...observed,
       expected_metrics: meta.expected_metrics ?? null,
+      // Slice dimensions (B2, report-only). language/class/length_bucket are
+      // always derivable; the rest default to `unspecified` until the corpus
+      // carries that metadata.
+      length_bucket: lengthBucket([...body].length),
+      domain: meta.domain ?? UNSPECIFIED,
+      register: meta.register ?? UNSPECIFIED,
+      generator: meta.generator ?? UNSPECIFIED,
+      edited: meta.edited ?? UNSPECIFIED,
     });
   }
 
@@ -314,6 +323,19 @@ function main() {
       overall: summarizeRanking(rankingRecords(fixtureLog)),
       perLanguage: summarizeRankingByLanguage(fixtureLog),
     },
+    slices: summarizeSlices(
+      fixtureLog.map((f) => ({
+        language: f.lang,
+        class: f.class,
+        lengthBucket: f.length_bucket,
+        domain: f.domain,
+        register: f.register,
+        generator: f.generator,
+        edited: f.edited,
+        predicted_hot: f.predicted_hot,
+        expected_hot: f.expected_hot,
+      }))
+    ),
     fixtures: fixtureLog,
   };
 

--- a/tests/quality/slice-metrics.mjs
+++ b/tests/quality/slice-metrics.mjs
@@ -1,0 +1,104 @@
+// Additive slice aggregation for the deterministic benchmark (B2).
+//
+// Groups the per-fixture confusion outcomes by metadata dimension and reports
+// counts + accuracy/precision/recall/F1, or an explicit insufficient-data state
+// when a slice has fewer than `minCount` records. This is REPORT-ONLY: it never
+// changes a detector threshold or the hot/cold decision. Dimensions absent from
+// fixture frontmatter (domain/register/generator/edited) collapse to a single
+// `unspecified` bucket until the corpus carries that metadata.
+
+export const DEFAULT_MIN_SLICE_COUNT = 5;
+export const UNSPECIFIED = 'unspecified';
+
+// Slice dimensions, in stable report order. `language`, `class`, and
+// `lengthBucket` are always derivable from current fixtures; the rest depend on
+// frontmatter that may not exist yet (then `unspecified`).
+export const SLICE_DIMENSIONS = Object.freeze([
+  'language',
+  'class',
+  'lengthBucket',
+  'domain',
+  'register',
+  'generator',
+  'edited',
+]);
+
+// Deterministic length bucket from a code-point count. Documented + tested so
+// the buckets are stable across Node versions and platforms.
+export function lengthBucket(charCount) {
+  if (typeof charCount !== 'number' || !Number.isFinite(charCount) || charCount <= 0) return 'empty';
+  if (charCount <= 400) return 'short';
+  if (charCount <= 1200) return 'medium';
+  return 'long';
+}
+
+function round(n, digits = 3) {
+  return Math.round(n * 10 ** digits) / 10 ** digits;
+}
+
+function confusion(records) {
+  let tp = 0;
+  let fp = 0;
+  let fn = 0;
+  let tn = 0;
+  for (const r of records) {
+    const predicted = Boolean(r.predicted_hot);
+    const expected = Boolean(r.expected_hot);
+    if (predicted && expected) tp += 1;
+    else if (predicted && !expected) fp += 1;
+    else if (!predicted && expected) fn += 1;
+    else tn += 1;
+  }
+  return { tp, fp, fn, tn };
+}
+
+// One slice's metrics. Below `minCount` records, metrics are null with
+// supported:false / reason:'insufficient_data' but counts are still reported.
+export function sliceMetric(records, minCount = DEFAULT_MIN_SLICE_COUNT) {
+  const n = records.length;
+  const { tp, fp, fn, tn } = confusion(records);
+  if (n < minCount) {
+    return { n, tp, fp, fn, tn, accuracy: null, precision: null, recall: null, f1: null, supported: false, reason: 'insufficient_data' };
+  }
+  const accuracy = (tp + tn) / n;
+  const precision = tp + fp > 0 ? tp / (tp + fp) : null;
+  const recall = tp + fn > 0 ? tp / (tp + fn) : null;
+  const f1 = precision != null && recall != null && precision + recall > 0
+    ? (2 * precision * recall) / (precision + recall)
+    : null;
+  return {
+    n,
+    tp,
+    fp,
+    fn,
+    tn,
+    accuracy: round(accuracy),
+    precision: precision == null ? null : round(precision),
+    recall: recall == null ? null : round(recall),
+    f1: f1 == null ? null : round(f1),
+    supported: true,
+    reason: null,
+  };
+}
+
+// Build the full slice report. `records` carry the slice dimension fields plus
+// predicted_hot / expected_hot. Output is deterministic (dimensions in
+// SLICE_DIMENSIONS order; values sorted by key).
+export function summarizeSlices(records, { minCount = DEFAULT_MIN_SLICE_COUNT, dimensions = SLICE_DIMENSIONS } = {}) {
+  const list = Array.isArray(records) ? records : [];
+  const out = {};
+  for (const dimension of dimensions) {
+    const groups = new Map();
+    for (const record of list) {
+      const key = record[dimension] ?? UNSPECIFIED;
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(record);
+    }
+    const values = {};
+    for (const key of [...groups.keys()].sort()) {
+      values[key] = sliceMetric(groups.get(key), minCount);
+    }
+    out[dimension] = { minCount, values };
+  }
+  return out;
+}

--- a/tests/unit/benchmark-report.test.js
+++ b/tests/unit/benchmark-report.test.js
@@ -67,6 +67,9 @@ function benchmarkResults(overrides = {}) {
       },
       perLanguage: {},
     },
+    slices: {
+      language: { minCount: 5, values: { en: { n: 1, tp: 1, fp: 0, fn: 0, tn: 0, accuracy: null, precision: null, recall: null, f1: null, supported: false, reason: 'insufficient_data' } } },
+    },
     fixtures: [
       {
         fixture_id: 'unit-ai-01',

--- a/tests/unit/slice-metrics.test.js
+++ b/tests/unit/slice-metrics.test.js
@@ -1,0 +1,92 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  lengthBucket,
+  sliceMetric,
+  summarizeSlices,
+  DEFAULT_MIN_SLICE_COUNT,
+  UNSPECIFIED,
+  SLICE_DIMENSIONS,
+} from '../quality/slice-metrics.mjs';
+
+test('lengthBucket maps documented code-point thresholds deterministically', () => {
+  assert.equal(lengthBucket(0), 'empty');
+  assert.equal(lengthBucket(-5), 'empty');
+  assert.equal(lengthBucket(1), 'short');
+  assert.equal(lengthBucket(400), 'short');
+  assert.equal(lengthBucket(401), 'medium');
+  assert.equal(lengthBucket(1200), 'medium');
+  assert.equal(lengthBucket(1201), 'long');
+  assert.equal(lengthBucket(Number.NaN), 'empty');
+});
+
+test('sliceMetric reports an insufficient-data state below minCount but keeps counts', () => {
+  const records = [
+    { predicted_hot: true, expected_hot: true },
+    { predicted_hot: false, expected_hot: false },
+  ];
+  const m = sliceMetric(records, DEFAULT_MIN_SLICE_COUNT);
+  assert.equal(m.n, 2);
+  assert.equal(m.tp, 1);
+  assert.equal(m.tn, 1);
+  assert.equal(m.supported, false);
+  assert.equal(m.reason, 'insufficient_data');
+  assert.equal(m.accuracy, null);
+  assert.equal(m.precision, null);
+  assert.equal(m.recall, null);
+  assert.equal(m.f1, null);
+});
+
+test('sliceMetric computes confusion metrics at or above minCount', () => {
+  // 3 AI flagged (tp), 2 natural not flagged (tn) -> perfect.
+  const records = [
+    { predicted_hot: true, expected_hot: true },
+    { predicted_hot: true, expected_hot: true },
+    { predicted_hot: true, expected_hot: true },
+    { predicted_hot: false, expected_hot: false },
+    { predicted_hot: false, expected_hot: false },
+  ];
+  const m = sliceMetric(records, 5);
+  assert.equal(m.supported, true);
+  assert.equal(m.reason, null);
+  assert.equal(m.n, 5);
+  assert.equal(m.accuracy, 1);
+  assert.equal(m.precision, 1);
+  assert.equal(m.recall, 1);
+  assert.equal(m.f1, 1);
+
+  // One false negative drops recall but not precision.
+  const withMiss = sliceMetric([...records, { predicted_hot: false, expected_hot: true }], 5);
+  assert.equal(withMiss.n, 6);
+  assert.equal(withMiss.fn, 1);
+  assert.equal(withMiss.precision, 1);
+  assert.equal(withMiss.recall, 0.75);
+});
+
+test('summarizeSlices groups every dimension, defaults missing metadata to unspecified, and is deterministic', () => {
+  const records = [
+    { language: 'ko', class: 'ai', lengthBucket: 'short', predicted_hot: true, expected_hot: true },
+    { language: 'ko', class: 'natural', lengthBucket: 'short', predicted_hot: false, expected_hot: false },
+    { language: 'en', class: 'ai', lengthBucket: 'medium', domain: 'news', predicted_hot: true, expected_hot: true },
+  ];
+  const slices = summarizeSlices(records, { minCount: 2 });
+  // Every dimension present in stable order.
+  assert.deepEqual(Object.keys(slices), [...SLICE_DIMENSIONS]);
+  // language: ko has 2 (supported at minCount 2), en has 1 (insufficient).
+  assert.equal(slices.language.values.ko.n, 2);
+  assert.equal(slices.language.values.ko.supported, true);
+  assert.equal(slices.language.values.en.supported, false);
+  assert.equal(slices.language.minCount, 2);
+  // Missing dimensions collapse to a single `unspecified` bucket.
+  assert.deepEqual(Object.keys(slices.register.values), [UNSPECIFIED]);
+  assert.equal(slices.register.values[UNSPECIFIED].n, 3);
+  // domain: one `news` (insufficient) + two `unspecified`; keys sorted.
+  assert.deepEqual(Object.keys(slices.domain.values), ['news', UNSPECIFIED]);
+});
+
+test('summarizeSlices tolerates empty input', () => {
+  const slices = summarizeSlices([]);
+  assert.deepEqual(Object.keys(slices), [...SLICE_DIMENSIONS]);
+  assert.deepEqual(slices.language.values, {});
+});


### PR DESCRIPTION
## What
Wave 4 / B2. Adds **report-only** slice aggregation to the deterministic benchmark. (Plan listed B2 as blocked-needs-data; maintainer approved proceeding with a conservative additive default policy.)

## Changes
- NEW `tests/quality/slice-metrics.mjs`: `lengthBucket`, `sliceMetric` (below-min-count → counts + `insufficient_data`), `summarizeSlices` over language/class/lengthBucket/domain/register/generator/edited.
- `tests/quality/benchmark.mjs`: each fixture row gains slice dims; results gain a ranking-sibling `slices` field.
- `scripts/benchmark-report.mjs`: "## Slice metrics" section + `slices` schema guard.
- `package.json`: ship `slice-metrics.mjs` (benchmark.mjs imports it).
- `docs/benchmarks/latest.{md,json}` regenerated; NEW `tests/unit/slice-metrics.test.js`.

## Policy (additive, public-safe, no threshold change)
language/class always derived; lengthBucket from code-point count; domain/register/generator/edited default to `unspecified` until fixtures carry that metadata; thin buckets render `insufficient data`. No detector behavior change — benchmark stays 100% / ROC·PR-AUC 1.000.

## Gate
- Architect: round-1 **WATCH** (ship slice-metrics.mjs since benchmark.mjs imports it) → fixed → re-review **CLEAR / APPROVE**.
- Executor QA: 72 assertions + 7 unit tests, **0 failed**; benchmark integrity, schema guard, no private-text leak.
- Full suite 738 pass; lint green; dogfood OK; release:check OK.