### PR TITLE
feat(cli): --verify meaning-floor rewrite + deterministic guard (deprecate --ouroboros)

### DIFF
--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -132,8 +132,8 @@ ouroboros:
       filler: 0.08
       structure: 0.15
       viral-hook: 0.10  # score-only pack (excluded from rewrite)
-  fidelity-floor: 70             # stop ouroboros if fidelity drops below this
-  mps-floor: 70                  # stop ouroboros if MPS (meaning preservation) drops below this
+  fidelity-floor: 70             # stop ouroboros if fidelity drops below this; also the --verify fidelity floor
+  mps-floor: 70                  # stop ouroboros if MPS (meaning preservation) drops below this; also the --verify MPS floor
   combined-weights:
     default:
       ai-likeness: 0.60

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -48,6 +48,23 @@ patina --lang en --score --exit-on 30 draft.md
 - `patina doctor --json` emits setup diagnostics for CI without making an LLM call.
 
 
+## Meaning verification: `--verify`
+
+`--verify` folds a meaning-preservation check into the normal rewrite. After the rewrite it scores MPS and fidelity; if either is below the floor (`ouroboros.mps-floor` / `ouroboros.fidelity-floor`, default 70) it runs **one** conservative retry that re-rewrites from the original with a strict meaning-preservation directive. If the retry still misses, patina emits the closest (highest-fidelity) candidate and warns on stderr — fail-closed but non-destructive, so stdout always carries usable text.
+
+```bash
+patina --verify draft.md
+patina --verify --lang ko --backend codex-cli draft.md
+```
+
+- It is a rewrite modifier, not a separate mode: combining it with `--score`, `--audit`, `--diff`, `--ouroboros`, `--preview`, or `--restyle voice|content` is an input error (those either do not rewrite or loosen the meaning floors `--verify` enforces).
+- The MPS/fidelity scorers run through the **selected backend**, so `--verify` works with HTTP and local CLI backends alike. It adds up to four extra model calls (two scorers, plus a retry that re-scores), so the plain rewrite stays the fast/cheap default.
+- `--ouroboros` is **deprecated** in favor of `--verify`; the iterative loop will be removed in a future release.
+
+### Deterministic meaning guard (always on, no LLM)
+
+Every rewrite (with or without `--verify`) runs a cheap deterministic guard that warns on stderr when numbers present in the source go missing from the rewrite. It never blocks output and makes no model calls (length is intentionally not checked — a humanizer legitimately changes length).
+
 ## Korean persona rewrite: `--persona`
 
 `--persona <name>` selects a validated Korean persona from `personas/ko` (or a same-id custom persona) for the rewrite harness. With no explicit persona, Korean rewrite mode uses the conservative `preserve` persona: style-only, minimal change, and MPS/fidelity hard floors still enforced.

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
 import { getRepoRoot } from './config.js';
 import { runDoctor } from './commands/doctor.js';
 import { handleAuth, printBackendStatus } from './commands/auth.js';
-import { parseArgs, validateModeExclusivity, validateServeRequest, validatePreviewRequest, validateOutputRouting, validateTransformRequest, validatePersonaRequest, printHelp } from './cli/args.js';
+import { parseArgs, validateModeExclusivity, validateServeRequest, validatePreviewRequest, validateOutputRouting, validateTransformRequest, validatePersonaRequest, validateVerifyRequest, printHelp } from './cli/args.js';
 import { runDefault } from './cli/run.js';
 import { inputError, renderCliError, getProcessExitCode } from './errors.js';
 import { createLogger } from './logger.js';
@@ -75,6 +75,7 @@ export async function main(args) {
   validateModeExclusivity(parsed);
   validateTransformRequest(parsed);
   validatePersonaRequest(parsed);
+  validateVerifyRequest(parsed);
   validatePreviewRequest(parsed);
   validateServeRequest(parsed);
   validateOutputRouting(parsed);

--- a/src/cli/args.js
+++ b/src/cli/args.js
@@ -19,7 +19,7 @@ const FLAG_OPTIONS = new Set([
   '--ouroboros', '--batch', '--in-place', '--allow-private-base-url',
   '--stop-on-retryable-storm', '--no-stop-on-retryable-storm',
   '--list-backends', '--allow-insecure-base-url', '--no-interactive',
-  '--rewrite-headings',
+  '--rewrite-headings', '--verify',
 ]);
 
 // Expand `--name=value` into two tokens for known value-taking options and
@@ -170,6 +170,10 @@ export function parseArgs(rawArgs) {
       }
       case '--ouroboros':
         parsed.ouroboros = true;
+        break;
+
+      case '--verify':
+        parsed.verify = true;
         break;
       case '--batch':
         parsed.batch = true;
@@ -474,6 +478,36 @@ export function validatePersonaRequest(parsed) {
   }
 }
 
+// --verify folds the meaning-floor check into rewrite mode (score MPS/fidelity,
+// one conservative retry, fail-closed). It is a rewrite modifier, not a mode, so
+// it is rejected alongside non-rewrite modes and the meaning-loosening depths.
+export function validateVerifyRequest(parsed) {
+  if (!parsed.verify) return;
+  const blocked = [
+    ['score', '--score'],
+    ['audit', '--audit'],
+    ['diff', '--diff'],
+    ['ouroboros', '--ouroboros'],
+    ['preview', '--preview'],
+  ];
+  for (const [key, flag] of blocked) {
+    if (parsed[key]) {
+      throw inputError(
+        `--verify cannot be combined with ${flag}`,
+        '--verify is a rewrite-mode meaning check; it does not apply to non-rewrite or preview surfaces.',
+        'Run `patina --verify <file>` for a verified rewrite, or drop --verify.'
+      );
+    }
+  }
+  if (parsed.restyle === 'voice' || parsed.restyle === 'content') {
+    throw inputError(
+      `--verify cannot be combined with --restyle ${parsed.restyle}`,
+      'Voice/content transformations intentionally change wording or structure, which fights the meaning-preservation floors --verify enforces.',
+      'Use --verify with the default --restyle sentence, or drop --verify for a free transformation.'
+    );
+  }
+}
+
 export function validatePreviewRequest(parsed) {
   if (parsed.ocr && !parsed.preview) {
     throw inputError(
@@ -675,7 +709,9 @@ MODES
   --audit                 Detect patterns only (no rewrite)
   --score                 Output AI-likeness score (0-100)
   --exit-on <n>           With --score, exit 3 when overall score > n
-  --ouroboros             Iterative self-improvement loop
+  --verify                Rewrite, then verify meaning (MPS/fidelity floors) with
+                          one conservative retry; fail-closed to the best candidate
+  --ouroboros             [deprecated] Iterative self-improvement loop (use --verify)
   --preview               Rewrite one http(s) URL or local .html file in place on a snapshot
                           of the page (adds one explanation call)
   --ocr                   With --preview (URL/.html): extract text inside page images via an

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -11,7 +11,7 @@ import { buildTransformVariants } from './args.js';
 import { invokeBackendChain, selectBackendChain, selectOcrBackends, listBackends } from '../backends/index.js';
 import { selectProvider, resolveProviderConfig } from '../providers.js';
 import { validateBaseURL, applyInsecureBaseURLOptIn, applyPrivateBaseURLOptIn } from '../security.js';
-import { formatOutput, formatRewriteBodyForBrowser, validateScoreWeights, buildDeterministicAuditBackstop } from '../output.js';
+import { formatOutput, formatRewriteBodyForBrowser, validateScoreWeights, buildDeterministicAuditBackstop, stripSelfAudit } from '../output.js';
 import {
   buildBrowserDiffPromptInput,
   renderExplanationHtml,
@@ -23,6 +23,7 @@ import { fetchPreviewPage, prepareSnapshotHtml, freezeSnapshotAssets, extractPro
 import { collectImageCandidates, stageOcrImages, ocrStagedImages, describeImage, hasOcrRunnerOverride } from '../ocr.js';
 import { rmSync } from 'node:fs';
 import { runOuroboros } from '../ouroboros.js';
+import { verifyRewrite, deterministicMeaningGuard } from '../verify.js';
 import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals } from '../scoring.js';
 import { detectKoreanRegister } from '../features/stylometry.js';
 import { logBatchSafetyPlan, createBatchCircuitBreaker, shouldHandleBatchFailure, writeBatchOutput } from './batch.js';
@@ -111,6 +112,11 @@ export async function runDefault(parsed, logger) {
     : parsed.score ? 'score'
     : parsed.ouroboros ? 'ouroboros'
     : 'rewrite';
+  if (parsed.ouroboros) {
+    logger.warn('ouroboros.deprecated', {
+      message: '[patina] --ouroboros is deprecated; use --verify (rewrite + meaning-floor retry). The loop will be removed in a future release.',
+    });
+  }
   const persona = resolvePersonaForRun({ parsed, config, mode, lang, repoRoot });
 
   const voiceSamplePath = (mode === 'rewrite' || mode === 'ouroboros')
@@ -277,6 +283,55 @@ export async function runDefault(parsed, logger) {
           });
         }
         cancellation.throwIfCanceled();
+
+        if (mode === 'rewrite') {
+          // The backend result still carries the [BODY]/[SELF_AUDIT] tags that
+          // formatOutput strips for display; verify scoring and the meaning guard
+          // must measure the clean prose, not the tags.
+          const stripQuiet = { warn() {} };
+          if (parsed.verify) {
+            const cleanRewrite = stripSelfAudit(result, { logger: stripQuiet });
+            const verifyCallLLM = ({ prompt: verifyPrompt, signal: verifySignal, timeout: verifyTimeout }) =>
+              invokeBackendChain({
+                backends,
+                prompt: verifyPrompt,
+                apiKey: resolved.apiKey,
+                baseURL: resolved.baseURL,
+                model: resolved.model,
+                modelSource: resolved.modelSource,
+                signal: verifySignal ?? cancellation.signal,
+                timeout: verifyTimeout ?? timeoutMs,
+                maxConcurrency: 1,
+                maxRetries: 0,
+                logger,
+              });
+            const verification = await verifyRewrite({
+              original: text,
+              rewrite: cleanRewrite,
+              config,
+              patterns,
+              profile: profile.body ? profile : null,
+              voice: voice.body ? voice : null,
+              voiceSample,
+              scoring: scoring.body ? scoring : null,
+              apiKey: resolved.apiKey,
+              baseURL: resolved.baseURL,
+              model: resolved.model,
+              callLLM: verifyCallLLM,
+              signal: cancellation.signal,
+              timeout: timeoutMs,
+              logger,
+            });
+            result = verification.text;
+            logger.info('verify.result', {
+              message: `[patina] verify: MPS ${verification.mps ?? 'n/a'}, fidelity ${verification.fidelity}${verification.verified ? ' (passed)' : ' (below floor)'}${verification.retried ? ' [retried]' : ''}`,
+            });
+          }
+          const finalText = parsed.verify ? result : stripSelfAudit(result, { logger: stripQuiet });
+          for (const w of deterministicMeaningGuard(text, finalText)) {
+            logger.warn('rewrite.meaning_guard', { message: `[patina] ${w}` });
+          }
+        }
 
         if (mode === 'score' && !parsed.ouroboros) {
           result = withDeterministicScore(result, {

--- a/src/verify.js
+++ b/src/verify.js
@@ -1,0 +1,159 @@
+// @ts-check
+import { scoreMPS as defaultScoreMPS, scoreFidelity as defaultScoreFidelity } from './scoring.js';
+import { buildPrompt } from './prompt-builder.js';
+import { stripSelfAudit } from './output.js';
+import { createLogger } from './logger.js';
+
+// Numeric tokens (integers, decimals, grouped numbers). Used by the cheap,
+// LLM-free meaning guard to catch numbers that silently vanish in a rewrite.
+const NUMBER_RE = /\d[\d.,]*/g;
+
+function numbersIn(text) {
+  const out = new Set();
+  for (const m of String(text ?? '').matchAll(NUMBER_RE)) {
+    // Normalize grouping commas (1,200 === 1200) and strip trailing separators
+    // so the same number in a different format is not flagged as dropped.
+    const normalized = m[0].replace(/,/g, '').replace(/\.+$/, '');
+    if (normalized) out.add(normalized);
+  }
+  return out;
+}
+
+/**
+ * Cheap, LLM-free meaning-drift heuristic for the default rewrite path. Returns
+ * human-readable warning strings (never throws, never blocks output). Kept
+ * deliberately conservative — only source numbers that vanish from the rewrite —
+ * so the default path stays fast and free of false positives (a humanizer
+ * legitimately changes length, so length is not a reliable drift signal here).
+ *
+ * @param {string} original
+ * @param {string} rewrite
+ * @returns {string[]}
+ */
+export function deterministicMeaningGuard(original, rewrite) {
+  const warnings = [];
+  const orig = String(original ?? '');
+  const out = String(rewrite ?? '');
+
+  const oNums = numbersIn(orig);
+  const rNums = numbersIn(out);
+  const dropped = [...oNums].filter((n) => !rNums.has(n));
+  if (dropped.length > 0) {
+    warnings.push(
+      `numbers in the source are missing from the rewrite: ${dropped.slice(0, 6).join(', ')}${dropped.length > 6 ? '…' : ''}`,
+    );
+  }
+
+  return warnings;
+}
+
+// Trusted directive appended (outside the input data fence) for the conservative
+// retry. The first rewrite drifted; this asks for minimal, meaning-safe edits.
+const STRICT_RETRY_DIRECTIVE = [
+  '',
+  '## STRICT MEANING PRESERVATION (verify retry)',
+  'A previous rewrite of this text drifted from the source meaning and failed the',
+  'meaning-preservation floor. Rewrite again with MINIMAL changes:',
+  '- Preserve every claim, number, named entity, polarity, and causal relationship exactly.',
+  '- Prefer leaving a sentence unchanged over altering what it asserts.',
+  '- Only remove AI-pattern wording; never rephrase content whose meaning could shift.',
+  '',
+].join('\n');
+
+/**
+ * Verify that a produced rewrite preserves meaning. Scores MPS + fidelity; if
+ * either is below the configured floor, runs ONE conservative retry from the
+ * original. If the retry still misses, returns the highest-fidelity candidate
+ * with a warning (fail-closed but non-destructive — the caller still gets text).
+ *
+ * Transport-agnostic: `callLLM` is injected by the caller and is expected to be
+ * routed through the selected backend chain, so verify works with HTTP and local
+ * CLI backends alike.
+ *
+ * @param {object} options
+ * @returns {Promise<{text: string, mps: number|null, fidelity: number, verified: boolean, retried: boolean, reason: string}>}
+ */
+export async function verifyRewrite({
+  original,
+  rewrite,
+  config,
+  patterns,
+  profile,
+  voice,
+  voiceSample,
+  scoring,
+  apiKey,
+  baseURL,
+  model,
+  callLLM,
+  signal,
+  timeout,
+  logger = createLogger(),
+  scoreFns = {},
+}) {
+  const scoreMPS = scoreFns.scoreMPS || defaultScoreMPS;
+  const scoreFidelity = scoreFns.scoreFidelity || defaultScoreFidelity;
+  const oc = config?.ouroboros || {};
+  const mpsFloor = oc['mps-floor'] ?? 70;
+  const fidelityFloor = oc['fidelity-floor'] ?? 70;
+
+  const grade = async (text) => {
+    const [mpsResult, fidelityResult] = await Promise.all([
+      scoreMPS({ original, rewritten: text, apiKey, baseURL, model, callLLM, signal, timeout, logger }),
+      scoreFidelity({ original, rewritten: text, apiKey, baseURL, model, callLLM, signal, timeout, logger }),
+    ]);
+    // Fail closed: a missing MPS stays null (treated as a floor miss); a missing
+    // fidelity clamps to 0, matching scoreFidelity's own behavior.
+    return { mps: mpsResult?.mps ?? null, fidelity: fidelityResult?.fidelity ?? 0 };
+  };
+  const passes = (s) => s.mps !== null && s.mps >= mpsFloor && s.fidelity >= fidelityFloor;
+
+  const first = await grade(rewrite);
+  if (passes(first)) {
+    return { text: rewrite, mps: first.mps, fidelity: first.fidelity, verified: true, retried: false, reason: 'passed' };
+  }
+  logger.warn?.('verify.retry', {
+    message: `[patina] verify: rewrite below floor (MPS ${first.mps ?? 'n/a'}, fidelity ${first.fidelity}); retrying with stricter meaning preservation…`,
+  });
+
+  const retryPrompt = buildPrompt({
+    config,
+    patterns,
+    profile,
+    voice,
+    voiceSample,
+    scoring,
+    text: original,
+    mode: 'rewrite',
+    includeSelfAudit: false,
+  }) + STRICT_RETRY_DIRECTIVE;
+
+  let retryText;
+  try {
+    const raw = await callLLM({ prompt: retryPrompt, apiKey, baseURL, model, signal, timeout });
+    retryText = stripSelfAudit(raw, { logger });
+  } catch (err) {
+    logger.warn?.('verify.retry_failed', {
+      message: `[patina] verify: retry call failed (${/** @type {any} */ (err)?.message || err}); keeping the first rewrite.`,
+    });
+    return { text: rewrite, mps: first.mps, fidelity: first.fidelity, verified: false, retried: true, reason: 'retry-error' };
+  }
+
+  const second = await grade(retryText);
+  if (passes(second)) {
+    return { text: retryText, mps: second.mps, fidelity: second.fidelity, verified: true, retried: true, reason: 'passed-on-retry' };
+  }
+
+  // Fail-closed but non-destructive: emit the highest-fidelity candidate (closest
+  // to the source meaning), tie-broken by higher MPS, with a loud warning.
+  const candidates = [
+    { text: rewrite, mps: first.mps, fidelity: first.fidelity },
+    { text: retryText, mps: second.mps, fidelity: second.fidelity },
+  ];
+  candidates.sort((a, b) => (b.fidelity - a.fidelity) || ((b.mps ?? -1) - (a.mps ?? -1)));
+  const best = candidates[0];
+  logger.warn?.('verify.failed', {
+    message: `[patina] verify: meaning floors not met after a retry (best MPS ${best.mps ?? 'n/a'}, fidelity ${best.fidelity}; floors ${mpsFloor}/${fidelityFloor}). Emitting the closest candidate — review the meaning before publishing.`,
+  });
+  return { text: best.text, mps: best.mps, fidelity: best.fidelity, verified: false, retried: true, reason: 'floor-not-met' };
+}

--- a/tests/unit/verify.test.js
+++ b/tests/unit/verify.test.js
@@ -1,0 +1,156 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { deterministicMeaningGuard, verifyRewrite } from '../../src/verify.js';
+import { validateVerifyRequest } from '../../src/cli/args.js';
+
+// ---------- deterministicMeaningGuard (no LLM) ----------
+
+test('deterministicMeaningGuard flags numbers dropped from the source', () => {
+  const warnings = deterministicMeaningGuard('Revenue grew 42% to 1.5M in 2025.', 'Revenue grew a lot recently.');
+  assert.ok(warnings.some((w) => /numbers/.test(w)), warnings.join(' | '));
+});
+
+test('deterministicMeaningGuard stays silent when numbers and length are preserved', () => {
+  const original = 'The team shipped 3 features and fixed 12 bugs across this sprint cycle.';
+  const rewrite = 'The team shipped 3 features and fixed 12 bugs during this sprint.';
+  assert.deepEqual(deterministicMeaningGuard(original, rewrite), []);
+});
+
+test('deterministicMeaningGuard treats grouped and plain numbers as equal (1,200 === 1200)', () => {
+  assert.deepEqual(
+    deterministicMeaningGuard('We reached 1200 users and 42% growth.', 'We reached 1,200 users with 42% growth.'),
+    [],
+  );
+});
+
+// ---------- verifyRewrite (injected scorers + callLLM) ----------
+
+const baseArgs = {
+  original: 'Original claim with the number 42.',
+  config: {},
+  patterns: [],
+  profile: null,
+  voice: null,
+  voiceSample: null,
+  scoring: null,
+  apiKey: 'k',
+  baseURL: 'b',
+  model: 'm',
+  logger: { warn() {}, info() {} },
+};
+
+test('verifyRewrite accepts the first rewrite when both floors pass (no retry)', async () => {
+  let calls = 0;
+  const result = await verifyRewrite({
+    ...baseArgs,
+    rewrite: 'good rewrite',
+    callLLM: async () => { calls += 1; return 'RETRY'; },
+    scoreFns: { scoreMPS: async () => ({ mps: 90 }), scoreFidelity: async () => ({ fidelity: 85 }) },
+  });
+  assert.equal(result.verified, true);
+  assert.equal(result.retried, false);
+  assert.equal(result.text, 'good rewrite');
+  assert.equal(calls, 0);
+});
+
+test('verifyRewrite retries conservatively and accepts a passing retry', async () => {
+  let calls = 0;
+  const result = await verifyRewrite({
+    ...baseArgs,
+    rewrite: 'first',
+    callLLM: async () => { calls += 1; return '[BODY]second[/BODY]'; },
+    scoreFns: {
+      scoreMPS: async ({ rewritten }) => ({ mps: rewritten === 'first' ? 50 : 90 }),
+      scoreFidelity: async ({ rewritten }) => ({ fidelity: rewritten === 'first' ? 50 : 88 }),
+    },
+  });
+  assert.equal(calls, 1);
+  assert.equal(result.verified, true);
+  assert.equal(result.retried, true);
+  assert.equal(result.text, 'second');
+});
+
+test('verifyRewrite fails closed to the highest-fidelity candidate', async () => {
+  const result = await verifyRewrite({
+    ...baseArgs,
+    rewrite: 'first-rw',
+    callLLM: async () => 'retry-rw',
+    scoreFns: {
+      scoreMPS: async ({ rewritten }) => ({ mps: rewritten === 'first-rw' ? 40 : 60 }),
+      scoreFidelity: async ({ rewritten }) => ({ fidelity: rewritten === 'first-rw' ? 50 : 65 }),
+    },
+  });
+  assert.equal(result.verified, false);
+  assert.equal(result.reason, 'floor-not-met');
+  assert.equal(result.text, 'retry-rw');
+  assert.equal(result.fidelity, 65);
+});
+
+test('verifyRewrite keeps the first rewrite when the retry call throws', async () => {
+  const result = await verifyRewrite({
+    ...baseArgs,
+    rewrite: 'first',
+    callLLM: async () => { throw new Error('network down'); },
+    scoreFns: { scoreMPS: async () => ({ mps: 40 }), scoreFidelity: async () => ({ fidelity: 40 }) },
+  });
+  assert.equal(result.verified, false);
+  assert.equal(result.reason, 'retry-error');
+  assert.equal(result.text, 'first');
+});
+
+test('verifyRewrite treats a null MPS as a floor miss (fail closed)', async () => {
+  let mpsCalls = 0;
+  const result = await verifyRewrite({
+    ...baseArgs,
+    rewrite: 'first',
+    callLLM: async () => 'retry',
+    scoreFns: {
+      scoreMPS: async () => (mpsCalls++ === 0 ? { mps: null } : { mps: 90 }),
+      scoreFidelity: async () => ({ fidelity: 90 }),
+    },
+  });
+  assert.equal(result.retried, true);
+  assert.equal(result.verified, true);
+  assert.equal(result.text, 'retry');
+});
+
+test('verifyRewrite honors configured floors', async () => {
+  // fidelity 75 passes the default 70 floor but fails an 80 floor → retry.
+  let calls = 0;
+  const result = await verifyRewrite({
+    ...baseArgs,
+    config: { ouroboros: { 'mps-floor': 80, 'fidelity-floor': 80 } },
+    rewrite: 'first',
+    callLLM: async () => { calls += 1; return 'retry'; },
+    scoreFns: {
+      scoreMPS: async ({ rewritten }) => ({ mps: rewritten === 'first' ? 75 : 90 }),
+      scoreFidelity: async ({ rewritten }) => ({ fidelity: rewritten === 'first' ? 75 : 90 }),
+    },
+  });
+  assert.equal(calls, 1);
+  assert.equal(result.verified, true);
+  assert.equal(result.retried, true);
+});
+
+// ---------- validateVerifyRequest ----------
+
+test('validateVerifyRequest rejects non-rewrite and preview surfaces', () => {
+  for (const flag of ['score', 'audit', 'diff', 'ouroboros', 'preview']) {
+    assert.throws(
+      () => validateVerifyRequest({ verify: true, [flag]: true }),
+      /--verify cannot be combined/,
+      flag,
+    );
+  }
+});
+
+test('validateVerifyRequest rejects voice/content restyle depths', () => {
+  assert.throws(() => validateVerifyRequest({ verify: true, restyle: 'voice' }), /--verify cannot be combined with --restyle/);
+  assert.throws(() => validateVerifyRequest({ verify: true, restyle: 'content' }), /--verify cannot be combined with --restyle/);
+});
+
+test('validateVerifyRequest allows a plain verified rewrite and is a no-op without --verify', () => {
+  assert.doesNotThrow(() => validateVerifyRequest({ verify: true, restyle: 'sentence' }));
+  assert.doesNotThrow(() => validateVerifyRequest({}));
+});


### PR DESCRIPTION
Folds the meaning-floor check (the genuinely valuable part of `--ouroboros`) into the rewrite path as an opt-in `--verify`, and adds a free deterministic guard to every rewrite. Phase 1 of replacing the `--ouroboros` loop.

## Why
An A/B (single vs ouroboros, run on DeepSeek) showed the multi-pass loop's value is the **floor + rollback**, not the iteration: a single pass removed more AI but breached the fidelity floor (drifted meaning), while ouroboros stayed conservative (MPS/fidelity 100). So the floor gate belongs in rewrite, not in a separate mode.

## What
- **`--verify`** (rewrite modifier): after the rewrite, score MPS + fidelity; if either is below the floor (`ouroboros.mps-floor` / `ouroboros.fidelity-floor`, default 70), run **one** conservative retry from the original with a strict meaning-preservation directive; if it still misses, emit the highest-fidelity candidate with a loud stderr warning (fail-closed but non-destructive). Scorers run through the **selected backend chain**, so it works with HTTP and local CLI backends alike.
- **Deterministic meaning guard (always on, no LLM):** every rewrite warns on stderr when a number present in the source vanishes from the rewrite. Length is intentionally not checked (a humanizer legitimately changes length). Measures the cleaned prose (`[BODY]`/`[SELF_AUDIT]` tags stripped).
- **`--ouroboros` deprecated:** prints a deprecation notice pointing at `--verify`. The loop (`src/ouroboros.js`) and its tests are unchanged in this PR; the alias/removal is a follow-up (Phase 2) to avoid churning the large ouroboros test surface in one PR.
- Validation: `--verify` is a rewrite modifier, rejected with `--score/--audit/--diff/--ouroboros/--preview` and `--restyle voice|content`.

## Files
- `src/verify.js` (new): `verifyRewrite()` + `deterministicMeaningGuard()`
- `src/cli/args.js`: `--verify` flag, `validateVerifyRequest`, help (mark `--ouroboros` deprecated)
- `src/cli.js`: wire `validateVerifyRequest`
- `src/cli/run.js`: strip tags → verify → guard; one-time `--ouroboros` deprecation warning
- `.patina.default.yaml`, `docs/CLI.md`: document that `--verify` reuses the floors
- `tests/unit/verify.test.js` (new): guard + verifyRewrite branches + validation (12 tests)

## Verification
- `npm run lint` (syntax/eslint/typecheck/spellcheck) clean
- `npm test` — full suite green (incl. 12 new verify tests; all existing ouroboros/persona/transform/web tests unchanged)
- Live smoke (DeepSeek `deepseek-v4-flash`): `patina --verify` end-to-end → scored MPS 100 / fidelity 75 (passed); a drifting rewrite triggered the conservative retry and fail-closed-to-best path. Plain rewrite path: guard silent on number-preserving rewrites.
