### PR TITLE
fix(cli): getProcessExitCode in the self-invoke guard for score-gate exit parity (#526)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,7 @@ import { runDoctor } from './commands/doctor.js';
 import { handleAuth, printBackendStatus } from './commands/auth.js';
 import { parseArgs, validateModeExclusivity, validateServeRequest, validatePreviewRequest, validateOutputRouting, validateTransformRequest, printHelp } from './cli/args.js';
 import { runDefault } from './cli/run.js';
-import { inputError, renderCliError, getExitCode } from './errors.js';
+import { inputError, renderCliError, getProcessExitCode } from './errors.js';
 import { createLogger } from './logger.js';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -87,6 +87,6 @@ export async function main(args) {
 if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
   main(process.argv.slice(2)).catch((err) => {
     createLogger().error('cli.error', { message: renderCliError(err) });
-    process.exit(getExitCode(err));
+    process.exit(getProcessExitCode(err));
   });
 }


### PR DESCRIPTION
## What

The #526 fix routed `bin/patina.js` through `getProcessExitCode` so a `--score --exit-on` gate result (exit **3**) is no longer masked by a non-fatal batch-summary error (exit **1**). But the `src/cli.js` self-invocation guard (used when run as `node src/cli.js …`) still called the plain `getExitCode`, so the same masking persisted on that secondary entrypoint — the missed-sibling follow-up noted in #527 ([comment](https://github.com/devswha/patina/issues/527#issuecomment-4732305244)).

This uses `getProcessExitCode` there too for parity.

## Impact

No user-facing change — the installed `patina` binary goes through `bin/patina.js` (already fixed). This closes the residual on the dev/`node src/cli.js` path.

## Verification

- `npm run lint` clean
- `npm test` → 834 pass / 0 fail / 1 skip
- Behavior: with `process.exitCode = 3` + a thrown exit-1 runtime error, `getProcessExitCode → 3` (old `getExitCode → 1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)