### PR TITLE
feat(harness): signal-impact ablation tool + deterministic-signal conventions (5.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "patina",
       "source": "./",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "description": "Strip the AI packaging, keep the meaning. Detect and rewrite AI writing patterns across KO/EN/ZH/JA with MPS/fidelity checks. Runs the root SKILL.md as the /patina skill.",
       "homepage": "https://github.com/devswha/patina",
       "repository": "https://github.com/devswha/patina",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
   "name": "patina",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese so text reads as if a human wrote it. Meaning-preservation (MPS) verified, audit-friendly. The root SKILL.md is loaded as the /patina skill.",
   "author": {
     "name": "devswha",

--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "5.2.0"
+version: "5.3.0"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
+## 5.3.0 — 2026-06-15
+
+**Harness & conventions: a reproducible per-signal impact (ablation) tool and a documented workflow for adding deterministic detection signals.**
+
+Semver rationale: minor — adds a contributor-facing benchmark tool and workflow docs. No CLI, schema, pattern, or detection-behavior change; all four languages are byte-identical.
+
+### Added
+- `scripts/signal-impact.mjs` (`npm run benchmark:signal-impact`): joins a labeled manifest (`expected_hot`) to its local text, runs `analyzeText()` once per row, and recomputes the hot verdict with each signal ablated to report each signal's **marginal** catch/FP contribution (attributable TP/FP) plus Δrecall/Δfpr/ΔF1. Deterministic and gitignore-safe (reads local/private corpus, emits aggregate metrics only). Replaces the ad-hoc eval-kernel measurement used to calibrate the 5.2.0 KO signal.
+- `docs/HARNESS.md`: an index of every measurement, calibration, and gate tool (deterministic vs LLM, command, docs link), linked from `README*` and `tests/quality/README.md`.
+- `CONTRIBUTING.md` / `CONTRIBUTING_KR.md` "Adding a Deterministic Detection Signal": codifies the calibration loop (diagnose → FP-safe discriminator → first-class implementation → mirror every surface → measure with the harness → version), the advisory-vs-hot-signal rule, the FP tolerance bar, and the surfaces to keep in sync.
+
 ## 5.2.0 — 2026-06-15
 
 **Korean detection: a deterministic "uniform plain-다 register" hot signal that catches short, length-uniform AI Korean the burstiness gate skipped.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,53 @@ npm run benchmark:report
 
 This regenerates `tests/quality/results.json`, `docs/benchmarks/latest.json`, and `docs/benchmarks/latest.md`.
 
+## Adding a Deterministic Detection Signal
+
+Patterns (above) are LLM-executed catalog entries. A **detection signal** is
+different: a deterministic hot/cold input computed in `src/features/*` and
+folded into the per-paragraph hot OR rule (burstiness, MATTR, lexicon density,
+the Korean diagnostics composite, the ending-monotony signal, etc.). The
+analysis layer stays LLM-free, so a new signal is real engineering with a
+calibration bar. Follow this loop:
+
+1. **Diagnose the miss with evidence.** Find where detection fails on a labeled
+   manifest, not by intuition. `score_review.trigger_counts` in the scored
+   manifests shows which signals fire on which rows; `npm run benchmark:signal-impact`
+   reports each existing signal's marginal catch/FP so you can see the gap.
+2. **Find a false-positive-safe discriminator.** Compare AI misses against human
+   controls **at matched length/register** (a short-text confound is not an AI
+   tell). The discriminator must separate AI from *the human register that
+   shares the surface feature* — e.g. plain `-다` AI vs formal-human `-다` needed
+   a burstiness conjunct, not `-다` alone.
+3. **Implement it first-class, never by coupling an advisory payload.** Advisory
+   signals (`translationese`, `koPostEditese.v1`) must not feed the hot verdict
+   (see [docs/TRANSLATIONESE-KO.md](docs/TRANSLATIONESE-KO.md)). Add a dedicated
+   computation in `src/features/stylometry.js`, wire it into the hot OR in
+   `src/features/index.js`, and add a precision gate (length/count floors) if it
+   over-fires on short or corner-case text.
+4. **Mirror every surface.** A signal is not done until it is consistent across:
+   `src/features/index.js` (Node), `playground/analyzer.js` (browser parity —
+   there are parity tests), `scripts/rebaseline-score.mjs` `trigger_counts`, the
+   hot-rule prose in `core/stylometry.md` and `SKILL.md`, and unit tests
+   (including precision guards).
+5. **Measure with the harness, not by hand.** Run `npm run benchmark:signal-impact`
+   for the marginal before/after, `npm run benchmark` (the 49-fixture suite must
+   stay 100% — natural fixtures must not flip hot), and confirm the human-control
+   false-positive rate stays within the published CI in
+   `docs/benchmarks/rebaseline-latest.md`. Record the measured numbers in the
+   changelog. The frozen public claim manifests are refreshed in a separate
+   rebaseline pass, not in the signal PR.
+6. **Version it.** A new detection signal changes hot behavior → **minor** bump
+   (it is additive, not a removal). Bump all version surfaces and add a changelog
+   entry with the measured catch/FP deltas and the failure mode you guarded.
+
+Acceptance bar (mirrors the roadmap's deterministic-feature-expansion criteria):
+recall or precision improves on the labeled manifest, the human-control
+false-positive rate stays within the published tolerance, and the signal ships
+with a documented failure mode plus before/after examples.
+
+See [docs/HARNESS.md](docs/HARNESS.md) for the full measurement-tool map.
+
 ## Translating Examples
 
 - Preserve the original semantic anchors: numbers, entities, negation, causation, and modality.

--- a/CONTRIBUTING_KR.md
+++ b/CONTRIBUTING_KR.md
@@ -96,6 +96,21 @@ npm run benchmark:report
 
 이 명령은 `tests/quality/results.json`, `docs/benchmarks/latest.json`, `docs/benchmarks/latest.md`를 다시 생성합니다.
 
+## 결정론 검출 신호 추가
+
+위의 패턴은 LLM이 실행하는 카탈로그 항목입니다. **검출 신호(detection signal)**는 다릅니다 — `src/features/*`에서 계산되어 단락 단위 hot OR 규칙에 합류하는 결정론적 hot/cold 입력입니다(burstiness, MATTR, lexicon density, 한국어 진단 composite, ending-monotony 신호 등). 분석 레이어는 LLM-free를 유지하므로, 새 신호는 보정 기준을 갖춘 실제 엔지니어링입니다. 다음 루프를 따르세요:
+
+1. **근거로 누락을 진단합니다.** 직관이 아니라 라벨드 매니페스트에서 검출이 실패하는 지점을 찾습니다. scored 매니페스트의 `score_review.trigger_counts`가 어떤 신호가 어떤 행에서 발동하는지 보여주고, `npm run benchmark:signal-impact`가 각 기존 신호의 한계 catch/FP를 알려줘 공백을 드러냅니다.
+2. **오탐-안전한 판별자를 찾습니다.** AI 누락을 **길이/레지스터가 매칭된** 사람 대조군과 비교합니다(짧은 길이 교란은 AI tell이 아닙니다). 판별자는 *같은 표면 특징을 공유하는 사람 레지스터*와 AI를 갈라야 합니다 — 예: 평서형 `-다` AI vs 격식 사람 `-다`는 `-다` 단독이 아니라 burstiness 결합 조건이 필요했습니다.
+3. **advisory 페이로드를 끌어쓰지 말고 1급 신호로 구현합니다.** advisory 신호(`translationese`, `koPostEditese.v1`)는 hot 판정에 들어가면 안 됩니다([docs/TRANSLATIONESE-KO.md](docs/TRANSLATIONESE-KO.md)). `src/features/stylometry.js`에 전용 계산을 추가하고 `src/features/index.js`의 hot OR에 연결하며, 짧은/코너케이스 텍스트에 과발동하면 정밀도 게이트(길이/횟수 하한)를 둡니다.
+4. **모든 표면을 미러링합니다.** 다음이 일치해야 신호가 완성됩니다: `src/features/index.js`(Node), `playground/analyzer.js`(브라우저 패리티 — 패리티 테스트 있음), `scripts/rebaseline-score.mjs`의 `trigger_counts`, `core/stylometry.md`·`SKILL.md`의 hot 규칙 산문, 그리고 유닛 테스트(정밀도 가드 포함).
+5. **손이 아니라 하네스로 측정합니다.** `npm run benchmark:signal-impact`로 한계 before/after를, `npm run benchmark`로 49-fixture(자연 fixture가 hot으로 뒤집히면 안 됨 — 100% 유지)를 확인하고, 사람 대조군 오탐율이 `docs/benchmarks/rebaseline-latest.md`의 공개 CI 내에 머무는지 확인합니다. 측정값은 changelog에 기록합니다. 동결된 공개 claim 매니페스트는 신호 PR이 아니라 별도 rebaseline pass에서 갱신합니다.
+6. **버전을 올립니다.** 새 검출 신호는 hot 동작을 바꾸므로 **minor** 범프입니다(제거가 아닌 추가). 모든 버전 surface를 올리고, 측정한 catch/FP 델타와 가드한 실패 모드를 담은 changelog 항목을 추가합니다.
+
+수용 기준(로드맵의 deterministic-feature-expansion 기준과 동일): 라벨드 매니페스트에서 재현율 또는 정밀도가 개선되고, 사람 대조군 오탐율이 공개 허용치 내에 머물며, 신호가 문서화된 실패 모드와 before/after 예시를 함께 제공합니다.
+
+전체 측정 도구 지도는 [docs/HARNESS.md](docs/HARNESS.md)를 참고하세요.
+
 ## 예시 번역
 
 - 숫자, 엔티티, 부정, 인과, 양태 같은 원문의 semantic anchor를 보존합니다.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 5.2.0" src="https://img.shields.io/badge/version-5.2.0-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 5.3.0" src="https://img.shields.io/badge/version-5.3.0-blue"></a>
 </p>
 
 <p align="center">
@@ -187,7 +187,7 @@ If meaning drifts, the change is retried or rolled back. Deterministic analysis 
 
 ```yaml
 # .patina.default.yaml
-version: "5.2.0"
+version: "5.3.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score
@@ -206,6 +206,7 @@ Start here:
 - [Patterns](docs/PATTERNS.md) — full pattern catalog
 - [Subagents & strict flow](docs/agents.md) — optional read-only detector/fidelity/naturalness subagents and the `--strict` multi-pass mode
 - [Benchmarks](docs/benchmarks/README.md) · [latest report](docs/benchmarks/latest.md) · [2026 rebaseline](docs/research/2026-rebaseline.md)
+- [Measurement harness](docs/HARNESS.md) — index of every benchmark, calibration, and gate tool (incl. the signal-impact ablation harness)
 - [FAQ](docs/FAQ.md) ([한국어](docs/FAQ_KR.md))
 - [Ethics](docs/ETHICS.md)
 - [Contributing](CONTRIBUTING.md) ([한국어](CONTRIBUTING_KR.md))

--- a/README_JA.md
+++ b/README_JA.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#クイックスタート)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-5.2.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.3.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-en.gif" alt="patina が英語のAIっぽい文を整え、スコアを表示するターミナルデモGIF" width="780">

--- a/README_KR.md
+++ b/README_KR.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#빠른-시작)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-5.2.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.3.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-ko.gif" alt="patina가 한국어 AI풍 문장을 다듬고 결과 점수를 보여주는 터미널 데모 GIF" width="780">
@@ -331,6 +331,7 @@ tone:                     # casual | professional | academic | narrative | marke
 - **[Korean Translationese](docs/TRANSLATIONESE-KO.md)** — 한국어 번역투/calque 탐지 catalog와 advisory 경계
 - **[Korean Translationese Scholarship](docs/research/ko-translationese-scholarship.md)** — 번역투·translation universals·post-editese 학술 근거(이근희·김순영·Baker·Toury·Toral)와 patina 신호 매핑
 - **[Subagents (strict flow)](docs/agents.md)** — 선택형 멀티 에이전트 strict 플로우(detector·fidelity-auditor·naturalness-reviewer)와 Claude Code 플러그인 자동발견
+- **[Measurement Harness](docs/HARNESS.md)** — 벤치마크·보정·게이트 도구 전체 인덱스 + 신호 임팩트(ablation) 하네스
 - **[Launch Copy](docs/social/patina-launch-copy.md)** — launch sequence, score gate, Show HN/Product Hunt/Reddit/X/Korean drafts
 - **[Signs of AI Writing](docs/social/signs-of-ai-writing_KR.md)** ([English](docs/social/signs-of-ai-writing.md)) — cited example이 붙은 공유용 편집 checklist
 - **[Stylometry](core/stylometry.md)** — burstiness + MATTR + AI 어휘 알고리즘

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#快速开始)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-5.2.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.3.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-en.gif" alt="patina 将带有 AI 味的英文文案改写并显示评分的终端演示 GIF" width="780">

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 5.2.0
+version: 5.3.0
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -13,6 +13,40 @@ Two rules govern everything here:
   corpus rows (`artifacts/rebaseline-2025/{*.local.jsonl,private/*.jsonl}`,
   gitignored) but only ever emit aggregate metrics and hashes.
 
+## Architecture
+
+```text
+CONVENTIONS  (how to contribute — governs everything below)
+  CONTRIBUTING.md (patterns / signals / fixtures / versioning) · this file (map)
+  AGENTS.md (src/features = deterministic, LLM-free) · TRANSLATIONESE-KO (advisory rule)
+        │
+        ▼
+INPUT          ENGINE (deterministic, LLM-free)                 SURFACES
+ text ──► src/features/* → analyzeText() → per-paragraph    ──► Node CLI (src/)
+              stylometry · lexicon · ko-diagnostics ·            /patina skill (SKILL.md)
+              ending-monotony · discourse-tells                  playground (browser)
+                       │  HOT? = OR(signals)                          ▲ node↔playground
+                       ▼  measured by                                   parity test
+  ┌──────────────────────────────────────────────────────────────────────────┐
+  │ HARNESS                                                                    │
+  │  (1) regression (det.)   benchmark · benchmark:ranges · benchmark:report   │
+  │  (2) calibration (det.)  signal-impact · rebaseline:score/report ·         │
+  │                          low-fpr · katfish-ko · lexicon:freshness          │
+  │  (3) robustness/perf     robustness · perf                                 │
+  │  (4) LLM quality (opt-in) quality:live · adversarial-mps                   │
+  │  (5) comparison (det.)   detector-comparison                               │
+  └──────────────────────────────────────────────────────────────────────────┘
+                       │  enforced by
+                       ▼
+  GATES (CI / pre-publish, deterministic)
+   lint · test · release:check · check:no-private-assets · prose-score
+```
+
+Hot decision = OR of the per-paragraph signals (`burstiness_low`, `mattr_low`,
+`lexicon_hot`, `ko_diagnostics`, `candor`, `thematic_break`, `ko_ending_monotony`)
+plus the document-level `markup_leakage` / `structural_model`. The signal-impact
+harness below ablates each one to report its marginal contribution.
+
 ## Quality & regression (deterministic, CI-safe)
 
 | Tool | Command | What it measures | Docs |

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -1,0 +1,83 @@
+# Patina measurement & quality harness
+
+A map of every measurement, calibration, and gate tool in the repo: what it is,
+whether it is deterministic or LLM-backed, the command, and where the detailed
+docs live. This is an **index** — each tool documents itself in the linked file.
+
+Two rules govern everything here:
+
+- **The analysis layer stays deterministic and LLM-free.** `src/features/*`,
+  scoring, and every tool in the "Deterministic" rows below run with no model
+  call, no API key, and no network, so they are reproducible and CI-safe.
+- **Private text never gets committed.** Calibration tools may read local/private
+  corpus rows (`artifacts/rebaseline-2025/{*.local.jsonl,private/*.jsonl}`,
+  gitignored) but only ever emit aggregate metrics and hashes.
+
+## Quality & regression (deterministic, CI-safe)
+
+| Tool | Command | What it measures | Docs |
+|---|---|---|---|
+| Suspect-zone benchmark | `npm run benchmark` | 49-fixture hot/cold accuracy, ROC/PR-AUC, F1, confusion — the regression guard | [tests/quality/README.md](../tests/quality/README.md) |
+| Benchmark report | `npm run benchmark:report` | Refreshes `docs/benchmarks/latest.{md,json}` + ranking diagnostics | [benchmarks/README.md](benchmarks/README.md) |
+| Regression ranges | `npm run benchmark:ranges` | Pins per-fixture CV/MATTR/lexicon expectations | [tests/quality/README.md](../tests/quality/README.md) |
+| Signal impact / ablation | `npm run benchmark:signal-impact` | Per-signal **marginal** catch/FP contribution on a labeled manifest — use when adding/tuning a deterministic hot signal | this file (below) |
+| Robustness | `npm run benchmark:robustness` | Adversarial detection robustness | `scripts/robustness-report.mjs` |
+| Performance | `npm run benchmark:perf` | Deterministic analyzer speed (report-only) | `scripts/perf-report.mjs` |
+| Detector comparison | `npm run benchmark:compare` | Offline/manual third-party detector comparison | [benchmarks/README.md](benchmarks/README.md) |
+
+## Claim calibration (deterministic; needs the private corpus)
+
+| Tool | Command | Purpose | Docs |
+|---|---|---|---|
+| Rebaseline summary | `npm run benchmark:rebaseline` / `:report` | Validates the public manifest + computes the headline catch/FP claim | [tests/quality/README.md](../tests/quality/README.md) |
+| Rebaseline score | `npm run benchmark:rebaseline:score` | Re-runs the analyzer over private rows → public scored manifest (predicted_hot + trigger_counts) | [tests/quality/README.md](../tests/quality/README.md) |
+| Low-FPR metrics | `npm run benchmark:rebaseline:low-fpr` | TPR@1%/5%FPR operating points | `scripts/rebaseline-low-fpr-report.mjs` |
+| KatFish calibration | `npm run benchmark:katfish-ko` | KO diagnostic catch/FP deltas (aggregate-only) | [tests/quality/README.md](../tests/quality/README.md) |
+| Lexicon freshness | `npm run lexicon:freshness` | AI-lexicon provenance sidecar check | `scripts/lexicon-freshness.mjs` |
+| FP fixture export | `node scripts/fp-fixture-export.mjs` | Turns FP reports into suspect-zone fixtures | `scripts/fp-fixture-export.mjs` |
+
+## LLM-backed quality (opt-in, non-deterministic, may incur cost)
+
+| Tool | Command | Purpose | Docs |
+|---|---|---|---|
+| Live rewrite quality | `npm run quality:live` (`PATINA_LIVE=1` to call a model) | before/after AI score, MPS, fidelity on rewrites | [tests/quality/README.md](../tests/quality/README.md) |
+| Adversarial MPS | `npm run quality:adversarial-mps` | Guards against MPS hiding unchanged AI style | [tests/quality/README.md](../tests/quality/README.md) |
+
+## Gates (deterministic, run in CI / pre-publish)
+
+| Tool | Command | Purpose |
+|---|---|---|
+| Lint | `npm run lint` | syntax + eslint + tsc + cspell |
+| Tests | `npm test` | unit + e2e (`node --test`) |
+| Release metadata | `npm run release:check` | version sync across all version-bearing surfaces |
+| Private-asset leak | `npm run check:no-private-assets` | no private/vendor text in the npm tarball or tree |
+| Prose score gate | `patina-score` / `npm run badge` | hot-paragraph ratio CI gate (default 30) |
+
+## Signal impact harness (`scripts/signal-impact.mjs`)
+
+Reproducible answer to "what does deterministic hot signal X buy us, and at what
+false-positive cost?" — the question every new `src/features` signal must answer
+(see [CONTRIBUTING.md → Adding a Deterministic Detection Signal](../CONTRIBUTING.md)).
+
+```bash
+# Full per-signal ablation table on the KO manifest (default)
+npm run benchmark:signal-impact
+
+# One signal's marginal contribution as JSON
+npm run benchmark:signal-impact -- --ablate ko_ending_monotony --json
+
+# Another manifest / language / explicit text source
+npm run benchmark:signal-impact -- --manifest artifacts/rebaseline-2025/manifest.en.scored.public.jsonl --lang en
+```
+
+It joins a labeled manifest (`expected_hot`) to its local text, runs
+`analyzeText()` once per row, then recomputes the document hot verdict with each
+signal ablated. For each signal it reports:
+
+- **attributable TP / FP** — rows the signal *alone* keeps hot (no other signal
+  fires): the catch it adds and the false positives it costs.
+- **Δrecall / Δfpr / ΔF1** — the metric delta versus removing the signal.
+
+`recomputeHot()` mirrors the OR rule in `analyzeText`, so `PARAGRAPH_SIGNALS` /
+`DOCUMENT_SIGNALS` in the script must be kept in sync when a hot disjunct is
+added or removed (a unit test pins the signal list).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",
@@ -40,6 +40,7 @@
     "quality:live": "node tests/quality/live-quality.mjs",
     "benchmark:rebaseline:intake": "node scripts/rebaseline-intake.mjs",
     "benchmark:rebaseline:score": "node scripts/rebaseline-score.mjs",
+    "benchmark:signal-impact": "node scripts/signal-impact.mjs",
     "benchmark:rebaseline:web": "node scripts/rebaseline-web-collect.mjs",
     "benchmark:katfish-ko": "node scripts/katfish-calibration.mjs",
     "lexicon:freshness": "node scripts/lexicon-freshness.mjs --check",
@@ -126,6 +127,7 @@
     "scripts/adversarial-mps-report.mjs",
     "scripts/rebaseline-intake.mjs",
     "scripts/rebaseline-score.mjs",
+    "scripts/signal-impact.mjs",
     "tests/quality/adversarial-mps/",
     "tests/quality/rebaseline-manifest.example.jsonl",
     "artifacts/rebaseline-2025/README.md",

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "5.2.0"
+    "patina-cli": "5.3.0"
   },
   "license": "MIT",
   "repository": {

--- a/scripts/signal-impact.mjs
+++ b/scripts/signal-impact.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+// Per-signal impact / ablation harness for the deterministic hot decision.
+//
+// Answers the calibration question this repo keeps asking by hand: "what does
+// hot signal X buy us, and at what false-positive cost?" For a labeled manifest
+// (expected_hot) joined to its text, it runs analyzeText() once per row, then
+// recomputes the document hot verdict with each signal ablated to report each
+// signal's MARGINAL contribution (rows it alone makes hot) plus the confusion
+// matrix with/without it.
+//
+// Deterministic and gitignore-safe: it needs local text (private rebaseline rows
+// stay local) but only ever emits aggregate metrics, never the text itself.
+//
+// Usage:
+//   node scripts/signal-impact.mjs [--manifest <jsonl>] [--lang ko]
+//        [--text <jsonl|glob> ...] [--ablate <signal>] [--json]
+//
+// Defaults to the KO rebaseline manifest + the standard private text sources.
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { analyzeText } from '../src/features/index.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ARTIFACTS = 'artifacts/rebaseline-2025';
+
+// Paragraph-level hot disjuncts, mirrored from src/features/index.js#analyzeText.
+// Keep this list in sync when a paragraph signal is added/removed.
+export const PARAGRAPH_SIGNALS = [
+  ['burstiness_low', (p) => p.burstiness?.band === 'low'],
+  ['mattr_low', (p) => p.mattr?.band === 'low'],
+  ['lexicon_hot', (p) => Boolean(p.lexicon?.hot)],
+  ['ko_diagnostics', (p) => Boolean(p.koDiagnostics?.hot)],
+  ['candor', (p) => Boolean(p.candorHot)],
+  ['thematic_break', (p) => Boolean(p.thematicBreakHot)],
+  ['ko_ending_monotony', (p) => Boolean(p.endingMonotonyHot)],
+];
+
+// Document-level hot disjuncts.
+export const DOCUMENT_SIGNALS = [
+  ['markup_leakage', (a) => Boolean(a.markupLeakage?.leaked)],
+  ['structural_model', (a) => a.structuralClassifier?.hot === true],
+];
+
+export const ALL_SIGNALS = [
+  ...DOCUMENT_SIGNALS.map(([name]) => name),
+  ...PARAGRAPH_SIGNALS.map(([name]) => name),
+];
+
+// Recompute the document hot verdict from an analysis, optionally excluding a
+// set of signal names. Mirrors the OR rule in analyzeText so ablation is exact.
+export function recomputeHot(analysis, excluded = new Set()) {
+  for (const [name, test] of DOCUMENT_SIGNALS) {
+    if (!excluded.has(name) && test(analysis)) return true;
+  }
+  return (analysis.paragraphs ?? []).some((paragraph) =>
+    PARAGRAPH_SIGNALS.some(([name, test]) => !excluded.has(name) && test(paragraph)),
+  );
+}
+
+function confusionFrom(predictions) {
+  let TP = 0;
+  let FP = 0;
+  let FN = 0;
+  let TN = 0;
+  for (const { expected, predicted } of predictions) {
+    if (expected && predicted) TP += 1;
+    else if (!expected && predicted) FP += 1;
+    else if (expected && !predicted) FN += 1;
+    else TN += 1;
+  }
+  const n = TP + FP + FN + TN;
+  const pct = (x) => Math.round(x * 1000) / 10;
+  const prec = TP + FP > 0 ? TP / (TP + FP) : 0;
+  const rec = TP + FN > 0 ? TP / (TP + FN) : 0;
+  return {
+    n,
+    accuracy: pct(n ? (TP + TN) / n : 0),
+    precision: pct(prec),
+    recall: pct(rec),
+    f1: Math.round((prec + rec > 0 ? (2 * prec * rec) / (prec + rec) : 0) * 1000) / 1000,
+    fpr: pct(FP + TN > 0 ? FP / (FP + TN) : 0),
+    TP,
+    FP,
+    FN,
+    TN,
+  };
+}
+
+// Core: given manifest rows (with expected_hot) and a sample_id -> text map,
+// return the baseline confusion, per-signal ablation, and catch-by-family.
+export function signalImpact({ rows, textById, lang }) {
+  const analyzed = [];
+  for (const row of rows) {
+    const text = textById[row.sample_id];
+    if (typeof text !== 'string' || !text.trim()) continue;
+    const analysis = analyzeText(text, { lang: lang ?? row.language ?? 'en' });
+    analyzed.push({ row, analysis, expected: Boolean(row.expected_hot) });
+  }
+
+  const predAll = analyzed.map((a) => ({ expected: a.expected, predicted: recomputeHot(a.analysis) }));
+  const baseline = confusionFrom(predAll);
+
+  const ablation = ALL_SIGNALS.map((signal) => {
+    const excluded = new Set([signal]);
+    const without = confusionFrom(
+      analyzed.map((a) => ({ expected: a.expected, predicted: recomputeHot(a.analysis, excluded) })),
+    );
+    // Rows this signal alone keeps hot (no other signal fires): its marginal set.
+    let attributableTP = 0;
+    let attributableFP = 0;
+    for (const a of analyzed) {
+      const withSig = recomputeHot(a.analysis);
+      const withoutSig = recomputeHot(a.analysis, excluded);
+      if (withSig && !withoutSig) {
+        if (a.expected) attributableTP += 1;
+        else attributableFP += 1;
+      }
+    }
+    return {
+      signal,
+      attributableTP,
+      attributableFP,
+      recallWithout: without.recall,
+      fprWithout: without.fpr,
+      f1Without: without.f1,
+      deltaRecall: Math.round((baseline.recall - without.recall) * 10) / 10,
+      deltaFpr: Math.round((baseline.fpr - without.fpr) * 10) / 10,
+      deltaF1: Math.round((baseline.f1 - without.f1) * 1000) / 1000,
+    };
+  }).filter((entry) => entry.attributableTP > 0 || entry.attributableFP > 0 || entry.deltaRecall !== 0);
+
+  const families = {};
+  for (const a of analyzed) {
+    const ai = a.expected;
+    if (!ai) continue;
+    const fam = a.row.model_family ?? 'unspecified';
+    families[fam] ??= { n: 0, caught: 0 };
+    families[fam].n += 1;
+    if (recomputeHot(a.analysis)) families[fam].caught += 1;
+  }
+  const catchByFamily = Object.entries(families)
+    .map(([family, v]) => ({ family, n: v.n, catch: Math.round((v.caught / v.n) * 1000) / 10 }))
+    .sort((x, y) => x.family.localeCompare(y.family));
+
+  return { lang, matched: analyzed.length, total: rows.length, baseline, ablation, catchByFamily };
+}
+
+function loadJsonl(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+// Build a sample_id -> text index from the standard private/local rebaseline
+// sources (first occurrence wins), plus any explicit --text paths.
+function buildTextIndex(extraPaths) {
+  const textById = {};
+  const candidates = [];
+  const root = resolve(REPO_ROOT, ARTIFACTS);
+  if (existsSync(root)) {
+    for (const f of readdirSync(root)) {
+      if (f.endsWith('.local.jsonl') || (f.endsWith('.jsonl') && f.includes('intake'))) candidates.push(join(root, f));
+    }
+    const priv = join(root, 'private');
+    if (existsSync(priv)) {
+      for (const f of readdirSync(priv)) if (f.endsWith('.jsonl')) candidates.push(join(priv, f));
+    }
+  }
+  for (const p of [...candidates, ...extraPaths.map((p) => resolve(REPO_ROOT, p))]) {
+    if (!existsSync(p)) continue;
+    for (const row of loadJsonl(p)) {
+      if (row.sample_id && typeof row.text === 'string' && !(row.sample_id in textById)) {
+        textById[row.sample_id] = row.text;
+      }
+    }
+  }
+  return textById;
+}
+
+function parseArgs(argv) {
+  const opts = { manifest: `${ARTIFACTS}/manifest.ko.scored.public.jsonl`, lang: null, text: [], json: false, ablate: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') opts.json = true;
+    else if (arg === '--manifest') opts.manifest = argv[++i];
+    else if (arg === '--lang') opts.lang = argv[++i];
+    else if (arg === '--ablate') opts.ablate = argv[++i];
+    else if (arg === '--text') opts.text.push(argv[++i]);
+  }
+  return opts;
+}
+
+function renderMarkdown(report, opts) {
+  const b = report.baseline;
+  const lines = [
+    `# Signal impact — ${opts.manifest}`,
+    '',
+    `- lang: ${report.lang ?? '(per-row)'}`,
+    `- rows: ${report.total} | text-matched: ${report.matched}`,
+    '',
+    '## Baseline (all signals)',
+    '',
+    '| accuracy | precision | recall | f1 | fpr | TP/FP/FN/TN |',
+    '|---:|---:|---:|---:|---:|---|',
+    `| ${b.accuracy}% | ${b.precision}% | ${b.recall}% | ${b.f1} | ${b.fpr}% | ${b.TP}/${b.FP}/${b.FN}/${b.TN} |`,
+    '',
+    '## Per-signal ablation',
+    '',
+    'attributable = rows this signal alone keeps hot (no other signal fires).',
+    '',
+    '| signal | attrib TP | attrib FP | ΔrecallPP | ΔfprPP | ΔF1 |',
+    '|---|---:|---:|---:|---:|---:|',
+    ...report.ablation.map(
+      (e) => `| ${e.signal} | ${e.attributableTP} | ${e.attributableFP} | ${e.deltaRecall} | ${e.deltaFpr} | ${e.deltaF1} |`,
+    ),
+    '',
+    '## Catch by model family (AI rows)',
+    '',
+    '| family | n | catch |',
+    '|---|---:|---:|',
+    ...report.catchByFamily.map((c) => `| ${c.family} | ${c.n} | ${c.catch}% |`),
+    '',
+  ];
+  return lines.join('\n');
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const manifestPath = resolve(REPO_ROOT, opts.manifest);
+  if (!existsSync(manifestPath)) {
+    console.error(`manifest not found: ${opts.manifest}`);
+    process.exit(2);
+  }
+  const rows = loadJsonl(manifestPath);
+  const textById = buildTextIndex(opts.text);
+  const report = signalImpact({ rows, textById, lang: opts.lang });
+  if (report.matched === 0) {
+    console.error(
+      'No local text matched the manifest. This harness needs the private/local rebaseline corpus ' +
+        '(artifacts/rebaseline-2025/{*.local.jsonl,private/*.jsonl}) or explicit --text sources.',
+    );
+    process.exit(1);
+  }
+  if (opts.ablate) {
+    const entry = report.ablation.find((e) => e.signal === opts.ablate) ?? { signal: opts.ablate, attributableTP: 0, attributableFP: 0, deltaRecall: 0, deltaFpr: 0, deltaF1: 0 };
+    console.log(opts.json ? JSON.stringify(entry, null, 2) : JSON.stringify(entry));
+    return;
+  }
+  console.log(opts.json ? JSON.stringify(report, null, 2) : renderMarkdown(report, opts));
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tests/quality/README.md
+++ b/tests/quality/README.md
@@ -4,6 +4,10 @@ Deterministic measurement of patina's stylometry / lexicon signal layer
 against a labeled fixture set. Runs with no LLM calls, no API key, no
 network — fast enough to run on every CI build.
 
+> This is one layer of the repo's measurement harness. See
+> [docs/HARNESS.md](../../docs/HARNESS.md) for the full tool map (benchmark,
+> calibration, signal-impact, LLM-quality, and gates).
+
 ## Run it
 
 ```bash

--- a/tests/unit/signal-impact.test.js
+++ b/tests/unit/signal-impact.test.js
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { signalImpact, recomputeHot, ALL_SIGNALS } from '../../scripts/signal-impact.mjs';
+import { analyzeText } from '../../src/features/index.js';
+
+// Uniform plain-다, 2 sentences, >= 20 tokens: hot ONLY via ko_ending_monotony
+// (the 3-sentence burstiness gate is inert at 2 sentences).
+const AI_ENDING = '주말에 집안일을 한꺼번에 몰아서 처리하면 평일에 쉬는 시간이 크게 줄어든다. ' +
+  '작은 루틴을 미리 정해 두면 오후 시간이 한결 가벼워지고 일정도 정리된다.';
+
+// Formal plain-다 but varied sentence lengths (high CV): cold.
+const HUMAN_VARIED =
+  '비가 내렸다. 우산도 없이 한참을 걷다가 결국 근처 카페로 들어가 따뜻한 커피를 한 잔 시켜 놓고 창밖을 멍하니 바라보며 비가 그치기를 기다렸다.';
+
+test('recomputeHot reconstructs analyzeText.hot and supports ablation', () => {
+  const a = analyzeText(AI_ENDING, { lang: 'ko' });
+  assert.equal(a.hot, true);
+  assert.equal(recomputeHot(a), true);
+  // Ablating the only firing signal makes it cold.
+  assert.equal(recomputeHot(a, new Set(['ko_ending_monotony'])), false);
+  // Ablating an unrelated signal leaves it hot.
+  assert.equal(recomputeHot(a, new Set(['lexicon_hot'])), true);
+
+  const cold = analyzeText(HUMAN_VARIED, { lang: 'ko' });
+  assert.equal(cold.hot, false);
+  assert.equal(recomputeHot(cold), false);
+});
+
+test('signalImpact reports baseline confusion and per-signal marginal contribution', () => {
+  const rows = [
+    { sample_id: 'ai1', expected_hot: true, model_family: 'gpt-family', language: 'ko' },
+    { sample_id: 'h1', expected_hot: false, language: 'ko' },
+  ];
+  const textById = { ai1: AI_ENDING, h1: HUMAN_VARIED };
+  const report = signalImpact({ rows, textById, lang: 'ko' });
+
+  assert.equal(report.matched, 2);
+  assert.equal(report.total, 2);
+  assert.equal(report.baseline.TP, 1);
+  assert.equal(report.baseline.FP, 0);
+  assert.equal(report.baseline.FN, 0);
+  assert.equal(report.baseline.TN, 1);
+  assert.equal(report.baseline.recall, 100);
+  assert.equal(report.baseline.fpr, 0);
+
+  const em = report.ablation.find((e) => e.signal === 'ko_ending_monotony');
+  assert.ok(em, 'ko_ending_monotony should appear in ablation');
+  assert.equal(em.attributableTP, 1); // the AI row is hot solely because of this signal
+  assert.equal(em.attributableFP, 0);
+  assert.equal(em.deltaRecall, 100); // removing it drops recall from 100 to 0
+
+  // Catch-by-family only counts AI (expected_hot) rows.
+  assert.deepEqual(report.catchByFamily, [{ family: 'gpt-family', n: 1, catch: 100 }]);
+});
+
+test('signalImpact skips rows without local text and reports coverage', () => {
+  const rows = [
+    { sample_id: 'ai1', expected_hot: true, language: 'ko' },
+    { sample_id: 'missing', expected_hot: true, language: 'ko' },
+  ];
+  const report = signalImpact({ rows, textById: { ai1: AI_ENDING }, lang: 'ko' });
+  assert.equal(report.total, 2);
+  assert.equal(report.matched, 1);
+});
+
+test('ALL_SIGNALS lists every hot disjunct used by analyzeText', () => {
+  for (const name of [
+    'burstiness_low',
+    'mattr_low',
+    'lexicon_hot',
+    'ko_diagnostics',
+    'candor',
+    'thematic_break',
+    'ko_ending_monotony',
+    'markup_leakage',
+    'structural_model',
+  ]) {
+    assert.ok(ALL_SIGNALS.includes(name), `${name} should be a known signal`);
+  }
+});


### PR DESCRIPTION
## Summary

Defines and consolidates patina's **measurement harness and signal-authoring conventions** after a burst of additions. Bumps to **5.3.0** (minor — contributor-facing tooling + workflow; no CLI/schema/detection-behavior change, all four languages byte-identical).

## What's added

**Signal-impact harness** — `scripts/signal-impact.mjs` (`npm run benchmark:signal-impact`)
- Joins a labeled manifest (`expected_hot`) to its local text, runs `analyzeText()` once per row, then recomputes the document hot verdict with each signal **ablated** to report each signal's **marginal** contribution: attributable TP/FP (rows it alone keeps hot) + Δrecall/Δfpr/ΔF1, plus catch-by-model-family.
- Deterministic and gitignore-safe (reads local/private corpus, emits aggregate metrics only). `recomputeHot()` mirrors the `analyzeText` OR rule; a unit test pins the signal list.
- Replaces the ad-hoc eval-kernel measurement used to calibrate the 5.2.0 KO signal. Reproduces it exactly: `--ablate ko_ending_monotony` → attributable TP 15 / FP 3, Δrecall +11.6, ΔF1 +0.072.

**Harness map** — `docs/HARNESS.md`
- Index of every measurement/calibration/gate tool: deterministic vs LLM, command, and link to detailed docs. Linked from `README*` and `tests/quality/README.md`.

**Convention** — `CONTRIBUTING.md` + `CONTRIBUTING_KR.md` "Adding a Deterministic Detection Signal"
- Codifies the calibration loop: diagnose with evidence → FP-safe discriminator (length/register-matched) → first-class implementation (never couple an advisory payload) → mirror every surface (Node, playground, rebaseline-score, core/stylometry.md, SKILL.md, tests) → measure with the harness → version. Plus the FP-tolerance bar and acceptance criteria.

## Verification

- `npm test` — **791 pass / 0 fail** (4 new signal-impact unit tests)
- `npm run lint` — syntax OK (159 files), cspell 0 issues
- `npm run release:check` — OK for 5.3.0
- `npm run check:no-private-assets` — OK (311 packed)
- `npm run benchmark` — 49-fixture suite still 100%
