### PR TITLE
fix(batch): reject empty --suffix=/--outdir= and warn on ambiguous failure-rate (#504, #508 G4)

### DIFF
--- a/src/cli/args.js
+++ b/src/cli/args.js
@@ -487,6 +487,24 @@ export function validateOutputRouting(parsed) {
       'Pick one of --in-place, --suffix, or --outdir.'
     );
   }
+  // An empty value (e.g. `--suffix=` or `--outdir=`) passes the
+  // `!== undefined` destination check above but is falsy, so writeBatchOutput
+  // would silently fall through to stdout (#504). Reject it here so the
+  // validator's "present" guarantee matches writeBatchOutput's truthiness gate.
+  if (parsed.suffix === '') {
+    throw inputError(
+      '--suffix requires a non-empty value',
+      'An empty --suffix= would leave the filename unchanged and silently print to stdout instead of writing files.',
+      'Pass a suffix like --suffix .patina (writes draft.patina.md).'
+    );
+  }
+  if (parsed.outdir === '') {
+    throw inputError(
+      '--outdir requires a non-empty value',
+      'An empty --outdir= would silently print to stdout instead of writing files.',
+      'Pass a directory like --outdir out/.'
+    );
+  }
   if (parsed.outdir !== undefined) {
     const seen = new Map();
     for (const file of parsed.files) {
@@ -563,6 +581,14 @@ function parseFailureRateOption(value, option) {
       `Received "${value}".`,
       `Use ${option} 0.25 for 25%, or ${option} 25.`
     );
+  }
+  // A value in the open (1, 2) interval is ambiguous: it is too big to be a
+  // ratio (>1) so it is read as a percent, but a tiny one (1.5 -> 1.5% -> 0.015)
+  // almost certainly is not what the user meant (#508 G4). Stay backward
+  // compatible (no throw) but surface the interpretation so the mistake is
+  // visible instead of silent.
+  if (n > 1 && n < 2) {
+    process.stderr.write(`[patina] --max-failure-rate ${value} read as ${n}% (ratio ${ratio}). Use a value <=1 for a ratio (0.015 = 1.5%) or >=2 for a clear percent.\n`);
   }
   return ratio;
 }

--- a/src/cli/batch.js
+++ b/src/cli/batch.js
@@ -149,6 +149,9 @@ export async function writeBatchOutput(parsed, inputPath, output) {
     return;
   }
 
+  // suffix/outdir are gated on truthiness below. validateOutputRouting (#504)
+  // rejects empty-string suffix/outdir before we get here, so an empty value
+  // can never reach the silent stdout fallback — the two layers agree.
   let outPath;
   if (parsed.inPlace) {
     outPath = inputPath;

--- a/tests/unit/cli-args.test.js
+++ b/tests/unit/cli-args.test.js
@@ -104,3 +104,92 @@ test('applyScoreGate throws a typed runtime error when overall is missing (#440)
   assert.match(err.what, /score gate could not find a numeric overall value/);
   assert.match(err.action, /--format json/);
 });
+
+test('empty --suffix=/--outdir= is rejected instead of silently printing to stdout (#504)', () => {
+  // The bug: '' passes the `!== undefined` destination check but is falsy, so
+  // writeBatchOutput fell through to stdout (no files written, no error).
+  let suffixErr;
+  try {
+    validateOutputRouting(parseArgs(['--batch', '--suffix=', 'a.md', 'b.md']));
+  } catch (e) {
+    suffixErr = e;
+  }
+  assert.ok(suffixErr instanceof PatinaCliError);
+  assert.equal(suffixErr.exitCode, 2);
+  assert.match(suffixErr.what, /--suffix requires a non-empty value/);
+
+  let outdirErr;
+  try {
+    validateOutputRouting(parseArgs(['--batch', '--outdir=', 'a.md', 'b.md']));
+  } catch (e) {
+    outdirErr = e;
+  }
+  assert.ok(outdirErr instanceof PatinaCliError);
+  assert.equal(outdirErr.exitCode, 2);
+  assert.match(outdirErr.what, /--outdir requires a non-empty value/);
+
+  // The existing 'requires --batch' and 'cannot be combined' errors still take
+  // precedence over the empty-value check.
+  assert.throws(
+    () => validateOutputRouting(parseArgs(['--suffix=', 'a.md'])),
+    /--suffix requires --batch/,
+  );
+  assert.throws(
+    () => validateOutputRouting(parseArgs(['--batch', '--suffix=', '--outdir', 'out', 'a.md'])),
+    /--suffix and --outdir cannot be combined/,
+  );
+});
+
+test('valid non-empty --suffix/--outdir still pass routing validation (#504)', () => {
+  validateOutputRouting(parseArgs(['--batch', '--suffix=.patina', 'a.md', 'b.md']));
+  validateOutputRouting(parseArgs(['--batch', '--suffix', '-humanized', 'a.md', 'b.md']));
+  validateOutputRouting(parseArgs(['--batch', '--outdir=out', 'a.md', 'b.md']));
+  validateOutputRouting(parseArgs(['--batch', '--outdir', 'out/', 'a.md', 'b.md']));
+  // --in-place takes no value and is unaffected.
+  validateOutputRouting(parseArgs(['--batch', '--in-place', 'a.md', 'b.md']));
+});
+
+test('--max-failure-rate in the ambiguous (1,2) interval warns but still returns the percent ratio (#508 G4)', () => {
+  const original = process.stderr.write;
+  const lines = [];
+  process.stderr.write = (chunk) => {
+    lines.push(String(chunk));
+    return true;
+  };
+  let parsed;
+  try {
+    parsed = parseArgs(['--max-failure-rate', '1.5']);
+  } finally {
+    process.stderr.write = original;
+  }
+  // Backward compatible: 1.5 is still read as 1.5% -> ratio 0.015 (no throw).
+  assert.equal(parsed.maxFailureRate, 0.015);
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /\[patina\] --max-failure-rate 1\.5 read as 1\.5% \(ratio 0\.015\)/);
+  assert.match(lines[0], /Use a value <=1 for a ratio/);
+});
+
+test('--max-failure-rate values outside (1,2) do not warn (#508 G4)', () => {
+  const original = process.stderr.write;
+  const lines = [];
+  process.stderr.write = (chunk) => {
+    lines.push(String(chunk));
+    return true;
+  };
+  let ratios;
+  try {
+    ratios = {
+      // ratio form (<=1): no percent reinterpretation, no warning.
+      quarter: parseArgs(['--max-failure-rate', '0.25']).maxFailureRate,
+      // clear percent (>=2): unambiguous, no warning.
+      twentyFive: parseArgs(['--max-failure-rate', '25']).maxFailureRate,
+      twoPointFive: parseArgs(['--max-failure-rate', '2.5']).maxFailureRate,
+    };
+  } finally {
+    process.stderr.write = original;
+  }
+  assert.equal(ratios.quarter, 0.25);
+  assert.equal(ratios.twentyFive, 0.25);
+  assert.equal(ratios.twoPointFive, 0.025);
+  assert.deepEqual(lines, []);
+});


### PR DESCRIPTION
## Summary
**#504** — `validateOutputRouting` treated a destination as present with `!== undefined`, but `writeBatchOutput` gates the write on truthiness, so an empty `--suffix=` / `--outdir=` passed validation and then silently fell through to stdout (no files written, no error). Now rejects empty-string suffix/outdir with a typed `inputError` so the validator's "present" guarantee matches the write gate.

**#508 G4** — `--max-failure-rate` values in the open (1, 2) interval are read as a tiny percent (1.5 → 0.015 = 1.5%), almost certainly not the user's intent. Emits a one-line stderr heads-up explaining the interpretation; behavior unchanged (no throw).

## Verification
New unit tests for empty routing + the (1,2) warning; full suite green; eslint + tsc clean.

Closes #504
Addresses #508 (G4)