### PR TITLE
test(e2e): clean up the cli-api mock API-key temp dir in after()

### DIFF
--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -16,6 +16,7 @@ const REPO_ROOT = resolve(__dirname, '../..');
 
 let mock;
 let mockApiKeyPath;
+let keyDir;
 
 async function captureConsole(fn) {
   const logs = [];
@@ -62,13 +63,14 @@ async function withEnv(envOverrides, fn) {
 describe('CLI End-to-End with Mock API', () => {
   before(async () => {
     mock = await startMockServer('This is the humanized result.');
-    const keyDir = mkdtempSync(join(tmpdir(), 'patina-api-key-'));
+    keyDir = mkdtempSync(join(tmpdir(), 'patina-api-key-'));
     mockApiKeyPath = resolve(keyDir, 'key.txt');
     writeFileSync(mockApiKeyPath, 'test-key\n');
   });
 
   after(async () => {
     await mock.stop();
+    if (keyDir) rmSync(keyDir, { recursive: true, force: true });
   });
 
   it('should call LLM API with correct prompt structure', async () => {


### PR DESCRIPTION
## Summary
`before()` created a per-suite temp dir via `mkdtempSync` but stored it in a local `const`, so it was never removed — a temp-dir leak (same class as the #508 G7 fix). Hoist `keyDir` to suite scope and `rmSync` it in `after()`, matching the cleanup pattern every other temp dir in this file already uses.

## Verification
`node --test tests/e2e/cli-api.test.js` → 26/26 pass; `rmSync` already imported.