### PR TITLE
fix: low-severity runtime roundup #2 (#527 H1-H14)

### DIFF
--- a/src/backends/claude-cli.js
+++ b/src/backends/claude-cli.js
@@ -83,9 +83,13 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
 
     let settled = false;
     let cleanupSignal = () => {};
-    const timer = setTimeout(() => {
-      finishReject(new Error(`claude-cli backend: timed out after ${timeout}ms`), { kill: true });
-    }, timeout);
+    // A non-finite timeout means "no timeout" — without this guard Node clamps
+    // setTimeout(fn, Infinity) to 1ms and the child is SIGKILLed ~immediately (#527 H13).
+    const timer = Number.isFinite(timeout)
+      ? setTimeout(() => {
+        finishReject(new Error(`claude-cli backend: timed out after ${timeout}ms`), { kill: true });
+      }, timeout)
+      : null;
     if (signal) {
       const onAbort = () => finishReject(abortError('claude-cli backend: aborted'), { kill: true });
       signal.addEventListener('abort', onAbort, { once: true });

--- a/src/backends/codex-cli.js
+++ b/src/backends/codex-cli.js
@@ -90,9 +90,13 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
 
     let settled = false;
     let cleanupSignal = () => {};
-    const timer = setTimeout(() => {
-      finishReject(new Error(`codex-cli backend: timed out after ${timeout}ms`), { kill: true });
-    }, timeout);
+    // A non-finite timeout means "no timeout" — without this guard Node clamps
+    // setTimeout(fn, Infinity) to 1ms and the child is SIGKILLed ~immediately (#527 H13).
+    const timer = Number.isFinite(timeout)
+      ? setTimeout(() => {
+        finishReject(new Error(`codex-cli backend: timed out after ${timeout}ms`), { kill: true });
+      }, timeout)
+      : null;
     if (signal) {
       const onAbort = () => finishReject(abortError('codex-cli backend: aborted'), { kill: true });
       signal.addEventListener('abort', onAbort, { once: true });

--- a/src/backends/gemini-cli.js
+++ b/src/backends/gemini-cli.js
@@ -89,9 +89,13 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
 
     let settled = false;
     let cleanupSignal = () => {};
-    const timer = setTimeout(() => {
-      finishReject(new Error(`gemini-cli backend: timed out after ${timeout}ms`), { kill: true });
-    }, timeout);
+    // A non-finite timeout means "no timeout" — without this guard Node clamps
+    // setTimeout(fn, Infinity) to 1ms and the child is SIGKILLed ~immediately (#527 H13).
+    const timer = Number.isFinite(timeout)
+      ? setTimeout(() => {
+        finishReject(new Error(`gemini-cli backend: timed out after ${timeout}ms`), { kill: true });
+      }, timeout)
+      : null;
     if (signal) {
       const onAbort = () => finishReject(abortError('gemini-cli backend: aborted'), { kill: true });
       signal.addEventListener('abort', onAbort, { once: true });

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -28,6 +28,7 @@ const openaiHttp = {
     model,
     signal,
     timeout = DEFAULT_BACKEND_TIMEOUT_MS,
+    deadline,
     maxRetries,
     temperature,
     seed,
@@ -39,7 +40,7 @@ const openaiHttp = {
       // never ride an HTTP API call.
       throw new Error('openai-http backend: image input is not supported — use codex-cli, claude-cli, or gemini-cli for OCR');
     }
-    return callLLM({ prompt, apiKey, baseURL, model, signal, timeout, maxRetries, temperature, seed, onResponse });
+    return callLLM({ prompt, apiKey, baseURL, model, signal, timeout, deadline, maxRetries, temperature, seed, onResponse });
   },
 };
 
@@ -239,6 +240,10 @@ export async function invokeBackendChain({
           modelSource,
           signal,
           timeout: remainingTimeout,
+          // Thread the shared chain deadline so a multi-retry HTTP backend's
+          // total wall-clock stays bounded by the one budget, not per-attempt
+          // (#527 H6). CLI backends ignore it.
+          deadline,
           maxRetries: effectiveMaxRetries,
           temperature,
           seed,

--- a/src/backends/kimi-cli.js
+++ b/src/backends/kimi-cli.js
@@ -24,11 +24,11 @@ export function isAuthenticated() {
   const root = kimiDataDir();
   return hasKimiCredential(root) ||
     hasNonEmptyKimiConfig(root) ||
-    KIMI_ENV_KEYS.some((key) => !!process.env[key]);
+    KIMI_ENV_KEYS.some((key) => Boolean(process.env[key]?.trim()));
 }
 
 export function authHint() {
-  if (KIMI_ENV_KEYS.some((key) => !!process.env[key])) {
+  if (KIMI_ENV_KEYS.some((key) => Boolean(process.env[key]?.trim()))) {
     return 'Authenticated via KIMI_API_KEY/MOONSHOT_API_KEY env var.';
   }
   return `Run \`${loginCommand}\` once interactively to log in with Kimi Code OAuth.`;
@@ -91,9 +91,13 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
 
     let settled = false;
     let cleanupSignal = () => {};
-    const timer = setTimeout(() => {
-      finishReject(new Error(`kimi-cli backend: timed out after ${timeout}ms`), { kill: true });
-    }, timeout);
+    // A non-finite timeout means "no timeout" — without this guard Node clamps
+    // setTimeout(fn, Infinity) to 1ms and the child is SIGKILLed ~immediately (#527 H13).
+    const timer = Number.isFinite(timeout)
+      ? setTimeout(() => {
+        finishReject(new Error(`kimi-cli backend: timed out after ${timeout}ms`), { kill: true });
+      }, timeout)
+      : null;
     if (signal) {
       const onAbort = () => finishReject(abortError('kimi-cli backend: aborted'), { kill: true });
       signal.addEventListener('abort', onAbort, { once: true });

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -825,18 +825,22 @@ async function runPreviewJob({
         });
       }
     }
-    console.log(stdoutBody);
-
+    // Do the throwing/binding work (temp-file write, serve port bind) BEFORE the
+    // large stdout write: process.exit() does not drain a piped stdout, so a
+    // throw after console.log(stdoutBody) truncates piped output (#527 H7).
     const pagePath = writeBrowserDiffPage(built.html, { prefix: 'patina-preview-' });
     const imageSummary = built.imageChangedCount > 0 ? `, ${built.imageChangedCount} image(s) flagged` : '';
-    console.error(`[patina] Preview page saved at ${pagePath} (${built.changedCount} of ${built.totalCount} blocks rewritten${imageSummary})`);
+    let serveHandle = null;
     if (parsed.serve) {
-      const { url: servedUrl, done } = await serveBrowserDiffPage(built.html, {
-        signal: cancellation.signal,
-      });
-      console.error(`[patina] Serving preview at ${servedUrl}`);
+      serveHandle = await serveBrowserDiffPage(built.html, { signal: cancellation.signal });
+    }
+
+    console.log(stdoutBody);
+    console.error(`[patina] Preview page saved at ${pagePath} (${built.changedCount} of ${built.totalCount} blocks rewritten${imageSummary})`);
+    if (serveHandle) {
+      console.error(`[patina] Serving preview at ${serveHandle.url}`);
       console.error('[patina] Stops after 10 idle minutes; press Ctrl+C to stop now.');
-      await done;
+      await serveHandle.done;
     } else {
       try {
         await openBrowserDiffPage(pagePath);
@@ -844,6 +848,11 @@ async function runPreviewJob({
         console.error(`[patina] Browser open failed: ${err.message}`);
       }
     }
+  } catch (err) {
+    // Match runDefault: a Ctrl-C abort during a preview backend call surfaces as
+    // a clean exit-130 cancellation, not a generic exit-1 runtime failure (#527 H3).
+    if (cancellation.signal.aborted) throw cancellationError();
+    throw err;
   } finally {
     cancellation.cleanup();
   }

--- a/src/cli/score-gate.js
+++ b/src/cli/score-gate.js
@@ -26,7 +26,10 @@ export function extractScoreOverall(result, output) {
 
 // Strict numeric coercer for the score gate: accepts a value that is already a
 // plain number (Number()), and rejects anything else. output.js toFiniteNumber
-// now parses strictly too (#505), so the two agree on real inputs.
+// (#505) parses strictly too; the two agree on every value the scoring pipeline
+// actually emits (a number, or null). They can still differ on non-string,
+// non-number junk (e.g. [] -> 0 here vs null there) that the pipeline never
+// produces, so the divergence is unreachable end-to-end (#527 H14).
 function toFiniteScore(value) {
   if (value === null || value === undefined || value === '') return null;
   const n = Number(value);

--- a/src/features/lexicon-core.js
+++ b/src/features/lexicon-core.js
@@ -40,7 +40,12 @@ export function parseLexiconBody(body, { skipUnderscore = false } = {}) {
 // so a phrase hard-wrapped across a single newline inside a paragraph (which
 // only blank lines split) still matches instead of silently undercounting.
 export function phraseToRegex(phrase) {
-  const escaped = phrase
+  // Collapse runs of consecutive wildcards (optionally whitespace-separated)
+  // into a single `~`. Adjacent `[\s\S]{0,40}` / `\s+` quantifiers overlap and
+  // backtrack exponentially on long inputs — a ReDoS reachable only via a
+  // hand-authored custom lexicon, but cheap to neutralize here (#527 H12).
+  const collapsed = String(phrase).replace(/~(?:\s*~)+/g, '~');
+  const escaped = collapsed
     .toLowerCase()
     .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     .replace(/\s+/g, '\\s+');

--- a/src/output.js
+++ b/src/output.js
@@ -460,7 +460,9 @@ export function parseFirstJson(text) {
   const rawCandidates = [
     text.trim(),
     text.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1],
-    text.match(/\{[\s\S]*\}/)?.[0],
+    // Each balanced {...} span in order, not a greedy first-{..last-} slice
+    // (which grabs stray braces like "result {A}: {\"overall\":7}") (#527 H10).
+    ...balancedBraceSpans(text),
   ];
   const candidates = /** @type {string[]} */ (
     rawCandidates.filter((candidate) => typeof candidate === 'string' && candidate.length > 0)
@@ -471,6 +473,38 @@ export function parseFirstJson(text) {
     } catch {}
   }
   return null;
+}
+
+// Collect each balanced {...} substring in order, ignoring braces inside JSON
+// string literals. Bounded by text length; runs only on model output.
+function balancedBraceSpans(text) {
+  const spans = [];
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== '{') continue;
+    let depth = 0;
+    let inStr = false;
+    let esc = false;
+    let end = -1;
+    for (let j = i; j < text.length; j++) {
+      const ch = text[j];
+      if (inStr) {
+        if (esc) esc = false;
+        else if (ch === '\\') esc = true;
+        else if (ch === '"') inStr = false;
+        continue;
+      }
+      if (ch === '"') inStr = true;
+      else if (ch === '{') depth++;
+      else if (ch === '}') {
+        depth--;
+        if (depth === 0) { end = j; break; }
+      }
+    }
+    if (end === -1) continue;
+    spans.push(text.slice(i, end + 1));
+    i = end;
+  }
+  return spans;
 }
 
 // Append the v3.10 YAML footer to every output mode (rewrite/diff/audit/score).

--- a/src/preview.js
+++ b/src/preview.js
@@ -411,14 +411,24 @@ async function embedFontsAsDataUris(css, { origin, baseUrl, signal, fetchImpl, l
   return { css, fontCount };
 }
 
+// String.fromCodePoint throws a RangeError on a code point > U+10FFFF (or
+// negative), so a page with a numeric reference like &#xFFFFFFFF; would crash
+// prose extraction / srcdoc inlining. Out-of-range references aren't valid
+// characters — leave the original entity text in place rather than throw (#527 H1).
+function fromCodePointSafe(codePoint, original) {
+  return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff
+    ? String.fromCodePoint(codePoint)
+    : original;
+}
+
 function decodeHtmlEntities(value) {
   return String(value)
     // Numeric character references (&#60; / &#x3c;) — browsers decode all of
     // these in attribute values, so srcdoc inlining must too or numeric-entity
     // markup renders as inert escaped text and its prose never reaches the
     // extractor (#447).
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
+    .replace(/&#x([0-9a-f]+);/gi, (m, hex) => fromCodePointSafe(parseInt(hex, 16), m))
+    .replace(/&#(\d+);/g, (m, dec) => fromCodePointSafe(Number(dec), m))
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
     .replace(/&quot;/gi, '"')
@@ -1141,7 +1151,12 @@ const PREVIEW_CSP = [
 ].join('; ');
 
 function injectHead(html, sourceUrl) {
-  const baseTag = /<base\b/i.test(html) ? '' : `<base href="${htmlEscape(sourceUrl)}">`;
+  // Drop any page-supplied <base>: an attacker <base href="//evil/"> would
+  // otherwise survive (it is not a javascript: URL) and govern every relative
+  // URL in the inert snapshot. Always resolve relatives against patina's own
+  // base for the previewed source instead (#527 H2).
+  html = html.replace(/<base\b[^>]*>/gi, '');
+  const baseTag = `<base href="${htmlEscape(sourceUrl || '')}">`;
   // CSP first so it governs everything that follows (and the page's own,
   // permissive CSP was already stripped by stripActiveContent).
   const csp = `<meta http-equiv="Content-Security-Policy" content="${PREVIEW_CSP}">`;
@@ -1428,8 +1443,8 @@ function collectExcludedRanges(html) {
 
 function decodeEntities(text) {
   return text
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
+    .replace(/&#x([0-9a-f]+);/gi, (m, hex) => fromCodePointSafe(parseInt(hex, 16), m))
+    .replace(/&#(\d+);/g, (m, dec) => fromCodePointSafe(Number(dec), m))
     .replace(/&nbsp;/gi, ' ')
     .replace(/&quot;/gi, '"')
     .replace(/&#39;/g, "'")

--- a/src/prompt-builder.js
+++ b/src/prompt-builder.js
@@ -670,7 +670,15 @@ function buildMinimalPrompt({ config, patterns, profile, voiceSample, text, tone
   if (tone && tone.tone_source) {
     prompt += lang === 'ko' ? `## 톤 메타\n` : `## Tone metadata\n`;
     prompt += `- tone: ${tone.tone === null ? 'null' : tone.tone}\n`;
-    prompt += `- source: ${tone.tone_source}\n\n`;
+    prompt += `- source: ${tone.tone_source}\n`;
+    if (tone.tone_source === 'auto') {
+      // Minimal mode previously emitted `tone: auto` without telling the model
+      // to resolve it, so auto-tone quality diverged from the strict path (#527 H4).
+      prompt += lang === 'ko'
+        ? `- (auto: 본문에서 단일 톤을 추정해 적용하고, 아래 YAML 푸터의 tone/tone_evidence/tone_confidence를 그 값으로 채운다.)\n`
+        : `- (auto: infer a single tone from the text, apply it, and fill the YAML footer's tone/tone_evidence/tone_confidence with the resolved values.)\n`;
+    }
+    prompt += `\n`;
   }
 
   if (voiceSample) {

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -102,19 +102,32 @@ function parseStrictJson(text) {
   const whole = tryParseJson(body);
   if (whole.ok && isJsonObject(whole.value)) return whole.value;
 
-  // Otherwise scan for the first balanced {...} span that parses. A naive
-  // indexOf('{')..lastIndexOf('}') slice breaks when prose carries stray
-  // braces, e.g. "result for {A}: {\"overall\":20}" slices from `{A}`, and
-  // "{...} note: use {x}" slices to the trailing `{x}` — both then throw and
-  // spuriously null an otherwise-valid score (#508 G2).
+  // Otherwise scan every balanced {...} span and keep the RICHEST object. A
+  // naive indexOf('{')..lastIndexOf('}') slice breaks when prose carries stray
+  // braces, e.g. "result for {A}: {\"overall\":20}" slices from `{A}` (#508 G2).
+  // Returning the FIRST parseable object is also wrong when a chatty model
+  // emits a stray/echoed object (or an empty `{}`) before the real score —
+  // that nulls a valid score without a retry (#527 H8). And a lone unbalanced
+  // '{' must skip, not abandon the scan, or a later valid object is missed
+  // (#527 H9). Picking the object with the most keys favors the score object
+  // (many keys) over a small echo while leaving the single-object case exact.
+  let best = null;
+  let bestKeys = -1;
   for (let i = 0; i < body.length; i++) {
     if (body[i] !== '{') continue;
     const end = matchingBraceEnd(body, i);
-    if (end === -1) break;
+    if (end === -1) continue; // this '{' never balances; a later one might
     const candidate = tryParseJson(body.slice(i, end + 1));
-    if (candidate.ok && isJsonObject(candidate.value)) return candidate.value;
-    i = end; // skip past this unparseable span
+    if (candidate.ok && isJsonObject(candidate.value)) {
+      const keys = Object.keys(candidate.value).length;
+      if (keys >= 1 && keys > bestKeys) {
+        best = candidate.value;
+        bestKeys = keys;
+      }
+    }
+    i = end; // skip past this span
   }
+  if (best !== null) return best;
 
   throw new SchemaError('No JSON object found', text);
 }
@@ -367,9 +380,16 @@ export function scoreDeterministicSignals({
       structuralClassifier.hot === true && typeof structuralClassifier.score === 'number'
         ? Math.max(STRUCTURAL_CLASSIFIER_MIN_FLOOR, roundScore(structuralClassifier.score * 100))
         : 0;
-    const overall = leaked
-      ? Math.max(hotRatioOverall, LEAKAGE_SCORE_FLOOR)
-      : Math.max(hotRatioOverall, structuralFloor);
+    // All floors apply together. Previously leakage and the structural-classifier
+    // floor were mutually exclusive, so a document that BOTH leaked and scored a
+    // high structural floor was capped at the (lower) leakage floor — a near-proof
+    // leakage token could LOWER the overall score. Take the max of every signal so
+    // a floor can only ever raise the score (#527 H5).
+    const overall = Math.max(
+      hotRatioOverall,
+      leaked ? LEAKAGE_SCORE_FLOOR : 0,
+      structuralFloor,
+    );
     const signalScore = roundScore(summarizeSignalStrength(paragraphs, {
       burstinessBands: config.stylometry?.burstiness?.bands,
       mattrBands: config.stylometry?.ttr?.bands,

--- a/tests/unit/issue-527-fixes.test.js
+++ b/tests/unit/issue-527-fixes.test.js
@@ -1,0 +1,86 @@
+// Regression tests for the #527 low-severity runtime fixes.
+// H2 is covered by tests/unit/preview.test.js (base-tag stripping); H5 (floor
+// max) is covered by the quality benchmark and is provably non-lowering; H3/H6/
+// H7/H13 are integration/spawn paths exercised elsewhere.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseFirstJson } from '../../src/output.js';
+import { phraseToRegex } from '../../src/features/lexicon-core.js';
+import { prepareSnapshotHtml, extractProseBlocks } from '../../src/preview.js';
+import { buildPrompt } from '../../src/prompt-builder.js';
+import * as kimi from '../../src/backends/kimi-cli.js';
+
+// H10 — parseFirstJson finds the real object amid stray braces instead of a
+// greedy first-{..last-} slice that JSON.parse rejects.
+test('H10: parseFirstJson skips stray braces and parses the embedded object', () => {
+  assert.deepEqual(parseFirstJson('result for {A}: {"overall": 7}'), { overall: 7 });
+  assert.deepEqual(parseFirstJson('{"overall": 9} note: use {x} carefully'), { overall: 9 });
+  assert.deepEqual(parseFirstJson('prefix {"a": 1} mid {x} end'), { a: 1 });
+  assert.equal(parseFirstJson('no json here'), null);
+});
+
+// H12 — multi-wildcard custom-lexicon phrases no longer backtrack exponentially.
+test('H12: phraseToRegex collapses consecutive wildcards and stays linear', () => {
+  const re = phraseToRegex('~ ~ zzz');
+  // Consecutive wildcards collapse to one bounded class — no adjacent
+  // [\s\S]{0,40}\s+[\s\S]{0,40} that backtracks catastrophically.
+  assert.equal((re.source.match(/\[\\s\\S\]\{0,40\}/g) || []).length, 1);
+  const start = process.hrtime.bigint();
+  re.test(' '.repeat(400)); // would hang (>6s) before the fix
+  const ms = Number(process.hrtime.bigint() - start) / 1e6;
+  assert.ok(ms < 200, `phraseToRegex match took ${ms.toFixed(0)}ms`);
+  // Still matches its intent: a gap then the literal tail.
+  assert.ok(phraseToRegex('~ zzz').test('anything here zzz'));
+});
+
+// H1 — out-of-range numeric HTML entities no longer crash entity decoding.
+test('H1: out-of-range numeric entities do not throw in preview decoding', () => {
+  assert.doesNotThrow(() =>
+    prepareSnapshotHtml('<html><body><p>&#xFFFFFFFF; lorem ipsum dolor sit amet consectetur.</p></body></html>'));
+  assert.doesNotThrow(() =>
+    extractProseBlocks('<p>&#1114112; lorem ipsum dolor sit amet consectetur adipiscing.</p>'));
+  // Valid numeric entities still decode (the guard must not break normal cases).
+  const { blocks } = extractProseBlocks('<p>A&#66;C lorem ipsum dolor sit amet consectetur adipiscing elit.</p>');
+  assert.ok(blocks.some((b) => (b.text || '').includes('ABC')));
+});
+
+// H4 — minimal-mode rewrite with --tone auto includes the detection instruction.
+test('H4: minimal prompt with tone auto includes the auto-detection instruction', () => {
+  const prompt = buildPrompt({
+    config: { language: 'en' },
+    patterns: [],
+    profile: null,
+    voice: null,
+    scoring: null,
+    text: 'A short draft paragraph that needs a gentle humanizing rewrite pass.',
+    mode: 'rewrite',
+    promptMode: 'minimal',
+    tone: { tone: null, tone_source: 'auto', tone_evidence: [], tone_confidence: null },
+  });
+  assert.ok(/infer a single tone/i.test(prompt), 'minimal auto prompt must instruct tone detection');
+});
+
+// H11 — a whitespace-only env key no longer mis-advertises kimi as authenticated.
+test('H11: kimi env-key auth rejects a whitespace-only key', () => {
+  const saved = {
+    KIMI_API_KEY: process.env.KIMI_API_KEY,
+    MOONSHOT_API_KEY: process.env.MOONSHOT_API_KEY,
+    KIMI_SHARE_DIR: process.env.KIMI_SHARE_DIR,
+  };
+  try {
+    process.env.KIMI_SHARE_DIR = '/nonexistent-patina-kimi-test-dir';
+    delete process.env.MOONSHOT_API_KEY;
+    process.env.KIMI_API_KEY = '   \t ';
+    assert.equal(kimi.isAuthenticated(), false);
+    assert.ok(!kimi.authHint().startsWith('Authenticated'));
+    process.env.KIMI_API_KEY = 'sk-real-key';
+    assert.equal(kimi.isAuthenticated(), true);
+    assert.ok(kimi.authHint().startsWith('Authenticated'));
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+});

--- a/tests/unit/preview.test.js
+++ b/tests/unit/preview.test.js
@@ -338,7 +338,7 @@ test('buildPreviewHtml swaps rewrites in place and hardens the snapshot', () => 
   assert.ok(out.includes('score 42 → 17'));
 });
 
-test('buildPreviewHtml keeps an existing base tag and omits the toggle when nothing changed', () => {
+test('buildPreviewHtml drops a page-supplied base tag and injects its own (and omits the toggle when nothing changed)', () => {
   const html = `<html><head><base href="https://keep.test/"></head><body><p>${LONG_EN}</p></body></html>`;
   const { blocks } = extractProseBlocks(html);
   const { html: out, changedCount } = buildPreviewHtml({
@@ -348,8 +348,10 @@ test('buildPreviewHtml keeps an existing base tag and omits the toggle when noth
     sourceUrl: 'https://other.test/',
   });
   assert.strictEqual(changedCount, 0);
-  assert.ok(out.includes('href="https://keep.test/"'));
-  assert.ok(!out.includes('href="https://other.test/"'));
+  // #527 H2: a page-supplied <base> is not trusted — it is stripped and patina's
+  // own base for the previewed source is injected instead.
+  assert.ok(!out.includes('href="https://keep.test/"'));
+  assert.ok(out.includes('href="https://other.test/"'));
   assert.ok(!out.includes('id="ptna-v-rew"'));
   assert.ok(!out.includes('class="ptna-views"'));
   assert.ok(out.includes('0 of 1 blocks rewritten'));


### PR DESCRIPTION
Closes #527.

Addresses all 14 low-severity runtime findings from the second-pass adversarial review. Each was traced + reproduced against `main`; see #527 for the per-item detail.

## Highlights
- **H1** preview no longer crashes on out-of-range numeric HTML entities (`&#xFFFFFFFF;`).
- **H2** page-supplied `<base>` is stripped (not trusted); patina injects its own.
- **H5** leakage + structural-classifier floors now combine via `max` (a leakage token could previously *lower* a higher structural floor).
- **H8/H9/H10** balanced-brace JSON extraction in both `parseStrictJson` and `parseFirstJson` (stray braces / leading stray object / lone unbalanced `{`).
- **H11** kimi rejects a whitespace-only env key; **H12** `phraseToRegex` kills a custom-lexicon ReDoS; **H13** CLI backends don't arm `setTimeout(Infinity)`.
- **H3/H7** preview Ctrl-C → exit 130, and temp-file/serve work happens before the big stdout write (no piped-output truncation).
- **H4** minimal-mode `--tone auto` regains the detection instruction; **H6** openai-http threads the shared chain deadline; **H14** corrects an overstated comment.

## Verification
- `npm run lint` clean
- `npm test` → 839 pass / 0 fail / 1 skip (adds `tests/unit/issue-527-fixes.test.js`, updates the preview base-tag test for H2)
- `npm run benchmark` → 100% accuracy, ROC-AUC 1.000 (no scoring regression from H5)
- Repros from #527 re-run green: translationese/ReDoS, entity crash, kimi whitespace, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)