### PR TITLE
fix(rebaseline): allow explicit zero control totals in claim-manifest (#W0.6)

### DIFF
--- a/scripts/rebaseline-build-claim-manifest.mjs
+++ b/scripts/rebaseline-build-claim-manifest.mjs
@@ -44,8 +44,8 @@ export function parseArgs(argv = process.argv.slice(2)) {
     else if (arg === '--hape') args.hape = argv[++i];
     else if (arg === '--output') args.output = argv[++i];
     else if (arg === '--scored-at') args.scoredAt = argv[++i];
-    else if (arg === '--ko-control-total') args.koControlTotal = parsePositiveInt(argv[++i], '--ko-control-total');
-    else if (arg === '--en-control-total') args.enControlTotal = parsePositiveInt(argv[++i], '--en-control-total');
+    else if (arg === '--ko-control-total') args.koControlTotal = parseNonNegativeInt(argv[++i], '--ko-control-total');
+    else if (arg === '--en-control-total') args.enControlTotal = parseNonNegativeInt(argv[++i], '--en-control-total');
     else if (arg === '--json') args.json = true;
     else if (arg === '--help' || arg === '-h') args.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
@@ -57,8 +57,10 @@ export function buildClaimManifest(options = {}) {
   const generatedRows = loadJsonl(options.generated || DEFAULT_GENERATED, { requireText: true });
   const generatedScored = scorePrivateRows(generatedRows, { scoredAt: options.scoredAt || localDate() });
 
-  const koControls = selectKoControls(options.koControls || DEFAULT_KO_CONTROLS, options.koControlTotal || DEFAULT_KO_CONTROL_TOTAL);
-  const enControlPrivateRows = selectHapeEnglishControls(options.hape || DEFAULT_HAPE, options.enControlTotal || DEFAULT_EN_CONTROL_TOTAL);
+  // Use ?? so an EXPLICIT 0 control total is honored (zero controls) instead of
+  // silently falling back to the default (Wave 0.6).
+  const koControls = selectKoControls(options.koControls || DEFAULT_KO_CONTROLS, options.koControlTotal ?? DEFAULT_KO_CONTROL_TOTAL);
+  const enControlPrivateRows = selectHapeEnglishControls(options.hape || DEFAULT_HAPE, options.enControlTotal ?? DEFAULT_EN_CONTROL_TOTAL);
   const enControlScored = scorePrivateRows(enControlPrivateRows, { scoredAt: options.scoredAt || localDate() });
 
   const records = [...generatedScored.publicRecords, ...koControls, ...enControlScored.publicRecords]
@@ -209,10 +211,17 @@ function normalizeDate(value) {
   return parsed.toISOString().slice(0, 10);
 }
 
-function parsePositiveInt(value, label) {
-  const n = Number(value);
-  if (!Number.isInteger(n) || n <= 0) throw new Error(`${label} must be a positive integer`);
-  return n;
+
+// Allows an explicit 0 (e.g. zero control rows for a generated-only claim
+// manifest). Rejects negatives and non-integers.
+function parseNonNegativeInt(value, label) {
+  // Validate the raw token with a decimal-integer grammar BEFORE Number() so an
+  // empty/whitespace token (e.g. an empty env expansion) fails fast instead of
+  // coercing to 0 via Number('').
+  if (typeof value !== 'string' || !/^(0|[1-9][0-9]*)$/u.test(value.trim())) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return Number(value.trim());
 }
 
 function localDate() {

--- a/tests/unit/rebaseline-build-claim-manifest.test.js
+++ b/tests/unit/rebaseline-build-claim-manifest.test.js
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { hashText, summarizeManifest } from '../../scripts/rebaseline-summary.mjs';
 import {
   buildClaimManifest,
+  parseArgs,
   selectHapeEnglishControls,
   selectKoControls,
   writeClaimManifest,
@@ -108,6 +109,42 @@ test('buildClaimManifest scores generated and English control rows without leaki
     const summary = summarizeManifest(rows);
     assert.equal(summary.catchByLanguageFamily['en|gpt-family'].n, 1);
     assert.equal(summary.falsePositiveByLanguage.en.n, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('control-total flags accept an explicit 0 and reject invalid tokens (#W0.6)', () => {
+  // Explicit 0 accepted for both flags.
+  assert.equal(parseArgs(['--ko-control-total', '0']).koControlTotal, 0);
+  assert.equal(parseArgs(['--en-control-total', '0']).enControlTotal, 0);
+  // Positive accepted for both flags.
+  assert.equal(parseArgs(['--ko-control-total', '25']).koControlTotal, 25);
+  assert.equal(parseArgs(['--en-control-total', '25']).enControlTotal, 25);
+  // Negatives rejected for both flags.
+  assert.throws(() => parseArgs(['--ko-control-total', '-1']), /non-negative integer/u);
+  assert.throws(() => parseArgs(['--en-control-total', '-3']), /non-negative integer/u);
+  // Fractional rejected for both flags.
+  assert.throws(() => parseArgs(['--ko-control-total', '1.5']), /non-negative integer/u);
+  assert.throws(() => parseArgs(['--en-control-total', '2.7']), /non-negative integer/u);
+  // Empty/whitespace token (e.g. empty env expansion) fails fast, not coerced to 0.
+  assert.throws(() => parseArgs(['--ko-control-total', '']), /non-negative integer/u);
+  assert.throws(() => parseArgs(['--en-control-total', '   ']), /non-negative integer/u);
+});
+
+test('selectKoControls and selectHapeEnglishControls honor an explicit 0 total (#W0.6)', () => {
+  // Explicit 0 -> zero controls, no fallback to the default total.
+  assert.deepEqual(selectKoControls('artifacts/rebaseline-2025/human-controls.public.jsonl', 0), []);
+
+  const dir = mkdtempSync(join(tmpdir(), 'patina-w06-unit-'));
+  try {
+    const input = join(dir, 'hape.jsonl');
+    writeJsonl(input, [
+      { sample_id: 'h1', language: 'en', class: 'natural-human', register: 'acad', generated_at: '2024', prompt_id: 'acad_1', text: 'Human academic paragraph.' },
+    ]);
+    assert.deepEqual(selectHapeEnglishControls(input, 0), []);
+    // Positive totals still work.
+    assert.equal(selectHapeEnglishControls(input, 1).length, 1);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What
Wave 0.6 of the corpus-expansion plan (ultragoal G006) — last Wave 0 tooling story. Removes the invalid zero-control failure mode the ralplan review flagged.

## Change
`--ko-control-total`/`--en-control-total` now use `parseNonNegativeInt` (validates a decimal-integer token before `Number()`, so explicit `0` is accepted and empty/whitespace/negative/fractional tokens fail fast). `buildClaimManifest` uses `?? DEFAULT` (was `|| DEFAULT`) so an explicit `0` is honored (zero controls) instead of silently falling back to 100. Dead `parsePositiveInt` removed. Measure-only per-language waves don't use claim-manifest at all.

## Gate
- Architect: round-1 **WATCH/COMMENT** (Number('')→0; asymmetric tests) → hardened token grammar + symmetric tests → re-review **CLEAR×3 / APPROVE**.
- Executor QA: **pass** (explicit-0 accepted, negatives/fractional/empty rejected, helpers return [] for 0, positive unchanged, no dangling ref).
- Full suite 766 pass; benchmark 100% / ROC·PR-AUC 1.000; lint green; no-private-assets OK.