### PR TITLE
fix(web): prevent free-rewrite UI hang (#541) + mobile Korean hero wrap (#542)

### DIFF
--- a/playground/chatgpt.css
+++ b/playground/chatgpt.css
@@ -121,12 +121,13 @@ a { color: inherit; }
   mask-image: radial-gradient(120% 90% at 50% 16%, #000 32%, transparent 78%);
 }
 .hero__inner { position: relative; z-index: 1; width: 100%; max-width: 800px; margin: 0 auto; text-align: center; }
-.hero__title { font-size: clamp(40px, 6.4vw, 64px); font-weight: 600; line-height: 1.05; letter-spacing: -1.6px; margin: 0 0 14px; }
+.hero__title { font-size: clamp(40px, 6.4vw, 64px); font-weight: 600; line-height: 1.05; letter-spacing: -1.6px; margin: 0 0 14px; word-break: keep-all; text-wrap: balance; }
 .hero__title .grad {
   background: linear-gradient(92deg, var(--copper), var(--accent) 55%, #7aa0ff);
   -webkit-background-clip: text; background-clip: text; color: transparent;
+  white-space: nowrap;
 }
-.hero__sub { font-size: 18px; color: var(--text-dim); margin: 0 auto 44px; max-width: 720px; text-wrap: balance; }
+.hero__sub { font-size: 18px; color: var(--text-dim); margin: 0 auto 44px; max-width: 720px; text-wrap: balance; word-break: keep-all; }
 
 /* prompt card (the Lovable hero input) */
 .prompt {

--- a/playground/chatgpt.js
+++ b/playground/chatgpt.js
@@ -346,11 +346,26 @@ async function submit(text) {
   let started = false;
   const start = () => { if (started) return; started = true; if (typing.parentElement) typing.remove(); textEl.style.display = ''; textEl.classList.add('streaming'); };
 
+  // Fail-safe: if no stream frame arrives for IDLE_MS, abort so the UI never
+  // hangs on a stalled backend (issue #541). The timer re-arms on every frame.
+  const controller = new AbortController();
+  const IDLE_MS = 60000;
+  let timedOut = false;
+  let idleTimer;
+  const armIdle = () => {
+    clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => { timedOut = true; controller.abort(); }, IDLE_MS);
+  };
+  armIdle();
+
   try {
     const { ok, finalFrame } = await streamRewrite({
       body: reqBody,
-      onDelta: (_t, acc) => { start(); textEl.textContent = acc; scrollDown(); },
+      signal: controller.signal,
+      onStart: () => armIdle(),
+      onDelta: (_t, acc) => { armIdle(); start(); textEl.textContent = acc; scrollDown(); },
       onDone: (frame) => {
+        armIdle();
         start();
         const rewrite = typeof frame.rewrite === 'string' ? frame.rewrite : textEl.textContent;
         textEl.textContent = rewrite; textEl.classList.remove('streaming');
@@ -369,9 +384,13 @@ async function submit(text) {
     }
   } catch (e) {
     if (typing.parentElement) typing.remove();
-    textEl.style.display = '';
-    body.appendChild(el('div', 'error-note', `Network error: ${String(e?.message || e)}`));
+    textEl.style.display = ''; textEl.classList.remove('streaming');
+    const msg = timedOut
+      ? 'Rewrite timed out — no response from the server. Please try again.'
+      : `Network error: ${String(e?.message || e)}`;
+    body.appendChild(el('div', 'error-note', msg));
   } finally {
+    clearTimeout(idleTimer);
     state.busy = false;
     updateHeroSend(); updateChatSend();
     els.input.focus();


### PR DESCRIPTION
Fixes #541 and #542.

## #541 — Free rewrite stream stalls / UI hangs after `start`
Adds a client-side idle timeout. A per-request `AbortController` aborts the stream if no frame (`start`/`delta`/`done`) arrives within 60s, re-armed on every frame. On failure the typing indicator is removed, `state.busy` is reset, and an error note is shown (timeout-specific message). Previously a slow/stalled backend left the typing indicator spinning forever and `state.busy` stuck, which also blocked subsequent sends.

## #542 — Korean mobile hero orphans final syllable
`word-break: keep-all` on `.hero__title` / `.hero__sub` and `white-space: nowrap` on `.grad`, so Hangul breaks only at spaces. Verified at 375px that `자연스럽게` stays on one line (no `자연스럽` / `게` orphan).

Files: `playground/chatgpt.js`, `playground/chatgpt.css`. Verified via headless browser; `npm run lint` clean.
