### PR TITLE
refactor(cli): alias --ouroboros to --verify, remove CLI loop (Phase 2)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -57,9 +57,9 @@ patina --verify draft.md
 patina --verify --lang ko --backend codex-cli draft.md
 ```
 
-- It is a rewrite modifier, not a separate mode: combining it with `--score`, `--audit`, `--diff`, `--ouroboros`, `--preview`, or `--restyle voice|content` is an input error (those either do not rewrite or loosen the meaning floors `--verify` enforces).
+- It is a rewrite modifier, not a separate mode: combining it with `--score`, `--audit`, `--diff`, `--preview`, or `--restyle voice|content` is an input error (those either do not rewrite or loosen the meaning floors `--verify` enforces).
 - The MPS/fidelity scorers run through the **selected backend**, so `--verify` works with HTTP and local CLI backends alike. It adds up to four extra model calls (two scorers, plus a retry that re-scores), so the plain rewrite stays the fast/cheap default.
-- `--ouroboros` is **deprecated** in favor of `--verify`; the iterative loop will be removed in a future release.
+- `--ouroboros` is **deprecated** and now runs `--verify`; the iterative loop has been removed from the CLI (it survives only as a research baseline in `npm run quality:rewrite-ab`).
 
 ### Deterministic meaning guard (always on, no LLM)
 

--- a/scripts/rewrite-ab.mjs
+++ b/scripts/rewrite-ab.mjs
@@ -5,11 +5,11 @@
 // both (before/after AI score, MPS, fidelity) and measures edit churn, then
 // reports per-fixture winners + aggregate deltas.
 //
-// The CLI multi-pass already exists as `--ouroboros` (detect -> rewrite -> score
-// -> rollback with MPS/fidelity floors), so the default comparison is
-// `single` (one-shot rewrite) vs `ouroboros` (multi-pass). This is the
-// deterministic-question-with-an-LLM answer to "does the multi-pass pipeline
-// produce better rewrites than a single pass?"
+// The multi-pass `runOuroboros` loop (detect -> rewrite -> score -> rollback with
+// MPS/fidelity floors) is retained as a research baseline here, even though the
+// CLI's `--ouroboros` now aliases the lighter `--verify`. The default comparison
+// is `single` (one-shot rewrite) vs `ouroboros` (multi-pass) — the
+// deterministic-question-with-an-LLM answer to "does multi-pass beat one pass?"
 //
 // LLM-backed and opt-in (like quality:live): non-deterministic, may incur
 // provider cost. The core comparison/aggregation is pure and unit-tested with

--- a/src/cli/args.js
+++ b/src/cli/args.js
@@ -169,7 +169,10 @@ export function parseArgs(rawArgs) {
         break;
       }
       case '--ouroboros':
+        // Deprecated alias: the iterative loop was removed; --ouroboros now runs
+        // --verify. parsed.ouroboros is kept as the deprecation/conflict marker.
         parsed.ouroboros = true;
+        parsed.verify = true;
         break;
 
       case '--verify':
@@ -487,7 +490,6 @@ export function validateVerifyRequest(parsed) {
     ['score', '--score'],
     ['audit', '--audit'],
     ['diff', '--diff'],
-    ['ouroboros', '--ouroboros'],
     ['preview', '--preview'],
   ];
   for (const [key, flag] of blocked) {
@@ -711,7 +713,7 @@ MODES
   --exit-on <n>           With --score, exit 3 when overall score > n
   --verify                Rewrite, then verify meaning (MPS/fidelity floors) with
                           one conservative retry; fail-closed to the best candidate
-  --ouroboros             [deprecated] Iterative self-improvement loop (use --verify)
+  --ouroboros             [deprecated] alias for --verify (the iterative loop was removed)
   --preview               Rewrite one http(s) URL or local .html file in place on a snapshot
                           of the page (adds one explanation call)
   --ocr                   With --preview (URL/.html): extract text inside page images via an

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -22,7 +22,7 @@ import {
 import { fetchPreviewPage, prepareSnapshotHtml, freezeSnapshotAssets, extractProseBlocks, alignRewrites, buildPreviewHtml, buildContextCardHtml } from '../preview.js';
 import { collectImageCandidates, stageOcrImages, ocrStagedImages, describeImage, hasOcrRunnerOverride } from '../ocr.js';
 import { rmSync } from 'node:fs';
-import { runOuroboros } from '../ouroboros.js';
+
 import { verifyRewrite, deterministicMeaningGuard } from '../verify.js';
 import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals } from '../scoring.js';
 import { detectKoreanRegister } from '../features/stylometry.js';
@@ -31,7 +31,7 @@ import { applyScoreGate, extractScoreOverall } from './score-gate.js';
 import { loadInputs } from './input.js';
 import { PatinaCliError, runtimeError, inputError } from '../errors.js';
 import { providerHttpKeyEnvVars, resolveHttpApiKey } from '../auth.js';
-import { DEFAULT_BACKEND_TIMEOUT_MS, getBackendSafety, backendSupportsStructuredOutput } from '../backends/contract.js';
+import { DEFAULT_BACKEND_TIMEOUT_MS, getBackendSafety } from '../backends/contract.js';
 import { resolve } from 'node:path';
 import { loadPersona } from '../personas/loader.js';
 import { evaluatePersonaGate } from '../personas/gates.js';
@@ -110,16 +110,15 @@ export async function runDefault(parsed, logger) {
   const mode = parsed.diff ? 'diff'
     : parsed.audit ? 'audit'
     : parsed.score ? 'score'
-    : parsed.ouroboros ? 'ouroboros'
     : 'rewrite';
   if (parsed.ouroboros) {
     logger.warn('ouroboros.deprecated', {
-      message: '[patina] --ouroboros is deprecated; use --verify (rewrite + meaning-floor retry). The loop will be removed in a future release.',
+      message: '[patina] --ouroboros is deprecated and now runs --verify (rewrite + meaning-floor retry); the iterative loop has been removed.',
     });
   }
   const persona = resolvePersonaForRun({ parsed, config, mode, lang, repoRoot });
 
-  const voiceSamplePath = (mode === 'rewrite' || mode === 'ouroboros')
+  const voiceSamplePath = mode === 'rewrite'
     ? (parsed.voiceSample ?? config['voice-sample'])
     : null;
   const voiceSample = voiceSamplePath
@@ -133,9 +132,7 @@ export async function runDefault(parsed, logger) {
 
   const inputTexts = parsed.preview ? [] : await loadInputs(parsed, logger);
   const timeoutMs = parsed.timeoutMs ?? DEFAULT_BACKEND_TIMEOUT_MS;
-  const backendSelection = parsed.ouroboros
-    ? null
-    : selectBackendChain({
+  const backendSelection = selectBackendChain({
       name: parsed.backend ?? config.backend ?? (resolved.baseURLSource !== 'default' ? 'openai-http' : undefined),
       model: resolved.model,
       modelSource: resolved.modelSource,
@@ -203,9 +200,9 @@ export async function runDefault(parsed, logger) {
     path,
     text,
     readError,
-    // A read failure (#503) or ouroboros mode means there is no prompt to
-    // build; the read error is replayed inside the per-file batch loop below.
-    prompt: (readError || parsed.ouroboros) ? null : buildPrompt({
+    // A read failure (#503) means there is no prompt to build; the read error is
+    // replayed inside the per-file batch loop below.
+    prompt: readError ? null : buildPrompt({
       config,
       patterns,
       profile: profile.body ? profile : null,
@@ -248,40 +245,19 @@ export async function runDefault(parsed, logger) {
         if (readError) throw readError;
         let result;
 
-        if (parsed.ouroboros) {
-          result = await runOuroboros({
-            config,
-            patterns,
-            profile: profile.body ? profile : null,
-            voice: voice.body ? voice : null,
-            voiceSample,
-            scoring: scoring.body ? scoring : null,
-            text,
-            apiKey: resolved.apiKey,
-            baseURL: resolved.baseURL,
-            model: resolved.model,
-            timeout: timeoutMs,
-            signal: cancellation.signal,
-            logger,
-            // Opt-in structured output for the openai-http scorer; default off.
-            structuredOutput: config['structured-output'] === true && backendSupportsStructuredOutput('openai-http'),
-            persona,
-          });
-        } else {
-          result = await invokeBackendChain({
-            backends,
-            prompt,
-            apiKey: resolved.apiKey,
-            baseURL: resolved.baseURL,
-            model: resolved.model,
-            modelSource: resolved.modelSource,
-            signal: cancellation.signal,
-            timeout: timeoutMs,
-            maxConcurrency: parsed.maxConcurrency,
-            maxRetries: parsed.maxRetries,
-            logger,
-          });
-        }
+        result = await invokeBackendChain({
+          backends,
+          prompt,
+          apiKey: resolved.apiKey,
+          baseURL: resolved.baseURL,
+          model: resolved.model,
+          modelSource: resolved.modelSource,
+          signal: cancellation.signal,
+          timeout: timeoutMs,
+          maxConcurrency: parsed.maxConcurrency,
+          maxRetries: parsed.maxRetries,
+          logger,
+        });
         cancellation.throwIfCanceled();
 
         if (mode === 'rewrite') {
@@ -333,7 +309,7 @@ export async function runDefault(parsed, logger) {
           }
         }
 
-        if (mode === 'score' && !parsed.ouroboros) {
+        if (mode === 'score') {
           result = withDeterministicScore(result, {
             text,
             config,
@@ -368,15 +344,9 @@ export async function runDefault(parsed, logger) {
 
         let output;
         let scoreValidationOutput = null;
-        if (parsed.ouroboros) {
-          const ouroborosBody = formatOuroborosOutput(result);
-          output = formatOutput(ouroborosBody, mode, parsed, { tone: toneResolution, logger, auditBackstop, persona: null });
-          scoreValidationOutput = ouroborosBody;
-        } else {
-          output = formatOutput(result, mode, parsed, { tone: toneResolution, logger, auditBackstop, persona: personaReport });
-          if (mode === 'score') {
-            scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' }, { logger });
-          }
+        output = formatOutput(result, mode, parsed, { tone: toneResolution, logger, auditBackstop, persona: personaReport });
+        if (mode === 'score') {
+          scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' }, { logger });
         }
 
         // v3.11 Phase 1.3: surface weight drift between config and the score
@@ -610,25 +580,6 @@ function resolveApiKey(parsed, provider) {
     apiKeyFile: parsed.apiKeyFile,
     envVars: providerHttpKeyEnvVars(provider?.apiKeyEnv),
   });
-}
-
-function formatOuroborosOutput(result) {
-  let output = '## Ouroboros Iteration Log\n\n';
-  output += '| Iter | Before | After | Improvement | Reason |\n';
-  output += '|------|--------|-------|-------------|--------|\n';
-
-  for (const entry of result.log) {
-    output += `| ${entry.iteration} | ${entry.before ?? '—'} | ${entry.after} | ${entry.improvement ?? '—'} | ${entry.reason} |\n`;
-  }
-
-  output += `\nFinal score: ${result.finalScore}/100 (±10)\n`;
-  output += `Iterations: ${result.iterations}/${result.log.length > 0 ? result.log[result.log.length - 1].iteration : 0}\n`;
-  output += `Reason: ${result.reason}\n\n`;
-  output += '## Final Text\n\n';
-  output += result.finalText.trim();
-  output += '\n';
-
-  return output;
 }
 
 async function runPreviewJob({

--- a/tests/unit/verify.test.js
+++ b/tests/unit/verify.test.js
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { deterministicMeaningGuard, verifyRewrite } from '../../src/verify.js';
-import { validateVerifyRequest } from '../../src/cli/args.js';
+import { validateVerifyRequest, parseArgs } from '../../src/cli/args.js';
 
 // ---------- deterministicMeaningGuard (no LLM) ----------
 
@@ -136,7 +136,7 @@ test('verifyRewrite honors configured floors', async () => {
 // ---------- validateVerifyRequest ----------
 
 test('validateVerifyRequest rejects non-rewrite and preview surfaces', () => {
-  for (const flag of ['score', 'audit', 'diff', 'ouroboros', 'preview']) {
+  for (const flag of ['score', 'audit', 'diff', 'preview']) {
     assert.throws(
       () => validateVerifyRequest({ verify: true, [flag]: true }),
       /--verify cannot be combined/,
@@ -153,4 +153,12 @@ test('validateVerifyRequest rejects voice/content restyle depths', () => {
 test('validateVerifyRequest allows a plain verified rewrite and is a no-op without --verify', () => {
   assert.doesNotThrow(() => validateVerifyRequest({ verify: true, restyle: 'sentence' }));
   assert.doesNotThrow(() => validateVerifyRequest({}));
+});
+
+test('--ouroboros is a deprecated alias that turns on --verify', () => {
+  const parsed = parseArgs(['--ouroboros', 'draft.md']);
+  assert.equal(parsed.verify, true);
+  assert.equal(parsed.ouroboros, true);
+  // The alias must not self-conflict in the verify validator.
+  assert.doesNotThrow(() => validateVerifyRequest(parsed));
 });


### PR DESCRIPTION
Phase 2 of replacing the ouroboros loop (Phase 1 was #552, which added `--verify`).

## What
- **`--ouroboros` is now a deprecated alias of `--verify`.** It sets `parsed.verify`, prints a deprecation notice, and runs the rewrite + meaning-floor verify path instead of the iterative loop. `parsed.ouroboros` is kept only as the deprecation/conflict marker (mode-exclusivity, persona/transform rejection).
- **Removed the CLI loop wiring** from `src/cli/run.js`: the `runOuroboros` invocation, the `ouroboros` output mode, `formatOuroborosOutput`, and the `parsed.ouroboros` special-cases for backend selection, prompt building, scoring, and voice samples. Dropped the now-unused `runOuroboros` / `backendSupportsStructuredOutput` imports.
- **`runOuroboros` (`src/ouroboros.js`) is intentionally kept** — it is the multi-pass baseline used by `npm run quality:rewrite-ab` (the A/B harness that informed this whole change). Removing it would gut that research tool, so it stays as a harness-only baseline. `ouroboros.test.js`, the `ouroboros:` config namespace (shared scoring weights/floors), and the prompt-builder `ouroboros` mode are likewise unchanged.

## Files
- `src/cli/args.js`: `--ouroboros` → `parsed.verify = true` (+ marker); drop `--ouroboros` from `validateVerifyRequest`'s incompatible list (it IS verify now); help reworded.
- `src/cli/run.js`: remove the loop path + dead imports + `formatOuroborosOutput`.
- `tests/unit/verify.test.js`: drop `ouroboros` from the verify-rejection loop; add an alias test (`--ouroboros` sets `verify` and `ouroboros`, no self-conflict).
- `docs/CLI.md`, `scripts/rewrite-ab.mjs`: deprecation/comment wording.

## Verification
- `npm run lint` clean; `npm test` — full suite green (988 pass / 1 skip), including the unchanged `ouroboros.test.js`, `prompt-builder.snapshot`, `threshold-parity`, `tone` (#523), `persona-args`, and `transform-options` tests.
- Live smoke (DeepSeek): `patina --ouroboros …` now prints the deprecation notice, runs verify (`MPS 100, fidelity 75 (passed)`), emits a clean rewrite, and produces **no** "Ouroboros Iteration Log".
