### PR TITLE
fix(backends): settle interactive command promise once (#533)

### DIFF
--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -353,26 +353,31 @@ export function runInteractiveCommand({
   }
 
   return new Promise((resolve, reject) => {
+    // A failed spawn can emit both 'error' and 'close'; settle once so we never
+    // resolve-then-reject (or build a second Error) on the same invocation (#533).
+    let settled = false;
+    const settle = (fn) => { if (settled) return; settled = true; fn(); };
+
     const proc = spawn(command, args, { cwd, env, stdio });
 
     proc.on('error', (err) => {
       if (err.code === 'ENOENT') {
-        reject(new Error(`${backendName}: \`${command}\` CLI not found. ${notFoundHint || 'Install the CLI and try again.'}`));
+        settle(() => reject(new Error(`${backendName}: \`${command}\` CLI not found. ${notFoundHint || 'Install the CLI and try again.'}`)));
         return;
       }
-      reject(new Error(`${backendName}: failed to spawn ${command} (${err.message})`));
+      settle(() => reject(new Error(`${backendName}: failed to spawn ${command} (${err.message})`)));
     });
 
     proc.on('close', (code, signal) => {
       if (code === 0) {
-        resolve();
+        settle(() => resolve());
         return;
       }
       if (signal) {
-        reject(new Error(`${backendName}: ${command} was terminated by ${signal}`));
+        settle(() => reject(new Error(`${backendName}: ${command} was terminated by ${signal}`)));
         return;
       }
-      reject(new Error(`${backendName}: ${command} exited with code ${code}`));
+      settle(() => reject(new Error(`${backendName}: ${command} exited with code ${code}`)));
     });
   });
 }


### PR DESCRIPTION
Fixes #533.

`runInteractiveCommand()` registered both `proc.on('error')` and `proc.on('close')`. A failed spawn can emit `error` and then `close`, so both handlers could call reject (or resolve-then-reject), constructing a second `Error` needlessly on an already-settled promise.

Added a one-shot `settled` guard so the promise settles exactly once regardless of event ordering.

Verified:
- ENOENT spawn rejects exactly once with the "CLI not found" message (no second settle on the trailing `close`).
- `node --test tests/e2e/auth-login.test.js` → 5/5 pass (no regression).
- `eslint` clean.
