### PR TITLE
fix(batch): route file-read errors through the circuit breaker + cap input size (#503, #508 G1)

### DIFF
--- a/src/cli/input.js
+++ b/src/cli/input.js
@@ -1,4 +1,4 @@
-import { loadInputText } from '../loader.js';
+import { loadInputText, MAX_INPUT_BYTES } from '../loader.js';
 import { inputError } from '../errors.js';
 
 // The second parameter used to be a logger for the stdin prompt; the prompt
@@ -32,8 +32,24 @@ export async function loadInputs(parsed, _logger) {
 
   const inputs = [];
   for (const file of parsed.files) {
-    const text = loadInputText(file);
-    inputs.push({ path: file, text });
+    if (parsed.batch) {
+      // Batch mode (#503): one unreadable file must not abort the whole run
+      // before the circuit breaker exists. Collect the typed read error and let
+      // run.js's per-file loop route it through recordFailure/shouldStop so
+      // --max-failures/--max-failure-rate stay in control (exit 2 still applies
+      // if the breaker trips or this is effectively a single-file batch).
+      try {
+        const text = loadInputText(file);
+        inputs.push({ path: file, text });
+      } catch (readError) {
+        inputs.push({ path: file, text: null, readError });
+      }
+    } else {
+      // Single-file mode stays fail-fast: surface the typed inputError (exit 2)
+      // immediately.
+      const text = loadInputText(file);
+      inputs.push({ path: file, text });
+    }
   }
   return inputs;
 }
@@ -41,10 +57,43 @@ export async function loadInputs(parsed, _logger) {
 function readStdin({ interactive = false } = {}) {
   return new Promise((resolve, reject) => {
     let data = '';
+    let bytes = 0;
     let cleanupSigint = () => {};
+
+    const onData = (chunk) => {
+      // Track bytes (not chars) so the cap matches the on-disk file cap and
+      // multi-byte input cannot silently slip past it (#508 G1).
+      bytes += Buffer.byteLength(chunk, 'utf8');
+      if (bytes > MAX_INPUT_BYTES) {
+        cleanup();
+        const mb = (MAX_INPUT_BYTES / (1024 * 1024)).toFixed(0);
+        reject(inputError(
+          'stdin input too large',
+          `Piped stdin exceeded the ${MAX_INPUT_BYTES}-byte (~${mb} MB) limit.`,
+          'Pass a file path instead of piping, or split the input into smaller chunks.'
+        ));
+        return;
+      }
+      data += chunk;
+    };
+    const onEnd = () => {
+      cleanup();
+      resolve(data);
+    };
+    const onError = (err) => {
+      cleanup();
+      reject(err);
+    };
+    function cleanup() {
+      cleanupSigint();
+      process.stdin.removeListener('data', onData);
+      process.stdin.removeListener('end', onEnd);
+      process.stdin.removeListener('error', onError);
+    }
+
     if (interactive) {
       const onSigint = () => {
-        cleanupSigint();
+        cleanup();
         const err = inputError(
           'interrupted',
           'Ctrl-C canceled interactive stdin before patina could process text.',
@@ -58,17 +107,9 @@ function readStdin({ interactive = false } = {}) {
       cleanupSigint = () => process.removeListener('SIGINT', onSigint);
     }
     process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => {
-      data += chunk;
-    });
-    process.stdin.on('end', () => {
-      cleanupSigint();
-      resolve(data);
-    });
-    process.stdin.on('error', (err) => {
-      cleanupSigint();
-      reject(err);
-    });
+    process.stdin.on('data', onData);
+    process.stdin.on('end', onEnd);
+    process.stdin.on('error', onError);
     if (interactive) process.stdin.resume();
   });
 }

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -188,10 +188,13 @@ export async function runDefault(parsed, logger) {
     return;
   }
 
-  const jobs = inputTexts.map(({ path, text }) => ({
+  const jobs = inputTexts.map(({ path, text, readError }) => ({
     path,
     text,
-    prompt: parsed.ouroboros ? null : buildPrompt({
+    readError,
+    // A read failure (#503) or ouroboros mode means there is no prompt to
+    // build; the read error is replayed inside the per-file batch loop below.
+    prompt: (readError || parsed.ouroboros) ? null : buildPrompt({
       config,
       patterns,
       profile: profile.body ? profile : null,
@@ -224,9 +227,12 @@ export async function runDefault(parsed, logger) {
 
   cancellation.install();
   try {
-    for (const { path, text, prompt } of jobs) {
+    for (const { path, text, prompt, readError } of jobs) {
       try {
         cancellation.throwIfCanceled();
+        // Route a deferred batch read failure (#503) into the per-file catch so
+        // it counts against the circuit breaker (batch) or rethrows (single).
+        if (readError) throw readError;
         let result;
 
         if (parsed.ouroboros) {

--- a/src/loader.js
+++ b/src/loader.js
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { resolve, sep } from 'node:path';
 import yaml from 'js-yaml';
 import { validateProfileName } from './security.js';
@@ -117,16 +117,62 @@ export function loadCoreFile(repoRoot, filename) {
 }
 
 /**
+ * Maximum size (in bytes) of a single input file patina will read into memory.
+ * Guards against accidental memory exhaustion on huge or binary inputs (#508 G1).
+ */
+export const MAX_INPUT_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Map a low-level fs error to a typed inputError that names the file path.
+ *
+ * @param {string} path File path that failed to read.
+ * @param {NodeJS.ErrnoException} err Underlying fs error.
+ * @returns {import('./errors.js').PatinaCliError} Typed input error (exit code 2).
+ */
+function mapInputReadError(path, err) {
+  const byCode = {
+    ENOENT: 'file not found',
+    EACCES: 'permission denied',
+    EISDIR: 'path is a directory',
+  };
+  const why = (err && byCode[err.code]) || (err && err.message) || 'unknown read error';
+  return inputError(
+    `cannot read input file: ${path}`,
+    `${path}: ${why}.`,
+    'Check the path, permissions, and that it points to a readable text file.'
+  );
+}
+
+/**
  * Read user input text from disk.
  *
  * @param {string} path Input file path.
+ * @param {number} [maxBytes=MAX_INPUT_BYTES] Reject files larger than this many bytes.
  * @returns {string} UTF-8 input text.
- * @throws {Error} When the file cannot be read.
+ * @throws {import('./errors.js').PatinaCliError} Typed inputError (exit 2) when the file is missing, unreadable, a directory, or over the size cap.
  * @example
  * const text = loadInputText('draft.md');
  */
-export function loadInputText(path) {
-  return readFileSync(path, 'utf8');
+export function loadInputText(path, maxBytes = MAX_INPUT_BYTES) {
+  let stats;
+  try {
+    stats = statSync(path);
+  } catch (err) {
+    throw mapInputReadError(path, err);
+  }
+  if (stats.size > maxBytes) {
+    const mb = (maxBytes / (1024 * 1024)).toFixed(0);
+    throw inputError(
+      `input file too large: ${path}`,
+      `The file is ${stats.size} bytes, over the ${maxBytes}-byte (~${mb} MB) limit.`,
+      'Split the document into smaller files or trim it before running patina.'
+    );
+  }
+  try {
+    return readFileSync(path, 'utf8');
+  } catch (err) {
+    throw mapInputReadError(path, err);
+  }
 }
 
 /**

--- a/tests/unit/input-loading.test.js
+++ b/tests/unit/input-loading.test.js
@@ -1,0 +1,184 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { loadInputText, MAX_INPUT_BYTES } from '../../src/loader.js';
+import { loadInputs } from '../../src/cli/input.js';
+import { createBatchCircuitBreaker } from '../../src/cli/batch.js';
+import { PatinaCliError } from '../../src/errors.js';
+
+function withTmpDir(run) {
+  const dir = mkdtempSync(join(tmpdir(), 'patina-input-'));
+  try {
+    return run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ── loadInputText: typed errors + size cap (#503, #508 G1) ───────────────────
+
+test('loadInputText reads a normal file', () => {
+  withTmpDir((dir) => {
+    const file = join(dir, 'ok.md');
+    writeFileSync(file, 'Hello, world.', 'utf8');
+    assert.equal(loadInputText(file), 'Hello, world.');
+  });
+});
+
+test('loadInputText maps a missing file to a typed inputError (exit 2)', () => {
+  withTmpDir((dir) => {
+    const missing = join(dir, 'nope.md');
+    assert.throws(
+      () => loadInputText(missing),
+      (err) => {
+        assert.ok(err instanceof PatinaCliError, 'is a PatinaCliError');
+        assert.equal(err.exitCode, 2, 'exits with code 2, not generic 1');
+        assert.match(err.message, /file not found/);
+        assert.ok(err.message.includes(missing), 'names the offending path');
+        return true;
+      }
+    );
+  });
+});
+
+test('loadInputText maps a directory path to a typed EISDIR inputError (exit 2)', () => {
+  withTmpDir((dir) => {
+    assert.throws(
+      () => loadInputText(dir),
+      (err) => {
+        assert.ok(err instanceof PatinaCliError);
+        assert.equal(err.exitCode, 2);
+        assert.match(err.message, /path is a directory/);
+        return true;
+      }
+    );
+  });
+});
+
+test('loadInputText rejects a file above the size cap with a typed inputError (exit 2)', () => {
+  withTmpDir((dir) => {
+    const file = join(dir, 'big.md');
+    writeFileSync(file, 'this is more than four bytes', 'utf8');
+    // Inject a tiny cap so the oversize branch runs deterministically without
+    // materializing a 25 MB fixture.
+    assert.throws(
+      () => loadInputText(file, 4),
+      (err) => {
+        assert.ok(err instanceof PatinaCliError);
+        assert.equal(err.exitCode, 2);
+        assert.match(err.message, /too large/);
+        return true;
+      }
+    );
+    // The same file is fine under the real (generous) cap.
+    assert.equal(loadInputText(file), 'this is more than four bytes');
+  });
+});
+
+test('MAX_INPUT_BYTES is the documented 25 MB cap', () => {
+  assert.equal(MAX_INPUT_BYTES, 25 * 1024 * 1024);
+});
+
+// ── loadInputs: batch collects read errors, single-file fails fast (#503) ────
+
+test('loadInputs in batch mode collects a read error instead of aborting the loop', async () => {
+  await withTmpDir(async (dir) => {
+    const okA = join(dir, 'a.md');
+    const missing = join(dir, 'missing.md');
+    const okB = join(dir, 'b.md');
+    writeFileSync(okA, 'A', 'utf8');
+    writeFileSync(okB, 'B', 'utf8');
+
+    const inputs = await loadInputs({ files: [okA, missing, okB], batch: true }, null);
+
+    // All three files still produce an entry — the bad one did not abort the run.
+    assert.equal(inputs.length, 3);
+
+    assert.equal(inputs[0].text, 'A');
+    assert.equal(inputs[0].readError, undefined);
+
+    assert.equal(inputs[1].text, null);
+    assert.ok(inputs[1].readError instanceof PatinaCliError);
+    assert.equal(inputs[1].readError.exitCode, 2);
+    assert.match(inputs[1].readError.message, /file not found/);
+
+    assert.equal(inputs[2].text, 'B');
+    assert.equal(inputs[2].readError, undefined);
+  });
+});
+
+test('loadInputs in non-batch mode fails fast on the first unreadable file', async () => {
+  await withTmpDir(async (dir) => {
+    const okA = join(dir, 'a.md');
+    const missing = join(dir, 'missing.md');
+    const okB = join(dir, 'b.md');
+    writeFileSync(okA, 'A', 'utf8');
+    writeFileSync(okB, 'B', 'utf8');
+
+    await assert.rejects(
+      () => loadInputs({ files: [okA, missing, okB], batch: false }, null),
+      (err) => {
+        assert.ok(err instanceof PatinaCliError);
+        assert.equal(err.exitCode, 2);
+        assert.match(err.message, /file not found/);
+        return true;
+      }
+    );
+  });
+});
+
+// ── #503 end-to-end contract: read failures flow through the circuit breaker ─
+
+test('a batch read failure counts against the budget and lets readable files process', async () => {
+  await withTmpDir(async (dir) => {
+    const okA = join(dir, 'a.md');
+    const missing = join(dir, 'missing.md');
+    const okB = join(dir, 'b.md');
+    writeFileSync(okA, 'A', 'utf8');
+    writeFileSync(okB, 'B', 'utf8');
+
+    const parsed = { files: [okA, missing, okB], batch: true, maxFailures: 5, maxFailureRate: 1 };
+    const inputs = await loadInputs(parsed, null);
+    const breaker = createBatchCircuitBreaker({ parsed, total: inputs.length });
+
+    // Mirror run.js's per-file loop: replay readError as a recorded failure.
+    let processed = 0;
+    for (const { readError } of inputs) {
+      if (readError) {
+        breaker.recordFailure({ path: 'x', err: readError });
+        assert.equal(breaker.shouldStop(), false, 'one read failure under budget does not abort');
+      } else {
+        breaker.recordSuccess();
+        processed++;
+      }
+    }
+
+    assert.equal(processed, 2, 'both readable files were processed');
+    assert.equal(breaker.failures.length, 1, 'exactly one failure recorded');
+    assert.equal(breaker.shouldStop(), false);
+  });
+});
+
+test('a batch read failure trips --max-failures 1 like any other per-file failure', async () => {
+  await withTmpDir(async (dir) => {
+    const okA = join(dir, 'a.md');
+    const missing = join(dir, 'missing.md');
+    writeFileSync(okA, 'A', 'utf8');
+
+    const parsed = { files: [okA, missing], batch: true, maxFailures: 1 };
+    const inputs = await loadInputs(parsed, null);
+    const breaker = createBatchCircuitBreaker({ parsed, total: inputs.length });
+
+    const failed = inputs.find((entry) => entry.readError);
+    assert.ok(failed, 'missing file surfaced a readError entry');
+    breaker.recordFailure({ path: failed.path, err: failed.readError });
+
+    // The read failure now participates in the documented breaker contract
+    // instead of crashing the run with a raw exit 1 (#503).
+    assert.equal(breaker.shouldStop(), true);
+    assert.match(breaker.toError().message, /max failures reached \(1\/1\)/);
+  });
+});


### PR DESCRIPTION
## Summary
**#503** — in `--batch` mode all inputs were read eagerly before the circuit breaker existed, so one unreadable file threw a raw fs `ENOENT` that aborted the whole run (bypassing `--max-failures`/`--max-failure-rate`) and exited 1 with a generic message. `loadInputText` now maps fs errors to a typed `inputError` (exit 2) naming the path; `loadInputs` collects per-file read errors in batch mode and `run.js` replays them inside the per-file loop so they count against the breaker (or rethrow for a single-file run). Non-batch stays fail-fast.

**#508 G1** — cap single-file reads (`statSync` vs `MAX_INPUT_BYTES` = 25 MB) and bound unbounded stdin growth (byte-counted) with typed `inputError`s.

## Verification
New unit tests incl. read-failure flowing through `--max-failures`; full suite green; eslint + tsc clean.

Closes #503
Addresses #508 (G1)