### PR TITLE
test(fixtures): expand rewrite-quality corpus to 10 KO + 10 EN (enable A/B measurement)

### DIFF
--- a/tests/fixtures/live-quality/en/academic-01.md
+++ b/tests/fixtures/live-quality/en/academic-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: en-academic-01
+language: en
+profile: academic
+register: academic-summary
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - p<0.05
+  - 120 participants
+  - control group
+  - sleep
+expected_focus:
+  - reduce overclaim
+  - keep statistics
+---
+This study was conducted to investigate the impact of sleep duration on cognitive performance, and the findings are highly significant. In an experiment involving a total of 120 participants, the experimental group demonstrated a statistically significant difference compared to the control group (p<0.05).
+
+These results robustly underscore that sleep plays a crucial role in cognitive function, and it is anticipated that they will provide an important foundation for future research in this domain.

--- a/tests/fixtures/live-quality/en/blog-01.md
+++ b/tests/fixtures/live-quality/en/blog-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: en-blog-01
+language: en
+profile: blog
+register: blog
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - remote work
+  - 2020
+  - commute
+  - productivity
+expected_focus:
+  - cut AI cliches
+  - keep claims
+---
+In today's fast-paced world, remote work has emerged as a transformative force that is fundamentally reshaping modern workplace culture since 2020. This paradigm plays a crucial role in enhancing individual productivity by significantly reducing the time spent on the daily commute.
+
+Moreover, it is important to note that remote work serves as a pivotal mechanism for fostering a healthier work-life balance, delivering a holistic and seamless impact across diverse organizational cultures.

--- a/tests/fixtures/live-quality/en/chat-01.md
+++ b/tests/fixtures/live-quality/en/chat-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: en-chat-01
+language: en
+profile: casual-conversation
+register: chat-update
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - deploy
+  - 3 PM
+  - login
+  - cache
+expected_focus:
+  - de-robotify
+  - keep schedule
+---
+Hi team, I wanted to share an update regarding the work completed today. I am pleased to inform you that the login-related issue has been successfully resolved. Additionally, the cache invalidation logic has been substantially improved.
+
+Please be advised that a deployment is scheduled for 3 PM today, and as a result, a temporary service interruption may occur. We appreciate your understanding in this matter.

--- a/tests/fixtures/live-quality/en/email-01.md
+++ b/tests/fixtures/live-quality/en/email-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: en-email-01
+language: en
+profile: email
+register: email
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - Monday
+  - Room A
+  - 10 AM
+  - quarterly report
+expected_focus:
+  - warm but plain
+  - keep logistics
+---
+Hello, I would like to extend my sincere gratitude for taking the time out of your busy schedule. I am reaching out to provide some important information regarding the upcoming quarterly report.
+
+The meeting is scheduled to take place next Monday at 10 AM in Room A. Should you have any unavoidable circumstances, I would greatly appreciate it if you could let me know in advance. I wish you a wonderful day.

--- a/tests/fixtures/live-quality/en/howto-01.md
+++ b/tests/fixtures/live-quality/en/howto-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: en-howto-01
+language: en
+profile: instructional
+register: technical-how-to
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - npm install
+  - Node 18
+  - .env
+  - port 3000
+expected_focus:
+  - remove boilerplate
+  - keep commands
+---
+This guide will enable you to seamlessly set up your development environment. First and foremost, it is crucial to verify that Node 18 or higher is installed on your system. Subsequently, you can install the dependencies by executing the npm install command.
+
+Environment variables are managed through the .env file, and once the configuration is complete, the application will run on port 3000. By adhering to these steps, a stable and robust setup can be achieved.

--- a/tests/fixtures/live-quality/en/instructional-01.md
+++ b/tests/fixtures/live-quality/en/instructional-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: en-instructional-01
+language: en
+profile: instructional
+register: instructional
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - 200ml
+  - 3 minutes
+  - medium heat
+  - 2 eggs
+expected_focus:
+  - plainer steps
+  - keep quantities
+---
+This recipe will empower anyone to effortlessly craft a perfect dish. First and foremost, it is essential to thoroughly whisk 2 eggs in a bowl. Subsequently, you can achieve the appropriate consistency by adding 200ml of water.
+
+By simmering the mixture over medium heat for 3 minutes, you can attain a wonderfully tender texture. If you faithfully follow these steps, you will be able to create a delicious result without fail.

--- a/tests/fixtures/live-quality/en/marketing-01.md
+++ b/tests/fixtures/live-quality/en/marketing-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: en-marketing-01
+language: en
+profile: marketing
+register: marketing
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - 7-day
+  - free trial
+  - $9
+  - per month
+expected_focus:
+  - cut hype
+  - keep price/terms
+---
+Embark on a transformative journey that will completely revolutionize your daily routine, starting right now. Through our 7-day free trial, you can experience the overwhelming value firsthand. This is not merely a service; it is the dawn of an entirely new lifestyle.
+
+After the trial concludes, you can unlock every single feature without limits for an affordable $9 per month. Don't hesitate any longer; your future self will thank you.

--- a/tests/fixtures/live-quality/en/news-01.md
+++ b/tests/fixtures/live-quality/en/news-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: en-news-01
+language: en
+profile: formal
+register: news
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - $2.4 billion
+  - small businesses
+  - 2026
+  - loan guarantees
+expected_focus:
+  - neutral tone
+  - keep figures
+---
+The government has unveiled a multifaceted support package designed to alleviate the financial burden on small businesses in 2026. The cornerstone of this initiative is the provision of $2.4 billion in loan guarantees, which is expected to deliver tangible relief to entrepreneurs facing liquidity challenges.
+
+Officials emphasized that this policy will serve as a pivotal turning point in revitalizing the regional economy, and they stated that they would continuously monitor its effects to maximize the policy's impact.

--- a/tests/fixtures/live-quality/en/product-01.md
+++ b/tests/fixtures/live-quality/en/product-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: en-product-01
+language: en
+profile: default
+register: product-doc
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - 30 templates
+  - Notion
+  - workflows
+  - teams
+expected_focus:
+  - strip hype
+  - keep features
+---
+This product is an innovative solution meticulously designed to transform productivity for modern teams. It offers 30 templates optimized for diverse workflows, and its user-friendly design empowers anyone to leverage them effortlessly and seamlessly.
+
+Ultimately, this solution introduces a new paradigm for maximizing work efficiency, positioning itself as a pivotal tool that will spearhead the future of seamless team collaboration with Notion.

--- a/tests/fixtures/live-quality/en/social-01.md
+++ b/tests/fixtures/live-quality/en/social-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: en-social-01
+language: en
+profile: social
+register: social
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - river
+  - Sunday
+  - bike
+  - 10 km
+expected_focus:
+  - cut hype/hashtag
+  - keep place/distance
+---
+Friends, my experience by the river this Sunday was truly a life-changing moment, without exaggeration! Riding my bike for a full 10 km, the freedom I felt was simply beyond words and impossible to describe.
+
+I wholeheartedly recommend this to everyone who is exhausted by their hectic daily lives. A small start will bring an astonishing transformation to your life. Take on the challenge right now!

--- a/tests/fixtures/live-quality/ko/academic-01.md
+++ b/tests/fixtures/live-quality/ko/academic-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: ko-academic-01
+language: ko
+profile: academic
+register: academic-summary
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - p<0.05
+  - 120명
+  - 대조군
+  - 수면
+expected_focus:
+  - 과장 표현 완화
+  - 통계치 보존
+---
+본 연구는 수면 시간이 인지 수행에 미치는 영향을 규명하고자 수행되었으며, 그 결과는 매우 시사하는 바가 크다. 총 120명의 참가자를 대상으로 한 실험에서, 실험군은 대조군에 비해 통계적으로 유의미한 차이를 보였다(p<0.05).
+
+이러한 결과는 수면이 인지 기능에 있어 핵심적인 역할을 담당한다는 점을 강력하게 시사하며, 향후 연구에 중요한 토대를 제공할 것으로 기대된다.

--- a/tests/fixtures/live-quality/ko/blog-01.md
+++ b/tests/fixtures/live-quality/ko/blog-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: ko-blog-01
+language: ko
+profile: blog
+register: blog
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - 재택근무
+  - 2020년
+  - 통근
+  - 생산성
+expected_focus:
+  - 번역투 완화
+  - 수치·시점 보존
+---
+재택근무는 2020년 이후 현대 직장 문화를 근본적으로 재편하는 핵심적인 변화로 자리매김하였다. 이 방식은 통근에 소요되는 시간을 절감함으로써 개인의 생산성 향상에 기여하는 중요한 매개체로 기능한다.
+
+또한 재택근무는 일과 삶의 균형을 도모하는 데 있어 의미 있는 역할을 수행하며, 다양한 조직 문화 전반에 걸쳐 긍정적인 영향을 미치는 것으로 평가된다.

--- a/tests/fixtures/live-quality/ko/chat-01.md
+++ b/tests/fixtures/live-quality/ko/chat-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: ko-chat-01
+language: ko
+profile: casual-conversation
+register: chat-update
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - 배포
+  - 오후 3시
+  - 로그인
+  - 캐시
+expected_focus:
+  - 기계적 문체 완화
+  - 일정·대상 보존
+---
+안녕하세요 팀 여러분, 금일 진행된 작업에 대해 공유드립니다. 로그인 관련 이슈가 성공적으로 해결되었음을 알려드립니다. 또한 캐시 무효화 로직이 개선되었습니다.
+
+금일 오후 3시에 배포가 진행될 예정이며, 이에 따라 일시적인 서비스 중단이 발생할 수 있음을 사전에 안내드립니다.

--- a/tests/fixtures/live-quality/ko/email-01.md
+++ b/tests/fixtures/live-quality/ko/email-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: ko-email-01
+language: ko
+profile: email
+register: email
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - 월요일
+  - 회의실 A
+  - 10시
+  - 분기 보고
+expected_focus:
+  - 상투적 표현 완화
+  - 일정·장소 보존
+---
+안녕하세요. 바쁘신 와중에 시간 내어 주셔서 진심으로 감사드립니다. 다름이 아니라 분기 보고와 관련하여 안내 말씀 드리고자 연락드립니다.
+
+회의는 다음 주 월요일 10시에 회의실 A에서 진행될 예정입니다. 부득이한 사정이 있으실 경우 사전에 말씀해 주시면 감사하겠습니다. 좋은 하루 되시기 바랍니다.

--- a/tests/fixtures/live-quality/ko/howto-01.md
+++ b/tests/fixtures/live-quality/ko/howto-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: ko-howto-01
+language: ko
+profile: instructional
+register: technical-how-to
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - npm install
+  - Node 18
+  - .env
+  - 포트 3000
+expected_focus:
+  - 장황함 제거
+  - 명령·버전 보존
+---
+본 가이드를 통해 개발 환경을 손쉽게 구성하실 수 있습니다. 먼저 Node 18 이상이 설치되어 있는지 확인하는 것이 중요합니다. 그 다음 npm install 명령을 실행함으로써 의존성을 설치할 수 있습니다.
+
+환경 변수는 .env 파일을 통해 관리되며, 설정이 완료되면 애플리케이션은 포트 3000에서 실행됩니다. 이러한 절차를 준수하면 안정적인 구동이 가능합니다.

--- a/tests/fixtures/live-quality/ko/instructional-01.md
+++ b/tests/fixtures/live-quality/ko/instructional-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: ko-instructional-01
+language: ko
+profile: instructional
+register: instructional
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - 200ml
+  - 3분
+  - 중불
+  - 계란 2개
+expected_focus:
+  - 번역투 완화
+  - 분량·시간 보존
+---
+이 레시피를 통해 누구나 손쉽게 완벽한 요리를 완성할 수 있습니다. 먼저 계란 2개를 그릇에 풀어 주는 것이 중요합니다. 그 다음 물 200ml를 첨가함으로써 적절한 농도를 맞출 수 있습니다.
+
+중불에서 3분간 저어 주면 부드러운 식감을 얻을 수 있습니다. 이러한 단계를 충실히 따르면 실패 없이 맛있는 결과물을 만들어 낼 수 있습니다.

--- a/tests/fixtures/live-quality/ko/marketing-01.md
+++ b/tests/fixtures/live-quality/ko/marketing-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: ko-marketing-01
+language: ko
+profile: marketing
+register: marketing
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - 7일
+  - 무료 체험
+  - 구독
+  - 월 9900원
+expected_focus:
+  - 과장 완화
+  - 가격·조건 보존
+---
+지금 바로 당신의 일상을 완전히 바꿔놓을 혁신적인 경험을 시작하세요. 7일 무료 체험을 통해 압도적인 가치를 직접 확인하실 수 있습니다. 이것은 단순한 서비스가 아니라 새로운 라이프스타일의 시작입니다.
+
+체험 종료 후에는 월 9900원의 합리적인 구독으로 모든 기능을 제한 없이 누리실 수 있습니다. 더 이상 망설이지 마세요.

--- a/tests/fixtures/live-quality/ko/news-01.md
+++ b/tests/fixtures/live-quality/ko/news-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: ko-news-01
+language: ko
+profile: formal
+register: news
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - 3조 2000억 원
+  - 소상공인
+  - 2026년
+  - 전환보증
+expected_focus:
+  - 관료적 문체 완화
+  - 금액·연도 보존
+---
+정부는 2026년 소상공인의 금융 부담을 완화하기 위한 다각적인 지원 방안을 발표하였다. 이번 대책의 핵심은 전환보증 3조 2000억 원을 공급하는 것으로, 이를 통해 자금난을 겪는 사업자에게 실질적인 도움을 제공할 것으로 기대된다.
+
+관계 당국은 본 정책이 지역 경제 활성화에 있어 중요한 전환점이 될 것이라고 강조하며, 지속적인 모니터링을 통해 정책 효과를 제고하겠다고 밝혔다.

--- a/tests/fixtures/live-quality/ko/product-01.md
+++ b/tests/fixtures/live-quality/ko/product-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: ko-product-01
+language: ko
+profile: default
+register: product-doc
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - 30개
+  - 템플릿
+  - Notion
+  - 워크플로우
+expected_focus:
+  - 홍보 어휘 제거
+  - 기능·수치 보존
+---
+본 제품은 현대 팀의 생산성을 혁신적으로 변화시키기 위해 설계된 획기적인 솔루션입니다. 다양한 워크플로우에 최적화된 30개의 Notion 템플릿을 제공하며, 사용자 친화적인 디자인을 통해 누구나 손쉽게 활용할 수 있습니다.
+
+이 솔루션은 업무 효율성을 극대화하는 새로운 패러다임을 제시하며, 팀 협업의 미래를 선도하는 핵심 도구로 자리매김할 것입니다.

--- a/tests/fixtures/live-quality/ko/social-01.md
+++ b/tests/fixtures/live-quality/ko/social-01.md
@@ -1,0 +1,21 @@
+---
+fixture_id: ko-social-01
+language: ko
+profile: social
+register: social
+source_type: synthetic-ai
+model_family: fixture
+prompt_id: live-quality-v2
+redistribution: repo-ok
+anchors:
+  - 한강
+  - 일요일
+  - 자전거
+  - 10km
+expected_focus:
+  - 과장·해시태그식 완화
+  - 장소·거리 보존
+---
+여러분, 이번 일요일 한강에서의 경험은 그야말로 인생을 바꾸는 순간이었습니다! 자전거를 타고 무려 10km를 달리며 느낀 자유로움은 말로 표현할 수 없을 정도였어요.
+
+바쁜 일상에 지친 모든 분들께 강력히 추천드립니다. 작은 시작이 여러분의 삶에 놀라운 변화를 가져다줄 것입니다. 지금 바로 도전해 보세요!


### PR DESCRIPTION
## Summary

Expands the rewrite-quality (live) fixture corpus from **1 → 11 fixtures per language** so the `quality:rewrite-ab` and `quality:live` harnesses can measure rewrite-pipeline A/B (single vs ouroboros) at a meaningful sample size. **No version bump** — test data only, no schema/behavior change.

Adds **10 KO + 10 EN** synthetic, redistributable (`repo-ok`) AI-sounding fixtures across registers: blog, academic-summary, product-doc, chat-update, technical-how-to, marketing, news, email, instructional, social. Each carries meaning **anchors** (numbers/entities that must survive a rewrite) for MPS/fidelity grading.

## Why

The earlier measurement attempt found the real blocker: `tests/fixtures/live-quality/ko/` had only **1 fixture**, so single-vs-ouroboros (and the multi-agent `--strict` question) couldn't be measured (n=1). This unblocks the measurement phase.

## Verification

- `npm test` — **797 pass / 0 fail** (live-quality fixture-shape test green)
- `npm run release:check` — OK for 5.4.0 (unchanged)
- `npm run check:no-private-assets` — OK (332 packed; all fixtures `repo-ok`)
- harness loads **ko 11 / en 11**; all 20 new fixtures have anchors present in their text

Next phase: run `quality:rewrite-ab --configs single,ouroboros` across the corpus with a backend, then decide keep/cut the multi-agent surface from data.
