### PR TITLE
feat(rebaseline): multilingual web-collector support gate (#W0.4)

### DIFF
--- a/scripts/rebaseline-web-collect.mjs
+++ b/scripts/rebaseline-web-collect.mjs
@@ -23,7 +23,18 @@ export const DEFAULT_MAX_PER_SOURCE = 8;
 export const DEFAULT_TARGET_PER_REGISTER = 50;
 export const DEFAULT_DELAY_MS = 250;
 
-const HANGUL_RE = /[\u3131-\u318e\uac00-\ud7a3]/gu;
+// Per-language script + boilerplate config (Wave 0.4). Each language requires a
+// minimum count of its script characters and a minimum script/letter ratio so a
+// paragraph in the wrong script (or boilerplate) is rejected.
+export const LANGUAGE_SCRIPTS = {
+  ko: { scriptRe: /[\u3131-\u318e\uac00-\ud7a3]/gu, minScriptChars: 25, minRatio: 0.35 },
+  // ja and zh share Han ideographs, so disambiguate with kana: ja REQUIRES
+  // kana (Han-only text is Chinese), zh FORBIDS more than a stray kana.
+  ja: { scriptRe: /[\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff\u3400-\u4dbf]/gu, minScriptChars: 20, minRatio: 0.30, requireRe: /[\u3040-\u309f\u30a0-\u30ff]/gu, minRequired: 5 },
+  zh: { scriptRe: /[\u4e00-\u9fff\u3400-\u4dbf]/gu, minScriptChars: 25, minRatio: 0.30, forbidRe: /[\u3040-\u309f\u30a0-\u30ff]/gu, maxForbidden: 2 },
+  en: { scriptRe: /[A-Za-z]/gu, minScriptChars: 40, minRatio: 0.50 },
+};
+export const DEFAULT_LANGUAGE = 'ko';
 const BAD_BOILERPLATE_RE = /(본문듣기|말하기 속도|글자크기|인쇄하기|공유하기|목록|검색|닫기|저작권자|무단 전재|재배포 금지|자료출처|문의:|페이스북|트위터|카카오|Copyright|All rights reserved|View all|Apply now)/iu;
 
 export function parseArgs(argv = process.argv.slice(2)) {
@@ -36,6 +47,7 @@ export function parseArgs(argv = process.argv.slice(2)) {
     targetPerRegister: DEFAULT_TARGET_PER_REGISTER,
     delayMs: DEFAULT_DELAY_MS,
     collectedAt: new Date().toISOString().slice(0, 10),
+    language: null,
     dryRun: false,
     json: false,
     help: false,
@@ -53,6 +65,7 @@ export function parseArgs(argv = process.argv.slice(2)) {
     else if (arg === '--collected-at') args.collectedAt = argv[++i];
     else if (arg === '--dry-run') args.dryRun = true;
     else if (arg === '--json') args.json = true;
+    else if (arg === '--language') args.language = argv[++i];
     else if (arg === '--help' || arg === '-h') args.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
@@ -67,6 +80,9 @@ export function parseArgs(argv = process.argv.slice(2)) {
     if (!Number.isFinite(value) || value < 0) throw new Error(`${name} must be a non-negative number`);
   }
   if (args.minChars > args.maxChars) throw new Error('minChars cannot exceed maxChars');
+  if (args.language != null && !Object.prototype.hasOwnProperty.call(LANGUAGE_SCRIPTS, args.language)) {
+    throw new Error(`--language must be one of ${Object.keys(LANGUAGE_SCRIPTS).join(', ')}`);
+  }
   if (Number.isNaN(Date.parse(args.collectedAt))) throw new Error('collected-at must be an ISO-like date');
 
   return args;
@@ -129,9 +145,18 @@ function normalizeSource(input, lineNumber) {
     throw new Error('max_rows must be a non-negative number when present');
   }
   source.max_rows = source.max_rows === undefined ? null : Number(source.max_rows);
+  source.language = typeof source.language === 'string' && source.language.trim()
+    ? source.language.trim().toLowerCase()
+    : DEFAULT_LANGUAGE;
+  if (!Object.prototype.hasOwnProperty.call(LANGUAGE_SCRIPTS, source.language)) {
+    throw new Error(`language must be one of ${Object.keys(LANGUAGE_SCRIPTS).join(', ')}`);
+  }
+  // Keep only an EXPLICIT sample_prefix here; an implicit prefix is derived in
+  // collectSources from the effective language so a --language override never
+  // leaves a stale prefix.
   source.sample_prefix = typeof source.sample_prefix === 'string' && source.sample_prefix.trim()
     ? source.sample_prefix.trim()
-    : `ko-human-web-${slugify(source.source_id)}`;
+    : null;
   source.source_kind = typeof source.source_kind === 'string' && source.source_kind.trim()
     ? source.source_kind.trim()
     : 'public-web';
@@ -146,6 +171,7 @@ export async function collectSources(sources, options = {}) {
     targetPerRegister: options.targetPerRegister ?? DEFAULT_TARGET_PER_REGISTER,
     delayMs: options.delayMs ?? DEFAULT_DELAY_MS,
     collectedAt: options.collectedAt || new Date().toISOString().slice(0, 10),
+    language: options.language ?? null,
     fetchImpl: options.fetchImpl || globalThis.fetch,
   };
   if (typeof opts.fetchImpl !== 'function') throw new Error('fetch is not available in this runtime');
@@ -156,7 +182,15 @@ export async function collectSources(sources, options = {}) {
   const seenHashes = new Set();
   const registerCounts = Object.fromEntries(MATRIX.registers.map((register) => [register, 0]));
 
-  for (const source of sources) {
+  for (const rawSource of sources) {
+    // Resolve the effective language (--language overrides per-source) and
+    // derive the default sample_prefix from it so an override can't leave a
+    // stale prefix; an explicit prefix is preserved.
+    const language = opts.language || rawSource.language || DEFAULT_LANGUAGE;
+    const samplePrefix = typeof rawSource.sample_prefix === 'string' && rawSource.sample_prefix.trim()
+      ? rawSource.sample_prefix.trim()
+      : `${language}-human-web-${slugify(rawSource.source_id)}`;
+    const source = { ...rawSource, language, sample_prefix: samplePrefix };
     if (registerCounts[source.register] >= opts.targetPerRegister) continue;
     let html;
     try {
@@ -166,7 +200,7 @@ export async function collectSources(sources, options = {}) {
       continue;
     }
 
-    const candidates = extractTextCandidates(html, opts);
+    const candidates = extractTextCandidates(html, { ...opts, language: source.language });
     const sourceLimit = Math.min(
       source.max_rows ?? opts.maxPerSource,
       opts.maxPerSource,
@@ -224,6 +258,7 @@ async function fetchHtml(url, fetchImpl) {
 export function extractTextCandidates(html, options = {}) {
   const minChars = options.minChars ?? DEFAULT_MIN_CHARS;
   const maxChars = options.maxChars ?? DEFAULT_MAX_CHARS;
+  const language = options.language ?? DEFAULT_LANGUAGE;
   const plain = decodeHtmlEntities(String(html || ''))
     .replace(/<!--[\s\S]*?-->/gu, ' ')
     .replace(/<script\b[\s\S]*?<\/script>/giu, ' ')
@@ -237,7 +272,7 @@ export function extractTextCandidates(html, options = {}) {
   const candidates = [];
   for (const raw of plain.split(/\n+/u)) {
     const text = normalizeParagraph(raw);
-    if (!isUsefulKoreanParagraph(text, { minChars, maxChars })) continue;
+    if (!isUsefulParagraph(text, { language, minChars, maxChars })) continue;
     const key = text.toLowerCase();
     if (seen.has(key)) continue;
     seen.add(key);
@@ -246,14 +281,17 @@ export function extractTextCandidates(html, options = {}) {
   return candidates;
 }
 
-function isUsefulKoreanParagraph(text, { minChars, maxChars }) {
+export function isUsefulParagraph(text, { language = DEFAULT_LANGUAGE, minChars, maxChars }) {
+  const cfg = LANGUAGE_SCRIPTS[language] || LANGUAGE_SCRIPTS[DEFAULT_LANGUAGE];
   const chars = Array.from(text);
   if (chars.length < minChars || chars.length > maxChars) return false;
   if (BAD_BOILERPLATE_RE.test(text)) return false;
-  const hangulCount = (text.match(HANGUL_RE) || []).length;
-  if (hangulCount < 25) return false;
+  const scriptCount = (text.match(cfg.scriptRe) || []).length;
+  if (scriptCount < cfg.minScriptChars) return false;
   const letterish = chars.filter((char) => /[\p{L}\p{N}]/u.test(char)).length || 1;
-  if (hangulCount / letterish < 0.35) return false;
+  if (scriptCount / letterish < cfg.minRatio) return false;
+  if (cfg.requireRe && (text.match(cfg.requireRe) || []).length < cfg.minRequired) return false;
+  if (cfg.forbidRe && (text.match(cfg.forbidRe) || []).length > cfg.maxForbidden) return false;
   if ((text.match(/https?:\/\//giu) || []).length > 0) return false;
   if ((text.match(/[|{}[\]<>]/gu) || []).length > 5) return false;
   return true;
@@ -262,7 +300,7 @@ function isUsefulKoreanParagraph(text, { minChars, maxChars }) {
 function buildPrivateRecord({ source, text, textHash, ordinal, collectedAt }) {
   const suffix = String(ordinal).padStart(2, '0');
   return {
-    language: 'ko',
+    language: source.language ?? DEFAULT_LANGUAGE,
     class: 'natural-human',
     model_family: 'human-reference',
     provider: 'web-human-control',
@@ -280,7 +318,7 @@ function buildPrivateRecord({ source, text, textHash, ordinal, collectedAt }) {
       rationale: 'Raw text stays in gitignored private intake. Commit only URL, license note, metadata, score, and sha256 digest until redistribution review is complete.',
       license_basis: source.source_license,
     },
-    reviewer_notes: source.reviewer_notes || 'Human-control candidate from public Korean web source; not a public benchmark claim.',
+    reviewer_notes: source.reviewer_notes || `Human-control candidate from a public ${source.language ?? DEFAULT_LANGUAGE} web source; not a public benchmark claim.`,
     sample_id: `${source.sample_prefix}-${suffix}`,
     register: source.register,
     source_url: source.url,

--- a/tests/unit/rebaseline-web-collect.test.js
+++ b/tests/unit/rebaseline-web-collect.test.js
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   collectSources,
   extractTextCandidates,
+  isUsefulParagraph,
   loadSourceRows,
   parseArgs,
   renderSummary,
@@ -150,4 +151,114 @@ test('parseArgs and renderSummary expose operator-facing controls', () => {
   });
   assert.match(summary, /Private rows: 2/u);
   assert.match(summary, /unit warning/u);
+});
+
+// --- Wave 0.4: multilingual collector support ------------------------------
+
+const MULTILINGUAL_SAMPLES = {
+  ko: '이 문서는 공개 웹 문서에서 가져온 한국어 문단 후보를 검증하기 위한 예시이며 실제 벤치마크에는 원문을 공개하지 않고 해시만 남깁니다.',
+  en: 'This public web document is a sample English paragraph used to validate the multilingual collector path; only hashes and source metadata are kept, never the raw paragraph text itself.',
+  zh: '这是一段用于验证多语言采集器的公开网页中文示例段落，实际基准只保留哈希和来源元数据，绝不会公开原始文本内容，以便稳定地观察误报情况。',
+  ja: 'これは多言語コレクターを検証するための公開ウェブの日本語サンプル段落です。実際のベンチマークではハッシュと出典メタデータのみを保持し、原文は決して公開しません。',
+};
+
+test('isUsefulParagraph accepts each language script and rejects wrong-script / chrome', () => {
+  const opts = { minChars: 40, maxChars: 2000 };
+  for (const lang of ['ko', 'en', 'zh', 'ja']) {
+    assert.equal(isUsefulParagraph(MULTILINGUAL_SAMPLES[lang], { ...opts, language: lang }), true, `${lang} accepts its own script`);
+  }
+  assert.equal(isUsefulParagraph(MULTILINGUAL_SAMPLES.ko, { ...opts, language: 'en' }), false);
+  assert.equal(isUsefulParagraph(MULTILINGUAL_SAMPLES.ko, { ...opts, language: 'zh' }), false);
+  assert.equal(isUsefulParagraph(MULTILINGUAL_SAMPLES.en, { ...opts, language: 'ko' }), false);
+  assert.equal(isUsefulParagraph(MULTILINGUAL_SAMPLES.en, { ...opts, language: 'ja' }), false);
+  assert.equal(isUsefulParagraph('short text', { ...opts, language: 'en' }), false);
+  assert.equal(isUsefulParagraph(`Copyright ${MULTILINGUAL_SAMPLES.en}`, { ...opts, language: 'en' }), false);
+});
+
+test('parseArgs --language validates against supported languages', () => {
+  assert.equal(parseArgs(['--language', 'en']).language, 'en');
+  assert.equal(parseArgs(['--language', 'zh']).language, 'zh');
+  assert.equal(parseArgs([]).language, null);
+  assert.throws(() => parseArgs(['--language', 'xx']), /--language must be one of/u);
+});
+
+test('extractTextCandidates honors the language script filter', () => {
+  const html = `<p>${MULTILINGUAL_SAMPLES.en}</p><p>${MULTILINGUAL_SAMPLES.ko}</p>`;
+  const en = extractTextCandidates(html, { language: 'en', minChars: 40, maxChars: 2000 });
+  assert.ok(en.includes(MULTILINGUAL_SAMPLES.en));
+  assert.ok(!en.includes(MULTILINGUAL_SAMPLES.ko));
+  const ko = extractTextCandidates(html, { language: 'ko', minChars: 40, maxChars: 2000 });
+  assert.ok(ko.includes(MULTILINGUAL_SAMPLES.ko));
+  assert.ok(!ko.includes(MULTILINGUAL_SAMPLES.en));
+});
+
+test('collectSources stamps the source language onto private records', async () => {
+  const source = {
+    source_id: 'en-gov-1',
+    url: 'https://example.gov/article',
+    register: 'product-doc',
+    source_title: 'Example',
+    source_license: 'public-domain',
+    language: 'en',
+    max_rows: null,
+    sample_prefix: 'en-human-web-en-gov-1',
+    source_kind: 'public-web',
+  };
+  const fetchImpl = async () => ({
+    ok: true,
+    headers: { get: () => 'text/html' },
+    text: async () => `<p>${MULTILINGUAL_SAMPLES.en}</p>`,
+  });
+  const direct = await collectSources([source], { fetchImpl, minChars: 40, maxChars: 2000, delayMs: 0 });
+  assert.equal(direct.records.length, 1);
+  assert.equal(direct.records[0].language, 'en');
+  assert.ok(direct.records[0].sample_id.startsWith('en-human-web-'));
+});
+
+test('ja requires kana and zh forbids kana (CJK Han disambiguation)', () => {
+  const opts = { minChars: 40, maxChars: 2000 };
+  // Han-only Chinese text under ja -> rejected (no kana present).
+  assert.equal(isUsefulParagraph(MULTILINGUAL_SAMPLES.zh, { ...opts, language: 'ja' }), false);
+  // Kana-bearing Japanese text under zh -> rejected (kana forbidden).
+  assert.equal(isUsefulParagraph(MULTILINGUAL_SAMPLES.ja, { ...opts, language: 'zh' }), false);
+  // Each still accepts its own script.
+  assert.equal(isUsefulParagraph(MULTILINGUAL_SAMPLES.ja, { ...opts, language: 'ja' }), true);
+  assert.equal(isUsefulParagraph(MULTILINGUAL_SAMPLES.zh, { ...opts, language: 'zh' }), true);
+});
+
+test('collectSources derives sample_prefix from the effective language', async () => {
+  const fetchImpl = async () => ({
+    ok: true,
+    headers: { get: () => 'text/html' },
+    text: async () => `<p>${MULTILINGUAL_SAMPLES.en}</p>`,
+  });
+  const baseSource = {
+    url: 'https://example.gov/a',
+    register: 'product-doc',
+    source_title: 'X',
+    source_license: 'public-domain',
+    max_rows: null,
+    source_kind: 'public-web',
+  };
+  // (a) implicit prefix (null) is derived from the per-source language.
+  const implicit = await collectSources(
+    [{ ...baseSource, source_id: 'en-gov-2', language: 'en', sample_prefix: null }],
+    { fetchImpl, minChars: 40, maxChars: 2000, delayMs: 0 },
+  );
+  assert.ok(implicit.records[0].sample_id.startsWith('en-human-web-en-gov-2-'));
+
+  // (b) --language override regenerates an implicit ko prefix to the override language.
+  const overridden = await collectSources(
+    [{ ...baseSource, source_id: 'src-1', language: 'ko', sample_prefix: null }],
+    { fetchImpl, language: 'en', minChars: 40, maxChars: 2000, delayMs: 0 },
+  );
+  assert.equal(overridden.records[0].language, 'en');
+  assert.ok(overridden.records[0].sample_id.startsWith('en-human-web-'), 'override must regenerate the implicit prefix');
+
+  // (c) an EXPLICIT prefix is preserved even under override (user choice).
+  const explicit = await collectSources(
+    [{ ...baseSource, source_id: 'src-2', language: 'ko', sample_prefix: 'custom-control' }],
+    { fetchImpl, language: 'en', minChars: 40, maxChars: 2000, delayMs: 0 },
+  );
+  assert.ok(explicit.records[0].sample_id.startsWith('custom-control-'));
 });


### PR DESCRIPTION
## What
Wave 0.4 of the corpus-expansion plan (ultragoal G004) — prerequisite GATE before EN/ZH/JA web collection.

## Change
Generalizes `scripts/rebaseline-web-collect.mjs` from KO-only to **ko/en/zh/ja**: a `LANGUAGE_SCRIPTS` config (per-language scriptRe + minScriptChars + minRatio) replaces the hardcoded Hangul check; `isUsefulParagraph({language})`; `normalizeSource` accepts a per-source language (default ko); `parseArgs --language` override; `collectSources` threads the effective language into extraction + record stamping.

### CJK disambiguation
`ja` **requires kana** (Han-only text is Chinese) and `zh` **forbids kana** — resolves the Han-sharing ambiguity.

### Prefix consistency
`normalizeSource` keeps only **explicit** `sample_prefix`; `collectSources` derives the prefix from the **resolved** language, so a `--language` override never leaves a stale `ko-human-web-*` id (explicit prefixes preserved).

Backward compatible (KO sources default to ko; 5 pre-existing tests unchanged). Output stays private/hash-only; this gate does not itself collect.

## Gate
- Architect: round-1 **BLOCK** (stale override prefix) → fixed → re-review **CLEAR×3 / APPROVE**.
- Executor QA: round-1 2 fails (ja Han-only accept; undefined prefix) → fixed → re-QA **27 assertions, 0 failed**.
- 11 web-collect tests; full suite 761 pass; benchmark 100% / ROC·PR-AUC 1.000; no-private-assets OK.