### PR TITLE
fix: low-severity robustness footguns (#508 G3, G5, G7, G9)

### DIFF
--- a/src/browser-diff.js
+++ b/src/browser-diff.js
@@ -131,6 +131,17 @@ export function serveBrowserDiffPage(html, options = {}) {
         signal?.addEventListener?.('abort', close, { once: true });
         resetIdleTimer();
       }
+      // Startup errors (e.g. EADDRINUSE) already rejected via rejectServer.
+      // Once listening, the outer promise is resolved, so a later socket error
+      // would be swallowed — surface it through the logger and shut down.
+      server.removeListener('error', rejectServer);
+      server.on('error', (err) => {
+        const logger = options.logger;
+        const msg = `[patina] local preview server error: ${err?.message || err}`;
+        if (logger?.warn) logger.warn('serve.socket_error', { message: msg });
+        else process.stderr.write(msg + '\n');
+        close();
+      });
       resolveServer({
         url: `http://127.0.0.1:${port}${pagePath}`,
         close,

--- a/src/config.js
+++ b/src/config.js
@@ -36,7 +36,7 @@ export function loadConfig(path = resolve(REPO_ROOT, '.patina.default.yaml'), { 
   const config = parsed;
 
   // User config: ~/.patina.yaml (global), then ./.patina.yaml (project, takes precedence).
-  for (const userPath of [resolve(homedir(), '.patina.yaml'), resolve(process.cwd(), '.patina.yaml')]) {
+  for (const userPath of [...new Set([resolve(homedir(), '.patina.yaml'), resolve(process.cwd(), '.patina.yaml')])]) {
     if (!existsSync(userPath)) continue;
     mergeYamlMapping(config, userPath, 'User config');
   }

--- a/src/logger.js
+++ b/src/logger.js
@@ -29,13 +29,14 @@ export function createLogger({
   const emit = (levelName, event, fields = {}) => {
     if (LEVELS[levelName] < threshold) return;
     closeProgress();
-    if (!fields.message) return;
+    const text = fields.message || event;
+    if (!text) return;
     // Honor an injected custom stream (tests, child loggers) like progress/
     // closeProgress already do, instead of always hardcoding stderr (#449). The
     // default process.stderr stays on console.error so the common path keeps a
     // single write API on that fd.
-    if (stream && stream !== process.stderr) stream.write(`${fields.message}\n`);
-    else console.error(fields.message);
+    if (stream && stream !== process.stderr) stream.write(`${text}\n`);
+    else console.error(text);
   };
 
   const progress = (_event, fields = {}) => {

--- a/src/ocr.js
+++ b/src/ocr.js
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync, copyFileSync, readFileSync, statSync, chmodSync, existsSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, copyFileSync, readFileSync, statSync, chmodSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -284,73 +284,78 @@ export async function stageOcrImages(candidates, options = {}) {
   const skipped = [];
   let spent = 0;
   let budgetExhausted = false;
-  for (const [index, candidate] of candidates.entries()) {
-    if (signal?.aborted) break;
-    if (budgetExhausted) {
-      skipped.push({ candidate, reason: 'total image budget reached' });
-      continue;
-    }
-    try {
-      let bytes;
-      let ext = candidate.ext;
-      if (candidate.kind === 'data') {
-        bytes = Buffer.from(candidate.dataUri.slice(candidate.dataUri.indexOf(',') + 1), 'base64');
-      } else if (candidate.kind === 'file') {
-        const filePath = fileURLToPath(candidate.url);
-        const size = statSync(filePath).size;
-        if (size > maxBytes) throw new Error(tooBig);
-        if (spent + size > totalBudget) {
+  try {
+    for (const [index, candidate] of candidates.entries()) {
+      if (signal?.aborted) break;
+      if (budgetExhausted) {
+        skipped.push({ candidate, reason: 'total image budget reached' });
+        continue;
+      }
+      try {
+        let bytes;
+        let ext = candidate.ext;
+        if (candidate.kind === 'data') {
+          bytes = Buffer.from(candidate.dataUri.slice(candidate.dataUri.indexOf(',') + 1), 'base64');
+        } else if (candidate.kind === 'file') {
+          const filePath = fileURLToPath(candidate.url);
+          const size = statSync(filePath).size;
+          if (size > maxBytes) throw new Error(tooBig);
+          if (spent + size > totalBudget) {
+            skipped.push({ candidate, reason: 'total image budget reached' });
+            budgetExhausted = true;
+            continue;
+          }
+          const target = join(dir, `img-${index}.${candidate.ext}`);
+          copyFileSync(filePath, target);
+          try { chmodSync(target, 0o600); } catch {}
+          spent += size;
+          staged.push({ ...candidate, path: target, bytes: size });
+          continue;
+        } else {
+          // Image URLs come from page content, so a hostile page must not be
+          // able to use --ocr to probe cloud metadata or internal services.
+          if (!(await isSubresourceFetchAllowed(candidate.url, { baseUrl, lookupImpl }))) {
+            skipped.push({ candidate, reason: 'private/internal address blocked' });
+            continue;
+          }
+          // Cap by streaming at the per-image limit: never trust Content-Length
+          // presence/value, and bound an unbounded chunked stream before it
+          // exhausts memory. The total budget is enforced below. Redirect hops
+          // are re-guarded so a public image URL cannot 30x into private space.
+          bytes = await fetchCappedBytes(fetchImpl, candidate.url, {
+            signal,
+            maxBytes,
+            fetchTimeoutMs,
+            tooBig,
+            guardHop: (next) => isSubresourceFetchAllowed(next, { baseUrl, lookupImpl }),
+          });
+          if (!ext) {
+            // Extension-less CDN URL: identify the format from the bytes.
+            ext = sniffImageType(bytes);
+            if (!ext) throw new Error('not a recognizable image (jpg/png/webp/gif)');
+          }
+        }
+        if (bytes.length > maxBytes) throw new Error(tooBig);
+        if (spent + bytes.length > totalBudget) {
           skipped.push({ candidate, reason: 'total image budget reached' });
           budgetExhausted = true;
           continue;
         }
-        const target = join(dir, `img-${index}.${candidate.ext}`);
-        copyFileSync(filePath, target);
+        const target = join(dir, `img-${index}.${ext}`);
+        writeFileSync(target, bytes);
         try { chmodSync(target, 0o600); } catch {}
-        spent += size;
-        staged.push({ ...candidate, path: target, bytes: size });
-        continue;
-      } else {
-        // Image URLs come from page content, so a hostile page must not be
-        // able to use --ocr to probe cloud metadata or internal services.
-        if (!(await isSubresourceFetchAllowed(candidate.url, { baseUrl, lookupImpl }))) {
-          skipped.push({ candidate, reason: 'private/internal address blocked' });
-          continue;
-        }
-        // Cap by streaming at the per-image limit: never trust Content-Length
-        // presence/value, and bound an unbounded chunked stream before it
-        // exhausts memory. The total budget is enforced below. Redirect hops
-        // are re-guarded so a public image URL cannot 30x into private space.
-        bytes = await fetchCappedBytes(fetchImpl, candidate.url, {
-          signal,
-          maxBytes,
-          fetchTimeoutMs,
-          tooBig,
-          guardHop: (next) => isSubresourceFetchAllowed(next, { baseUrl, lookupImpl }),
-        });
-        if (!ext) {
-          // Extension-less CDN URL: identify the format from the bytes.
-          ext = sniffImageType(bytes);
-          if (!ext) throw new Error('not a recognizable image (jpg/png/webp/gif)');
-        }
+        spent += bytes.length;
+        staged.push({ ...candidate, ext, path: target, bytes: bytes.length });
+      } catch (err) {
+        if (signal?.aborted) break;
+        skipped.push({ candidate, reason: err?.message || 'fetch failed' });
       }
-      if (bytes.length > maxBytes) throw new Error(tooBig);
-      if (spent + bytes.length > totalBudget) {
-        skipped.push({ candidate, reason: 'total image budget reached' });
-        budgetExhausted = true;
-        continue;
-      }
-      const target = join(dir, `img-${index}.${ext}`);
-      writeFileSync(target, bytes);
-      try { chmodSync(target, 0o600); } catch {}
-      spent += bytes.length;
-      staged.push({ ...candidate, ext, path: target, bytes: bytes.length });
-    } catch (err) {
-      if (signal?.aborted) break;
-      skipped.push({ candidate, reason: err?.message || 'fetch failed' });
     }
+    return { dir, staged, skipped };
+  } catch (err) {
+    rmSync(dir, { recursive: true, force: true });
+    throw err;
   }
-  return { dir, staged, skipped };
 }
 
 // Magic-byte sniffing for extension-less candidates: the format comes from

--- a/tests/unit/browser-diff.test.js
+++ b/tests/unit/browser-diff.test.js
@@ -183,3 +183,47 @@ test('serveBrowserDiffPage closes when the abort signal fires', async () => {
   await done;
   await assert.rejects(() => fetch(url));
 });
+
+test('serveBrowserDiffPage surfaces post-listen socket errors to the logger and shuts down (G9)', async () => {
+  let serverCloseCalls = 0;
+  class FakeServer extends EventEmitter {
+    listen(_port, _host, cb) {
+      // Mimic the async "listening" callback the real http.Server emits.
+      process.nextTick(cb);
+      return this;
+    }
+
+    address() {
+      return { port: 4321 };
+    }
+
+    close(cb) {
+      serverCloseCalls += 1;
+      if (cb) cb();
+      return this;
+    }
+  }
+
+  const fake = new FakeServer();
+  const warnings = [];
+  const logger = { warn: (event, fields) => warnings.push({ event, fields }) };
+
+  const { url, done } = await serveBrowserDiffPage('<html/>', {
+    createServer: () => fake,
+    randomToken: () => 'tok',
+    idleTimeoutMs: 60_000,
+    logger,
+  });
+  assert.match(url, /^http:\/\/127\.0\.0\.1:4321\/tok\/$/);
+
+  // After listening, the startup reject handler is gone and the post-listen
+  // handler turns a runtime socket error into a logged warning + shutdown,
+  // instead of swallowing it against the already-resolved outer promise.
+  fake.emit('error', new Error('boom'));
+  await done;
+
+  assert.strictEqual(warnings.length, 1);
+  assert.strictEqual(warnings[0].event, 'serve.socket_error');
+  assert.match(warnings[0].fields.message, /local preview server error: boom/);
+  assert.ok(serverCloseCalls >= 1, 'a socket error should shut the server down');
+});

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -79,3 +79,20 @@ test('loadConfig: non-additive arrays replace so exact list values remain contro
     assert.deepEqual(config['model-list'], ['codex']);
   });
 });
+
+test('loadConfig: when HOME equals cwd the shared .patina.yaml is applied once, not twice (G5)', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'patina-config-same-'));
+  const defaultPath = join(root, 'default.yaml');
+  writeFileSync(defaultPath, 'tone: auto\n');
+  // blocklist is an additive list key whose union dedupes primitives, so a
+  // double-merge of the same file is only observable with object entries:
+  // each YAML parse yields fresh object identities the Set cannot collapse.
+  // With HOME === cwd the two candidate paths resolve equal and must dedupe.
+  writeFileSync(join(root, '.patina.yaml'), 'blocklist:\n  - term: shared-entry\n');
+
+  await withEnv({ home: root, cwd: root }, async () => {
+    const config = loadConfig(defaultPath);
+    assert.strictEqual(config.blocklist.length, 1);
+    assert.deepStrictEqual(config.blocklist, [{ term: 'shared-entry' }]);
+  });
+});

--- a/tests/unit/logger.test.js
+++ b/tests/unit/logger.test.js
@@ -24,3 +24,22 @@ test('logger respects quiet and PATINA_LOG_LEVEL', () => {
     else process.env.PATINA_LOG_LEVEL = previous;
   }
 });
+
+test('logger falls back to the structured event name when no message is provided (G3)', () => {
+  const cap = captureStream();
+  const logger = createLogger({ stream: cap.stream, level: 'info' });
+  // Previously dropped silently because emit() short-circuited on a missing
+  // message; now the event name is written instead.
+  logger.warn('some.event', { code: 42 });
+  // A message-bearing call is unchanged: the message still wins over the event.
+  logger.warn('explicit', { message: '[patina] explicit message' });
+  assert.deepEqual(cap.lines, ['some.event', '[patina] explicit message']);
+});
+
+test('logger still drops an event with neither a message nor an event name', () => {
+  const cap = captureStream();
+  const logger = createLogger({ stream: cap.stream, level: 'info' });
+  logger.warn('');
+  logger.warn(undefined, { code: 1 });
+  assert.deepEqual(cap.lines, []);
+});

--- a/tests/unit/ocr.test.js
+++ b/tests/unit/ocr.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, readdirSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -284,5 +284,29 @@ test('file: image candidates are confined to the previewed file directory (#447)
     assert.equal(urls.includes(outsideUrl), false, 'out-of-tree absolute path rejected');
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('stageOcrImages removes the temp dir when the body throws before returning (G7)', async () => {
+  // Point os.tmpdir() at an isolated sandbox so we can prove the staging temp
+  // dir was created and then cleaned up. The dir leaks on the buggy path
+  // because the caller never receives `dir` when the function throws.
+  const sandbox = mkdtempSync(join(tmpdir(), 'patina-ocr-sandbox-'));
+  const prevTmp = process.env.TMPDIR;
+  process.env.TMPDIR = sandbox;
+  try {
+    // Forces a throw inside the outer try but before the per-candidate inner
+    // try, so the catch's rmSync(dir) is exercised.
+    const exploding = { entries() { throw new Error('forced staging failure'); } };
+    await assert.rejects(
+      () => stageOcrImages(exploding, { lookupImpl: PUBLIC_LOOKUP }),
+      /forced staging failure/,
+    );
+    const leftovers = readdirSync(sandbox).filter((name) => name.startsWith('patina-ocr-'));
+    assert.deepStrictEqual(leftovers, [], 'temp dir should be removed after a throw');
+  } finally {
+    if (prevTmp === undefined) delete process.env.TMPDIR;
+    else process.env.TMPDIR = prevTmp;
+    rmSync(sandbox, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
Low-severity robustness fixes from the #508 roundup:

- **G3 logger** — emit the structured event name when a log call has no `message`, instead of dropping the event entirely (an error path could swallow its own diagnostic).
- **G5 config** — dedupe the user-config path list so a run from `$HOME` does not merge `~/.patina.yaml` twice.
- **G7 ocr** — wrap `stageOcrImages`'s body in try/catch so a throw between `mkdtempSync` and the return removes the 0700 temp dir instead of leaking it.
- **G9 browser-diff** — after the `--serve` socket is listening, swap the `error` handler so a runtime socket error is surfaced (logger/stderr) and shuts the server down, instead of rejecting an already-resolved promise (silent no-op).

## Verification
New unit tests for each (logger event fallback, config single-merge, ocr cleanup-on-throw, serve socket error surfaced); full suite green; eslint + tsc clean.

Addresses #508 (G3, G5, G7, G9)