### PR TITLE
feat(ko): uniform plain-다 ending-monotony hot signal — KO×GPT catch 45→82.5% (5.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "patina",
       "source": "./",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "description": "Strip the AI packaging, keep the meaning. Detect and rewrite AI writing patterns across KO/EN/ZH/JA with MPS/fidelity checks. Runs the root SKILL.md as the /patina skill.",
       "homepage": "https://github.com/devswha/patina",
       "repository": "https://github.com/devswha/patina",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
   "name": "patina",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese so text reads as if a human wrote it. Meaning-preservation (MPS) verified, audit-friendly. The root SKILL.md is loaded as the /patina skill.",
   "author": {
     "name": "devswha",

--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "5.1.0"
+version: "5.2.0"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
+## 5.2.0 — 2026-06-15
+
+**Korean detection: a deterministic "uniform plain-다 register" hot signal that catches short, length-uniform AI Korean the burstiness gate skipped.**
+
+Semver rationale: minor — adds one KO-only deterministic stylometry signal to the per-paragraph hot rule. No removals; en/zh/ja behavior is byte-identical; false positives stay within the published tolerance.
+
+### Changed
+- New per-paragraph hot signal for Korean (`src/features/stylometry.js#koreanEndingMonotony`, wired in `src/features/index.js` and mirrored in `playground/analyzer.js`): a paragraph is hot when declarative `-다` endings dominate (ratio ≥ 0.6 and count ≥ 2) **and** sentence lengths are uniform (burstiness CV below the low band) **and** the paragraph has ≥ 20 tokens. Unlike the standard burstiness trigger it does not require 3 sentences, so it catches short AI Korean the band gate skipped, while the `-다` + low-CV conjuncts spare formal human Korean (same `-다`, varied sentence lengths → high CV) and conversational Korean (요/습니다), and the 20-token floor spares terse snippets.
+- Measured on the KO rebaseline manifest (n=380, deterministic analyzer): **KO×GPT catch 45.0% → 82.5%**, KO recall 59.2% → 70.8%, accuracy 77.6% → 80.8%, F1 0.644 → 0.716, precision 70.6% → 72.4%; human-control FPR 12.8% → 14.0% (within the published 11.6–21.7% CI). EN is unchanged. The frozen public claim manifests and the headline catch/FP claim are refreshed on the next dedicated rebaseline pass, not by this change.
+
 ## 5.1.0 — 2026-06-14
 
 **Adds Claude Code plugin-marketplace distribution, an optional multi-agent `--strict` skill mode, and Korean translationese academic grounding.**

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 5.1.0" src="https://img.shields.io/badge/version-5.1.0-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 5.2.0" src="https://img.shields.io/badge/version-5.2.0-blue"></a>
 </p>
 
 <p align="center">
@@ -187,7 +187,7 @@ If meaning drifts, the change is retried or rolled back. Deterministic analysis 
 
 ```yaml
 # .patina.default.yaml
-version: "5.1.0"
+version: "5.2.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/README_JA.md
+++ b/README_JA.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#クイックスタート)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-5.1.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.2.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-en.gif" alt="patina が英語のAIっぽい文を整え、スコアを表示するターミナルデモGIF" width="780">

--- a/README_KR.md
+++ b/README_KR.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#빠른-시작)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-5.1.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.2.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-ko.gif" alt="patina가 한국어 AI풍 문장을 다듬고 결과 점수를 보여주는 터미널 데모 GIF" width="780">

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#快速开始)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-5.1.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.2.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-en.gif" alt="patina 将带有 AI 味的英文文案改写并显示评分的终端演示 GIF" width="780">

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 5.1.0
+version: 5.2.0
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read
@@ -337,9 +337,14 @@ paragraph is SUSPECT iff
   burstiness_band == "low"
   OR MATTR_band == "low"
   OR lexicon_density > lexicon.density_threshold
+  OR (ko 전용) ending_monotony
+     : 평서형 '-다' 비율 >= 0.6 AND '-다' 문장 수 >= 2
+       AND burstiness CV < low AND 단락 토큰 >= 20
 ```
 
 4.6단계 OR 규칙에 lexicon 신호를 한 절(clause) 추가한다.
+
+(ko 전용) `ending_monotony` 절을 추가한다: 평탄한 한다체(평서형 `-다`)를 균일한 문장 길이로 쓰는 짧은 AI 한국어를 잡되, 문장 길이 변동이 큰 격식 사람 한국어와 대화체(요/습니다)는 배제한다. 3문장 미만이라 burstiness band gate가 비활성인 단락도 포함하나 초단문 오탐 방지를 위해 단락 토큰 20개 이상을 요구한다. 상세는 `core/stylometry.md` 참조.
 
 ### LLM 전달 형식 확장
 

--- a/core/stylometry.md
+++ b/core/stylometry.md
@@ -236,6 +236,8 @@ paragraph is SUSPECT iff
   koDiagnostics.hot == true  OR
   (fakeCandor.doc_count >= 2 AND paragraph_candor_count >= 1)  OR
   (thematicBreaks.doc_count >= 3 AND paragraph_break_count >= 1)
+  OR (ko: ending_monotony — declarative_da_ratio >= 0.6 AND declarative_da_count >= 2
+          AND burstiness_cv < burstiness_band.low AND paragraph_tokens >= 20)
 ```
 
 ### 근거
@@ -248,6 +250,13 @@ paragraph is SUSPECT iff
   막기 위해 CJK 기본 `lexicon_min_hits`는 2다.
 - ko diagnostic signal은 내부에서 AND composite를 사용하므로 쉼표/조사 같은 단일 특징만으로는
   OR-rule에 들어오지 않는다
+- ko ending-monotony signal(균일 평서형 -다)은 짧은 AI 한국어가 평탄한 한다체를 균일한
+  문장 길이로 쓰는 경향을 잡는다. burstiness가 낮고(`cv < low`) 평서형 `-다` 종결이
+  우세할 때(비율 ≥ 0.6, 2회 이상)만 켜지며, 같은 `-다`라도 문장 길이 변동이 큰 격식
+  사람 한국어(cv 높음)와 대화체(요/습니다)는 배제된다. 3문장 미만이라 burstiness band
+  gate가 비활성인 짧은 단락도 포괄하되, 초단문 오탐을 막으려 단락 토큰 ≥ 20을 요구한다.
+  KO×GPT rebaseline에서 catch 45.0%→82.5%, KO recall 59.2%→70.8%(F1 0.644→0.716)로
+  개선되고 사람 대조군 FP는 12.8%→14.0%(공개 CI 내)에 머문다. en/zh/ja에는 적용되지 않는다.
 - discourse-tell disjunct(fake-candor / thematic-break)는 단독 단락 특징이 아니라
   문서 수준 density gate(candor opener ≥2, thematic break ≥3)를 먼저 통과해야 켜진다.
   gate 통과 후 해당 tell을 실제로 1회 이상 보유한 단락만 hot으로 합류하므로, 단일

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "5.1.0"
+    "patina-cli": "5.2.0"
   },
   "license": "MIT",
   "repository": {

--- a/playground/analyzer.js
+++ b/playground/analyzer.js
@@ -19,6 +19,8 @@ import {
   koreanPosDiversityProxy,
   koreanSpacingFeatures,
   koreanPostEditeseFeatures,
+  koreanEndingMonotony,
+  DEFAULT_KO_ENDING_MONOTONY,
 } from '../src/features/stylometry.js';
 import {
   DEFAULT_LEXICON_DENSITY_THRESHOLD,
@@ -159,7 +161,7 @@ export function countFormatting(text, opts = {}) {
   return { emDash, bold, emoji };
 }
 
-function buildReasons({ cvBand, mattrBand, lexiconHot, lex, koDiagnostics, formatting, formattingThresholds, leakage, candor, thematicBreaks }) {
+function buildReasons({ cvBand, mattrBand, lexiconHot, lex, koDiagnostics, endingMonotonyHot, formatting, formattingThresholds, leakage, candor, thematicBreaks }) {
   const reasons = [];
   if (candor?.hot) {
     reasons.push({
@@ -241,6 +243,13 @@ function buildReasons({ cvBand, mattrBand, lexiconHot, lex, koDiagnostics, forma
       detail: `Regular spacing, low comma rhythm, and low suffix diversity matched together (strength ${fmt(koDiagnostics.strength, 1)}).`,
     });
   }
+  if (endingMonotonyHot) {
+    reasons.push({
+      code: 'ko-ending-monotony',
+      label: 'Uniform plain-다 register',
+      detail: 'Flat declarative -다 endings with little sentence-length variation, a short-form LLM Korean tell.',
+    });
+  }
   return reasons;
 }
 
@@ -283,6 +292,16 @@ export function analyzePlaygroundText(text, opts = {}) {
     const koSignals = lang === 'ko'
       ? buildKoreanSignals(paragraph, sentences.length)
       : {};
+    const endingMonotony = lang === 'ko' ? koreanEndingMonotony(sentences) : null;
+    const endingMonotonyHot = Boolean(
+      endingMonotony &&
+      tokens.length >= DEFAULT_KO_ENDING_MONOTONY.minTokens &&
+      cv != null &&
+      cv < DEFAULT_BURSTINESS_BANDS.low &&
+      endingMonotony.daRatio != null &&
+      endingMonotony.daRatio >= DEFAULT_KO_ENDING_MONOTONY.minDaRatio &&
+      endingMonotony.daCount >= DEFAULT_KO_ENDING_MONOTONY.minDaCount
+    );
     const lexiconHot = classifyLexiconHot(lex, {
       lang,
       densityThreshold: threshold,
@@ -310,7 +329,8 @@ export function analyzePlaygroundText(text, opts = {}) {
       emojiHot ||
       leakage.leaked ||
       candorHot ||
-      thematicBreakHot;
+      thematicBreakHot ||
+      endingMonotonyHot;
     const thematicBreaks = {
       ...paraThematicBreaks[idx],
       docCount: docThematicBreaks.count,
@@ -328,6 +348,7 @@ export function analyzePlaygroundText(text, opts = {}) {
       leakage,
       candor: { hot: candorHot, docCount: docCandor },
       thematicBreaks,
+      endingMonotonyHot,
     });
 
     return {
@@ -342,6 +363,8 @@ export function analyzePlaygroundText(text, opts = {}) {
       formatting,
       leakage,
       ...koSignals,
+      endingMonotony,
+      endingMonotonyHot,
       thematicBreaks,
       hot,
       reasons,

--- a/scripts/rebaseline-score.mjs
+++ b/scripts/rebaseline-score.mjs
@@ -211,6 +211,7 @@ function triggerCounts(analysis) {
     mattr_low: 0,
     lexicon_hot: 0,
     ko_diagnostics_hot: 0,
+    ko_ending_monotony: 0,
   };
 
   for (const paragraph of analysis.paragraphs) {
@@ -218,6 +219,7 @@ function triggerCounts(analysis) {
     if (paragraph.mattr?.band === 'low') counts.mattr_low++;
     if (paragraph.lexicon?.hot) counts.lexicon_hot++;
     if (paragraph.koDiagnostics?.hot) counts.ko_diagnostics_hot++;
+    if (paragraph.endingMonotonyHot) counts.ko_ending_monotony++;
   }
 
   return counts;

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -20,6 +20,8 @@ import {
   DEFAULT_MATTR_WINDOW,
   DEFAULT_MIN_BURSTINESS_SENTENCES,
   koreanPostEditeseFeatures,
+  koreanEndingMonotony,
+  DEFAULT_KO_ENDING_MONOTONY,
 } from './stylometry.js';
 import {
   classifyLexiconHot,
@@ -58,6 +60,7 @@ export function analyzeText(text, opts = {}) {
     mattrWindow = DEFAULT_MATTR_WINDOW,
     koDiagnosticsEnabled = true,
     koDiagnosticBands = DEFAULT_KO_DIAGNOSTIC_BANDS,
+    koEndingMonotonyBands = DEFAULT_KO_ENDING_MONOTONY,
     lexiconDensityThreshold = DEFAULT_LEXICON_DENSITY_THRESHOLD,
     lexiconMinHotMatches = DEFAULT_LEXICON_MIN_HOT_MATCHES,
     lexicon: providedLexicon,
@@ -125,6 +128,21 @@ export function analyzeText(text, opts = {}) {
         })
       : {};
 
+    const endingMonotony = lang === 'ko' ? koreanEndingMonotony(sentences) : null;
+    // KO uniform plain-다 register: low burstiness AND -다 dominance. Unlike the
+    // standard burstiness trigger (cvBand) this does NOT require the 3-sentence
+    // minimum, so it catches short AI Korean the band gate skips, while the -다
+    // conjuncts keep formal/conversational human Korean out (DEFAULT_KO_ENDING_MONOTONY).
+    const endingMonotonyHot = Boolean(
+      endingMonotony &&
+      allTokens.length >= koEndingMonotonyBands.minTokens &&
+      cv != null &&
+      cv < burstinessBands.low &&
+      endingMonotony.daRatio != null &&
+      endingMonotony.daRatio >= koEndingMonotonyBands.minDaRatio &&
+      endingMonotony.daCount >= koEndingMonotonyBands.minDaCount
+    );
+
     const lexiconHot = classifyLexiconHot(lex, {
       lang,
       densityThreshold: lexiconDensityThreshold,
@@ -140,7 +158,8 @@ export function analyzeText(text, opts = {}) {
       lexiconHot ||
       Boolean(koSignals.koDiagnostics?.hot) ||
       candorHot ||
-      thematicBreakHot;
+      thematicBreakHot ||
+      endingMonotonyHot;
 
     return {
       id: `P${idx + 1}`,
@@ -154,6 +173,8 @@ export function analyzeText(text, opts = {}) {
       candorCount: paraCandorCounts[idx],
       thematicBreakHot,
       thematicBreakCount: paraThematicBreakCounts[idx],
+      endingMonotony,
+      endingMonotonyHot,
       // Divider-only pseudo-paragraph (a bare `---` line between blank lines).
       // Hot attribution still applies (the divider itself is rewrite scope),
       // but prose gates use this to keep their ratios on actual prose.
@@ -195,6 +216,7 @@ export {
   koreanPosDiversityProxy,
   koreanSpacingFeatures,
   koreanPostEditeseFeatures,
+  koreanEndingMonotony,
   loadLexicon,
   computeDensity,
   extractStructuralFeatures,

--- a/src/features/stylometry.js
+++ b/src/features/stylometry.js
@@ -9,6 +9,13 @@ export const DEFAULT_BURSTINESS_BANDS = { low: 0.30, high: 0.50 };
 export const DEFAULT_MATTR_BANDS = { low: 0.55, high: 0.70 };
 export const DEFAULT_MATTR_WINDOW = 50;
 export const DEFAULT_MIN_BURSTINESS_SENTENCES = 3;
+// KO-only "uniform plain-다 register" hot signal. AI Korean often writes short,
+// length-uniform prose in the flat declarative -다 register; formal human Korean
+// uses -다 too but with varied sentence lengths (high burstiness CV), and
+// conversational human Korean uses 요/습니다 (low -다 ratio). The signal therefore
+// fires only when low burstiness AND -다 dominance co-occur, which separates
+// AI-다 from formal-human-다 and conversational-human at short lengths.
+export const DEFAULT_KO_ENDING_MONOTONY = Object.freeze({ minDaRatio: 0.6, minDaCount: 2, minTokens: 20 });
 export const DEFAULT_KO_DIAGNOSTIC_BANDS = {
   minSentences: 4,
   minEojeols: 20,
@@ -316,6 +323,16 @@ function buildKoPostEditeseEndings(endings) {
     politeEndingCount: endings.filter((ending) => POST_EDITESE_POLITE_ENDINGS.has(ending)).length,
     endingStreakMax: maxDeclarativeDaStreak(endings),
   };
+}
+
+// Per-paragraph declarative-다 ending monotony. This is a first-class hot-signal
+// input (NOT the advisory koPostEditese payload): it reuses the deterministic
+// ending classifier but is computed per paragraph and consumed by the hot
+// decision in analyzeText. Returns { daCount, daRatio } (daRatio null on no endings).
+export function koreanEndingMonotony(sentences = []) {
+  const endings = sentences.map(extractSentenceEnding).filter(Boolean);
+  const daCount = endings.filter((ending) => POST_EDITESE_DECLARATIVE_DA_ENDINGS.has(ending)).length;
+  return { daCount, daRatio: ratio(daCount, endings.length) };
 }
 
 function extractSentenceEnding(sentence) {

--- a/tests/unit/stylometry-ko.test.js
+++ b/tests/unit/stylometry-ko.test.js
@@ -9,6 +9,8 @@ import {
   commaDensity,
   koreanPosDiversityProxy,
   koreanSpacingFeatures,
+  koreanEndingMonotony,
+  DEFAULT_KO_ENDING_MONOTONY,
 } from '../../src/features/stylometry.js';
 
 const KO_COMPOSITE_TEXT =
@@ -220,4 +222,52 @@ test('analyzeText KO per-paragraph diagnostics are unchanged after the single-pa
   });
   assert.equal(natural.posDiversity.matchedCount, 5);
   assert.equal(natural.hot, false);
+});
+
+test('DEFAULT_KO_ENDING_MONOTONY pins the calibrated thresholds', () => {
+  assert.deepEqual(DEFAULT_KO_ENDING_MONOTONY, { minDaRatio: 0.6, minDaCount: 2, minTokens: 20 });
+});
+
+test('koreanEndingMonotony reports declarative -다 dominance', () => {
+  assert.deepEqual(koreanEndingMonotony(splitProseSentences('하늘이 맑다. 바람이 분다.')), { daCount: 2, daRatio: 1 });
+  assert.deepEqual(koreanEndingMonotony(splitProseSentences('하늘이 맑다. 바람이 부네요.')), { daCount: 1, daRatio: 0.5 });
+  assert.deepEqual(koreanEndingMonotony([]), { daCount: 0, daRatio: null });
+});
+
+test('analyzeText flags uniform plain-다 KO hot via ending-monotony even below the 3-sentence burstiness gate', () => {
+  const text =
+    '주말에 집안일을 한꺼번에 몰아서 처리하면 평일에 쉬는 시간이 크게 줄어든다. ' +
+    '작은 루틴을 미리 정해 두면 오후 시간이 한결 가벼워지고 일정도 정리된다.';
+  const ko = analyzeText(text, { lang: 'ko' });
+  const p = ko.paragraphs[0];
+  assert.equal(p.sentenceCount, 2);
+  // < 3 sentences: the standard burstiness band gate is inert, so this paragraph
+  // is hot only because of the ending-monotony signal.
+  assert.equal(p.burstiness.band, null);
+  assert.deepEqual(p.endingMonotony, { daCount: 2, daRatio: 1 });
+  assert.equal(p.endingMonotonyHot, true);
+  assert.equal(ko.hot, true);
+});
+
+test('ko ending-monotony spares formal-varied, short, and conversational human Korean (precision guards)', () => {
+  // Formal plain-다 but with varied sentence lengths (high burstiness CV): not the AI tell.
+  const varied = analyzeText(
+    '비가 내렸다. 우산도 없이 한참을 걷다가 결국 근처 카페로 들어가 따뜻한 커피를 한 잔 시켜 놓고 창밖을 멍하니 바라보며 비가 그치기를 기다렸다.',
+    { lang: 'ko' },
+  );
+  assert.equal(varied.paragraphs[0].endingMonotonyHot, false);
+
+  // Uniform plain-다 but below the min-token gate.
+  const short = analyzeText('오늘은 날씨가 좋았다. 점심을 먹었다.', { lang: 'ko' });
+  assert.equal(short.paragraphs[0].endingMonotonyHot, false);
+
+  // Conversational 요-register: low declarative -다 ratio.
+  const convo = analyzeText('어제 친구랑 카페 갔는데 커피가 진짜 맛있었어요. 너도 한번 가봐요!', { lang: 'ko' });
+  assert.equal(convo.paragraphs[0].endingMonotonyHot, false);
+});
+
+test('ending-monotony is ko-only', () => {
+  const en = analyzeText('This is a short test. It has two sentences here.', { lang: 'en' });
+  assert.equal(en.paragraphs[0].endingMonotony, null);
+  assert.equal(en.paragraphs[0].endingMonotonyHot, false);
 });


### PR DESCRIPTION
## Summary

Adds a **KO-only deterministic hot signal** — *uniform plain-다 register* — that closes the biggest measured detection gap (KO×GPT recall 44%). Bumps to **5.2.0** (minor).

A paragraph is hot when declarative `-다` endings dominate (ratio ≥ 0.6 **and** count ≥ 2) **and** sentence lengths are uniform (burstiness CV below the low band) **and** the paragraph has ≥ 20 tokens. Unlike the standard burstiness trigger it does **not** require 3 sentences, so it catches short, length-uniform AI Korean the band gate skipped — while the `-다` + low-CV conjuncts spare formal human Korean (same `-다`, but varied sentence lengths → high CV) and conversational Korean (요/습니다), and the 20-token floor spares terse snippets.

Implemented as a **first-class signal** (not the advisory `koPostEditese` payload), wired into the per-paragraph hot OR in `src/features/index.js`, mirrored in `playground/analyzer.js` for browser parity, and counted in `rebaseline-score` trigger counts.

## Measured impact (KO rebaseline manifest, n=380, deterministic analyzer)

| metric | before → after |
|---|---|
| **KO×GPT catch** | **45.0% → 82.5%** |
| KO recall | 59.2% → 70.8% |
| KO accuracy | 77.6% → 80.8% |
| KO F1 | 0.644 → 0.716 |
| KO precision | 70.6% → 72.4% |
| human-control FPR | 12.8% → 14.0% (within published 11.6–21.7% CI) |

15 new true positives for 3 new false positives (5:1), so precision rose too. **EN/ZH/JA are byte-identical** (KO-only). The frozen public claim manifests and the headline catch/FP claim are refreshed on the next dedicated rebaseline pass, not here.

## How it was derived

Root cause: all 22 missed KO×GPT samples were single-paragraph 2–3 sentence snippets, and KO detection relied entirely on burstiness (which needs ≥3 sentences); MATTR/lexicon/ko-diagnostics fire ~0% for KO. The `-다`-monotony + low-CV separator was found by length-matched comparison of missed-AI vs 250 human controls, and the 20-token floor + low-CV conjunct were added after the signal over-fired on terse toy fixtures.

## Verification

- `npm test` — **787 pass / 0 fail** (5 new ending-monotony unit tests incl. precision guards)
- `npm run benchmark` — 49-fixture suite still **100%** (natural KO fixtures stay cold)
- `npm run lint` — syntax OK, cspell 0 issues
- `npm run release:check` — OK for 5.2.0
- `npm run check:no-private-assets` — OK
- node ↔ playground parity confirmed on KO samples

Documented in `core/stylometry.md` (hot rule + calibration + failure mode) and `SKILL.md`.
