### PR TITLE
fix(output): strict toFiniteNumber so JSON score gate cannot be flipped (#505)

### DIFF
--- a/src/cli/score-gate.js
+++ b/src/cli/score-gate.js
@@ -24,9 +24,9 @@ export function extractScoreOverall(result, output) {
   });
 }
 
-// Not the same as output.js toFiniteNumber: that helper strips non-numeric
-// characters before Number() (so "**12**" parses), while the score gate
-// rejects any value that is not already a plain number.
+// Strict numeric coercer for the score gate: accepts a value that is already a
+// plain number (Number()), and rejects anything else. output.js toFiniteNumber
+// now parses strictly too (#505), so the two agree on real inputs.
 function toFiniteScore(value) {
   if (value === null || value === undefined || value === '') return null;
   const n = Number(value);

--- a/src/output.js
+++ b/src/output.js
@@ -343,11 +343,11 @@ function extractOverall(result, body) {
 /**
  * Shared overall-score traversal: structured result field → embedded JSON →
  * markdown score table → inline "overall: N" text. Used by extractOverall
- * above and by the CLI score gate (src/cli/score-gate.js). The two call sites
- * intentionally keep different numeric coercers (toFiniteNumber here strips
- * non-numeric characters before Number(); the score gate's toFiniteScore
- * rejects anything that is not already a plain number), so the coercer is a
- * parameter rather than shared.
+ * above and by the CLI score gate (src/cli/score-gate.js). Both call sites now
+ * use strict numeric coercers (toFiniteNumber here, toFiniteScore in the score
+ * gate) that accept a plain numeric token and reject anything else (#505); the
+ * coercer stays a parameter so each site keeps its own small differences (e.g.
+ * the gate's empty-string handling).
  *
  * @param {string|object|null} result Structured result whose `overall` field is checked first.
  * @param {string} text Raw output text scanned for embedded JSON, a score table, or inline "overall: N".
@@ -431,8 +431,17 @@ function parseMarkdownCategories(body) {
 }
 
 function toFiniteNumber(value) {
-  if (value === null || value === undefined || value === '') return null;
-  const n = Number(String(value).replace(/[^\d.-]/g, ''));
+  // Strict parse: accept a plain numeric token (incl. exponent notation like
+  // "1e3") and reject anything else to null. Deleting non-numeric characters
+  // and re-parsing the residue silently salvaged junk ("1e3"→13, "12px"→12,
+  // "12abc34"→1234, "8%"→8), which could flip the --format json score gate via
+  // buildGateResult (#505). Markdown table cells are de-bolded before reaching
+  // here (parseMarkdownCategories strips ** first), so strictness is safe.
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (value === null || value === undefined) return null;
+  const str = String(value).trim();
+  if (str === '') return null;
+  const n = Number(str);
   return Number.isFinite(n) ? n : null;
 }
 

--- a/tests/unit/score-overall-coercion.test.js
+++ b/tests/unit/score-overall-coercion.test.js
@@ -4,27 +4,36 @@ import { strict as assert } from 'node:assert';
 import { extractScoreOverall } from '../../src/cli/score-gate.js';
 import { formatOutput } from '../../src/output.js';
 
-// Pins the intentional divergence between the two numeric coercers behind the
-// shared overall-score traversal (src/output.js extractOverallScore):
-// - score-gate toFiniteScore: plain Number() — rejects anything that is not
-//   already a plain number, but accepts exponent notation.
-// - output.js toFiniteNumber: strips non-numeric characters before Number()
-//   (so "**12**" or "12px" parse), which mangles exponent notation.
-// These must NOT be merged; see the comment in src/cli/score-gate.js.
+// Both numeric coercers behind the shared overall-score traversal
+// (src/output.js extractOverallScore) now parse strictly: a plain numeric
+// token (including exponent notation) is accepted, and anything else is
+// rejected to null. Previously output.js toFiniteNumber stripped non-numeric
+// characters before Number(), which mangled exponent notation ("1e3" -> 13)
+// and silently salvaged junk ("12px" -> 12, "12abc34" -> 1234, "8%" -> 8) —
+// a wrong-but-finite overall could flip the --format json gate (#505). The
+// score-gate toFiniteScore was already strict; the two now agree.
 
 function jsonOverall(overall) {
   const out = formatOutput({ raw: '', overall }, 'score', { format: 'json' });
   return JSON.parse(out).overall;
 }
 
-test('coercer divergence: "1e3" → 1000 via score gate, 13 via JSON output', () => {
+test('exponent notation parses to its real value on both paths (#505)', () => {
   assert.equal(extractScoreOverall({ overall: '1e3' }, ''), 1000);
-  assert.equal(jsonOverall('1e3'), 13);
+  assert.equal(jsonOverall('1e3'), 1000);
+  assert.equal(extractScoreOverall({ overall: '1e2' }, ''), 100);
+  assert.equal(jsonOverall('1e2'), 100);
 });
 
-test('coercer divergence: "12px" → null via score gate, 12 via JSON output', () => {
-  assert.equal(extractScoreOverall({ overall: '12px' }, ''), null);
-  assert.equal(jsonOverall('12px'), 12);
+test('non-numeric junk is rejected to null on both paths (#505)', () => {
+  for (const junk of ['12px', '12abc34', '8%', '**12**', 'abc']) {
+    assert.equal(extractScoreOverall({ overall: junk }, ''), null, `score gate: ${junk}`);
+    assert.equal(jsonOverall(junk), null, `json output: ${junk}`);
+  }
+  // Whitespace-only diverges only because the score gate's toFiniteScore
+  // coerces "  " to 0 (a pre-existing quirk, out of #505 scope); the strict
+  // JSON-output coercer rejects it.
+  assert.equal(jsonOverall('  '), null);
 });
 
 test('coercers agree on plain numbers', () => {
@@ -32,4 +41,6 @@ test('coercers agree on plain numbers', () => {
   assert.equal(jsonOverall(21), 21);
   assert.equal(extractScoreOverall({ overall: '21.5' }, ''), 21.5);
   assert.equal(jsonOverall('21.5'), 21.5);
+  // Surrounding whitespace is tolerated, whitespace-only is rejected.
+  assert.equal(jsonOverall(' 30 '), 30);
 });


### PR DESCRIPTION
## Summary
`toFiniteNumber` stripped every non-numeric character before `Number()`, so a non-plain-number `overall` silently produced a wrong-but-finite value: `"1e3"`→13, `"12px"`→12, `"12abc34"`→1234, `"8%"`→8. Because `extractOverall` feeds `buildGateResult` (`passed = overall <= gate`), a structured result with `overall: "1e3"` (1000) parsed as 13 and could report a **false PASS** of a `--exit-on` gate in `--format json`.

Now parses strictly: accept a plain numeric token (incl. exponent notation) and reject anything else to `null`. Markdown table cells are already de-bolded before reaching here, so strictness is safe. This aligns the JSON output coercer with the already-strict score-gate `toFiniteScore`; the divergence test is rewritten to assert agreement.

## Verification
Full suite (unit + e2e) green; eslint + tsc clean.

Closes #505