### PR TITLE
test: pin #503 read-error wiring + shared-deadline fall-through (#528)

### DIFF
--- a/tests/e2e/backends.test.js
+++ b/tests/e2e/backends.test.js
@@ -345,6 +345,41 @@ describe('Backend Fallback Chain', () => {
     // The final hop runs (no `next` to fall through to) and its error surfaces.
     assert.strictEqual(thirdCalls, 1);
   });
+
+  it('a fall-through hop receives the REMAINING shared deadline, not a fresh full timeout (#506 defect 1, #528 I4)', async () => {
+    let secondTimeout = null;
+    const result = await invokeBackendChain({
+      backends: [
+        {
+          name: 'first',
+          invoke: async () => {
+            // Consume a measurable slice of the shared budget, then fail over.
+            await new Promise((resolve) => setTimeout(resolve, 80));
+            const err = new Error('slow then rate-limited');
+            err.status = 429;
+            throw err;
+          },
+        },
+        {
+          name: 'second',
+          invoke: async ({ timeout }) => {
+            secondTimeout = timeout;
+            return 'ok';
+          },
+        },
+      ],
+      prompt: 'rewrite this',
+      timeout: 5000,
+      logger: { warn() {} },
+    });
+
+    assert.strictEqual(result, 'ok');
+    // One shared deadline spans the whole chain: the ~80ms the first hop spent
+    // must be deducted from the second hop's budget. A regression that handed
+    // the fallback backend a fresh full 5000ms would be caught here.
+    assert.ok(secondTimeout <= 5000, `fall-through hop budget ${secondTimeout} exceeded the shared deadline`);
+    assert.ok(secondTimeout < 5000 - 40, `fall-through hop saw ${secondTimeout}ms — the first hop's elapsed time was not deducted`);
+  });
 });
 
 describe('Codex auto-fallback removed (issue #88)', () => {

--- a/tests/unit/input-loading.test.js
+++ b/tests/unit/input-loading.test.js
@@ -8,6 +8,9 @@ import { loadInputText, MAX_INPUT_BYTES } from '../../src/loader.js';
 import { loadInputs } from '../../src/cli/input.js';
 import { createBatchCircuitBreaker } from '../../src/cli/batch.js';
 import { PatinaCliError } from '../../src/errors.js';
+import { runDefault } from '../../src/cli/run.js';
+import { parseArgs } from '../../src/cli/args.js';
+import { createLogger } from '../../src/logger.js';
 
 function withTmpDir(run) {
   const dir = mkdtempSync(join(tmpdir(), 'patina-input-'));
@@ -180,5 +183,38 @@ test('a batch read failure trips --max-failures 1 like any other per-file failur
     // instead of crashing the run with a raw exit 1 (#503).
     assert.equal(breaker.shouldStop(), true);
     assert.match(breaker.toError().message, /max failures reached \(1\/1\)/);
+  });
+});
+
+// #528 I1: the prior tests hand-roll run.js's per-file loop. Drive the REAL
+// runDefault so the readError wiring (jobs.map sets it; the loop replays it
+// through the circuit breaker) is exercised end-to-end. All inputs are missing
+// so openai-http is selected but never invoked (the read errors throw first),
+// keeping the test network-free.
+test('runDefault routes batch read failures through the circuit breaker, not a raw fs crash (#503, #528 I1)', async () => {
+  await withTmpDir(async (dir) => {
+    const missingA = join(dir, 'missing-a.md');
+    const missingB = join(dir, 'missing-b.md');
+    const savedKey = process.env.PATINA_API_KEY;
+    process.env.PATINA_API_KEY = 'test-key-never-used';
+    const logger = createLogger({ quiet: true });
+    try {
+      const parsed = parseArgs(['--batch', '--backend', 'openai-http', missingA, missingB]);
+      await assert.rejects(
+        runDefault(parsed, logger),
+        (err) => {
+          // #503 contract: read failures are recorded by the breaker and surface
+          // as a typed batch summary (PatinaCliError, exit 1) — NOT a raw ENOENT.
+          assert.ok(err instanceof PatinaCliError, `expected PatinaCliError, got ${err?.name}: ${err?.message}`);
+          assert.equal(err.exitCode, 1);
+          assert.doesNotMatch(String(err.message), /ENOENT/, 'raw fs error leaked to the user');
+          assert.match(String(err.message), /fail/i);
+          return true;
+        }
+      );
+    } finally {
+      if (savedKey === undefined) delete process.env.PATINA_API_KEY;
+      else process.env.PATINA_API_KEY = savedKey;
+    }
   });
 });


### PR DESCRIPTION
Closes #528.

The second-pass review flagged 7 fix tests (I1–I7) that don't pin the property they guard. Re-checking against current `main`:

| item | status |
|------|--------|
| **I1** #503 read-error wiring untested at the `runDefault` level | **fixed here** — new `runDefault`-driven test (all-missing batch, network-free) asserts a typed batch-summary error, not a raw ENOENT |
| **I4** shared-deadline untested at the fall-through hop | **fixed here** — two-hop test asserts the fallback backend gets the *remaining* budget, not a fresh full timeout |
| I2 translationese unspaced-Hangul timing | already covered — `#520 detectTranslationese stays fast …` (shipped with the #520 fix) |
| I3 real CLI timeout shape | already covered — `falls through local CLI timeout-shaped errors … (#525)` |
| I5 fence delimiter-embedding | already covered — `neutralizes embedded data fence delimiters …` (shipped with the #522 fix) |
| I6 browser-diff G9 / I7 OCR G7 | existing `serve.socket_error` (G9) and temp-dir cleanup (G7) tests cover the core behavior; the residual concerns are marginal and not worth test churn |

## Verification
- `npm run lint` clean
- `npm test` → 841 pass / 0 fail / 1 skip (adds 2 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)