### PR TITLE
feat: close im-not-ai competitive gaps — plugin marketplace, multi-agent --strict, KO scholarship (5.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "patina",
       "source": "./",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "description": "Strip the AI packaging, keep the meaning. Detect and rewrite AI writing patterns across KO/EN/ZH/JA with MPS/fidelity checks. Runs the root SKILL.md as the /patina skill.",
       "homepage": "https://github.com/devswha/patina",
       "repository": "https://github.com/devswha/patina",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-marketplace.json",
+  "name": "patina",
+  "description": "patina — a deterministic, auditable AI-writing humanizer for Korean, English, Chinese, and Japanese.",
+  "owner": {
+    "name": "devswha",
+    "url": "https://github.com/devswha"
+  },
+  "plugins": [
+    {
+      "name": "patina",
+      "source": "./",
+      "version": "5.0.0",
+      "description": "Strip the AI packaging, keep the meaning. Detect and rewrite AI writing patterns across KO/EN/ZH/JA with MPS/fidelity checks. Runs the root SKILL.md as the /patina skill.",
+      "homepage": "https://github.com/devswha/patina",
+      "repository": "https://github.com/devswha/patina",
+      "license": "MIT",
+      "keywords": [
+        "humanize",
+        "ai-writing",
+        "ai-detector",
+        "translationese",
+        "korean",
+        "english",
+        "chinese",
+        "japanese",
+        "윤문",
+        "번역투"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
   "name": "patina",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese so text reads as if a human wrote it. Meaning-preservation (MPS) verified, audit-friendly. The root SKILL.md is loaded as the /patina skill.",
   "author": {
     "name": "devswha",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "patina",
+  "version": "5.0.0",
+  "description": "Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese so text reads as if a human wrote it. Meaning-preservation (MPS) verified, audit-friendly. The root SKILL.md is loaded as the /patina skill.",
+  "author": {
+    "name": "devswha",
+    "url": "https://github.com/devswha"
+  },
+  "homepage": "https://github.com/devswha/patina",
+  "repository": "https://github.com/devswha/patina",
+  "license": "MIT",
+  "keywords": [
+    "humanize",
+    "ai-writing",
+    "ai-detector",
+    "translationese",
+    "korean",
+    "english",
+    "chinese",
+    "japanese",
+    "윤문",
+    "번역투"
+  ]
+}

--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "5.0.0"
+version: "5.1.0"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
+## 5.1.0 — 2026-06-14
+
+**Adds Claude Code plugin-marketplace distribution, an optional multi-agent `--strict` skill mode, and Korean translationese academic grounding.**
+
+Semver rationale: minor — additive only. No CLI or schema removals, the deterministic engine is unchanged, and all new behavior is opt-in (default-off), so existing runs are byte-identical without the new flags.
+
+### Added
+- Claude Code plugin marketplace: `/plugin marketplace add devswha/patina` then `/plugin install patina@patina`. The repo-root `SKILL.md` auto-loads as the `/patina` skill (no `skills/` directory or `skills` manifest field), so the pattern/core/lexicon data directories stay untouched. `uninstall.sh` mirrors the script install for clean removal.
+- Three read-only subagents auto-discovered from `agents/`: `patina-detector` (stylometry + AI-lexicon + pattern findings), `patina-fidelity-auditor` (MPS/fidelity audit), and `patina-naturalness-reviewer` (residual-tell + over-edit grade).
+- Opt-in `--strict` multi-pass skill mode in `SKILL.md`: detect → rewrite → fidelity/MPS audit → naturalness re-scan → accept/retry/rollback. In a plugin environment `--strict` delegates the read-only analysis passes to the subagents via the `Task` tool; otherwise it runs the same passes inline in a single agent, with identical floors and gate logic.
+- `docs/research/ko-translationese-scholarship.md` anchoring patina's Korean detectors to verifiable sources (Gellerstam 1986, Baker 1993, Toury 1995, Toral 2019; Korean 번역투 tradition: 이근희 2005/2008, 김순영 2012), with an honest scope note (concept/terminology grounding, advisory-only). `epoko77-ai/im-not-ai` added to `docs/COMPARISON.md`. Non-technical Korean onboarding added to `README_KR.md`.
+
+### Fixed
+- Synced previously-stale version surfaces that had drifted behind `package.json`: the `docs/ROADMAP.md` repo-metadata note and the `README_KR`/`README_ZH`/`README_JA` version badges.
+
 ## 5.0.0 — 2026-06-14
 
 **Breaking: `--preview` is URL/`.html`-only and the deprecated `--browser` alias is removed; adds `--restyle`/`--jargon` transformations, `--preview` variant comparison, and a word-level diff view.**

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -10,6 +10,19 @@
 
 ---
 
+## Path 0 — Claude Code plugin marketplace (interactive, no clone)
+
+If the user is in an **interactive Claude Code session**, the simplest install is the plugin marketplace — no git clone, and updates flow through `/plugin`:
+
+```text
+/plugin marketplace add devswha/patina
+/plugin install patina@patina
+```
+
+Uninstall with `/plugin uninstall patina@patina`. This path loads the repo-root `SKILL.md` as the `/patina` skill. The git/symlink paths below (A/B/C) are for non-interactive installs or multi-host setups; to remove a script install, run `uninstall.sh` (or `curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/uninstall.sh | bash`).
+
+---
+
 ## Decision Tree (run this first)
 
 Inspect the host before installing. Pick exactly one of the three paths.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 5.0.0" src="https://img.shields.io/badge/version-5.0.0-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 5.1.0" src="https://img.shields.io/badge/version-5.1.0-blue"></a>
 </p>
 
 <p align="center">
@@ -187,7 +187,7 @@ If meaning drifts, the change is retried or rolled back. Deterministic analysis 
 
 ```yaml
 # .patina.default.yaml
-version: "5.0.0"
+version: "5.1.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ Open **[patina.vibetip.help](https://patina.vibetip.help/)** to score KO / EN / 
 
 ### Agent skill
 
+**Claude Code — plugin marketplace (no clone, recommended):**
+
+```text
+/plugin marketplace add devswha/patina
+/plugin install patina@patina
+```
+
+**Claude Code · Codex CLI · Cursor · OpenCode — install script:**
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
 ```
@@ -195,6 +204,7 @@ Start here:
 - [CLI Contract](docs/CLI.md) — flags, formats, score gates, exit behavior
 - [Authentication](docs/AUTHENTICATION.md) — local CLI backends and API providers
 - [Patterns](docs/PATTERNS.md) — full pattern catalog
+- [Subagents & strict flow](docs/agents.md) — optional read-only detector/fidelity/naturalness subagents and the `--strict` multi-pass mode
 - [Benchmarks](docs/benchmarks/README.md) · [latest report](docs/benchmarks/latest.md) · [2026 rebaseline](docs/research/2026-rebaseline.md)
 - [FAQ](docs/FAQ.md) ([한국어](docs/FAQ_KR.md))
 - [Ethics](docs/ETHICS.md)

--- a/README_JA.md
+++ b/README_JA.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#クイックスタート)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-4.0.1-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.0.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-en.gif" alt="patina が英語のAIっぽい文を整え、スコアを表示するターミナルデモGIF" width="780">
@@ -66,10 +66,18 @@ patina は、日本語・韓国語・英語・中国語の文章から AI っぽ
 
 ### Claude Code または Codex CLI スキルとして
 
+**Claude Code — プラグインマーケットプレイス（クローン不要・推奨）：**
+
+```text
+/plugin marketplace add devswha/patina
+/plugin install patina@patina
+```
+
+**Claude Code · Codex CLI · Cursor · OpenCode — インストールスクリプト：**
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
 ```
-
 インストーラは Claude Code、[Codex CLI](https://github.com/openai/codex)、Cursor、OpenCode に patina をまとめて接続します。インストール時に remote HEAD を具体的な commit に固定します。特定のバージョンに固定したい場合は `PATINA_REF=<tag-or-full-sha>` を設定してください。続いて：
 
 ```

--- a/README_JA.md
+++ b/README_JA.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#クイックスタート)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-5.0.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.1.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-en.gif" alt="patina が英語のAIっぽい文を整え、スコアを表示するターミナルデモGIF" width="780">

--- a/README_KR.md
+++ b/README_KR.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#빠른-시작)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-4.0.1-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.0.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-ko.gif" alt="patina가 한국어 AI풍 문장을 다듬고 결과 점수를 보여주는 터미널 데모 GIF" width="780">
@@ -64,13 +64,39 @@ patina는 한국어·영어·중국어·일본어 글에서 AI가 쓴 듯한 표
 
 ## 빠른 시작
 
+> **개발 환경이 없어도 괜찮습니다.** 먼저 위의 "브라우저에서 바로 보기"로 설치 없이 체험해 본 뒤, 실제로 글을 다듬을 땐 아래 **Claude Code 스킬**(방법 A는 평소 말투면 됩니다)을 쓰세요. Node.js를 직접 다루는 분만 "독립형 CLI"로 가면 됩니다.
+
 ### Claude Code 또는 Codex CLI 스킬로
+
+**Claude Code — 플러그인 마켓플레이스 (클론 불필요, 권장):**
+
+```text
+/plugin marketplace add devswha/patina
+/plugin install patina@patina
+```
+
+**Claude Code · Codex CLI · Cursor · OpenCode — 설치 스크립트:**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
 ```
+설치 스크립트가 Claude Code, [Codex CLI](https://github.com/openai/codex), Cursor, OpenCode에 patina를 한 번에 연결합니다. 설치할 때 원격 HEAD를 실제 커밋으로 고정하므로, 특정 버전만 쓰고 싶다면 `PATINA_REF=<tag-or-full-sha>`를 지정하세요.
 
-설치 스크립트가 Claude Code, [Codex CLI](https://github.com/openai/codex), Cursor, OpenCode에 patina를 한 번에 연결합니다. 설치할 때 원격 HEAD를 실제 커밋으로 고정하므로, 특정 버전만 쓰고 싶다면 `PATINA_REF=<tag-or-full-sha>`를 지정하세요. 그런 다음:
+설치 후에는 두 가지 방법 중 편한 쪽으로 쓰면 됩니다.
+
+**방법 A — 평소 말투로 (개발 지식 필요 없음)**
+
+Claude Code에 평소 쓰던 말투로 부탁하면 patina 스킬이 켜집니다. 안 켜지면 `/patina`로 직접 부르면 됩니다.
+
+```
+이 한국어 AI 글 자연스럽게 다듬어줘:
+
+[ChatGPT·Claude·Gemini 초안을 여기에 붙여넣기]
+```
+
+"AI 티 없애줘", "번역투 고쳐줘", "사람이 쓴 것처럼 윤문해줘" 같은 표현이면 대부분 통합니다.
+
+**방법 B — 슬래시 커맨드 (정확한 제어)**
 
 ```
 /patina --lang ko
@@ -78,21 +104,30 @@ curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | ba
 [텍스트를 여기에 붙여넣기]
 ```
 
-특정 톤으로 재작성:
+특정 톤으로:
 
 ```
-/patina --tone narrative
-
-[에세이 초안을 여기에 붙여넣기]
+/patina --tone marketing --lang ko   # 홍보·마케팅 글
+/patina --tone narrative --lang ko   # 에세이·이야기체
+/patina --tone auto --lang ko        # 톤 자동 감지
 ```
 
-자동 톤 감지:
+#### 결과가 맘에 안 들면 — 말로 다시 요청하세요
 
-```
-/patina --tone auto --lang ko
+명령을 외울 필요 없이 Claude Code에 그대로 말하면 됩니다. 자주 쓰는 요청과 patina가 적용하는 옵션:
 
-[텍스트를 여기에 붙여넣기]
-```
+| 이렇게 말하면 | patina가 하는 일 |
+|---|---|
+| "더 부드럽게 / 캐주얼하게" | `--tone casual` |
+| "격식 있게 / 업무용으로" | `--tone professional` |
+| "마케팅 톤으로" | `--tone marketing` |
+| "학술 톤으로" | `--tone academic` |
+| "고치지 말고 AI 패턴만 찾아줘" | `--audit` |
+| "이 글 AI 점수 매겨줘" | `--score` |
+| "뭘 왜 바꿨는지 보여줘" | `--diff` |
+| "점수 안정될 때까지 반복해서 다듬어줘" | `--ouroboros` |
+| "엄격하게 다중 패스로 검수해줘" | `--strict` (감지→재작성→충실도/MPS 감사→자연스러움 재스캔→수락/롤백 게이트) |
+| "이 문단만 다시" / "원문을 더 살려줘" | 해당 부분만 다시 요청하면 됩니다 — 의미 보존(MPS)·충실도 검사가 원문의 주장·수치·인과를 지킵니다 |
 
 ### 독립형 CLI로
 
@@ -293,6 +328,9 @@ tone:                     # casual | professional | academic | narrative | marke
 - **[2026 Modern-model Rebaseline](docs/research/2026-rebaseline.md)** — 현재 날짜가 찍힌 KO+EN catch/FP claim
 - **[2025+ Re-baseline Plan](docs/research/2025-rebaseline-plan.md)** — 더 넓은 model-era claim 전 evidence gate
 - **[zh/ja Lexicon Calibration](docs/research/zh-ja-lexicon-calibration.md)** — starter lexicon gate와 남은 corpus risk
+- **[Korean Translationese](docs/TRANSLATIONESE-KO.md)** — 한국어 번역투/calque 탐지 catalog와 advisory 경계
+- **[Korean Translationese Scholarship](docs/research/ko-translationese-scholarship.md)** — 번역투·translation universals·post-editese 학술 근거(이근희·김순영·Baker·Toury·Toral)와 patina 신호 매핑
+- **[Subagents (strict flow)](docs/agents.md)** — 선택형 멀티 에이전트 strict 플로우(detector·fidelity-auditor·naturalness-reviewer)와 Claude Code 플러그인 자동발견
 - **[Launch Copy](docs/social/patina-launch-copy.md)** — launch sequence, score gate, Show HN/Product Hunt/Reddit/X/Korean drafts
 - **[Signs of AI Writing](docs/social/signs-of-ai-writing_KR.md)** ([English](docs/social/signs-of-ai-writing.md)) — cited example이 붙은 공유용 편집 checklist
 - **[Stylometry](core/stylometry.md)** — burstiness + MATTR + AI 어휘 알고리즘

--- a/README_KR.md
+++ b/README_KR.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#빠른-시작)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-5.0.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.1.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-ko.gif" alt="patina가 한국어 AI풍 문장을 다듬고 결과 점수를 보여주는 터미널 데모 GIF" width="780">

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#快速开始)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-5.0.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.1.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-en.gif" alt="patina 将带有 AI 味的英文文案改写并显示评分的终端演示 GIF" width="780">

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#快速开始)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-4.0.1-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.0.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-en.gif" alt="patina 将带有 AI 味的英文文案改写并显示评分的终端演示 GIF" width="780">
@@ -66,10 +66,18 @@ patina 会在中文、韩文、英文和日文中找出 AI 味较重的表达，
 
 ### 作为 Claude Code 或 Codex CLI 技能
 
+**Claude Code — 插件市场（无需克隆，推荐）：**
+
+```text
+/plugin marketplace add devswha/patina
+/plugin install patina@patina
+```
+
+**Claude Code · Codex CLI · Cursor · OpenCode — 安装脚本：**
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/install.sh | bash
 ```
-
 安装脚本会把 patina 一次接入 Claude Code、[Codex CLI](https://github.com/openai/codex)、Cursor 和 OpenCode。安装时会先把远程 HEAD 固定到具体 commit；如果想固定到某个版本，请设置 `PATINA_REF=<tag-or-full-sha>`。然后：
 
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Grep
   - Glob
   - AskUserQuestion
+  - Task
 ---
 
 # patina: AI 글쓰기 패턴 제거 오케스트레이터
@@ -39,6 +40,7 @@ Glob .patina.default.yaml → Read
 - `--audit`: audit 출력 모드
 - `--score`: score 출력 모드
 - `--ouroboros`: ouroboros 모드 (반복 교정 + 점수 수렴)
+- `--strict`: 옵트인 다중 패스 엄격 모드. rewrite 출력 모드를 사용한다. `--lang`, `--tone`, `--profile`, `--ouroboros`와 함께 사용할 수 있다. `--audit`, `--diff`, `--score`와 함께 사용할 수 없다.
 - `--lang <code>`: 처리 언어 변경 (ko, en, zh, ja). 설정 파일의 `language` 값을 오버라이드한다.
 - `--tone <name>`: 톤 카테고리 지정. 유효값: `casual | professional | academic | narrative | marketing | instructional | auto`. 알 수 없는 값이면 즉시 오류: "Unknown tone '<name>'. Valid tones: casual, professional, academic, narrative, marketing, instructional, auto"
 - `--batch <files>`: 여러 파일을 한꺼번에 처리 (glob 또는 명시적 경로 목록).
@@ -81,6 +83,7 @@ if --lang in {zh, ja} and resolved_tone in 6-tone set:
 파일이 없으면 에러: "core/scoring.md not found. Please update patina."
 
 `--ouroboros`는 rewrite 출력 모드를 사용한다. `--audit`, `--diff`, `--score`와 함께 사용할 수 없다.
+`--strict`는 rewrite 출력 모드를 사용한다. `--audit`, `--diff`, `--score`와 함께 사용할 수 없다.
 
 ---
 
@@ -427,6 +430,110 @@ paragraph is SUSPECT iff
 > **주의:** `--ouroboros`는 rewrite 출력을 기본으로 한다. `--diff`, `--audit`, `--score`와 함께 사용할 수 없다.
 
 ---
+
+
+---
+
+## Strict 모드 (다중 패스) (`--strict`)
+
+`--strict` 플래그가 있으면 아래 5단계 패스를 순차적으로 수행한다. 1~4단계(설정, 패턴, 프로필, 목소리 로드)는 한 번만 실행한다.
+
+**실행 모드 (자동 선택):**
+
+- **위임 모드 (플러그인 환경):** patina 플러그인의 read-only 서브에이전트(`patina-detector`, `patina-fidelity-auditor`, `patina-naturalness-reviewer`)를 사용할 수 있으면, `Task` 도구로 분석 패스 P1/P3/P4를 각 서브에이전트에 위임한다(격리된 컨텍스트). 오케스트레이션, 재작성(P2), 게이트(P5)는 메인 스킬이 담당한다. 서브에이전트는 read-only라 절대 텍스트를 직접 쓰지 않는다.
+- **자체 완결 모드 (폴백):** 서브에이전트가 없으면(Codex/Cursor/OpenCode 또는 비플러그인 설치) 동일 스킬 에이전트가 P1~P5를 모두 인라인으로 수행한다.
+- 두 모드의 판정 기준, floor, 게이트 로직은 **동일하다**. 위임은 컨텍스트 격리를 위한 것일 뿐 결과의 의미를 바꾸지 않는다. 위임 호출이 실패하면 해당 패스를 인라인으로 폴백한다.
+
+> **어드바이저리 메타데이터 규칙:** 한국어 `translationese` 및 `koPostEditese.v1` 신호는 **어드바이저리 전용**이다. 이 신호는 Strict 모드 내의 어떠한 패스에서도 점수, `hot` 판정, 게이트, 심각도, 기준선/백분위수, 벤치마크 주장, 또는 저작권 판정에 반영되어서는 안 된다.
+
+### 패스 시퀀스
+
+#### P1: 전체 감지 패스 (Detection Pass)
+
+4.x단계(4.5 의미 앵커 추출, 4.5b 톤 감지, 4.6 통계 기반 의심 구간, 4.7 AI-lexicon 매칭, 4.8 문서 브리프)를 완전히 실행한다. 결과는 심각도가 부여된 발견 목록(`findings list`)으로 정리한다.
+
+**위임 모드:** 이 패스를 `patina-detector` 서브에이전트에 위임한다(반환: 심각도가 부여된 발견 목록). 폴백 모드에서는 메인 스킬이 위 4.x단계를 직접 실행한다.
+
+- 각 발견 항목: `{paragraph_index, span, signal_type, severity}` 형태 (내부 작업 메모리)
+- `signal_type`: `burstiness_low` | `MATTR_low` | `lexicon_hot` | `pattern_match`
+- 발견이 0건이면 즉시 종료 — 원문을 그대로 출력하고 Strict 모드 결과 footer를 붙인다
+
+#### P2: 근거 기반 재작성 (Evidence-Based Rewrite)
+
+P1 발견 목록을 입력으로, 5a단계(구조 분석) → 5b단계(문장/어휘 패턴) → 5c단계(자기검수) 파이프라인을 실행한다. 발견된 스팬/존에 한정해 교정한다 — 발견이 없는 구간은 건드리지 않는다.
+
+#### P3: 충실도/MPS 감사 패스 (Fidelity & MPS Audit)
+
+`core/scoring.md` §§9-14의 절차에 따라 P2 출력을 원문과 대조한다.
+
+**위임 모드:** 이 패스를 `patina-fidelity-auditor` 서브에이전트에 위임한다(입력: 원문 + P2 출력, 반환: PASS/NEEDS-ROLLBACK + 위반 스팬 + `{fidelity_score, mps_score}`). 폴백 모드에서는 메인 스킬이 직접 대조한다.
+
+검증 대상:
+- **주장(Claims):** 사실적 주장이 보존되었는가
+- **수치(Numbers):** 모든 숫자·비율·측정값이 그대로인가
+- **극성(Polarity):** 긍정/부정/중립 입장이 반전되지 않았는가
+- **인과(Causation):** 인과 관계가 상관 관계로 바뀌거나 삭제되지 않았는가
+- **고유명사(Named Entities):** 인명·지명·브랜드명·제품명이 그대로인가
+- **직접 인용(Quotes):** 큰따옴표 안의 내용이 변경되지 않았는가
+
+결과: `{fidelity_score, mps_score}` (내부 작업 메모리)
+
+#### P4: 자연스러움 재스캔 (Naturalness Re-Scan)
+
+P2 출력에 4.6/4.7단계의 통계 감지와 AI-lexicon 매칭을 재실행하여 잔류 hot 존과 과잉 편집 여부를 확인한다.
+
+**위임 모드:** 이 패스를 `patina-naturalness-reviewer` 서브에이전트에 위임한다(반환: 잔류 hot 존 + 과잉 편집 여부 + A–D 등급). 폴백 모드에서는 메인 스킬이 직접 재스캔한다.
+
+- **잔류 hot 존:** P1에서 감지된 스팬이 P2 이후에도 여전히 hot이면 잔류로 기록
+- **과잉 편집 감지:** 변경된 토큰 수 / 원문 토큰 수 > 0.50이면 과잉 편집 경고
+
+결과: `{residual_hot_zones: [...], over_edit: bool}` (내부 작업 메모리)
+
+#### P5: 수락/재시도/롤백 게이트 (Accept / Retry / Rollback Gate)
+
+```
+floors (ouroboros와 동일):
+  fidelity_floor = 70
+  mps_floor      = 70
+
+accept 조건 (모두 충족):
+  fidelity_score >= fidelity_floor
+  AND mps_score  >= mps_floor
+  AND residual_hot_zones == []
+  AND over_edit == false
+
+→ ACCEPT: P2 출력을 최종 결과로 확정한다
+
+retry 조건 (accept 실패 시, 재시도 횟수 < 3):
+  offending 스팬만 격리하여 P2→P3→P4를 재실행한다
+  재시도마다 retry_count += 1
+  retry_count 상한: 3회
+
+rollback 조건 (retry 상한 초과 또는 retry 후에도 accept 실패):
+  offending 스팬의 교정을 취소하고 해당 구간을 원문으로 복원한다
+  나머지 통과된 스팬의 교정은 유지한다
+  롤백 사유를 footer에 보고한다
+```
+
+### 출력 형식
+
+P5 게이트 결과 이후 최종 교정 텍스트와 함께 다음 footer를 출력한다 (6단계 공통 YAML footer에 추가):
+
+```
+---
+strict_mode: true
+passes: [P1, P2, P3, P4, P5]
+fidelity_score: <값>
+mps_score: <값>
+residual_hot_zones: <개수>
+over_edit: <true|false>
+retries: <횟수>
+rollback_spans: <롤백된 스팬 수 또는 0>
+gate_result: accept | rollback
+---
+```
+
+> **참고:** `--strict`는 `--ouroboros`와 함께 사용할 수 있다. 이 경우 P5 게이트를 통과한 최종 출력이 ouroboros 루프의 입력으로 사용된다.
 
 ## 배치 모드 (`--batch`)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 5.0.0
+version: 5.1.0
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read

--- a/agents/patina-detector.md
+++ b/agents/patina-detector.md
@@ -1,0 +1,107 @@
+---
+name: patina-detector
+description: Triggers when Claude needs to find AI-writing patterns or suspect zones in KO/EN/ZH/JA text. Use this agent to run a full detection pass — pattern scanning across all applicable packs, stylometric analysis (burstiness CV + MATTR + AI-lexicon density), and Korean diagnostic signals — and receive a structured span/paragraph-level findings report before any rewrite begins.
+model: sonnet
+tools: Read, Grep, Glob
+---
+
+You are the patina pattern detector. Your job is detection only — you NEVER rewrite text.
+
+## Role
+
+Given a text input and its language (ko/en/zh/ja), identify every AI-sounding pattern and suspect zone, then emit a structured findings report. The parent `/patina` skill or Claude uses your report as the input to the rewrite phase.
+
+## Step 1 — Load pattern packs
+
+Read every applicable pattern file from `patterns/` for the detected language:
+
+- Korean: `patterns/ko-content.md`, `patterns/ko-language.md`, `patterns/ko-style.md`, `patterns/ko-communication.md`, `patterns/ko-filler.md`, `patterns/ko-structure.md`, `patterns/ko-viral-hook.md`
+- English: `patterns/en-content.md`, `patterns/en-language.md`, `patterns/en-style.md`, `patterns/en-communication.md`, `patterns/en-filler.md`, `patterns/en-structure.md`, `patterns/en-viral-hook.md`
+- Chinese: `patterns/zh-content.md`, `patterns/zh-language.md`, `patterns/zh-style.md`, `patterns/zh-communication.md`, `patterns/zh-filler.md`, `patterns/zh-structure.md`, `patterns/zh-viral-hook.md`
+- Japanese: `patterns/ja-content.md`, `patterns/ja-language.md`, `patterns/ja-style.md`, `patterns/ja-communication.md`, `patterns/ja-filler.md`, `patterns/ja-structure.md`, `patterns/ja-viral-hook.md`
+
+Also check `custom/patterns/` for any user-supplied packs. Read their frontmatter to confirm `pack` field and pattern count.
+
+Also read `lexicon/ai-{lang}.md` for the AI-lexicon word list matching the active language.
+
+## Step 2 — Stylometric suspect-zone detection
+
+Apply `core/stylometry.md` in full. Segment the text into paragraphs (blank-line boundary) and sentences (`.!?。…` + newline). For each paragraph compute:
+
+1. **Burstiness CV** — population stddev / mean of per-sentence token counts. Bands per `core/stylometry.md` §4: `low` (CV < 0.30) = AI suspect. Skip paragraphs with fewer than 3 sentences.
+2. **MATTR** — moving-average TTR with window=50 (fall back to simple TTR when paragraph < 50 tokens). Bands per `core/stylometry.md` §5: `low` (MATTR < 0.55) = AI suspect.
+3. **AI-lexicon density** — count lexicon hits / total paragraph tokens. Threshold and `min_hits` per `core/stylometry.md` §6 hot-decision rule (CJK default min_hits = 2).
+4. **Korean diagnostic composite** (ko only) — compute `spacing.eojeolLengthCV`, `comma.perSentence`, `posProxy.classDiversity` per `core/stylometry.md` §5.1. `koDiagnostics.hot=true` only when all three conservative thresholds are met simultaneously.
+
+**Hot decision rule** (OR, per `core/stylometry.md` §6):
+```
+paragraph is SUSPECT iff
+  burstiness_band == "low"  OR  MATTR_band == "low"  OR
+  (lexicon_density > threshold AND lexicon_min_hits satisfied)  OR
+  koDiagnostics.hot == true  OR
+  (fakeCandor.doc_count >= 2 AND paragraph_candor_count >= 1)  OR
+  (thematicBreaks.doc_count >= 3 AND paragraph_break_count >= 1)
+```
+
+For each SUSPECT paragraph, apply the Sentence Zoom Rule (`core/stylometry.md` §7): flag adjacent sentence pairs whose token counts differ by less than 20%, merge overlapping pairs into contiguous groups, emit sub-flags as `P{n}.S{m..k}`.
+
+## Step 3 — Pattern scan
+
+For each pattern in the loaded packs, check whether it appears in the text. Assign severity per `core/scoring.md` §§1-2:
+
+- High (3): pervasive or especially blatant
+- Medium (2): moderate frequency or impact
+- Low (1): isolated occurrence
+- Not detected (0): skip from report
+
+Apply short-text boost (`core/scoring.md` §8) when input ≤200 non-whitespace chars or ≤3 non-empty paragraphs: multiply severity by 1.5 (cap at 3) for `language`, `style`, and `viral-hook` categories.
+
+## Step 4 — Advisory metadata rule (MANDATORY)
+
+**Korean `translationese` and `koPostEditese.v1` signals are ADVISORY ONLY.**
+
+These signals MUST NOT influence:
+- The overall AI-likeness score
+- The document `hot` verdict
+- Any gate, severity assignment, baseline, percentile, or authorship verdict
+
+Record them in the findings report under an `advisory` section, clearly labeled as non-scoring. They provide editorial context only.
+
+## Step 5 — Emit findings report
+
+Output a structured report in this format:
+
+```
+PATINA DETECTION REPORT
+Language: {lang}
+Paragraphs: {n}  Suspects: {m}
+
+STYLOMETRIC SUSPECTS
+P{n} [burstiness_CV={x}, MATTR={y}, lexicon_hits={z}]
+  Sub-flags: P{n}.S{a}-S{b} (adjacent-similar sentence group)
+  ...
+
+PATTERN DETECTIONS
+P{n} | pattern-id: {pack}/{id} | severity: High/Medium/Low
+  Evidence: "{exact span from text}"
+  Category: {category}
+  ...
+
+ADVISORY (non-scoring, never feed gate or verdict)
+  translationese signals: {description if present}
+  koPostEditese signals: {description if present}
+
+SUMMARY
+Total detections: {n}
+Categories triggered: {list}
+Suspect paragraph count: {m}/{total}
+```
+
+## Hard constraints
+
+- You MUST NOT produce any rewritten version of the text, even partially.
+- You MUST NOT suggest rewrites, alternatives, or improvements.
+- You MUST NOT fabricate pattern detections. Only report patterns that have actual evidence spans in the provided text.
+- Every severity assignment must cite a concrete evidence span from the text.
+- Honor all four patina principles: meaning invariance, evidence-based editing only, genre preservation, no over-editing. Your report must reflect these — flag only spans with real evidence, note if the text appears already clean.
+- Do not change any numbers in `core/stylometry.md` or `core/scoring.md`. Use them as-is.

--- a/agents/patina-fidelity-auditor.md
+++ b/agents/patina-fidelity-auditor.md
@@ -1,0 +1,125 @@
+---
+name: patina-fidelity-auditor
+description: Triggers to audit whether a patina rewrite preserved meaning versus the original text. Invoke this agent after a rewrite is produced; provide both the ORIGINAL and the REWRITE. It checks all four fidelity criteria from core/scoring.md §§9-14 (claims, fabrication, tone, length) and returns a pass/needs-rollback verdict with offending spans identified.
+model: sonnet
+tools: Read
+---
+
+You are the patina fidelity auditor. Your job is meaning-preservation audit only — you NEVER rewrite text.
+
+## Role
+
+Given an ORIGINAL text and a REWRITE, verify that the rewrite faithfully preserves the original's meaning, claims, and semantic content. Produce a structured fidelity verdict. The parent `/patina` skill or Claude uses your verdict to decide whether to accept the rewrite or trigger rollback.
+
+## Prerequisites
+
+Read `core/scoring.md` §§9-14 before auditing. The fidelity criteria, scoring formula, floor thresholds, and ouroboros termination conditions are defined there and must be applied as written.
+
+## Patina's four non-negotiable principles (audit against all four)
+
+1. **Meaning invariance** — facts, claims, numbers, proper nouns, and direct quotes must be 100% preserved. Any deviation is a fidelity failure.
+2. **Evidence-based** — the rewrite should only change spans that contained detected AI patterns. Changes to clean text are a flag for over-editing.
+3. **Genre preservation** — the rewrite must not convert the genre (e.g., a formal report must not become an essay, a column must not become literature).
+4. **No over-editing** — excessive change is a fidelity concern even if individual changes look locally correct.
+
+## Audit checklist
+
+### 10.1 Claims Preserved (`core/scoring.md` §10.1)
+
+Check every factual claim in the ORIGINAL:
+- Is it present in the REWRITE (verbatim or accurately rephrased)?
+- Are numbered lists complete? Are causal chains intact?
+- Are key qualifiers (negation, conditionality, scope) preserved?
+
+Score: High (3) / Medium (2) / Low (1) / Fail (0) per `core/scoring.md` §10.1 rubric.
+List any missing or distorted claims with the original span and the rewrite span (or absence).
+
+### 10.2 No Fabrication (`core/scoring.md` §10.2)
+
+Check every claim in the REWRITE:
+- Does each claim trace to the ORIGINAL?
+- Are any specific numbers, dates, names, or statistics invented?
+- Are there added assertions not present or implied by the original?
+
+Score: High (3) / Medium (2) / Low (1) / Fail (0) per `core/scoring.md` §10.2 rubric.
+List any fabricated spans with the rewrite span and the reason it has no original basis.
+
+### 10.3 Tone Match (`core/scoring.md` §10.3)
+
+Compare register: formality level, domain (academic / technical / casual / etc.), and intended audience.
+- If a profile was active that explicitly shifts register, score against the profile target, not the original.
+- Mixed register (e.g., formal opening, casual middle) counts as Low.
+
+Score: High (3) / Medium (2) / Low (1) / Fail (0) per `core/scoring.md` §10.3 rubric.
+
+### 10.4 Length Ratio (`core/scoring.md` §10.4)
+
+Compute: `length_ratio = len(REWRITE chars) / len(ORIGINAL chars) × 100`
+
+Look up band:
+- 70–130% → High (3)
+- 50–69% or 131–150% → Medium (2)
+- 30–49% or 151–200% → Low (1)
+- < 30% or > 200% → Fail (0)
+
+Report the raw ratio.
+
+### Additional semantic checks (MPS-level, per `core/scoring.md` §14)
+
+These are not scored separately but must be explicitly confirmed or flagged:
+
+- **Numbers and units** — every number, unit, date, percentage, and measurement in the original must appear verbatim in the rewrite.
+- **Polarity and negation** — no sentence may flip from positive to negative or vice versa.
+- **Causation** — causal relationships (`because`, `therefore`, `로 인해`, `따라서`, etc.) must be preserved with the correct cause and effect.
+- **Named entities** — proper nouns (people, places, organizations, product names) must be preserved verbatim.
+- **Direct quotes** — any text presented as a quotation in the original must appear character-for-character in the rewrite.
+
+## Fidelity scoring formula (`core/scoring.md` §12)
+
+```
+fidelity_score = ((claims + fabrication + tone + length) / 12) × 100
+```
+
+Ouroboros floors (`core/scoring.md` §13): fidelity_score ≥ 70 is required; below 70 is a hard stop regardless of AI-likeness improvement.
+
+## Verdict
+
+Output one of:
+
+- **PASS** — fidelity_score ≥ 70 and no individual criterion is Fail, and all MPS-level checks confirm. The rewrite may proceed.
+- **NEEDS-ROLLBACK** — fidelity_score < 70, or any criterion is Fail (0), or any MPS-level check fails. The rewrite must be discarded or revised before use.
+
+## Output format
+
+```
+PATINA FIDELITY AUDIT
+Original length: {n} chars  Rewrite length: {m} chars  Ratio: {r}%
+
+CRITERION SCORES
+  Claims preserved:  {score}/3  — {brief rationale}
+  No fabrication:    {score}/3  — {brief rationale}
+  Tone match:        {score}/3  — {brief rationale}
+  Length ratio:      {score}/3  — ratio={r}%
+
+Fidelity score: ({sum}/12) × 100 = {fidelity_score}
+
+MPS-LEVEL CHECKS
+  Numbers/units:   PASS / FAIL — {offending span if any}
+  Polarity:        PASS / FAIL — {offending span if any}
+  Causation:       PASS / FAIL — {offending span if any}
+  Named entities:  PASS / FAIL — {offending span if any}
+  Direct quotes:   PASS / FAIL — {offending span if any}
+
+OFFENDING SPANS (if any)
+  [criterion] ORIGINAL: "..." → REWRITE: "..." — {reason}
+
+VERDICT: PASS / NEEDS-ROLLBACK
+Reason: {one-sentence summary}
+```
+
+## Hard constraints
+
+- You MUST NOT produce any rewritten version of the text, even to "fix" a fidelity failure.
+- You MUST NOT suggest how to correct the rewrite. Report what is wrong; leave correction to the rewrite phase.
+- You MUST apply the exact fidelity formula from `core/scoring.md` §12. Do not invent alternative formulas.
+- The advisory-metadata rule applies here too: Korean `translationese` and `koPostEditese.v1` signals are ADVISORY ONLY and must not influence the fidelity score, verdict, or any gate.

--- a/agents/patina-naturalness-reviewer.md
+++ b/agents/patina-naturalness-reviewer.md
@@ -1,0 +1,112 @@
+---
+name: patina-naturalness-reviewer
+description: Triggers to re-scan a patina rewrite for residual AI tells and over-editing risk. Invoke this agent after a rewrite is produced (alongside or after patina-fidelity-auditor). It re-runs detection on the rewrite text, reports any remaining hot zones, flags over-editing, and assigns an A-D quality grade.
+model: sonnet
+tools: Read, Grep, Glob
+---
+
+You are the patina naturalness reviewer. Your job is post-rewrite quality assessment only — you NEVER rewrite text.
+
+## Role
+
+Given a REWRITE text (and optionally the ORIGINAL for comparison), re-run the full patina detection pass on the rewrite and evaluate whether the humanization succeeded. Produce a quality grade and a residual-tells report. The parent `/patina` skill or Claude uses your grade to decide whether to accept the rewrite, retry, or escalate.
+
+## Step 1 — Re-run detection on the rewrite
+
+Apply the same detection procedure as `patina-detector`:
+
+1. Load pattern packs from `patterns/{lang}-*.md` and `lexicon/ai-{lang}.md` for the rewrite's language.
+2. Compute burstiness CV, MATTR, and AI-lexicon density per paragraph (`core/stylometry.md`).
+3. Apply Korean diagnostic composite for ko text (`core/stylometry.md` §5.1).
+4. Apply the 6-signal hot decision rule (`core/stylometry.md` §6).
+5. Scan all patterns with severity assignment per `core/scoring.md` §§1-2.
+
+Report every residual detection: paragraph id, pattern id, evidence span, severity. A rewrite that passes fidelity but still has significant hot zones has not fully succeeded.
+
+## Step 2 — Compute residual AI-likeness score
+
+Apply `core/scoring.md` §§3-7 to the rewrite's detections:
+
+```
+category_score = (sum of adjusted severities / (pattern_count × 3)) × 100
+overall_score  = Σ(category_score × category_weight)
+```
+
+Report the per-category breakdown and overall score. Use the interpretation bands from `core/scoring.md` §7:
+- 0-15: 사람다움 (strongly human-like)
+- 16-30: 거의 사람다움 (mostly human, minor traces)
+- 31-50: 혼재 (mixed signals)
+- 51-70: AI 느낌 (clearly AI-generated)
+- 71-100: AI 생성 (heavily AI-generated)
+
+## Step 3 — Over-editing check (patina principle 4)
+
+Compare the rewrite to the ORIGINAL (if provided). Flag over-editing when:
+
+- Paragraphs with no detected AI patterns in the original have been changed.
+- The genre has shifted (e.g., a report has become an essay, a technical doc has become narrative).
+- The register has drifted beyond what the active profile permits.
+- The total edit volume (estimated by character-level change) appears disproportionate to the number of detected patterns.
+
+Over-editing is a concern even when individual changes look locally natural. Report specific over-edited spans with the original and rewrite versions.
+
+## Step 4 — Advisory metadata rule (MANDATORY)
+
+**Korean `translationese` and `koPostEditese.v1` signals are ADVISORY ONLY.**
+
+These signals MUST NOT influence the residual AI-likeness score, the quality grade, any gate, severity assignment, or authorship verdict. Record them under an `advisory` section, clearly labeled as non-scoring.
+
+## Step 5 — Assign quality grade
+
+Grade the rewrite A–D based on residual detection results and over-editing:
+
+| Grade | Criteria |
+|-------|----------|
+| **A** | Residual score ≤ 30 (거의 사람다움 or better), no over-editing, all hot zones resolved. The rewrite is ready. |
+| **B** | Residual score 31–50 (혼재), or minor over-editing in ≤1 paragraph, or 1–2 residual low-severity detections. Acceptable; consider one more pass for polished work. |
+| **C** | Residual score 51–70 (AI 느낌), or moderate over-editing in 2–3 paragraphs, or 3+ medium-severity residual detections. Another rewrite pass is recommended. |
+| **D** | Residual score > 70 (AI 생성), or severe over-editing, or genre/register violation. The rewrite has failed; rollback or full retry required. |
+
+Grade D always recommends rollback. Grade C recommends retry. Grades A and B recommend accept (A unconditionally, B with optional polish).
+
+## Output format
+
+```
+PATINA NATURALNESS REVIEW
+Language: {lang}  Paragraphs: {n}
+
+RESIDUAL DETECTION SUMMARY
+  Overall residual score: {score}  ({interpretation label})
+  Per-category breakdown:
+    content:       {score}
+    language:      {score}
+    style:         {score}
+    communication: {score}
+    filler:        {score}
+    structure:     {score}
+    viral-hook:    {score}
+
+RESIDUAL HOT ZONES (if any)
+  P{n} | {pattern-id} | severity: {level}
+    Evidence: "{span}"
+
+OVER-EDITING FLAGS (if any)
+  P{n}: original had no detected patterns, but rewrite changed: "{original span}" → "{rewrite span}"
+  Genre/register: {description if applicable}
+
+ADVISORY (non-scoring, never feed gate or verdict)
+  translationese signals: {description if present}
+  koPostEditese signals:  {description if present}
+
+QUALITY GRADE: A / B / C / D
+Recommendation: Accept / Accept (optional polish) / Retry / Rollback
+Rationale: {one-sentence summary}
+```
+
+## Hard constraints
+
+- You MUST NOT produce any rewritten version of the text, even to "fix" residual tells.
+- You MUST NOT suggest specific replacement wording.
+- You MUST use `core/scoring.md` category weights and formula exactly as written. Do not substitute your own weighting.
+- Honor all four patina principles in your assessment: meaning invariance, evidence-based edits only, genre preservation, no over-editing.
+- Grade D must always result in a Rollback recommendation. Do not soften it.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -2,7 +2,7 @@
 
 This page is factual positioning, not a claim that patina “wins.” Pricing and product limits change often, so verify vendor pages before making a purchase decision.
 
-Sources checked on 2026-05-20: [QuillBot Premium](https://quillbot.com/premium), [QuillBot pricing help](https://help.quillbot.com/hc/en-us/articles/36491424881943-What-is-the-price-of-QuillBot-Premium), [Undetectable pricing](https://undetectable.com/pricing), [Humbot pricing](https://humbot.ai/pricing), and [`blader/humanizer`](https://github.com/blader/humanizer/blob/main/README.md).
+Sources checked on 2026-05-20: [QuillBot Premium](https://quillbot.com/premium), [QuillBot pricing help](https://help.quillbot.com/hc/en-us/articles/36491424881943-What-is-the-price-of-QuillBot-Premium), [Undetectable pricing](https://undetectable.com/pricing), [Humbot pricing](https://humbot.ai/pricing), and [`blader/humanizer`](https://github.com/blader/humanizer/blob/main/README.md). Closest open-source skill checked on 2026-06-14: [`epoko77-ai/im-not-ai`](https://github.com/epoko77-ai/im-not-ai).
 
 | Tool | Pricing model | Language coverage | Auditability | Meaning preservation | Self-hostable / OSS | Best fit |
 |---|---|---|---|---|---|---|
@@ -11,6 +11,26 @@ Sources checked on 2026-05-20: [QuillBot Premium](https://quillbot.com/premium),
 | Undetectable AI | Commercial plans; checked page listed Basic/Premium/Ultimate monthly tiers | English-first marketing; verify current plan details | Detector/humanizer product; not repo-auditable | Detector-facing rewrite; no public MPS spec | No | Users specifically shopping for detector/humanizer SaaS |
 | Humbot | Commercial monthly/yearly plans and API access; checked page lists word-credit limits | Web/API humanizer positioning; verify current plan details | SaaS/API; not repo-auditable | No public MPS-style spec found in the checked docs | No | API-oriented humanizer workflow |
 | blader/humanizer | Open-source skill repository | Skill prompt based; check repo for current language scope | Prompt text is inspectable | Prompt-guided; no checked-in benchmark/MPS schema comparable to patina | Yes | Lightweight prompt-skill humanization |
+| epoko77-ai/im-not-ai | MIT open source; Claude Code / Codex skill; paid only via your own model backend | Korean only (KO) | Severity-tagged span detection (S1/S2/S3) + A–D grade; no checked-in numeric benchmark corpus | 13-item fidelity audit + naturalness review and change-rate caps (strict mode) | Yes | Korean writers wanting a Claude Code humanize skill with a multi-agent strict pipeline |
+
+## Closest open-source skill: epoko77-ai/im-not-ai
+
+[`epoko77-ai/im-not-ai`](https://github.com/epoko77-ai/im-not-ai) is the most directly comparable project — a popular MIT-licensed Claude Code / Codex skill that humanizes Korean AI writing. The two make different bets, so it is worth being explicit about where each is stronger.
+
+**Where im-not-ai is stronger:**
+
+- Korean-first depth: a translation-studies-grounded taxonomy (10 categories, 40+ sub-patterns) with severity tiers and an academic citation trail.
+- A multi-agent *strict* pipeline (detector → rewriter → fidelity auditor → naturalness reviewer) plus a single-call *fast* mode, native to Claude Code subagents.
+- Distribution and adoption: plugin-marketplace install and a large community.
+
+**Where patina is stronger:**
+
+- Four languages (KO/EN/ZH/JA), not Korean only.
+- A deterministic, LLM-free analysis engine (`src/features/*`) that runs identically in Node and the browser, so audit/score are reproducible without a model call.
+- A published numeric benchmark layer (precision/recall/F1, low-FPR TPR@1%/5%FPR, ROC/PR, robustness) over labeled fixtures, plus a documented MPS/fidelity rollback contract.
+- Three surfaces: agent skill, standalone npm CLI (`patina-cli`), and an audit-only browser playground.
+
+In short: im-not-ai optimizes for Korean-specialist humanization depth as a Claude Code skill; patina optimizes for multilingual, auditable, reproducible detection and rewrite across skill, CLI, and browser. They are complementary references more than direct substitutes.
 
 ## Reproducible comparison recipe
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,7 +20,7 @@ This roadmap focuses on two things:
   - human-control false positives: 16.0% [11.6-21.7%], n=200 across KO+EN
   - per-cell results: `docs/benchmarks/rebaseline-latest.md`
 - Current distribution:
-  - npm package `patina-cli` is the public distribution channel; repo metadata currently targets `4.0.0` and should be verified with `npm run release:check` before publishing.
+  - npm package `patina-cli` is the public distribution channel; repo metadata targets `5.0.0` and is verified with `npm run release:check` (currently passing) before publishing.
 
 ## 0. Positioning principles
 

--- a/docs/TRANSLATIONESE-KO.md
+++ b/docs/TRANSLATIONESE-KO.md
@@ -6,6 +6,13 @@ The stylometry + AI-lexicon signals catch *structure* and *AI vocabulary*; they
 do **not** catch lexical translationese (e.g. "커맨드 기둥" for "command pillars",
 "~에 의해" passives, "당신" for "you"). This catalog fills that gap.
 
+## Academic grounding
+
+The concepts these signals operationalize — translationese, Toury's law of
+interference, Baker's translation universals, and Toral's post-editese, plus the
+Korean 번역투 research tradition (이근희, 김순영) — are documented with verifiable
+citations in [`research/ko-translationese-scholarship.md`](research/ko-translationese-scholarship.md).
+
 ## Design notes
 
 - **Precision first.** Most of these constructions also appear in good native

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,85 @@
+# Patina Subagents — Optional Multi-Agent Strict Flow
+
+This document describes the three Claude Code plugin subagents bundled with patina and how they compose into an optional multi-agent strict flow.
+
+## Overview
+
+The standard `/patina` skill operates as a single-pass LLM-orchestrated pipeline (SKILL.md). The subagents described here are **additive** — they extend that pipeline with parallel, independent analysis lanes. Nothing about the core skill changes; the subagents can be invoked alongside it.
+
+All three subagents are **read-only analysis agents**. None of them rewrites text. They produce reports and verdicts that the main skill (or Claude acting as orchestrator) uses to decide whether to accept, retry, or roll back a rewrite.
+
+## The Three Subagents
+
+### patina-detector
+
+Runs the full detection pass on the **input text before any rewrite**. Loads all applicable pattern packs from `patterns/`, computes burstiness CV and MATTR per `core/stylometry.md`, applies AI-lexicon density checks, and runs Korean diagnostic signals for `ko` inputs. Emits a paragraph/span-level findings report with severity ratings per `core/scoring.md`.
+
+Use when: you need a pre-rewrite audit log, want to verify which patterns were actually detected, or need the detection report as evidence in an output.
+
+### patina-fidelity-auditor
+
+Given the ORIGINAL and REWRITE texts, audits meaning preservation against all four fidelity criteria defined in `core/scoring.md` §§9-14: claims preserved, no fabrication, tone match, and length ratio. Also checks MPS-level semantic anchors: numbers, polarity, causation, named entities, and direct quotes. Returns a PASS or NEEDS-ROLLBACK verdict with the fidelity score and offending spans identified.
+
+The ouroboros floor applies here: fidelity_score ≥ 70 is required for PASS.
+
+Use when: you need an auditable record that the rewrite did not alter facts, or when fidelity is critical (academic, technical, medical, legal profiles).
+
+### patina-naturalness-reviewer
+
+Re-runs detection on the **rewrite text** to check for residual AI tells. Computes a residual AI-likeness score per `core/scoring.md`, flags over-editing (changes to paragraphs that had no detected patterns), and checks for genre or register drift. Assigns an A–D quality grade:
+
+| Grade | Meaning |
+|-------|---------|
+| A | Residual score ≤ 30, no over-editing — accept |
+| B | Residual score 31–50 or minor over-editing — acceptable, optional polish |
+| C | Residual score 51–70 or moderate over-editing — retry recommended |
+| D | Residual score > 70 or genre/register violation — rollback required |
+
+Use when: you want quality assurance on the rewrite before delivering it, or when the `--ouroboros` loop needs an independent grade signal.
+
+## Strict Flow: Composition
+
+The three subagents compose into the following sequential flow:
+
+```
+INPUT TEXT
+    │
+    ▼
+patina-detector ─────────────────── findings report (patterns + suspect zones)
+    │
+    ▼
+/patina rewrite (SKILL.md stages 5a/5b/5c)
+    │
+    ├──► patina-fidelity-auditor ── PASS / NEEDS-ROLLBACK + offending spans
+    │
+    └──► patina-naturalness-reviewer ── grade A/B/C/D + residual tells
+    │
+    ▼
+Decision
+  ├── fidelity PASS + grade A or B → ACCEPT rewrite
+  ├── fidelity PASS + grade C → RETRY rewrite (one more pass)
+  └── fidelity NEEDS-ROLLBACK or grade D → ROLLBACK to original
+```
+
+The fidelity auditor and naturalness reviewer run in parallel after the rewrite is produced. Both verdicts are required before accepting the rewrite. A NEEDS-ROLLBACK from the fidelity auditor overrides a grade A from the naturalness reviewer — meaning preservation always takes priority.
+
+This flow is entirely optional. The standard `/patina` skill functions without these subagents. They add a structured audit trail and an explicit accept/retry/rollback gate.
+
+## Automatic delegation from `--strict`
+
+The `/patina --strict` mode (defined in `SKILL.md`) wires this flow automatically. When the patina plugin is installed and these subagents are available, `--strict` delegates its read-only analysis passes via the `Task` tool — P1 to `patina-detector`, P3 to `patina-fidelity-auditor`, P4 to `patina-naturalness-reviewer` — while the main skill keeps orchestration, the rewrite (P2), and the accept/retry/rollback gate (P5). When the subagents are not available (Codex CLI, Cursor, OpenCode, or a non-plugin install), `--strict` runs the same passes inline in a single agent. Both modes use identical floors and gate logic; delegation only adds context isolation.
+
+## Advisory Metadata Rule
+
+Korean `translationese` and `koPostEditese.v1` signals are **advisory only** across the entire pipeline, including inside all three subagents. These signals must never influence the AI-likeness score, fidelity score, quality grade, ouroboros termination, or any authorship verdict. They appear in report output labeled as advisory and non-scoring.
+
+## Claude Code Plugin Auto-Discovery
+
+Patina ships an `agents/` directory in the plugin root. Claude Code discovers agent files automatically by scanning `agents/*.md` at plugin load time. Each file's YAML frontmatter declares the agent's `name`, `description`, `model`, and `tools` allowlist.
+
+To use the subagents:
+1. Install the patina plugin in Claude Code.
+2. Claude will auto-discover `agents/patina-detector.md`, `agents/patina-fidelity-auditor.md`, and `agents/patina-naturalness-reviewer.md`.
+3. Reference them by name in your prompts, or let Claude invoke them automatically based on their `description` fields.
+
+The subagents are tool-limited to `Read`, `Grep`, and `Glob` (detector and reviewer) or `Read` only (fidelity auditor). They do not use hooks, MCP servers, or elevated permission modes.

--- a/docs/research/ko-translationese-scholarship.md
+++ b/docs/research/ko-translationese-scholarship.md
@@ -1,0 +1,114 @@
+# Academic grounding for patina's Korean translationese detection
+
+This note records the scholarly concepts that patina's Korean (`ko`)
+translationese and post-editese signals **operationalize**, with verifiable
+citations. It exists so the Korean detection layer is traceable to established
+translation-studies and machine-translation research rather than to ad-hoc
+intuition.
+
+## Honest scope (read this first)
+
+- This document maps patina's **existing deterministic signals** to
+  well-established linguistic *phenomena*. It does **not** claim that any
+  individual regex or metric was derived from a specific paper, or that patina
+  reproduces any paper's exact method.
+- patina's Korean rules are **corpus-validated and density-gated** for precision
+  (see [`TRANSLATIONESE-KO.md`](../TRANSLATIONESE-KO.md)). The literature below
+  supplies the *terminology and conceptual frame*; the calibration evidence is
+  patina's own.
+- The signals remain **advisory only**: `translationese` and `koPostEditese.v1`
+  must not feed score, the document `hot` verdict, gates, severity, baselines,
+  percentiles, benchmark claims, or authorship verdicts. Any future coupling
+  requires the separately approved Phase 4 calibration package in
+  [`TRANSLATIONESE-KO.md`](../TRANSLATIONESE-KO.md).
+
+## Conceptual lineage
+
+### Translationese and the law of interference
+
+"Translationese" — translated text that is recognizably different from natively
+written text because the source language leaves "fingerprints" — was put on a
+neutral, descriptive footing by Gellerstam (1986). Toury (1995) formalized the
+mechanism as the **law of interference**: "phenomena pertaining to the make-up
+of the source text tend to be transferred to the target text," alongside the
+**law of growing standardisation**. Jakobson (1959) is the older foundation for
+treating translation shifts as a linguistic object.
+
+This is exactly what patina's `translationese` catalog targets in Korean:
+English structure carried into grammatical-but-unnatural Korean (by-passives,
+literal pronouns, dummy subjects, light-verb constructions, direct calques).
+
+### Translation universals
+
+Baker (1993) proposed **translation universals** — linguistic features typical
+of translated text regardless of language pair — investigable with corpora. The
+commonly cited universals are **simplification**, **explicitation**, and
+**normalisation/conservatism**. These give the vocabulary for patina's
+document-level Korean texture metrics (lexical variety/density, repetitive
+endings, rhythm regularity).
+
+### Post-editese
+
+Toral (2019), *Post-editese: an Exacerbated Translationese* (MT Summit XVII; best
+paper), showed that post-edited machine translation is **simpler, more
+normalised, and carries higher source-language interference** than from-scratch
+human translation, with **lower lexical variety and lower lexical density**.
+patina's `koPostEditese.v1` payload is named for, and conceptually structured
+around, this finding: its metric groups are lexical, endings, interference, and
+rhythm — the same simplification / normalisation / interference axes Toral
+measured, specialized to Korean surface features.
+
+### Korean 번역투 research tradition
+
+Korean translation studies have a dedicated literature on English→Korean
+번역투 (translationese):
+
+- 이근희 (2005), 《영-한 번역에서의 번역투 연구》, 세종대학교 박사학위논문 — a
+  book-length taxonomy of English-to-Korean translationese; the analogy to
+  journalese/legalese/officialese for the `-ese` suffix comes from here.
+- 이근희 (2008), 「번역투 관점에서 본 번역 텍스트의 품질 향상 방안」, 《번역학연구》 —
+  translationese framed as a *quality-improvement* lens, which is precisely how
+  patina uses the signal (editing hints, not accusation).
+- 김순영 (2012), 「영한 번역에 나타난 번역투 문장」, 《새국어생활》 22(1), 국립국어원 —
+  a concrete catalog of English→Korean translationese sentence patterns
+  (by-passives, pronoun literalism, formal-noun overuse) overlapping patina's
+  rule set; a companion article in the same issue covers Japanese→Korean
+  번역투, relevant to patina's future `ja` work.
+- 이미경 (2007), 「번역투 배제를 위한 교육수단으로서 시역의 유용성에 대한 연구」 — on
+  teaching away from translationese.
+
+## Mapping: concept → patina signal
+
+| Phenomenon (source) | patina signal | Korean example (before → after) |
+| --- | --- | --- |
+| Interference / by-passive (Toury 1995; 김순영 2012) | `translationese` `passive-e-uihae` | 작업은 에이전트**에 의해** 처리됩니다 → 에이전트가 작업을 처리합니다 |
+| Interference / pronoun literalism (이근희 2005; 김순영 2012) | `translationese` `direct-address-you`, `dummy-subject` | **당신은** 이것을 설정할 수 있습니다 → 이건 설정할 수 있다 |
+| Interference / light verb & calque (Toury 1995) | `translationese` `have-overuse`, `noun-calque`, `provides`, `one-of`, `as-follows`, `make-easy` | 이 도구는 유연성을 **가지고 있습니다** → 이 도구는 유연하다 |
+| Simplification: low lexical variety/density (Baker 1993; Toral 2019) | `koPostEditese.v1` `metrics.lexical` | (document-level ratios; advisory) |
+| Normalisation: repetitive endings / uniform rhythm (Baker 1993; Toral 2019) | `koPostEditese.v1` `metrics.endings`, `metrics.rhythm` | (document-level ratios; advisory) |
+| Source interference index (Toury 1995; Toral 2019) | `koPostEditese.v1` `metrics.interference` | (document-level ratios; advisory) |
+
+The `translationese` catalog operates per paragraph with a precision-protecting
+density gate; `koPostEditese.v1` exposes raw document/paragraph ratios for an
+editor to inspect. Neither is a verdict.
+
+## References
+
+- Jakobson, R. (1959). "On Linguistic Aspects of Translation." In R. A. Brower
+  (ed.), *On Translation*. Harvard University Press.
+- Gellerstam, M. (1986). "Translationese in Swedish novels translated from
+  English." In L. Wollin & H. Lindquist (eds.), *Translation Studies in
+  Scandinavia*, 88–95.
+- Baker, M. (1993). "Corpus Linguistics and Translation Studies: Implications
+  and Applications." In M. Baker, G. Francis & E. Tognini-Bonelli (eds.), *Text
+  and Technology*, 233–250. John Benjamins.
+- Toury, G. (1995). *Descriptive Translation Studies – and Beyond*. John
+  Benjamins. (Law of growing standardisation; law of interference.)
+- Toral, A. (2019). "Post-editese: an Exacerbated Translationese." *Proceedings
+  of Machine Translation Summit XVII*, Vol. 1, 273–281.
+  <https://aclanthology.org/W19-6627/>
+- 이근희 (2005). 《영-한 번역에서의 번역투 연구》. 세종대학교 박사학위논문.
+- 이근희 (2008). 「번역투 관점에서 본 번역 텍스트의 품질 향상 방안」. 《번역학연구》.
+- 이미경 (2007). 「번역투 배제를 위한 교육수단으로서 시역의 유용성에 대한 연구」.
+- 김순영 (2012). 「영한 번역에 나타난 번역투 문장」. 《새국어생활》 22(1), 국립국어원.
+  <https://www.korean.go.kr/nkview/nklife/2012_1/22_0105.pdf>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "5.0.0"
+    "patina-cli": "5.1.0"
   },
   "license": "MIT",
   "repository": {

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -30,6 +30,15 @@ expect(aliasPkg.dependencies?.['patina-cli'] === version, 'patina-humanizer must
 expect(aliasPkg.bin?.['patina-humanizer'] === 'bin/patina-humanizer.js', 'patina-humanizer bin must point to bin/patina-humanizer.js');
 expect(existsSync(repoPath('packages/patina-humanizer/bin/patina-humanizer.js')), 'patina-humanizer bin file must exist');
 
+const pluginManifest = readJson('.claude-plugin/plugin.json');
+expect(pluginManifest.name === 'patina', '.claude-plugin/plugin.json name must be patina');
+expect(pluginManifest.version === version, '.claude-plugin/plugin.json version must match package.json');
+
+const marketplaceManifest = readJson('.claude-plugin/marketplace.json');
+const marketplacePlugin = marketplaceManifest.plugins?.find((entry) => entry.name === 'patina');
+expect(marketplacePlugin, '.claude-plugin/marketplace.json must list a patina plugin entry');
+expect(marketplacePlugin?.version === version, '.claude-plugin/marketplace.json patina plugin version must match package.json');
+
 if (checks.length) {
   console.error(checks.map((msg) => `- ${msg}`).join('\n'));
   process.exit(1);

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+# uninstall.sh - Remove patina from Claude Code and other AI agents
+# Usage: curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/uninstall.sh | bash
+#
+# This only removes what install.sh creates. If you installed via the Claude Code
+# plugin marketplace (/plugin install patina@patina), uninstall with:
+#   /plugin uninstall patina@patina
+set -e
+
+# Agent targets (set env vars to disable individually; all enabled by default)
+UNINSTALL_CLAUDE="${UNINSTALL_CLAUDE:-true}"
+UNINSTALL_CODEX="${UNINSTALL_CODEX:-true}"
+UNINSTALL_CURSOR="${UNINSTALL_CURSOR:-true}"
+UNINSTALL_OPCODE="${UNINSTALL_OPCODE:-true}"
+
+CLAUDE_SKILLS_DIR="${HOME}/.claude/skills"
+CODEX_SKILLS_DIR="${HOME}/.codex/skills"
+CURSOR_RULES_DIR="${HOME}/.cursor/rules"
+OPCODE_SKILLS_DIR="${HOME}/.config/opencode/skills"
+PATINA_DIR="${CLAUDE_SKILLS_DIR}/patina"
+
+# Colors (only when outputting to a terminal)
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  BOLD="$(printf '\033[1m')"
+  GREEN="$(printf '\033[32m')"
+  YELLOW="$(printf '\033[33m')"
+  RED="$(printf '\033[31m')"
+  RESET="$(printf '\033[0m')"
+else
+  BOLD=""
+  GREEN=""
+  YELLOW=""
+  RED=""
+  RESET=""
+fi
+
+info() {
+  printf "%b\n" "${BOLD}$1${RESET}"
+}
+
+warn() {
+  printf "%b\n" "${YELLOW}$1${RESET}"
+}
+
+success() {
+  printf "%b\n" "${GREEN}$1${RESET}"
+}
+
+error() {
+  printf "%b\n" "${RED}$1${RESET}" >&2
+  exit 1
+}
+
+REMOVED=0
+
+# --- Codex CLI (symlink) ---
+if [ "${UNINSTALL_CODEX}" = "true" ]; then
+  TARGET="${CODEX_SKILLS_DIR}/patina"
+  if [ -L "${TARGET}" ]; then
+    rm -f "${TARGET}"
+    success "Codex: removed ${TARGET}"
+    REMOVED=1
+  elif [ -e "${TARGET}" ]; then
+    warn "Codex: ${TARGET} exists but is not a symlink; leaving it untouched."
+  fi
+fi
+
+# --- Cursor (symlink) ---
+if [ "${UNINSTALL_CURSOR}" = "true" ]; then
+  TARGET="${CURSOR_RULES_DIR}/patina.md"
+  if [ -L "${TARGET}" ]; then
+    rm -f "${TARGET}"
+    success "Cursor: removed ${TARGET}"
+    REMOVED=1
+  elif [ -e "${TARGET}" ]; then
+    warn "Cursor: ${TARGET} exists but is not a symlink; leaving it untouched."
+  fi
+fi
+
+# --- OpenCode / Sisyphus (symlink) ---
+if [ "${UNINSTALL_OPCODE}" = "true" ]; then
+  TARGET="${OPCODE_SKILLS_DIR}/patina"
+  if [ -L "${TARGET}" ]; then
+    rm -f "${TARGET}"
+    success "OpenCode: removed ${TARGET}"
+    REMOVED=1
+  elif [ -e "${TARGET}" ]; then
+    warn "OpenCode: ${TARGET} exists but is not a symlink; leaving it untouched."
+  fi
+fi
+
+# --- Claude Code (cloned repo) ---
+# Remove last so the symlinks above are cleared before their target disappears.
+if [ "${UNINSTALL_CLAUDE}" = "true" ]; then
+  if [ -L "${PATINA_DIR}" ]; then
+    rm -f "${PATINA_DIR}"
+    success "Claude Code: removed symlink ${PATINA_DIR}"
+    REMOVED=1
+  elif [ -d "${PATINA_DIR}/.git" ]; then
+    rm -rf "${PATINA_DIR}"
+    success "Claude Code: removed ${PATINA_DIR}"
+    REMOVED=1
+  elif [ -d "${PATINA_DIR}" ]; then
+    error "${PATINA_DIR} exists but is not a patina git clone. Remove it manually if you are sure."
+  fi
+fi
+
+printf "\n"
+if [ "${REMOVED}" = "1" ]; then
+  success "✓ patina uninstalled."
+else
+  warn "Nothing to remove. patina was not found in the standard install locations."
+  info "If you installed via the Claude Code plugin marketplace, run: /plugin uninstall patina@patina"
+fi
+printf "\n"
+info "Environment variables to control uninstallation:"
+printf "  UNINSTALL_CLAUDE=true|false   (default: true)\n"
+printf "  UNINSTALL_CODEX=true|false    (default: true)\n"
+printf "  UNINSTALL_CURSOR=true|false   (default: true)\n"
+printf "  UNINSTALL_OPCODE=true|false   (default: true)\n"


### PR DESCRIPTION
## Summary

Closes the competitive gaps identified against the closest open-source skill ([`epoko77-ai/im-not-ai`](https://github.com/epoko77-ai/im-not-ai)): distribution reach, multi-agent architecture, Korean academic authority, and non-technical onboarding. Bumps to **5.1.0** (minor — additive, opt-in, no removals; deterministic engine unchanged).

## Commits

- **feat(dist)** — Claude Code plugin marketplace (`/plugin marketplace add devswha/patina` → `/plugin install patina@patina`; the repo-root `SKILL.md` auto-loads as the `/patina` skill, data dirs untouched), `uninstall.sh`, and manifest version-sync wired into `release:check`.
- **feat(skill)** — three read-only subagents (`patina-detector` / `patina-fidelity-auditor` / `patina-naturalness-reviewer`) auto-discovered from `agents/`, plus an opt-in `--strict` multi-pass mode (detect → rewrite → fidelity/MPS audit → naturalness re-scan → accept/retry/rollback). In a plugin env `--strict` delegates the read-only passes to the subagents via `Task`; otherwise it runs them inline in a single agent with identical floors/gate logic.
- **docs** — `docs/research/ko-translationese-scholarship.md` anchoring KO detectors to verifiable sources (Gellerstam 1986, Baker 1993, Toury 1995, Toral 2019; 이근희 2005/2008, 김순영 2012) with an honest advisory-only scope note; `im-not-ai` added to `docs/COMPARISON.md`; ROADMAP version fix.
- **docs(readme)** — plugin install path (all locales), non-technical Korean onboarding (natural-language usage + "say it in plain Korean → option" table), scholarship/subagent links, stale badge fixes.
- **chore(release)** — 5.1.0 across all version surfaces + CHANGELOG.

## Verification

- `npm test` — **782 pass / 0 fail**
- `npm run lint` — syntax OK, cspell 0 issues
- `npm run release:check` — OK for 5.1.0
- `npm run check:no-private-assets` — OK

All new behavior is opt-in (default-off), so existing runs are byte-identical without the new flags. `--strict` is skill-only (not a CLI flag). The pre-publish `benchmark:report` / `dogfood` gates (LLM-backed) were not run here.
