### PR TITLE
chore(release): 5.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "patina",
       "source": "./",
-      "version": "5.4.0",
+      "version": "5.4.1",
       "description": "Strip the AI packaging, keep the meaning. Detect and rewrite AI writing patterns across KO/EN/ZH/JA with MPS/fidelity checks. Runs the root SKILL.md as the /patina skill.",
       "homepage": "https://github.com/devswha/patina",
       "repository": "https://github.com/devswha/patina",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
   "name": "patina",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese so text reads as if a human wrote it. Meaning-preservation (MPS) verified, audit-friendly. The root SKILL.md is loaded as the /patina skill.",
   "author": {
     "name": "devswha",

--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "5.4.0"
+version: "5.4.1"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
+## 5.4.1 — 2026-06-26
+
+**Web playground and install reliability fixes: rewrites no longer hang, language is auto-detected, the mobile Korean hero wraps cleanly, and fresh installs get their runtime dependency.**
+
+Semver rationale: patch — bug fixes only. No pattern, scoring, schema, or CLI-behavior changes; all four languages byte-identical.
+
+### Fixed
+
+- **web:** auto-detect the language from pasted text so EN/ZH/JA input is no longer rewritten under the default Korean pipeline (#543).
+- **web:** add a client-side idle timeout so a stalled rewrite stream no longer leaves the UI spinning; reset busy state and surface an error (#541).
+- **web:** keep the Korean hero and subtitle from orphaning a final syllable on mobile via `word-break: keep-all` (#542).
+- **web:** render the rewrite length (character/word) stats in the result foldout instead of a never-populated field (#544).
+- **web:** allow the Pretendard web font through the production CSP via `style-src`/`font-src` without loosening `script-src`/`connect-src` (#545).
+- **install:** install runtime dependencies (`js-yaml`) during `install.sh` so the local CLI runs from a fresh clone (#536).
+- **backends:** settle the interactive-command promise exactly once so a failed spawn cannot resolve-then-reject (#533).
+
 ## 5.4.0 — 2026-06-15
 
 **Rewrite-quality A/B harness: compare two rewrite configs (single vs ouroboros multi-pass) on the same fixtures so pipeline decisions are data-driven.**

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 5.4.0" src="https://img.shields.io/badge/version-5.4.0-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 5.4.1" src="https://img.shields.io/badge/version-5.4.1-blue"></a>
 </p>
 
 <p align="center">
@@ -189,7 +189,7 @@ If meaning drifts, the change is retried or rolled back. Deterministic analysis 
 
 ```yaml
 # .patina.default.yaml
-version: "5.4.0"
+version: "5.4.1"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 5.4.0
+version: 5.4.1
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "5.4.0"
+    "patina-cli": "5.4.1"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Release **5.4.1** (patch).

Version bump + metadata sync across every surface `release:check` enforces:
`package.json`, `SKILL.md`, `.patina.default.yaml`, `README.md` (badge + config example), `packages/patina-humanizer/package.json` (version + `patina-cli` dep), `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and a new `CHANGELOG.md` 5.4.1 entry.

Bundles the bug fixes from #546–#550 (issues #533, #536, #541, #542, #543, #544, #545). No pattern/scoring/schema/CLI-behavior changes — all four languages byte-identical.

### Merge order
1. Merge the fix PRs first: #546, #547, #548, #549, #550.
2. Merge this PR.
3. Tag `v5.4.1` on `main` → the Release workflow runs `release:check` + tests + benchmark/dogfood and publishes `patina-cli` / `patina-humanizer`.

### Verified
- `npm run release:check` → OK for 5.4.1
- `npm run lint` (syntax/eslint/typecheck/spellcheck) clean
- `npm test` → 975 pass / 1 skip / 0 fail
