### PR TITLE
feat(benchmark): B2 field reconciliation mapper (model_family→generator, edit_depth→edited) (#W0.1)

### DIFF
--- a/docs/benchmarks/latest.json
+++ b/docs/benchmarks/latest.json
@@ -7,7 +7,7 @@
   "schemaVersion": 3,
   "fixtureSchemaVersion": 1,
   "nodeVersion": "v22.17.1",
-  "generatedAt": "2026-06-13T19:36:48.740Z",
+  "generatedAt": "2026-06-14T09:51:18.214Z",
   "fixtureCount": 49,
   "overallAccuracy": 1,
   "overall": {
@@ -1318,12 +1318,38 @@
     "generator": {
       "minCount": 5,
       "values": {
-        "unspecified": {
-          "n": 49,
-          "tp": 26,
+        "human": {
+          "n": 23,
+          "tp": 0,
           "fp": 0,
           "fn": 0,
           "tn": 23,
+          "accuracy": 1,
+          "precision": null,
+          "recall": null,
+          "f1": null,
+          "supported": true,
+          "reason": null
+        },
+        "local-fixture": {
+          "n": 1,
+          "tp": 1,
+          "fp": 0,
+          "fn": 0,
+          "tn": 0,
+          "accuracy": null,
+          "precision": null,
+          "recall": null,
+          "f1": null,
+          "supported": false,
+          "reason": "insufficient_data"
+        },
+        "unspecified": {
+          "n": 25,
+          "tp": 25,
+          "fp": 0,
+          "fn": 0,
+          "tn": 0,
           "accuracy": 1,
           "precision": 1,
           "recall": 1,
@@ -1336,7 +1362,7 @@
     "edited": {
       "minCount": 5,
       "values": {
-        "unspecified": {
+        "none": {
           "n": 49,
           "tp": 26,
           "fp": 0,
@@ -1379,10 +1405,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "medium",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "en-ai-02",
@@ -1410,10 +1436,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "medium",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "en-ai-03",
@@ -1441,10 +1467,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "medium",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "en-ai-04",
@@ -1472,10 +1498,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "medium",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "en-ai-05",
@@ -1503,10 +1529,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "medium",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "en-ai-06-chat-register",
@@ -1539,10 +1565,10 @@
         "lexicon_density_max": 80
       },
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "en-ai-07-discourse-candor",
@@ -1579,10 +1605,10 @@
         }
       },
       "length_bucket": "medium",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "en-nat-01",
@@ -1610,10 +1636,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "medium",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "en-nat-02",
@@ -1641,10 +1667,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "medium",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "en-nat-03",
@@ -1672,10 +1698,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "medium",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "en-nat-04",
@@ -1703,10 +1729,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "medium",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "en-nat-05",
@@ -1734,10 +1760,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "medium",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "en-nat-06-single-opener",
@@ -1768,10 +1794,10 @@
         "hot_paragraphs": 0
       },
       "length_bucket": "medium",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "ja-ai-01",
@@ -1799,10 +1825,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "ja-ai-02",
@@ -1830,10 +1856,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "ja-ai-03",
@@ -1861,10 +1887,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "ja-ai-04-lexicon",
@@ -1902,10 +1928,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "ja-ai-05-formulaic-summary",
@@ -1944,10 +1970,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "ja-ai-06-broad-tech",
@@ -1985,10 +2011,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "ja-nat-01",
@@ -2016,10 +2042,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "ja-nat-02",
@@ -2047,10 +2073,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "ja-nat-03",
@@ -2078,10 +2104,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "ja-nat-04-lexicon-cold",
@@ -2109,10 +2135,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "ja-nat-05-station-note",
@@ -2140,10 +2166,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "ja-nat-06-maintenance-log",
@@ -2171,10 +2197,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "ko-ai-01",
@@ -2204,10 +2230,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "ko-ai-02",
@@ -2235,10 +2261,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "ko-ai-03",
@@ -2268,10 +2294,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "ko-ai-04",
@@ -2299,10 +2325,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "ko-ai-05",
@@ -2334,10 +2360,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "ko-ai-06-chat-register",
@@ -2370,10 +2396,10 @@
         "lexicon_density_max": 80
       },
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "ko-ai-07-ko-diagnostic",
@@ -2405,10 +2431,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "workplace-summary",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "local-fixture",
+      "edited": "none"
     },
     {
       "fixture_id": "ko-nat-01",
@@ -2436,10 +2462,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "ko-nat-02",
@@ -2467,10 +2493,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "ko-nat-03",
@@ -2498,10 +2524,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "ko-nat-04",
@@ -2529,10 +2555,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "ko-nat-05",
@@ -2560,10 +2586,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "zh-ai-01",
@@ -2591,10 +2617,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "zh-ai-02",
@@ -2622,10 +2648,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "zh-ai-03",
@@ -2653,10 +2679,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "zh-ai-04-lexicon",
@@ -2695,10 +2721,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "zh-ai-05-formulaic-summary",
@@ -2739,10 +2765,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "zh-ai-06-broad-tech",
@@ -2781,10 +2807,10 @@
       "hot_paragraphs": 1,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
+      "domain": "unspecified",
       "generator": "unspecified",
-      "edited": "unspecified"
+      "edited": "none"
     },
     {
       "fixture_id": "zh-nat-01",
@@ -2812,10 +2838,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "zh-nat-02",
@@ -2843,10 +2869,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "zh-nat-03",
@@ -2874,10 +2900,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "zh-nat-04-lexicon-cold",
@@ -2905,10 +2931,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "zh-nat-05-market-note",
@@ -2936,10 +2962,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     },
     {
       "fixture_id": "zh-nat-06-maintenance-log",
@@ -2967,10 +2993,10 @@
       "hot_paragraphs": 0,
       "expected_metrics": null,
       "length_bucket": "short",
-      "domain": "unspecified",
       "register": "unspecified",
-      "generator": "unspecified",
-      "edited": "unspecified"
+      "domain": "unspecified",
+      "generator": "human",
+      "edited": "none"
     }
   ],
   "sampleSizes": {

--- a/docs/benchmarks/latest.md
+++ b/docs/benchmarks/latest.md
@@ -7,7 +7,7 @@ This is the latest checked-in report for patina's deterministic suspect-zone ben
 ## Current result
 
 - Status: **passing**
-- Generated at: 2026-06-13T19:36:48.740Z
+- Generated at: 2026-06-14T09:51:18.214Z
 - Node: v22.17.1
 - Fixture schema: v1
 - Fixtures: 49
@@ -87,10 +87,12 @@ support the target; `max FP` of 0 is a strict zero-false-positive point.
 ## Slice metrics
 
 Report-only confusion metrics grouped by metadata dimension. `language`,
-`class`, and `lengthBucket` are derived from current fixtures; `domain`,
-`register`, `generator`, and `edited` collapse to `unspecified` until the
-corpus carries that metadata. Slices below the per-dimension minimum count are
-reported as `insufficient data` (counts only). No detector thresholds change.
+`class`, and `lengthBucket` are derived from current fixtures; `generator` and
+`edited` are resolved through the model_family/edit_depth mapper (human controls
+become `generator: human`, un-edited rows become `edited: none`); `domain` and
+`register` default to `unspecified` until the corpus carries that metadata.
+Slices below the per-dimension minimum count are reported as `insufficient data`
+(counts only). No detector thresholds change.
 
 ### language (min 5)
 
@@ -132,13 +134,15 @@ reported as `insufficient data` (counts only). No detector thresholds change.
 
 | value | n | accuracy | precision | recall | f1 | state |
 |---|---:|---:|---:|---:|---:|---|
-| unspecified | 49 | 100.0% | 100.0% | 100.0% | 1 | ok |
+| human | 23 | 100.0% | — | — | — | ok |
+| local-fixture | 1 | — | — | — | — | insufficient_data |
+| unspecified | 25 | 100.0% | 100.0% | 100.0% | 1 | ok |
 
 ### edited (min 5)
 
 | value | n | accuracy | precision | recall | f1 | state |
 |---|---:|---:|---:|---:|---:|---|
-| unspecified | 49 | 100.0% | 100.0% | 100.0% | 1 | ok |
+| none | 49 | 100.0% | 100.0% | 100.0% | 1 | ok |
 
 ## Sample sizes
 

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "tests/quality/benchmark.mjs",
     "tests/quality/ranking-metrics.mjs",
     "tests/quality/slice-metrics.mjs",
+    "tests/quality/slice-metadata.mjs",
     "tests/quality/adversarial-transforms.mjs",
     "scripts/robustness-report.mjs",
     "tests/quality/README.md",

--- a/scripts/benchmark-report.mjs
+++ b/scripts/benchmark-report.mjs
@@ -293,10 +293,12 @@ ${lowFprRows(results.ranking).join('\n')}
 ## Slice metrics
 
 Report-only confusion metrics grouped by metadata dimension. \`language\`,
-\`class\`, and \`lengthBucket\` are derived from current fixtures; \`domain\`,
-\`register\`, \`generator\`, and \`edited\` collapse to \`unspecified\` until the
-corpus carries that metadata. Slices below the per-dimension minimum count are
-reported as \`insufficient data\` (counts only). No detector thresholds change.
+\`class\`, and \`lengthBucket\` are derived from current fixtures; \`generator\` and
+\`edited\` are resolved through the model_family/edit_depth mapper (human controls
+become \`generator: human\`, un-edited rows become \`edited: none\`); \`domain\` and
+\`register\` default to \`unspecified\` until the corpus carries that metadata.
+Slices below the per-dimension minimum count are reported as \`insufficient data\`
+(counts only). No detector thresholds change.
 
 ${sliceSection(results.slices)}
 

--- a/tests/quality/benchmark.mjs
+++ b/tests/quality/benchmark.mjs
@@ -18,7 +18,8 @@ import { analyzeText } from '../../src/features/index.js';
 import { loadLexicon } from '../../src/features/lexicon.js';
 import { summarizeSignalStrength } from '../../src/features/signal-strength.js';
 import { summarizeRanking } from './ranking-metrics.mjs';
-import { summarizeSlices, lengthBucket, UNSPECIFIED } from './slice-metrics.mjs';
+import { summarizeSlices, lengthBucket } from './slice-metrics.mjs';
+import { resolveSliceFields } from './slice-metadata.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../..');
@@ -281,10 +282,10 @@ function main() {
       // always derivable; the rest default to `unspecified` until the corpus
       // carries that metadata.
       length_bucket: lengthBucket([...body].length),
-      domain: meta.domain ?? UNSPECIFIED,
-      register: meta.register ?? UNSPECIFIED,
-      generator: meta.generator ?? UNSPECIFIED,
-      edited: meta.edited ?? UNSPECIFIED,
+      // generator/edited resolved via the tested B2 reconciliation mapper
+      // (Wave 0.1): explicit B2-native fields win; model_family/edit_depth
+      // aliases and class defaults fill the rest. register/domain pass through.
+      ...resolveSliceFields(meta),
     });
   }
 

--- a/tests/quality/slice-metadata.mjs
+++ b/tests/quality/slice-metadata.mjs
@@ -1,0 +1,52 @@
+// Map rebaseline manifest / fixture provenance fields onto B2-native slice
+// dimensions (Wave 0.1). B2 (tests/quality/slice-metrics.mjs) reports the
+// dimensions `generator` and `edited`, but the rebaseline corpus pipeline
+// records `model_family` and `edit_depth`. This is the single tested
+// reconciliation layer: benchmark fixture ingestion resolves B2-native fields
+// through it now, and fixture export reuses the same mapper in Wave 0.2.
+// Explicit B2-native values always win over the provenance aliases; class-based
+// defaults fill the rest so existing
+// unedited fixtures report a meaningful `edited: none` and human controls
+// report `generator: human` instead of a blanket `unspecified`.
+
+import { UNSPECIFIED } from './slice-metrics.mjs';
+
+const NATURAL_CLASSES = new Set(['natural-human', 'natural', 'human-control']);
+// Classes that, absent an explicit edit pass, are genuinely un-edited.
+const UNEDITED_CLASSES = new Set(['natural-human', 'natural', 'human-control', 'ai-like', 'ai']);
+
+function present(value) {
+  return value !== undefined && value !== null && value !== '';
+}
+
+// B2 `generator`: explicit field > model_family alias > class default.
+// Human controls map to `human`; AI rows with no recorded model stay unknown.
+export function mapGenerator(meta = {}) {
+  if (present(meta.generator)) return meta.generator;
+  if (present(meta.model_family)) return meta.model_family;
+  if (NATURAL_CLASSES.has(meta.class)) return 'human';
+  return UNSPECIFIED;
+}
+
+// B2 `edited`: explicit field > edit_depth alias > class default.
+// Un-edited classes default to `none`; genuinely unknown classes stay
+// `unspecified`, so a natural-human row never fabricates edited-AI support.
+export function mapEdited(meta = {}) {
+  if (present(meta.edited)) return meta.edited;
+  if (present(meta.edit_depth)) return meta.edit_depth;
+  if (UNEDITED_CLASSES.has(meta.class)) return 'none';
+  return UNSPECIFIED;
+}
+
+// Resolve the four metadata-backed B2 slice dimensions for a fixture/manifest
+// row. `lengthBucket` is derived separately from the body and is not handled
+// here. `register`/`domain` have no provenance alias, so they pass through with
+// an `unspecified` default.
+export function resolveSliceFields(meta = {}) {
+  return {
+    register: present(meta.register) ? meta.register : UNSPECIFIED,
+    domain: present(meta.domain) ? meta.domain : UNSPECIFIED,
+    generator: mapGenerator(meta),
+    edited: mapEdited(meta),
+  };
+}

--- a/tests/unit/slice-metadata.test.js
+++ b/tests/unit/slice-metadata.test.js
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { mapGenerator, mapEdited, resolveSliceFields } from '../quality/slice-metadata.mjs';
+import { UNSPECIFIED } from '../quality/slice-metrics.mjs';
+
+test('mapGenerator: explicit field wins, then model_family alias, then class default', () => {
+  // model_family alias maps through.
+  assert.equal(mapGenerator({ class: 'ai-like', model_family: 'gpt-family' }), 'gpt-family');
+  // explicit B2-native generator wins over the alias.
+  assert.equal(mapGenerator({ class: 'ai-like', generator: 'claude-family', model_family: 'gpt-family' }), 'claude-family');
+  // human controls default to 'human'.
+  assert.equal(mapGenerator({ class: 'natural-human' }), 'human');
+  assert.equal(mapGenerator({ class: 'natural' }), 'human');
+  // AI row with no recorded model stays unknown (not a fabricated model).
+  assert.equal(mapGenerator({ class: 'ai-like' }), UNSPECIFIED);
+  assert.equal(mapGenerator({}), UNSPECIFIED);
+});
+
+test('mapEdited: explicit field wins, then edit_depth alias, then class default', () => {
+  assert.equal(mapEdited({ class: 'ai-like', edit_depth: 'light' }), 'light');
+  assert.equal(mapEdited({ class: 'ai-like', edit_depth: 'heavy' }), 'heavy');
+  // explicit B2-native edited wins over the alias.
+  assert.equal(mapEdited({ class: 'ai-like', edited: 'heavy', edit_depth: 'light' }), 'heavy');
+  // un-edited classes default to 'none' (a natural row never fabricates edited-AI support).
+  assert.equal(mapEdited({ class: 'natural-human' }), 'none');
+  assert.equal(mapEdited({ class: 'ai-like' }), 'none');
+  // genuinely unknown class stays unspecified.
+  assert.equal(mapEdited({ class: 'mystery' }), UNSPECIFIED);
+  assert.equal(mapEdited({}), UNSPECIFIED);
+});
+
+test('resolveSliceFields maps generator/edited and passes register/domain through', () => {
+  assert.deepEqual(
+    resolveSliceFields({ class: 'ai-like', register: 'product-doc', model_family: 'gpt-family', edit_depth: 'light' }),
+    { register: 'product-doc', domain: UNSPECIFIED, generator: 'gpt-family', edited: 'light' },
+  );
+  // natural-human fixture with no provenance -> human / none, register/domain unspecified.
+  assert.deepEqual(
+    resolveSliceFields({ class: 'natural-human' }),
+    { register: UNSPECIFIED, domain: UNSPECIFIED, generator: 'human', edited: 'none' },
+  );
+  // explicit B2-native fields are preserved verbatim.
+  assert.deepEqual(
+    resolveSliceFields({ class: 'ai-like', register: 'blog', domain: 'news', generator: 'open-weight', edited: 'heavy' }),
+    { register: 'blog', domain: 'news', generator: 'open-weight', edited: 'heavy' },
+  );
+});


### PR DESCRIPTION
## What
Wave 0.1 of the approved corpus-expansion plan (ultragoal story G001). The single tested reconciliation between the rebaseline corpus provenance fields (`model_family`/`edit_depth`) and B2's native slice dimensions (`generator`/`edited`).

## Changes
- NEW `tests/quality/slice-metadata.mjs`: `mapGenerator`/`mapEdited`/`resolveSliceFields`. Precedence: explicit B2-native > alias > class default (human controls → `generator: human`; un-edited classes → `edited: none`; unknown → `unspecified`). A natural-human row never fabricates edited-AI support.
- `tests/quality/benchmark.mjs`: ingestion resolves generator/edited via `resolveSliceFields(meta)` (drops blanket-unspecified default).
- NEW `tests/unit/slice-metadata.test.js`; `package.json` ships the module; `docs/benchmarks/latest.{md,json}` regenerated (generator now human/unspecified, edited none).

## Report-only
No detector threshold change; `src/features/*` untouched; benchmark stays **100% / ROC·PR-AUC 1.000**.

## Gate
- Architect: round-1 WATCH/COMMENT (2 P3 stale-prose items) → fixed → re-review **CLEAR×3 / APPROVE**.
- Executor QA: **38 assertions, 0 failed** (precedence, alias fallback, class defaults, no-fabricated-edited-AI, register/domain passthrough; benchmark integrity; packaging).
- Full suite 748 pass; lint green; dogfood/release:check/no-private-assets OK.