### PR TITLE
feat(harness): rewrite-quality A/B (single vs ouroboros multi-pass) (5.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "patina",
       "source": "./",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "description": "Strip the AI packaging, keep the meaning. Detect and rewrite AI writing patterns across KO/EN/ZH/JA with MPS/fidelity checks. Runs the root SKILL.md as the /patina skill.",
       "homepage": "https://github.com/devswha/patina",
       "repository": "https://github.com/devswha/patina",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
   "name": "patina",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese so text reads as if a human wrote it. Meaning-preservation (MPS) verified, audit-friendly. The root SKILL.md is loaded as the /patina skill.",
   "author": {
     "name": "devswha",

--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "5.3.0"
+version: "5.4.0"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
+## 5.4.0 — 2026-06-15
+
+**Rewrite-quality A/B harness: compare two rewrite configs (single vs ouroboros multi-pass) on the same fixtures so pipeline decisions are data-driven.**
+
+Semver rationale: minor — adds a contributor-facing, opt-in benchmark tool. No CLI, schema, pattern, or detection-behavior change; all four languages byte-identical.
+
+### Added
+- `scripts/rewrite-ab.mjs` (`npm run quality:rewrite-ab`): for each live-quality fixture it produces a rewrite per config, model-grades both (before/after AI score, MPS, fidelity via the existing `scoreText`/`scoreMPS`/`scoreFidelity`), measures word-level edit churn, and picks a per-fixture winner (lowest after-AI-score among configs meeting the MPS/fidelity floors, ties broken on churn) plus per-config aggregates and head-to-head wins. The default comparison is `single` (one-shot) vs `ouroboros` (the existing CLI multi-pass), so the "does a multi-pass/multi-agent pipeline rewrite better?" question can be answered with data before keeping such a pipeline. LLM-backed and opt-in (`--live` / `PATINA_LIVE`); the comparison/aggregation core is unit-tested with injected producers. Documented in `docs/HARNESS.md` and `tests/quality/README.md`.
+
 ## 5.3.0 — 2026-06-15
 
 **Harness & conventions: a reproducible per-signal impact (ablation) tool and a documented workflow for adding deterministic detection signals.**

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 5.3.0" src="https://img.shields.io/badge/version-5.3.0-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 5.4.0" src="https://img.shields.io/badge/version-5.4.0-blue"></a>
 </p>
 
 <p align="center">
@@ -187,7 +187,7 @@ If meaning drifts, the change is retried or rolled back. Deterministic analysis 
 
 ```yaml
 # .patina.default.yaml
-version: "5.3.0"
+version: "5.4.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/README_JA.md
+++ b/README_JA.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#クイックスタート)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-5.3.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.4.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-en.gif" alt="patina が英語のAIっぽい文を整え、スコアを表示するターミナルデモGIF" width="780">

--- a/README_KR.md
+++ b/README_KR.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#빠른-시작)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-5.3.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.4.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-ko.gif" alt="patina가 한국어 AI풍 문장을 다듬고 결과 점수를 보여주는 터미널 데모 GIF" width="780">

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#快速开始)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-5.3.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.4.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <img src="assets/demo/patina-demo-en.gif" alt="patina 将带有 AI 味的英文文案改写并显示评分的终端演示 GIF" width="780">

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 5.3.0
+version: 5.4.0
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -33,7 +33,7 @@ INPUT          ENGINE (deterministic, LLM-free)                 SURFACES
   │  (2) calibration (det.)  signal-impact · rebaseline:score/report ·         │
   │                          low-fpr · katfish-ko · lexicon:freshness          │
   │  (3) robustness/perf     robustness · perf                                 │
-  │  (4) LLM quality (opt-in) quality:live · adversarial-mps                   │
+  │  (4) LLM quality (opt-in) quality:live · quality:rewrite-ab · adversarial-mps │
   │  (5) comparison (det.)   detector-comparison                               │
   └──────────────────────────────────────────────────────────────────────────┘
                        │  enforced by
@@ -76,6 +76,7 @@ harness below ablates each one to report its marginal contribution.
 |---|---|---|---|
 | Live rewrite quality | `npm run quality:live` (`PATINA_LIVE=1` to call a model) | before/after AI score, MPS, fidelity on rewrites | [tests/quality/README.md](../tests/quality/README.md) |
 | Adversarial MPS | `npm run quality:adversarial-mps` | Guards against MPS hiding unchanged AI style | [tests/quality/README.md](../tests/quality/README.md) |
+| Rewrite A/B | `npm run quality:rewrite-ab` (`--live`) | Compares two rewrite configs (default `single` vs `ouroboros` multi-pass) on the same fixtures: after-AI/MPS/fidelity/edit-churn + per-fixture winner. Answers "does the multi-pass pipeline rewrite better?" | [tests/quality/README.md](../tests/quality/README.md) |
 
 ## Gates (deterministic, run in CI / pre-publish)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",
@@ -38,6 +38,7 @@
     "qa:mdx": "node scripts/qa/mdx-score.mjs",
     "playground:data": "node scripts/generate-playground-data.mjs",
     "quality:live": "node tests/quality/live-quality.mjs",
+    "quality:rewrite-ab": "node scripts/rewrite-ab.mjs",
     "benchmark:rebaseline:intake": "node scripts/rebaseline-intake.mjs",
     "benchmark:rebaseline:score": "node scripts/rebaseline-score.mjs",
     "benchmark:signal-impact": "node scripts/signal-impact.mjs",
@@ -128,6 +129,7 @@
     "scripts/rebaseline-intake.mjs",
     "scripts/rebaseline-score.mjs",
     "scripts/signal-impact.mjs",
+    "scripts/rewrite-ab.mjs",
     "tests/quality/adversarial-mps/",
     "tests/quality/rebaseline-manifest.example.jsonl",
     "artifacts/rebaseline-2025/README.md",

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "5.3.0"
+    "patina-cli": "5.4.0"
   },
   "license": "MIT",
   "repository": {

--- a/scripts/rewrite-ab.mjs
+++ b/scripts/rewrite-ab.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+// Rewrite-quality A/B harness: compare two rewrite configurations on the same
+// fixtures so multi-pass / pipeline questions are answered with data, not
+// intuition. For each fixture it produces a rewrite per config, model-grades
+// both (before/after AI score, MPS, fidelity) and measures edit churn, then
+// reports per-fixture winners + aggregate deltas.
+//
+// The CLI multi-pass already exists as `--ouroboros` (detect -> rewrite -> score
+// -> rollback with MPS/fidelity floors), so the default comparison is
+// `single` (one-shot rewrite) vs `ouroboros` (multi-pass). This is the
+// deterministic-question-with-an-LLM answer to "does the multi-pass pipeline
+// produce better rewrites than a single pass?"
+//
+// LLM-backed and opt-in (like quality:live): non-deterministic, may incur
+// provider cost. The core comparison/aggregation is pure and unit-tested with
+// injected produce/grade functions.
+//
+// Usage:
+//   PATINA_LIVE=1 PATINA_LIVE_PROVIDER=gemini PATINA_LIVE_API_KEY=... \
+//     npm run quality:rewrite-ab -- --configs single,ouroboros --language ko --limit 3
+//   npm run quality:rewrite-ab -- --json
+
+import { resolve } from 'node:path';
+
+import { callLLM as defaultCallLLM } from '../src/api.js';
+import { loadConfig, getRepoRoot } from '../src/config.js';
+import { loadCoreFile, loadPatterns, loadProfile } from '../src/loader.js';
+import { runOuroboros } from '../src/ouroboros.js';
+import {
+  DEFAULT_POLICY,
+  buildPatinaRewritePrompt,
+  deliveredRewrite,
+  evaluateModelGradedRewrite,
+  loadLiveFixtures,
+  resolveLiveSettings,
+} from '../tests/quality/live-quality.mjs';
+
+export const REWRITE_AB_SCHEMA_VERSION = 1;
+export const DEFAULT_CONFIGS = ['single', 'ouroboros'];
+
+// Normalized word-level edit ratio: 0 = identical, →1 = fully rewritten.
+// Conservative rewrites should keep this low; a config that "wins" on AI score
+// only by rewriting everything is visible here.
+export function editChurn(original, rewrite) {
+  const a = String(original ?? '').trim().split(/\s+/).filter(Boolean);
+  const b = String(rewrite ?? '').trim().split(/\s+/).filter(Boolean);
+  if (a.length === 0 && b.length === 0) return 0;
+  // LCS length (O(n*m); fixtures are short paragraphs).
+  const dp = Array.from({ length: a.length + 1 }, () => new Array(b.length + 1).fill(0));
+  for (let i = 1; i <= a.length; i += 1) {
+    for (let j = 1; j <= b.length; j += 1) {
+      dp[i][j] = a[i - 1] === b[j - 1] ? dp[i - 1][j - 1] + 1 : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+  const lcs = dp[a.length][b.length];
+  const denom = a.length + b.length;
+  return denom === 0 ? 0 : Math.round(((denom - 2 * lcs) / denom) * 1000) / 1000;
+}
+
+// Pick the winning config for one fixture: among configs that meet the MPS and
+// fidelity floors, the lowest after-AI-score wins; ties break on lower churn.
+// Returns 'none' when no config preserved meaning.
+export function pickWinner(entries, policy = DEFAULT_POLICY) {
+  const eligible = entries.filter(
+    (e) =>
+      typeof e.after_score === 'number' &&
+      typeof e.mps === 'number' &&
+      typeof e.fidelity === 'number' &&
+      e.mps >= policy.mpsFloor &&
+      e.fidelity >= policy.fidelityFloor,
+  );
+  if (eligible.length === 0) return 'none';
+  eligible.sort((x, y) => x.after_score - y.after_score || (x.churn ?? 1) - (y.churn ?? 1));
+  return eligible[0].config;
+}
+
+// Pure comparison core. `produce(config, fixture) -> rawRewrite` and
+// `grade(fixture, rawRewrite) -> { before_score, after_score, mps, fidelity, ... }`
+// are injected so this is unit-testable without a live model.
+export async function compareRewrites({ fixtures, configs = DEFAULT_CONFIGS, produce, grade, policy = DEFAULT_POLICY }) {
+  const perFixture = [];
+  const tally = Object.fromEntries([...configs, 'none'].map((c) => [c, 0]));
+
+  for (const fixture of fixtures) {
+    const entries = [];
+    for (const config of configs) {
+      try {
+        const raw = await produce(config, fixture);
+        const graded = await grade(fixture, raw);
+        entries.push({
+          config,
+          before_score: graded.before_score ?? null,
+          after_score: graded.after_score ?? null,
+          ai_delta: graded.ai_delta ?? null,
+          mps: graded.mps ?? null,
+          fidelity: graded.fidelity ?? null,
+          churn: editChurn(fixture.text, deliveredRewrite(raw)),
+          status: graded.status ?? null,
+          errors: graded.errors ?? [],
+        });
+      } catch (err) {
+        entries.push({ config, status: 'error', errors: [err.message], after_score: null, mps: null, fidelity: null });
+      }
+    }
+    const winner = pickWinner(entries, policy);
+    tally[winner] += 1;
+    perFixture.push({ fixture_id: fixture.fixture_id, language: fixture.language, register: fixture.register, winner, entries });
+  }
+
+  return { schema_version: REWRITE_AB_SCHEMA_VERSION, configs, policy, results: perFixture, summary: summarize(perFixture, configs, tally) };
+}
+
+function mean(values) {
+  const nums = values.filter((v) => typeof v === 'number');
+  return nums.length ? Math.round((nums.reduce((s, v) => s + v, 0) / nums.length) * 10) / 10 : null;
+}
+
+function summarize(perFixture, configs, tally) {
+  const byConfig = {};
+  for (const config of configs) {
+    const entries = perFixture.map((f) => f.entries.find((e) => e.config === config)).filter(Boolean);
+    byConfig[config] = {
+      n: entries.length,
+      mean_after_score: mean(entries.map((e) => e.after_score)),
+      mean_ai_delta: mean(entries.map((e) => e.ai_delta)),
+      mean_mps: mean(entries.map((e) => e.mps)),
+      mean_fidelity: mean(entries.map((e) => e.fidelity)),
+      mean_churn: mean(entries.map((e) => e.churn)),
+      wins: tally[config] ?? 0,
+    };
+  }
+  return { byConfig, wins: tally };
+}
+
+// ---- live (LLM-backed) production runners ----
+
+async function produceSingle(fixture, { settings, callLLM, repoRoot }) {
+  const prompt = await buildPatinaRewritePrompt(fixture, { repoRoot });
+  return callLLM({ prompt, apiKey: settings.apiKey, baseURL: settings.baseURL, model: settings.model, temperature: 0.2 });
+}
+
+async function produceOuroboros(fixture, { settings, callLLM, repoRoot }) {
+  const config = loadConfig();
+  config.language = fixture.language;
+  if (fixture.profile) config.profile = fixture.profile;
+  config.ouroboros = { ...(config.ouroboros || {}), enabled: true };
+  const patterns = loadPatterns(repoRoot, fixture.language);
+  const profile = loadProfile(repoRoot, config.profile || 'default');
+  const voice = loadCoreFile(repoRoot, 'voice.md');
+  const scoring = loadCoreFile(repoRoot, 'scoring.md');
+  const result = await runOuroboros({
+    config,
+    patterns,
+    profile: profile.body ? profile : null,
+    voice,
+    scoring,
+    text: fixture.text,
+    apiKey: settings.apiKey,
+    baseURL: settings.baseURL,
+    model: settings.model,
+    callLLM: (args) => callLLM({ ...args, timeout: settings.timeoutMs }),
+  });
+  return result.finalText;
+}
+
+function liveProducer(deps) {
+  return (config, fixture) => {
+    if (config === 'single') return produceSingle(fixture, deps);
+    if (config === 'ouroboros') return produceOuroboros(fixture, deps);
+    throw new Error(`unknown rewrite config: ${config}`);
+  };
+}
+
+function parseArgs(argv) {
+  const opts = { configs: DEFAULT_CONFIGS, json: false, language: null, limit: null, live: undefined };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') opts.json = true;
+    else if (arg === '--live') opts.live = true;
+    else if (arg === '--configs') opts.configs = argv[++i].split(',').map((s) => s.trim()).filter(Boolean);
+    else if (arg === '--language') opts.language = argv[++i];
+    else if (arg === '--limit') opts.limit = Number(argv[++i]);
+  }
+  return opts;
+}
+
+function renderMarkdown(report) {
+  const s = report.summary.byConfig;
+  const lines = [
+    '# Rewrite A/B',
+    '',
+    `configs: ${report.configs.join(' vs ')} | fixtures: ${report.results.length}`,
+    '',
+    '## Per-config aggregate',
+    '',
+    '| config | mean after-AI | mean ai-delta | mean MPS | mean fidelity | mean churn | wins |',
+    '|---|---:|---:|---:|---:|---:|---:|',
+    ...report.configs.map(
+      (c) => `| ${c} | ${s[c].mean_after_score} | ${s[c].mean_ai_delta} | ${s[c].mean_mps} | ${s[c].mean_fidelity} | ${s[c].mean_churn} | ${s[c].wins} |`,
+    ),
+    '',
+    `head-to-head wins: ${Object.entries(report.summary.wins).map(([k, v]) => `${k}=${v}`).join(' · ')}`,
+    '',
+  ];
+  return lines.join('\n');
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const repoRoot = getRepoRoot();
+  const settings = resolveLiveSettings(opts);
+  const live = opts.live ?? (process.env.PATINA_LIVE === '1' || Boolean(process.env.PATINA_LIVE_PROVIDER || process.env.PATINA_LIVE_API_KEY));
+  if (!live) {
+    console.error('Rewrite A/B is LLM-backed and opt-in. Set PATINA_LIVE=1 (+ PATINA_LIVE_PROVIDER/API_KEY) or pass --live.');
+    process.exit(1);
+  }
+  if (!settings.hasApiKey) {
+    console.error('No API key found for the live rewrite. Set PATINA_LIVE_API_KEY or the provider key.');
+    process.exit(1);
+  }
+  let fixtures = loadLiveFixtures();
+  if (opts.language) fixtures = fixtures.filter((f) => f.language === opts.language);
+  if (Number.isFinite(opts.limit) && opts.limit >= 0) fixtures = fixtures.slice(0, opts.limit);
+  if (fixtures.length === 0) {
+    console.error('no fixtures selected');
+    process.exit(1);
+  }
+
+  const deps = { settings, callLLM: defaultCallLLM, repoRoot };
+  const produce = liveProducer(deps);
+  const grade = (fixture, raw) => evaluateModelGradedRewrite(fixture, raw, { settings, policy: DEFAULT_POLICY, callLLM: defaultCallLLM });
+  const report = await compareRewrites({ fixtures, configs: opts.configs, produce, grade });
+  console.log(opts.json ? JSON.stringify(report, null, 2) : renderMarkdown(report));
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(new URL(import.meta.url).pathname)) {
+  main().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+  });
+}

--- a/tests/quality/README.md
+++ b/tests/quality/README.md
@@ -101,6 +101,29 @@ nonzero; AI-score target misses remain `warn` so the report is still usable.
 Keep this out of mandatory CI unless the live model path is deliberately
 allowed, because LLM output is non-deterministic and may incur provider cost.
 
+## Rewrite A/B (default vs ouroboros)
+
+`npm run quality:rewrite-ab` compares two rewrite configurations on the same
+fixtures so multi-pass / pipeline questions are answered with data. The default
+comparison is `single` (one-shot rewrite) vs `ouroboros` (the existing CLI
+multi-pass: detect → rewrite → score → rollback with MPS/fidelity floors).
+
+```bash
+PATINA_LIVE=1 PATINA_LIVE_PROVIDER=gemini PATINA_LIVE_API_KEY=... \
+  npm run quality:rewrite-ab -- --configs single,ouroboros --language ko --limit 3
+npm run quality:rewrite-ab -- --json
+```
+
+For each fixture it produces a rewrite per config, model-grades both
+(before/after AI score, MPS, fidelity via `scoreText`/`scoreMPS`/`scoreFidelity`),
+measures edit churn (word-level change ratio), and picks a per-fixture winner:
+the lowest after-AI-score among configs that meet the MPS/fidelity floors, ties
+broken on lower churn. The summary reports per-config means and head-to-head
+wins. Like `quality:live` it is LLM-backed and opt-in (non-deterministic, may
+incur cost); the comparison/aggregation core is unit-tested with injected
+producers. Use this to decide whether a multi-pass/multi-agent pipeline earns
+its cost before keeping it.
+
 ## Adversarial MPS fixtures
 
 `npm run quality:adversarial-mps` validates a small, repo-owned fixture set

--- a/tests/unit/rewrite-ab.test.js
+++ b/tests/unit/rewrite-ab.test.js
@@ -1,0 +1,77 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { editChurn, pickWinner, compareRewrites, DEFAULT_CONFIGS } from '../../scripts/rewrite-ab.mjs';
+
+test('editChurn is 0 for identical text, 1 for fully disjoint, fractional otherwise', () => {
+  assert.equal(editChurn('a b c', 'a b c'), 0);
+  assert.equal(editChurn('a b c', 'x y z'), 1);
+  assert.equal(editChurn('a b c d', 'a b x d'), 0.25); // LCS a,b,d = 3 of 8 tokens
+  assert.equal(editChurn('', ''), 0);
+});
+
+test('pickWinner takes lowest after-score among floor-passing configs', () => {
+  const winner = pickWinner([
+    { config: 'single', after_score: 40, mps: 80, fidelity: 80, churn: 0.2 },
+    { config: 'ouroboros', after_score: 20, mps: 85, fidelity: 85, churn: 0.3 },
+  ]);
+  assert.equal(winner, 'ouroboros');
+});
+
+test('pickWinner returns none when no config preserves meaning (floors)', () => {
+  const winner = pickWinner([
+    { config: 'single', after_score: 10, mps: 50, fidelity: 90, churn: 0.1 }, // mps < 70
+    { config: 'ouroboros', after_score: 12, mps: 90, fidelity: 50, churn: 0.1 }, // fidelity < 70
+  ]);
+  assert.equal(winner, 'none');
+});
+
+test('pickWinner breaks after-score ties on lower churn', () => {
+  const winner = pickWinner([
+    { config: 'single', after_score: 20, mps: 80, fidelity: 80, churn: 0.5 },
+    { config: 'ouroboros', after_score: 20, mps: 80, fidelity: 80, churn: 0.2 },
+  ]);
+  assert.equal(winner, 'ouroboros');
+});
+
+test('compareRewrites grades both configs, picks winners, and aggregates (injected produce/grade)', async () => {
+  const fixtures = [
+    { fixture_id: 'f1', language: 'ko', register: 'blog', text: '원문 문장 하나 둘 셋' },
+    { fixture_id: 'f2', language: 'ko', register: 'blog', text: '다른 원문 가 나 다' },
+  ];
+  // ouroboros returns a cleaner (lower after-score) rewrite; both preserve meaning.
+  const graded = {
+    single: { before_score: 60, after_score: 40, ai_delta: 20, mps: 80, fidelity: 82, status: 'warn' },
+    ouroboros: { before_score: 60, after_score: 20, ai_delta: 40, mps: 85, fidelity: 88, status: 'pass' },
+  };
+  const produce = async (config) => `rewrite-${config}`;
+  const grade = async (_fixture, raw) => graded[raw.replace('rewrite-', '')];
+
+  const report = await compareRewrites({ fixtures, configs: DEFAULT_CONFIGS, produce, grade });
+
+  assert.equal(report.results.length, 2);
+  assert.equal(report.results[0].winner, 'ouroboros');
+  assert.equal(report.results[1].winner, 'ouroboros');
+  assert.equal(report.summary.wins.ouroboros, 2);
+  assert.equal(report.summary.wins.single, 0);
+  assert.equal(report.summary.byConfig.ouroboros.mean_after_score, 20);
+  assert.equal(report.summary.byConfig.single.mean_after_score, 40);
+  assert.equal(report.summary.byConfig.ouroboros.wins, 2);
+  // both entries present per fixture
+  assert.equal(report.results[0].entries.length, 2);
+});
+
+test('compareRewrites records errors from a failing producer without aborting', async () => {
+  const fixtures = [{ fixture_id: 'f1', language: 'ko', text: '원문' }];
+  const produce = async (config) => {
+    if (config === 'ouroboros') throw new Error('boom');
+    return 'ok';
+  };
+  const grade = async () => ({ after_score: 30, mps: 80, fidelity: 80 });
+  const report = await compareRewrites({ fixtures, configs: ['single', 'ouroboros'], produce, grade });
+  const ouro = report.results[0].entries.find((e) => e.config === 'ouroboros');
+  assert.equal(ouro.status, 'error');
+  assert.deepEqual(ouro.errors, ['boom']);
+  // single still graded and wins
+  assert.equal(report.results[0].winner, 'single');
+});


### PR DESCRIPTION
## Summary

Builds the **robust measurement harness** to answer pipeline questions with data (per the plan: build the harness first, then measure). Bumps to **5.4.0** (minor — opt-in contributor tool; no CLI/schema/detection-behavior change).

`scripts/rewrite-ab.mjs` (`npm run quality:rewrite-ab`) compares two rewrite configurations on the same live-quality fixtures:
- produces a rewrite per config, model-grades both (before/after AI score, MPS, fidelity via the existing `scoreText`/`scoreMPS`/`scoreFidelity`),
- measures word-level **edit churn**,
- picks a per-fixture **winner** (lowest after-AI-score among configs meeting the MPS/fidelity floors; ties broken on churn),
- reports per-config aggregates + head-to-head wins.

## Why this shape

The earlier review flagged the multi-agent / `--strict` stack as **over-engineered because it was never measured**. The CLI multi-pass already exists as `--ouroboros` (detect → rewrite → score → rollback with MPS/fidelity floors), so the default A/B is `single` vs `ouroboros` — no redundant new `--strict` CLI mode. This makes "does a multi-pass pipeline rewrite better?" measurable, so the multi-agent surface can be kept or cut **with evidence** in the next (measurement) phase.

`--strict` itself lives only in `SKILL.md` (agent skill) and is not CLI-reachable; `--ouroboros` is its CLI-measurable proxy.

## Verification

- `npm test` — **797 pass / 0 fail** (6 new rewrite-ab unit tests: editChurn, pickWinner, compare/aggregate, error handling — all with injected producers, no live model)
- `npm run lint` — syntax OK (161 files), cspell 0 issues
- `npm run release:check` — OK for 5.4.0
- `npm run check:no-private-assets` — OK

LLM-backed and opt-in (`--live` / `PATINA_LIVE`), like `quality:live`; not in mandatory CI. Documented in `docs/HARNESS.md` and `tests/quality/README.md`.

Next phase (separate): run the A/B with a backend to measure `single` vs `ouroboros`, then decide keep/cut the multi-agent surface from data.
