### PR TITLE
fix(backends): single shared timeout budget, fall-through fallback, stricter auth (#506, #508 G8)

### DIFF
--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -123,11 +123,17 @@ export function stageCliImages(dir, images = []) {
 
 export function isRetryableBackendError(err, { attemptIndex = 0, signal } = {}) {
   if (signal?.aborted) return false;
+  // attemptIndex is retained for call-site compatibility but no longer gates
+  // the decision (#506 defect 2): a backend that timed out or aborted on its
+  // own (without the user aborting) is fallbackable at any hop.
+  void attemptIndex;
   const status = extractStatus(err);
   if (status === 429 || status === 503) return true;
   // A per-attempt timeout (api.js renames exhausted timer aborts to
-  // TimeoutError, #444) is as fallbackable as an AbortError on the first hop.
-  return (err?.name === 'AbortError' || err?.name === 'TimeoutError') && attemptIndex === 0;
+  // TimeoutError, #444) now falls through at ANY non-final hop, exactly like a
+  // 429/503. The chain caller already stops at the final hop via `!next`, so the
+  // predicate itself needs no index gate (#506 defect 2).
+  return err?.name === 'AbortError' || err?.name === 'TimeoutError';
 }
 
 export function describeBackendError(err) {
@@ -161,6 +167,7 @@ export async function withBackendConcurrencySlot({
   maxConcurrency,
   signal,
   timeout = DEFAULT_BACKEND_TIMEOUT_MS,
+  deadline = Number.isFinite(timeout) ? Date.now() + timeout : Infinity,
   pollMs = 250,
   staleMs = Math.max(timeout * 2, 30 * 60_000),
   fn,
@@ -168,21 +175,27 @@ export async function withBackendConcurrencySlot({
   if (typeof fn !== 'function') {
     throw new Error('backend concurrency slot requires fn');
   }
+  // The run phase gets whatever remains of the shared deadline after the slot
+  // wait, so slot-wait + run can never exceed the single budget (#506 defect 1).
+  // Callers that pass only `timeout` (no `deadline`) keep their full budget via
+  // the derived default above.
+  const remainingTimeout = () =>
+    (Number.isFinite(deadline) ? Math.max(0, deadline - Date.now()) : timeout);
   if (!Number.isFinite(maxConcurrency)) {
-    return fn();
+    return fn(remainingTimeout());
   }
 
   const slot = await acquireBackendSlot({
     backendName,
     maxConcurrency,
     signal,
-    timeout,
+    deadline,
     pollMs,
     staleMs,
   });
 
   try {
-    return await fn();
+    return await fn(remainingTimeout());
   } finally {
     releaseBackendSlot(slot);
   }
@@ -192,12 +205,11 @@ async function acquireBackendSlot({
   backendName,
   maxConcurrency,
   signal,
-  timeout,
+  deadline,
   pollMs,
   staleMs,
 }) {
   throwIfAborted(signal, `${backendName || 'backend'}: aborted while waiting for concurrency slot`);
-  const startedAt = Date.now();
   // Per-user slot root: the slot dirs are real locks, and a world-shared
   // tmpdir path means another user's slot dir cannot be removed (EACCES) and
   // would permanently consume a cap slot on a multi-user host (#445).
@@ -222,10 +234,10 @@ async function acquireBackendSlot({
     }
 
     throwIfAborted(signal, `${backendName || 'backend'}: aborted while waiting for concurrency slot`);
-    if (Date.now() - startedAt >= timeout) {
+    if (Date.now() >= deadline) {
       throw new Error(`${backendName || 'backend'}: timed out waiting for concurrency slot (cap ${maxConcurrency})`);
     }
-    await sleepWithAbort(Math.min(pollMs, timeout), signal, backendName);
+    await sleepWithAbort(Math.min(pollMs, Math.max(0, deadline - Date.now())), signal, backendName);
   }
 }
 

--- a/src/backends/gemini-cli.js
+++ b/src/backends/gemini-cli.js
@@ -24,12 +24,12 @@ export function isAuthenticated() {
   // for `gemini -p` to run; checking both avoids false negatives.
   return (
     existsSync(join(homedir(), '.gemini', 'gemini-credentials.json')) ||
-    !!process.env.GEMINI_API_KEY
+    !!process.env.GEMINI_API_KEY?.trim()
   );
 }
 
 export function authHint() {
-  if (process.env.GEMINI_API_KEY) {
+  if (process.env.GEMINI_API_KEY?.trim()) {
     return 'Authenticated via GEMINI_API_KEY env var.';
   }
   return `Run \`${loginCommand}\` once interactively to log in via Google OAuth, or set GEMINI_API_KEY.`;

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -215,6 +215,11 @@ export async function invokeBackendChain({
   }
 
   let lastError = null;
+  // One shared deadline across both phases (slot-wait + run budget) so the
+  // combined wall-clock can never reach 2x `timeout` under cap saturation
+  // (#506 defect 1). withBackendConcurrencySlot hands the run phase whatever
+  // time remains after the slot wait.
+  const deadline = Number.isFinite(timeout) ? Date.now() + timeout : Infinity;
   for (let attemptIndex = 0; attemptIndex < backends.length; attemptIndex++) {
     const backend = backends[attemptIndex];
     const effectiveMaxConcurrency = resolveBackendMaxConcurrency(backend.name, maxConcurrency);
@@ -225,14 +230,15 @@ export async function invokeBackendChain({
         maxConcurrency: effectiveMaxConcurrency,
         signal,
         timeout,
-        fn: () => backend.invoke({
+        deadline,
+        fn: (remainingTimeout) => backend.invoke({
           prompt,
           apiKey,
           baseURL,
           model,
           modelSource,
           signal,
-          timeout,
+          timeout: remainingTimeout,
           maxRetries: effectiveMaxRetries,
           temperature,
           seed,

--- a/src/backends/kimi-cli.js
+++ b/src/backends/kimi-cli.js
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DEFAULT_BACKEND_TIMEOUT_MS, runInteractiveCommand } from './contract.js';
@@ -23,7 +23,7 @@ export function isAvailable() {
 export function isAuthenticated() {
   const root = kimiDataDir();
   return hasKimiCredential(root) ||
-    existsSync(join(root, 'config.toml')) ||
+    hasNonEmptyKimiConfig(root) ||
     KIMI_ENV_KEYS.some((key) => !!process.env[key]);
 }
 
@@ -191,6 +191,18 @@ function hasKimiCredential(root) {
   try {
     return readdirSync(join(root, 'credentials'), { withFileTypes: true })
       .some((entry) => entry.isFile() && entry.name.endsWith('.json'));
+  } catch {
+    return false;
+  }
+}
+
+// A logged-in Kimi CLI writes a populated config.toml. A bare/zero-byte file
+// is created by some workflows without an actual login, so requiring a
+// non-empty file avoids the false positive of "exists but empty" (#508 G8).
+// statSync throws on a missing path, so the catch also covers the absent case.
+function hasNonEmptyKimiConfig(root) {
+  try {
+    return statSync(join(root, 'config.toml')).size > 0;
   } catch {
     return false;
   }

--- a/tests/e2e/backends.test.js
+++ b/tests/e2e/backends.test.js
@@ -142,7 +142,14 @@ describe('Backend Fallback Chain', () => {
     });
 
     assert.strictEqual(result, 'ok');
-    assert.strictEqual(seenTimeout, DEFAULT_BACKEND_TIMEOUT_MS);
+    // The run phase now receives the time remaining on the single shared
+    // deadline (#506 defect 1), not a fresh full timeout. With an uncapped
+    // backend almost no time is deducted, so it is the full budget minus the
+    // sub-ms setup — never more than the budget.
+    assert.ok(
+      seenTimeout > DEFAULT_BACKEND_TIMEOUT_MS - 1000 && seenTimeout <= DEFAULT_BACKEND_TIMEOUT_MS,
+      `expected ~${DEFAULT_BACKEND_TIMEOUT_MS} remaining budget, got ${seenTimeout}`
+    );
   });
 
   it('passes backend retry defaults through the backend contract', async () => {
@@ -252,32 +259,69 @@ describe('Backend Fallback Chain', () => {
     assert.strictEqual(secondCalled, false);
   });
 
-  it('only treats AbortError as fallbackable for the first backend', async () => {
+  it('falls through timeout/abort errors at any non-final hop (#506 defect 2)', async () => {
+    const events = [];
+    const logger = { warn: (event, fields) => events.push({ event, ...fields }) };
+    const result = await invokeBackendChain({
+      backends: [
+        {
+          name: 'first',
+          invoke: async () => {
+            const err = new Error('timed out');
+            err.name = 'TimeoutError';
+            throw err;
+          },
+        },
+        {
+          name: 'second',
+          invoke: async () => {
+            const err = new Error('aborted internally');
+            err.name = 'AbortError';
+            throw err;
+          },
+        },
+        { name: 'third', invoke: async () => 'ok' },
+      ],
+      prompt: 'rewrite this',
+      logger,
+    });
+
+    // Previously the abort/timeout gate stopped fallback after the first hop;
+    // now it falls through at every non-final hop, just like 429/503 (#506).
+    assert.strictEqual(result, 'ok');
+    assert.deepStrictEqual(events.map((entry) => entry.event), ['backend.fallback', 'backend.fallback']);
+  });
+
+  it('surfaces the final-hop timeout instead of swallowing it (#506 defect 2)', async () => {
+    let thirdCalls = 0;
     await assert.rejects(
       invokeBackendChain({
         backends: [
           {
             name: 'first',
-            invoke: async () => {
-              const err = new Error('timeout');
-              err.name = 'AbortError';
-              throw err;
-            },
+            invoke: async () => { const e = new Error('t1'); e.name = 'TimeoutError'; throw e; },
           },
           {
             name: 'second',
+            invoke: async () => { const e = new Error('t2'); e.name = 'TimeoutError'; throw e; },
+          },
+          {
+            name: 'third',
             invoke: async () => {
-              const err = new Error('timeout again');
-              err.name = 'AbortError';
-              throw err;
+              thirdCalls += 1;
+              const e = new Error('final timeout');
+              e.name = 'TimeoutError';
+              throw e;
             },
           },
-          { name: 'third', invoke: async () => 'should not run' },
         ],
         prompt: 'rewrite this',
+        logger: { warn() {} },
       }),
-      /timeout again/
+      /final timeout/
     );
+    // The final hop runs (no `next` to fall through to) and its error surfaces.
+    assert.strictEqual(thirdCalls, 1);
   });
 });
 

--- a/tests/unit/backend-auth.test.js
+++ b/tests/unit/backend-auth.test.js
@@ -1,0 +1,116 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { isAuthenticated as kimiAuthenticated } from '../../src/backends/kimi-cli.js';
+import {
+  isAuthenticated as geminiAuthenticated,
+  authHint as geminiAuthHint,
+} from '../../src/backends/gemini-cli.js';
+
+// Snapshot/restore so these tests never leak env mutations to siblings.
+function withEnv(keys, body) {
+  const saved = {};
+  for (const key of keys) saved[key] = process.env[key];
+  try {
+    return body();
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+const KIMI_ENV = ['KIMI_API_KEY', 'MOONSHOT_API_KEY', 'KIMI_SHARE_DIR'];
+const GEMINI_ENV = ['GEMINI_API_KEY'];
+
+test('kimi isAuthenticated rejects a missing or zero-byte config.toml, accepts a populated one (#508 G8)', () => {
+  withEnv(KIMI_ENV, () => {
+    const dir = mkdtempSync(join(tmpdir(), 'patina-kimi-auth-'));
+    try {
+      // Neutralize the env-key and credentials-dir paths so config.toml decides.
+      delete process.env.KIMI_API_KEY;
+      delete process.env.MOONSHOT_API_KEY;
+      process.env.KIMI_SHARE_DIR = dir;
+
+      // No config file at all → not authenticated.
+      assert.equal(kimiAuthenticated(), false);
+
+      // Zero-byte config — the previously-broken "exists ⇒ authenticated" case.
+      writeFileSync(join(dir, 'config.toml'), '');
+      assert.equal(kimiAuthenticated(), false);
+
+      // A populated config → authenticated.
+      writeFileSync(join(dir, 'config.toml'), 'api_key = "sk-test"\n');
+      assert.equal(kimiAuthenticated(), true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+test('kimi isAuthenticated still honors an env key with no config file', () => {
+  withEnv(KIMI_ENV, () => {
+    const dir = mkdtempSync(join(tmpdir(), 'patina-kimi-auth-'));
+    try {
+      process.env.KIMI_SHARE_DIR = dir; // empty: no config, no credentials dir
+      delete process.env.MOONSHOT_API_KEY;
+      process.env.KIMI_API_KEY = 'sk-env';
+      assert.equal(kimiAuthenticated(), true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// os.homedir() ignores $HOME on this platform (it resolves via getpwuid), so the
+// OAuth-credentials path cannot be redirected to a temp dir. authHint() reads
+// only the env var, so it is the deterministic surface for the trim guard.
+test('gemini authHint treats a whitespace-only GEMINI_API_KEY as not authenticated (#508 G8)', () => {
+  withEnv(GEMINI_ENV, () => {
+    process.env.GEMINI_API_KEY = '   \t ';
+    assert.doesNotMatch(geminiAuthHint(), /Authenticated via GEMINI_API_KEY/);
+
+    process.env.GEMINI_API_KEY = '';
+    assert.doesNotMatch(geminiAuthHint(), /Authenticated via GEMINI_API_KEY/);
+
+    delete process.env.GEMINI_API_KEY;
+    assert.doesNotMatch(geminiAuthHint(), /Authenticated via GEMINI_API_KEY/);
+
+    process.env.GEMINI_API_KEY = 'AIza-real-key';
+    assert.match(geminiAuthHint(), /Authenticated via GEMINI_API_KEY/);
+  });
+});
+
+// The env-key half of isAuthenticated is only observable when the OAuth
+// credentials file is absent; otherwise that file short-circuits to true. Skip
+// (rather than flake) on hosts that already have a real Gemini login on disk.
+const geminiOAuthPresent = existsSync(join(homedir(), '.gemini', 'gemini-credentials.json'));
+
+test('gemini isAuthenticated requires a non-blank GEMINI_API_KEY when no OAuth file exists (#508 G8)', {
+  skip: geminiOAuthPresent ? 'Gemini OAuth credentials present on this host mask the env-key path' : false,
+}, () => {
+  withEnv(GEMINI_ENV, () => {
+    delete process.env.GEMINI_API_KEY;
+    assert.equal(geminiAuthenticated(), false);
+
+    process.env.GEMINI_API_KEY = '';
+    assert.equal(geminiAuthenticated(), false);
+
+    process.env.GEMINI_API_KEY = '   \t ';
+    assert.equal(geminiAuthenticated(), false);
+
+    process.env.GEMINI_API_KEY = 'AIza-real-key';
+    assert.equal(geminiAuthenticated(), true);
+  });
+});
+
+test('gemini isAuthenticated accepts a non-blank GEMINI_API_KEY (env path unchanged)', () => {
+  withEnv(GEMINI_ENV, () => {
+    process.env.GEMINI_API_KEY = 'AIza-real-key';
+    assert.equal(geminiAuthenticated(), true);
+  });
+});

--- a/tests/unit/backend-contract.test.js
+++ b/tests/unit/backend-contract.test.js
@@ -74,3 +74,81 @@ test('a concurrency slot held by a dead pid is reclaimed immediately (#445)', as
     rmSync(join(tmpdir(), `patina-backend-slots-${userSlotSegment()}`, backendName), { recursive: true, force: true });
   }
 });
+
+test('isRetryableBackendError falls through timeout/abort at any non-final hop (#506 defect 2)', () => {
+  // Previously gated to attemptIndex === 0; a per-attempt timeout/abort is now
+  // fallbackable at every hop, exactly like a 429/503. The chain caller stops
+  // at the final hop via `!next`, so the predicate itself carries no gate.
+  assert.equal(isRetryableBackendError({ name: 'TimeoutError' }, { attemptIndex: 1 }), true);
+  assert.equal(isRetryableBackendError({ name: 'TimeoutError' }, { attemptIndex: 2 }), true);
+  assert.equal(isRetryableBackendError({ name: 'AbortError' }, { attemptIndex: 3 }), true);
+  // Regression guard: the original first-hop case still works.
+  assert.equal(isRetryableBackendError({ name: 'AbortError' }, { attemptIndex: 0 }), true);
+  // A user-initiated abort (signal.aborted) must NEVER fall through, at any hop.
+  const aborted = { aborted: true }; // isRetryableBackendError only reads signal.aborted
+  assert.equal(isRetryableBackendError({ name: 'TimeoutError' }, { attemptIndex: 1, signal: aborted }), false);
+  assert.equal(isRetryableBackendError({ name: 'AbortError' }, { attemptIndex: 0, signal: aborted }), false);
+  // A plain, non-timeout/abort error stays non-retryable regardless of index.
+  assert.equal(isRetryableBackendError({ name: 'Error', message: 'boom' }, { attemptIndex: 1 }), false);
+});
+
+test('withBackendConcurrencySlot threads the remaining shared deadline into the run phase (#506 defect 1)', async () => {
+  const backendName = `test-deadline-${process.pid}-${Date.now()}`;
+  const slotRoot = join(tmpdir(), `patina-backend-slots-${userSlotSegment()}`, backendName);
+  mkdirSync(join(slotRoot, 'slot-0'), { recursive: true });
+  // A LIVE owner (this process) holds the only slot, so acquisition has to wait
+  // until we release it — simulating a saturated cap. A long staleMs ensures the
+  // age-based reclaim never fires; pid-liveness keeps the slot held until release.
+  writeFileSync(join(slotRoot, 'slot-0', 'owner.json'), JSON.stringify({ pid: process.pid, backendName }), 'utf8');
+
+  const budgetMs = 600;
+  const releaseAfterMs = 150;
+  const start = Date.now();
+  const releaser = setTimeout(() => {
+    rmSync(join(slotRoot, 'slot-0'), { recursive: true, force: true });
+  }, releaseAfterMs);
+
+  try {
+    let received = null;
+    const result = await withBackendConcurrencySlot({
+      backendName,
+      maxConcurrency: 1,
+      timeout: budgetMs,
+      deadline: start + budgetMs,
+      pollMs: 25,
+      staleMs: 60 * 60_000,
+      fn: async (remainingTimeout) => { received = remainingTimeout; return 'ran'; },
+    });
+    const waited = Date.now() - start;
+
+    assert.equal(result, 'ran');
+    // The run phase received a REDUCED budget — the slot wait was deducted from
+    // the single shared deadline, so it is strictly less than the full budget.
+    assert.ok(received > 0, `expected a positive remaining budget, got ${received}`);
+    assert.ok(received < budgetMs, `expected remaining < ${budgetMs}, got ${received}`);
+    // The defect: wait + run could each consume the full timeout (2x wall-clock).
+    // With one shared deadline, wait + remaining-run can never exceed the budget.
+    assert.ok(
+      waited + received <= budgetMs + 25,
+      `slot wait(${waited}) + run budget(${received}) exceeded shared budget ${budgetMs}`
+    );
+  } finally {
+    clearTimeout(releaser);
+    rmSync(join(tmpdir(), `patina-backend-slots-${userSlotSegment()}`, backendName), { recursive: true, force: true });
+  }
+});
+
+test('withBackendConcurrencySlot hands the full timeout to an uncapped backend when no deadline is given', async () => {
+  // Backward compatibility: callers that pass only `timeout` (no `deadline`)
+  // still drive the run phase with (essentially) the full budget. Infinite cap
+  // skips slot acquisition, so almost no time is deducted.
+  let received = null;
+  const result = await withBackendConcurrencySlot({
+    backendName: 'uncapped',
+    maxConcurrency: Infinity,
+    timeout: 5000,
+    fn: async (remainingTimeout) => { received = remainingTimeout; return 'ok'; },
+  });
+  assert.equal(result, 'ok');
+  assert.ok(received > 4000 && received <= 5000, `expected ~full budget, got ${received}`);
+});


### PR DESCRIPTION
## Summary
**#506 defect 1** — `invokeBackendChain` passed the same `timeout` to the slot-acquisition wait **and** the per-call run, so under cap saturation (cap-1 claude/kimi) wall-clock could reach **2× timeout**. Now threads one shared `deadline` through both phases; the run phase gets whatever remains after the slot wait. Backward compatible: callers passing only `timeout` get the full budget via a derived deadline.

**#506 defect 2** — `isRetryableBackendError` gated timeout/abort fallback to the first hop (`attemptIndex === 0`), so a 3-deep chain stopped short on timeouts. Timeout/abort now falls through at any non-final hop, exactly like 429/503 (the caller already stops at the final hop via `!next`). User-initiated aborts (`signal.aborted`) still never fall through.

**#508 G8** — `kimi` `isAuthenticated` requires a non-empty `config.toml` (not mere existence); `gemini` requires a non-blank `GEMINI_API_KEY` (trim).

## Verification
New unit tests for both defects + auth; full suite green; eslint + tsc clean.

Closes #506
Addresses #508 (G8)