### PR TITLE
feat(rebaseline): fp-fixture-export retains B2 slice metadata (#W0.2)

### DIFF
--- a/scripts/fp-fixture-export.mjs
+++ b/scripts/fp-fixture-export.mjs
@@ -13,6 +13,7 @@ import yaml from 'js-yaml';
 import { DEFAULT_INTAKE_INPUT, loadIntakeRows } from './rebaseline-intake.mjs';
 import { MATRIX, canRedistributeText, canonicalizeClass, hashText } from './rebaseline-summary.mjs';
 import { parseFixture } from './update-benchmark-ranges.mjs';
+import { resolveSliceFields } from '../tests/quality/slice-metadata.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -125,18 +126,29 @@ function slugify(value) {
 }
 
 export function buildFixtureFile(record, fixtureId) {
+  // B2 slice metadata (Wave 0.2): retain register/domain when present and
+  // always record the mapper-resolved generator/edited so exported fixtures
+  // populate B2 slices instead of collapsing to `unspecified`. model_family /
+  // edit_depth are kept as provenance aliases when present.
+  const slice = resolveSliceFields(record);
   const meta = {
     fixture_id: fixtureId,
     language: record.language,
     class: 'natural',
     expected_hot: false,
-    why_designed_this_way: [
-      'Accepted false-positive report promoted to a natural control fixture.',
-      `Source: ${record.source_doc}`,
-      `Reviewer notes: ${String(record.reviewer_notes).trim()}`,
-    ].join('\n'),
-    topic: fixtureTopic(record),
   };
+  if (record.register) meta.register = record.register;
+  if (record.domain) meta.domain = record.domain;
+  meta.generator = slice.generator;
+  meta.edited = slice.edited;
+  if (record.model_family) meta.model_family = record.model_family;
+  if (record.edit_depth) meta.edit_depth = record.edit_depth;
+  meta.why_designed_this_way = [
+    'Accepted false-positive report promoted to a natural control fixture.',
+    `Source: ${record.source_doc}`,
+    `Reviewer notes: ${String(record.reviewer_notes).trim()}`,
+  ].join('\n');
+  meta.topic = fixtureTopic(record);
   return `---\n${yaml.dump(meta, { lineWidth: -1 })}---\n\n${record.text.trim()}\n`;
 }
 

--- a/tests/unit/fp-fixture-export.test.js
+++ b/tests/unit/fp-fixture-export.test.js
@@ -67,6 +67,13 @@ test('accepted public row becomes a numbered natural fixture', () => {
       language: 'ko',
       class: 'natural',
       expected_hot: false,
+      // B2 slice metadata (Wave 0.2): register passes through; generator/edited
+      // resolved by the mapper (model_family alias -> generator, un-edited -> none);
+      // model_family retained as provenance.
+      register: 'blog',
+      generator: 'human-reference',
+      edited: 'none',
+      model_family: 'human-reference',
       why_designed_this_way: [
         'Accepted false-positive report promoted to a natural control fixture.',
         `Source: ${BASE_ROW.source_doc}`,
@@ -258,4 +265,39 @@ test('topic prefers the intake topic field and self-describes the register fallb
   const noRegister = { ...BASE_ROW, text: TEXT };
   delete noRegister.register;
   assert.match(buildFixtureFile(noRegister, 'ko-nat-01-fp-issue-412'), /topic: false-positive report\n/);
+});
+
+test('exported fixture retains B2 slice metadata: register/domain/generator/edited (#W0.2)', () => {
+  withTempDir((dir) => {
+    // Natural-human row with a domain and NO model_family -> generator defaults
+    // to the human-control value, edited to none; register/domain pass through.
+    const row = {
+      ...BASE_ROW,
+      model_family: undefined,
+      domain: 'encyclopedia',
+      sample_id: 'ko-fp-nat-002',
+      prompt_id: 'fp-issue-500',
+      source_doc: 'https://github.com/devswha/patina/issues/500',
+      text: TEXT,
+    };
+    const input = writeIntake(dir, [row]);
+    const outDir = join(dir, 'fixtures');
+    const result = runFixtureExport({ input, outDir });
+    assert.deepEqual(result.errors, []);
+    assert.equal(result.written.length, 1);
+
+    const path = join(outDir, 'ko', 'natural', 'ko-nat-01-fp-issue-500.md');
+    const meta = yaml.load(readFileSync(path, 'utf8').match(/^---\n([\s\S]*?)\n---/u)[1]);
+    assert.equal(meta.register, 'blog');
+    assert.equal(meta.domain, 'encyclopedia');
+    assert.equal(meta.generator, 'human'); // no model_family -> human-control default
+    assert.equal(meta.edited, 'none'); // natural-human is un-edited
+    assert.equal('model_family' in meta, false); // absent provenance is not written
+    assert.equal('edit_depth' in meta, false);
+
+    // The exported fixture still parses through the benchmark ranges path.
+    const parsed = parseFixture(path);
+    assert.equal(parsed.meta.generator, 'human');
+    assert.equal(parsed.meta.edited, 'none');
+  });
 });


### PR DESCRIPTION
## What
Wave 0.2 of the corpus-expansion plan (ultragoal G002). Exported false-positive fixtures now carry B2 slice metadata so they populate the slice report.

## Change
`buildFixtureFile` (scripts/fp-fixture-export.mjs) writes register/domain (when present) + the Wave 0.1 mapper-resolved `generator`/`edited`, keeping `model_family`/`edit_depth` as provenance aliases. Natural-human is un-edited → `edited: none`; human controls without model_family → `generator: human`. Privacy wall unchanged (only natural-human + redistributable rows export); fixtures still parse through `update-benchmark-ranges`.

## Gate
- Architect: **CLEAR×3 / APPROVE** (single reconciliation mapper reused; privacy selection untouched; no leak).
- Executor QA: **54 assertions, 0 failed** (builder precedence/defaults, privacy refusals preserved, parseFixture compat, benchmark 100%, no-private-assets OK).
- Full suite 749 pass; benchmark 100% / ROC·PR-AUC 1.000.