### PR TITLE
fix(web): diff length foldout (#544) + allow Pretendard font in CSP (#545)

### DIFF
--- a/playground/chatgpt.js
+++ b/playground/chatgpt.js
@@ -298,12 +298,17 @@ function buildMeta(meta) {
     bar.appendChild(el('span', 'sig-after', after == null ? '—' : String(after)));
     b.appendChild(bar); det.appendChild(b); wrap.appendChild(det);
   }
-  if (meta?.diff?.before != null) {
+  if (meta?.diff && (meta.diff.charDelta != null || meta.diff.wordDelta != null)) {
     const det = el('details', 'foldout');
-    det.appendChild(el('summary', null, 'Original / result'));
+    det.appendChild(el('summary', null, 'Length (before → after)'));
     const b = el('div', 'foldout__body');
-    const r1 = el('div', 'diffrow'); r1.appendChild(el('span', 'k', 'Original')); r1.appendChild(el('span', null, String(meta.diff.before)));
-    const r2 = el('div', 'diffrow'); r2.appendChild(el('span', 'k', 'Result')); r2.appendChild(el('span', null, String(meta.diff.after ?? '')));
+    const sign = (d) => (Number(d) > 0 ? `+${d}` : String(d));
+    const r1 = el('div', 'diffrow');
+    r1.appendChild(el('span', 'k', 'Characters'));
+    r1.appendChild(el('span', null, `${meta.diff.beforeChars} → ${meta.diff.afterChars} (${sign(meta.diff.charDelta)})`));
+    const r2 = el('div', 'diffrow');
+    r2.appendChild(el('span', 'k', 'Words'));
+    r2.appendChild(el('span', null, `${meta.diff.beforeWords} → ${meta.diff.afterWords} (${sign(meta.diff.wordDelta)})`));
     b.appendChild(r1); b.appendChild(r2); det.appendChild(b); wrap.appendChild(det);
   }
   return wrap;

--- a/vercel.json
+++ b/vercel.json
@@ -49,7 +49,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; font-src 'self' https://cdn.jsdelivr.net; img-src 'self' data:; connect-src 'self'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'"
         }
       ]
     }


### PR DESCRIPTION
Fixes #544 and #545.

## #544 — "Original / result" diff foldout never rendered
`buildMeta()` gated on `meta.diff.before` (text), which the contract never emits — `summarizeDiff()` returns char/word counts. The foldout now renders the stats it actually receives, retitled **"Length (before → after)"**:

```
Characters  38 → 24 (-14)
Words       9 → 6 (-3)
```

Verified in the browser: the foldout now appears and shows the values.

## #545 — Pretendard web font blocked by production CSP
Allow jsdelivr for **styles and fonts only**:
- `style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net`
- new `font-src 'self' https://cdn.jsdelivr.net`

`script-src` and `connect-src` stay `'self'` — no third-party scripts or network connections are introduced. (Self-hosting the Pretendard subset is the stricter alternative; this is the minimal change that makes the existing `<link>` work.)

Files: `playground/chatgpt.js`, `vercel.json`. `eslint` clean; `vercel.json` valid JSON; CSP directives verified (script-src/connect-src unchanged).
