### PR TITLE
refactor(cli)!: remove --ouroboros and --restyle flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ prompts for them, and exposes `--timeout-ms`, `--max-concurrency`,
 |  |  |
 |---|---|
 | **168 patterns** | 33 rewrite-capable + 9 score-only viral-hook per language (42 each across KO/EN/ZH/JA) — see the full 168-pattern catalog in [PATTERNS.md](docs/PATTERNS.md) |
-| **Modes** | rewrite · audit · score · diff · ouroboros |
+| **Modes** | rewrite · verify · audit · score · diff |
 | **Surfaces** | agent skill · Node CLI · in-place preview · browser audit playground |
 | **Free usage** | logged-in `codex`, `claude`, or `gemini` CLI can run rewrites without `PATINA_API_KEY` |
 | **Calibration** | 67.3% editing-hotspot catch [63.5–71.0%] across GPT-5.5 / Claude Sonnet 4.6 / Gemini 2.5 Pro (n=600, KO+EN); 16.0% false positives [11.6–21.7%] on KO+EN human controls (n=200) |
@@ -138,7 +138,7 @@ patina --lang <ko|en|zh|ja> [mode] [--profile <name>] input.txt
 | `patina --score --exit-on 30 input.txt` | CI gate with exit code `3` when `overall > 30` |
 | `patina --diff input.txt` | show pattern-by-pattern changes |
 | `patina --preview page.html` | render rewrites back onto a saved HTML page with toggles and inline diff |
-| `patina --ouroboros input.txt` | iterate with MPS/fidelity rollback |
+| `patina --verify input.txt` | rewrite, then check MPS/fidelity floors with one retry |
 | `patina --tone auto --lang en input.txt` | infer and apply a KO/EN tone axis |
 | `patina --format json --quiet input.txt` | script-friendly output |
 | `patina --batch docs/*.md --outdir cleaned/` | batch file processing |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -44,7 +44,7 @@ patina --lang en --score --exit-on 30 draft.md
 - Score JSON may include `scores.llm`, `scores.deterministic`, and `scores.preference` when deterministic shadow scoring is available.
 - `mps` is populated when the underlying mode emits it.
 - `gateResult` is `null` unless `--exit-on` is used.
-- `--voice-sample <path>` or config `voice-sample: <path>` injects the first 1–3 user-written paragraphs into rewrite/Ouroboros prompts as style-only examples of how this person writes. `--profile` / `--tone` still define the outer register; samples refine cadence and texture without importing facts.
+- `--voice-sample <path>` or config `voice-sample: <path>` injects the first 1–3 user-written paragraphs into rewrite prompts as style-only examples of how this person writes. `--profile` / `--tone` still define the outer register; samples refine cadence and texture without importing facts.
 - `patina doctor --json` emits setup diagnostics for CI without making an LLM call.
 
 
@@ -57,9 +57,9 @@ patina --verify draft.md
 patina --verify --lang ko --backend codex-cli draft.md
 ```
 
-- It is a rewrite modifier, not a separate mode: combining it with `--score`, `--audit`, `--diff`, `--preview`, or `--restyle voice|content` is an input error (those either do not rewrite or loosen the meaning floors `--verify` enforces).
+- It is a rewrite modifier, not a separate mode: combining it with `--score`, `--audit`, `--diff`, or `--preview` is an input error (those do not rewrite).
 - The MPS/fidelity scorers run through the **selected backend**, so `--verify` works with HTTP and local CLI backends alike. It adds up to four extra model calls (two scorers, plus a retry that re-scores), so the plain rewrite stays the fast/cheap default.
-- `--ouroboros` is **deprecated** and now runs `--verify`; the iterative loop has been removed from the CLI (it survives only as a research baseline in `npm run quality:rewrite-ab`).
+- `--ouroboros` was **removed**. The iterative loop is gone; `--verify` is its meaning-floor replacement. (The multi-pass loop survives only as a research baseline in `npm run quality:rewrite-ab`.)
 
 ### Deterministic meaning guard (always on, no LLM)
 
@@ -84,11 +84,9 @@ Contract:
 | `--persona p file` | allowed | core v1 surface |
 | `--lang ko --persona p` | allowed | KO library only |
 | `--lang en|zh|ja --persona p` | input error | no non-KO persona library |
-| `--score/--audit/--diff/--ouroboros --persona p` | input error | persona v1 is rewrite-only |
+| `--score/--audit/--diff --persona p` | input error | persona v1 is rewrite-only |
 | `--preview --persona p` | input error | preview migration is later |
-| `--persona p --restyle sentence` | allowed | same as default cleanup depth |
-| `--persona p --restyle voice|content` | input error | conflicting legacy depth; content makes MPS advisory |
-| `--persona p --restyle a,b`, `--jargon x,y`, `--tone a,b` | input error | comma-list variants are preview-only |
+| `--persona p --jargon x,y`, `--tone a,b` | input error | comma-list variants are preview-only |
 | `--persona p --tone casual` | allowed as compatibility hint | persona remains outer contract |
 | `--persona p --profile blog` | allowed as compatibility hint | legacy profile remains non-authoritative |
 | `--persona p --voice-sample sample.md` | allowed | style-only anchor; sample facts are not imported |
@@ -113,37 +111,33 @@ For `--format json`, rewrite output includes a `persona` field when a persona ga
 }
 ```
 
-## Transformations beyond cleanup: `--restyle` / `--jargon`
+## Transformations beyond cleanup: `--jargon`
 
-By default patina is a conservative humanizer: it removes AI tells without changing a sentence's claim or framing. `--restyle` and `--jargon` are explicit opt-ins for when the goal is a different text, not the same text cleaned up. They apply to the default rewrite and `--preview` only; combining them with `--score`, `--audit`, `--diff`, or `--ouroboros` is an input error (those modes either do not rewrite, or enforce meaning-preservation floors a transformation would fight).
+By default patina is a conservative humanizer: it removes AI tells without changing a sentence's claim or framing. `--jargon` is an explicit opt-in for adjusting terminology for a different audience. It applies to the default rewrite and `--preview` only; combining it with `--score`, `--audit`, or `--diff` is an input error (those modes do not rewrite). A full voice/register change is `--persona` / `--tone` / `--voice-sample`, not a rewrite depth.
 
 ```bash
-patina --restyle voice --tone casual draft.md          # full voice/register transformation
-patina --restyle content draft.md                      # content-level re-planning
+patina --jargon remove draft.md                        # de-jargonized rewrite
 patina --preview --jargon remove https://example.com/  # de-jargonized in-place preview
-patina --restyle content --jargon remove draft.md      # both
+patina --jargon explain --tone casual draft.md         # gloss terms, casual register
 ```
 
-- `--restyle sentence` (default) — current behavior: AI-pattern cleanup, minimal paraphrase.
-- `--restyle voice` — rewrite the entire text in the target voice/register (`--tone`/`--profile` define the target), not just suspect zones. Claims, numbers, and argument order are preserved.
-- `--restyle content` — content-level re-planning: restructure sections, merge/cut redundancy, reorder arguments, re-angle for the audience. Core facts stay truthful, but coverage and emphasis may change; the Meaning-Preservation Score is reported as advisory instead of enforced for the run.
 - `--jargon keep` (default) — technical terms untouched.
 - `--jargon explain` — keep terms, add a brief plain-language gloss at first use.
 - `--jargon remove` — replace developer/technical jargon with everyday language; product names and proper nouns stay.
 
 ### Variant comparison in the preview
 
-With `--preview`, `--restyle`, `--jargon`, **and `--tone`** accept comma-separated lists; every combination becomes a **variant** — one rewrite call each, capped at 4 — and the preview bar gains a second toggle group to switch between them in place:
+With `--preview`, `--jargon` **and `--tone`** accept comma-separated lists; every combination becomes a **variant** — one rewrite call each, capped at 4 — and the preview bar gains a second toggle group to switch between them in place:
 
 ```bash
-patina --preview --restyle sentence,voice,content <url>     # cleanup / voice / content side by side
-patina --preview --restyle voice --tone casual,professional <url>  # same depth, two voices
-patina --preview --tone casual,marketing <url>              # tone-only comparison
+patina --preview --jargon keep,remove <url>                  # cleanup / de-jargoned side by side
+patina --preview --jargon remove --tone casual,professional <url>  # same policy, two voices
+patina --preview --tone casual,marketing <url>               # tone-only comparison
 ```
 
-- The bar groups variants two-level: one primary button per restyle depth (cleanup/voice/content) and, when a depth carries multiple options (tone/jargon), a secondary chip row that appears only while that depth is selected — click **voice**, then pick **casual** or **professional**. Each depth remembers its own option selection. The switch is CSS-only (chained radio groups), so the snapshot stays scriptless and the page CSP keeps `script-src 'none'`.
-- The score chip shows each variant's deterministic score (`score 23 → cleanup 5 · voice 8 · content 11`).
-- A comma-listed `--tone` joins the cross product: each variant resolves its own tone (and its backbone profile, unless `--profile` is explicit), exactly as a single run with that `--tone` would. Labels carry the tone when it varies (`voice·casual`).
+- The bar groups variants two-level: one primary button per jargon policy (cleanup/explain/remove) and, when a policy carries multiple options (tone), a secondary chip row that appears only while that policy is selected — click **remove**, then pick **casual** or **professional**. Each policy remembers its own option selection. The switch is CSS-only (chained radio groups), so the snapshot stays scriptless and the page CSP keeps `script-src 'none'`.
+- The score chip shows each variant's deterministic score (`score 23 → cleanup 5 · remove 8`).
+- A comma-listed `--tone` joins the cross product: each variant resolves its own tone (and its backbone profile, unless `--profile` is explicit), exactly as a single run with that `--tone` would. Labels carry the tone when it varies (`remove·casual`).
 - A block counts as changed when **any** variant changes it; a variant that left a block alone shows the original text under that button.
 - stdout carries the first variant's prose (pipe-safe); the explanation call is skipped in compare mode to keep the call budget at one per variant.
 - Compare mode needs a page snapshot (URL or `.html`) and is incompatible with `--ocr`; comma lists without `--preview` are an input error.

--- a/docs/FLAG-PARITY.md
+++ b/docs/FLAG-PARITY.md
@@ -9,7 +9,8 @@ Basis: local checkout plus `node bin/patina.js --help` and `SKILL.md` reviewed o
 | `--audit` | ✓ | ✓ | Detection-only mode. |
 | `--score` | ✓ | ✓ | Score mode is available on both surfaces. |
 | `--exit-on <n>` | ✓ | — | CLI score-gate spelling for CI. |
-| `--ouroboros` | ✓ | ✓ | Iterative rewrite / score convergence loop. |
+| `--verify` | ✓ | — | Rewrite + MPS/fidelity meaning-floor check with one retry (replaces the old loop). |
+| `--ouroboros` | — | ✓ | Removed from the CLI; the `/patina` skill still runs its own iterative loop. |
 | `--format <markdown\|text\|json>` | ✓ | — | CLI output-envelope feature. |
 | `--quiet` | ✓ | — | CLI stderr log suppression for scripts. |
 | `--batch` | ✓ | ✓ | Multi-file CLI/skill rewrite flow. |

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -49,9 +49,9 @@ language limitations. See [Stylometry](../core/stylometry.md#5-ttr-via-mattr).
 
 ## Mode
 
-A CLI output path such as rewrite, audit, score, diff, or ouroboros. Modes
-control whether patina edits text, reports findings, scores text, or loops
-until quality gates are met. See the [mode table](../README.md#modes).
+A CLI output path such as rewrite, verify, audit, score, or diff. Modes
+control whether patina edits text, verifies meaning preservation, reports
+findings, or scores text. See the [mode table](../README.md#modes).
 
 ## MPS
 
@@ -60,11 +60,12 @@ survive the rewrite pipeline and whether polarity is preserved. See
 [the FAQ](FAQ.md#what-is-mps) and
 [MPS scoring](../core/scoring.md#16-mps-scoring-formula).
 
-## Ouroboros mode
+## Ouroboros loop
 
 An iterative rewrite loop that keeps trying to lower AI-likeness while obeying
-meaning-preservation gates. It stops when the combined score is acceptable or
-when fidelity or MPS drops too far. See
+meaning-preservation gates. The standalone CLI replaced it with `--verify`
+(rewrite + meaning-floor retry); the loop still lives in the `/patina` skill
+and the `quality:rewrite-ab` research baseline. See
 [Ouroboros Termination](../core/scoring.md#ouroboros-termination).
 
 ## Pattern

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -11,7 +11,7 @@ Patina ships 168 pattern entries across four languages. The language-specific re
 
 ## Notes
 
-- Rewrite-capable patterns are applied by `--rewrite`, `--diff`, and `--ouroboros` according to their pack metadata and runtime mode.
+- Rewrite-capable patterns are applied by the rewrite modes (default rewrite, `--verify`, and the skill's `--ouroboros` loop) and `--diff`, according to their pack metadata and runtime mode.
 - Viral-hook patterns are score/audit-only SNS-marketing signals. They affect `--score` and `--audit`, but rewrite modes skip them because the rhetoric may be intentional.
 - Pattern packs are auto-discovered from `patterns/{lang}-*.md`. To add a language or custom pack, follow [CONTRIBUTING.md](../CONTRIBUTING.md) and the frontmatter format used in the existing packs.
 

--- a/personas/ko/blog-essay.md
+++ b/personas/ko/blog-essay.md
@@ -55,7 +55,6 @@ target_features:
   over_edit_churn: { max: 0.45, weight: 0.06 }
 legacy_profile_bridge:
   profiles: [blog]
-  restyle_default: voice
 ---
 
 # 개인 블로그 에세이

--- a/personas/ko/natural-ko.md
+++ b/personas/ko/natural-ko.md
@@ -86,7 +86,6 @@ target_features:
   over_edit_churn: { max: 0.6, weight: 0.08 }
 legacy_profile_bridge:
   profiles: [default]
-  restyle_default: voice
 ---
 
 # 담백한 한국어 (AI 티 제거)

--- a/personas/ko/pragmatic-founder.md
+++ b/personas/ko/pragmatic-founder.md
@@ -55,7 +55,6 @@ target_features:
   over_edit_churn: { max: 0.45, weight: 0.06 }
 legacy_profile_bridge:
   profiles: [blog, technical]
-  restyle_default: voice
 ---
 
 # 실전형 창업자

--- a/personas/ko/preserve.md
+++ b/personas/ko/preserve.md
@@ -39,7 +39,6 @@ blocks:
 target_features: {}
 legacy_profile_bridge:
   profiles: []
-  restyle_default: sentence
 ---
 
 # 원문 의미 보존

--- a/personas/ko/soft-professional.md
+++ b/personas/ko/soft-professional.md
@@ -55,7 +55,6 @@ target_features:
   over_edit_churn: { max: 0.40, weight: 0.06 }
 legacy_profile_bridge:
   profiles: [email, formal]
-  restyle_default: voice
 ---
 
 # 부드러운 업무 문체

--- a/personas/ko/technical-explainer.md
+++ b/personas/ko/technical-explainer.md
@@ -55,7 +55,6 @@ target_features:
   over_edit_churn: { max: 0.40, weight: 0.06 }
 legacy_profile_bridge:
   profiles: [technical]
-  restyle_default: voice
 ---
 
 # 기술 설명형

--- a/src/cli/args.js
+++ b/src/cli/args.js
@@ -16,7 +16,7 @@ const VALUE_OPTIONS = new Set([
 const FLAG_OPTIONS = new Set([
   '--help', '-h', '--version', '-v', '--preview', '--ocr',
   '--serve', '--diff', '--no-color', '--audit', '--score', '--quiet',
-  '--ouroboros', '--batch', '--in-place', '--allow-private-base-url',
+  '--batch', '--in-place', '--allow-private-base-url',
   '--stop-on-retryable-storm', '--no-stop-on-retryable-storm',
   '--list-backends', '--allow-insecure-base-url', '--no-interactive',
   '--rewrite-headings', '--verify',
@@ -103,13 +103,16 @@ export function parseArgs(rawArgs) {
         parsed.persona = readOptionValue(args, i, arg);
         i++;
         break;
-      case '--restyle': {
-        const value = readOptionValue(args, i, arg);
-        i++;
-        parsed.restyle = parseTransformList(value, arg, ['sentence', 'voice', 'content'],
-          'sentence = AI-pattern cleanup only (default), voice = full voice/register transformation, content = content-level re-planning. Comma-separate values with --preview to compare variants.');
-        break;
-      }
+      case '--restyle':
+        // Removed: patina's default (and only) rewrite depth is the conservative
+        // AI-tell cleanup the old `--restyle sentence` did. Voice/register
+        // rewriting moved to --persona/--tone/--voice-sample; content re-planning
+        // is out of scope for a meaning-preserving humanizer.
+        throw inputError(
+          '--restyle was removed',
+          'patina cleans AI tells without changing claims (the old --restyle sentence default). Voice/register changes are --persona / --tone / --voice-sample now; content re-planning is out of scope.',
+          'Drop --restyle, or use --persona/--tone for a voice change.'
+        );
       case '--jargon': {
         const value = readOptionValue(args, i, arg);
         i++;
@@ -169,11 +172,13 @@ export function parseArgs(rawArgs) {
         break;
       }
       case '--ouroboros':
-        // Deprecated alias: the iterative loop was removed; --ouroboros now runs
-        // --verify. parsed.ouroboros is kept as the deprecation/conflict marker.
-        parsed.ouroboros = true;
-        parsed.verify = true;
-        break;
+        // Removed: the iterative loop was replaced by --verify (rewrite +
+        // meaning-floor retry) in the v5.5 line.
+        throw inputError(
+          '--ouroboros was removed',
+          'The iterative loop was replaced by --verify (rewrite, then verify MPS/fidelity with one conservative retry).',
+          'Use --verify instead.'
+        );
 
       case '--verify':
         parsed.verify = true;
@@ -303,23 +308,23 @@ export function parseArgs(rawArgs) {
 
 // The output modes are mutually exclusive (SKILL.md). Without this guard, a
 // combination like `--audit --score` resolves to 'audit' and silently skips the
-// score gate (exit 0 always), and `--score --ouroboros` throws deep in the gate.
+// score gate (exit 0 always).
 export function validateModeExclusivity(parsed) {
-  const active = ['diff', 'audit', 'score', 'ouroboros'].filter((m) => parsed[m]);
+  const active = ['diff', 'audit', 'score'].filter((m) => parsed[m]);
   if (active.length > 1) {
     throw inputError(
       `--${active[0]} and --${active[1]} cannot be combined`,
-      'The diff / audit / score / ouroboros output modes are mutually exclusive.',
-      `Pick one of --diff, --audit, --score, or --ouroboros.`
+      'The diff / audit / score output modes are mutually exclusive.',
+      `Pick one of --diff, --audit, or --score.`
     );
   }
 }
 
-// Shared parser for --restyle/--jargon/--tone: a single value, or a
+// Shared parser for --jargon/--tone: a single value, or a
 // comma-separated list of values for --preview variant comparison. Tokens are
 // validated individually and deduped preserving order; the normalized joined
 // string is stored so downstream code has one canonical shape.
-const TRANSFORM_OPTION_NOUNS = { '--restyle': 'restyle depth', '--jargon': 'jargon policy', '--tone': 'tone' };
+const TRANSFORM_OPTION_NOUNS = { '--jargon': 'jargon policy', '--tone': 'tone' };
 
 function parseTransformList(value, option, valid, hint) {
   const tokens = String(value ?? '').split(',').map((t) => t.trim()).filter(Boolean);
@@ -344,59 +349,54 @@ function splitTransformValues(value, fallback) {
   return String(value ?? fallback).split(',').map((t) => t.trim()).filter(Boolean);
 }
 
-// Expand --restyle/--jargon/--tone into the rewrite variants a run executes.
+// Expand --jargon/--tone into the rewrite variants a run executes.
 // A single combination is the normal one-call path; multiple combinations
 // (comma lists) become --preview compare variants, one rewrite call each.
-// Tone joins the cross product so "voice in casual" and "voice in marketing"
+// Tone joins the cross product so "remove in casual" and "remove in marketing"
 // are directly comparable; tone appears in the label only when it varies.
 // The cross product is capped: every variant is a full LLM call.
 export const MAX_TRANSFORM_VARIANTS = 4;
 
 export function buildTransformVariants(parsed) {
-  const restyles = splitTransformValues(parsed.restyle, 'sentence');
   const jargons = splitTransformValues(parsed.jargon, 'keep');
   const tones = splitTransformValues(parsed.tone, '');
   const toneList = tones.length > 0 ? tones : [null];
   const multiTone = toneList.length > 1;
   const variants = [];
-  for (const restyle of restyles) {
-    for (const jargon of jargons) {
-      for (const tone of toneList) {
-        const parts = [];
-        if (restyle !== 'sentence') parts.push(restyle);
-        if (jargon !== 'keep') parts.push(jargon);
-        let label = parts.join('+');
-        if (multiTone) label = label ? `${label}·${tone}` : tone;
-        variants.push({ restyle, jargon, tone, label: label || 'cleanup' });
-      }
+  for (const jargon of jargons) {
+    for (const tone of toneList) {
+      const parts = [];
+      if (jargon !== 'keep') parts.push(jargon);
+      let label = parts.join('+');
+      if (multiTone) label = label ? `${label}·${tone}` : tone;
+      variants.push({ jargon, tone, label: label || 'cleanup' });
     }
   }
   if (variants.length > MAX_TRANSFORM_VARIANTS) {
     throw inputError(
       `too many transform variants (${variants.length})`,
-      `--restyle × --jargon × --tone combinations are capped at ${MAX_TRANSFORM_VARIANTS}; each variant is a full rewrite call.`,
-      'Drop values from one of the lists, e.g. `--restyle voice --tone casual,professional` with a single --jargon.'
+      `--jargon × --tone combinations are capped at ${MAX_TRANSFORM_VARIANTS}; each variant is a full rewrite call.`,
+      'Drop values from one of the lists, e.g. `--jargon keep,remove` with a single --tone.'
     );
   }
   return variants;
 }
 
-// --restyle/--jargon opt into transformations beyond AI-pattern cleanup. They
-// only apply where patina rewrites prose it owns end to end: the default
-// rewrite and --preview. Score/audit/diff report on text as-is, and ouroboros
-// enforces meaning-preservation floors that a content-level transformation
-// would fight — reject the combination instead of silently ignoring the flag.
-// Comma-list (compare) requests additionally need the preview surface: a
-// plain rewrite has one stdout, and --ocr ties image findings to a single
-// rewrite call, so neither can carry multiple variants.
+// --jargon opts into transformations beyond AI-pattern cleanup. It only applies
+// where patina rewrites prose it owns end to end: the default rewrite and
+// --preview. Score/audit/diff report on text as-is — reject the combination
+// instead of silently ignoring the flag. Comma-list (compare) requests
+// additionally need the preview surface: a plain rewrite has one stdout, and
+// --ocr ties image findings to a single rewrite call, so neither can carry
+// multiple variants.
 export function validateTransformRequest(parsed) {
   const variants = buildTransformVariants(parsed);
   if (variants.length > 1) {
     if (!parsed.preview) {
       throw inputError(
         'comparing transform variants requires --preview',
-        'Comma-separated --restyle/--jargon values render as toggleable variants on the preview page; a plain rewrite has a single stdout.',
-        'Run `patina --preview --restyle sentence,voice <url>` or pick one value.'
+        'Comma-separated --jargon/--tone values render as toggleable variants on the preview page; a plain rewrite has a single stdout.',
+        'Run `patina --preview --jargon keep,remove <url>` or pick one value.'
       );
     }
     if (parsed.ocr) {
@@ -407,15 +407,13 @@ export function validateTransformRequest(parsed) {
       );
     }
   }
-  const restyleActive = variants.some((v) => v.restyle !== 'sentence');
   const jargonActive = variants.some((v) => v.jargon !== 'keep');
-  if (!restyleActive && !jargonActive && variants.length === 1) return;
-  const flag = restyleActive ? '--restyle' : jargonActive ? '--jargon' : '--tone';
+  if (!jargonActive && variants.length === 1) return;
+  const flag = jargonActive ? '--jargon' : '--tone';
   const blocked = [
     ['score', '--score', 'does not rewrite text'],
     ['audit', '--audit', 'does not rewrite text'],
     ['diff', '--diff', 'documents pattern-based edits, not free transformations'],
-    ['ouroboros', '--ouroboros', 'enforces meaning-preservation floors that a transformation would fight'],
   ];
   for (const [key, name, why] of blocked) {
     if (parsed[key]) {
@@ -435,7 +433,6 @@ export function validatePersonaRequest(parsed) {
     ['score', '--score', 'score reads text as-is and does not run the rewrite persona harness'],
     ['audit', '--audit', 'audit reports detections on the original text'],
     ['diff', '--diff', 'diff is a pattern-report surface, not the persona rewrite harness'],
-    ['ouroboros', '--ouroboros', 'ouroboros persona integration is not part of v1'],
     ['preview', '--preview', 'preview persona migration is reserved for a later surface'],
   ];
   for (const [key, flag, why] of blockedModes) {
@@ -454,7 +451,7 @@ export function validatePersonaRequest(parsed) {
       'Use `--lang ko --persona <name>` or remove --persona for non-Korean text.'
     );
   }
-  for (const [flag, value] of [['--restyle', parsed.restyle], ['--jargon', parsed.jargon], ['--tone', parsed.tone]]) {
+  for (const [flag, value] of [['--jargon', parsed.jargon], ['--tone', parsed.tone]]) {
     if (typeof value === 'string' && value.includes(',')) {
       throw inputError(
         `${persona} cannot be combined with comma-list ${flag}`,
@@ -462,15 +459,6 @@ export function validatePersonaRequest(parsed) {
         `Pick one ${flag} value or remove --persona.`
       );
     }
-  }
-  if (parsed.restyle === 'voice' || parsed.restyle === 'content') {
-    throw inputError(
-      `--persona cannot be combined with --restyle ${parsed.restyle}`,
-      parsed.restyle === 'content'
-        ? 'Legacy --restyle content makes MPS advisory, but persona mode must keep MPS/fidelity hard floors enforced.'
-        : 'Legacy --restyle voice is a second depth/voice source that conflicts with persona frontmatter.',
-      'Use --persona with default --restyle sentence, or remove --persona for legacy restyle mode.'
-    );
   }
   if (parsed.jargon === 'explain' || parsed.jargon === 'remove') {
     throw inputError(
@@ -501,13 +489,6 @@ export function validateVerifyRequest(parsed) {
       );
     }
   }
-  if (parsed.restyle === 'voice' || parsed.restyle === 'content') {
-    throw inputError(
-      `--verify cannot be combined with --restyle ${parsed.restyle}`,
-      'Voice/content transformations intentionally change wording or structure, which fights the meaning-preservation floors --verify enforces.',
-      'Use --verify with the default --restyle sentence, or drop --verify for a free transformation.'
-    );
-  }
 }
 
 export function validatePreviewRequest(parsed) {
@@ -526,11 +507,11 @@ export function validatePreviewRequest(parsed) {
       'Run `patina --preview <url>` with a single URL.'
     );
   }
-  if (parsed.diff || parsed.audit || parsed.score || parsed.ouroboros) {
+  if (parsed.diff || parsed.audit || parsed.score) {
     throw inputError(
       '--preview only works in rewrite mode',
-      'The preview page is an additive rewrite surface, not a diff/audit/score/ouroboros mode.',
-      'Use `patina --preview <url>` by itself, without --diff, --audit, --score, or --ouroboros.'
+      'The preview page is an additive rewrite surface, not a diff/audit/score mode.',
+      'Use `patina --preview <url>` by itself, without --diff, --audit, or --score.'
     );
   }
   if (parsed.files.length !== 1) {
@@ -713,7 +694,6 @@ MODES
   --exit-on <n>           With --score, exit 3 when overall score > n
   --verify                Rewrite, then verify meaning (MPS/fidelity floors) with
                           one conservative retry; fail-closed to the best candidate
-  --ouroboros             [deprecated] alias for --verify (the iterative loop was removed)
   --preview               Rewrite one http(s) URL or local .html file in place on a snapshot
                           of the page (adds one explanation call)
   --ocr                   With --preview (URL/.html): extract text inside page images via an
@@ -748,14 +728,7 @@ LANGUAGE & PROFILE
                           Comma list with --preview compares tones as variants
   --voice-sample <path>   Use 1-3 user paragraphs as style-only voice anchors
   --persona <name>         Korean rewrite persona (default preserve); incompatible
-                          with score/audit/diff/ouroboros/preview and legacy
-                          voice/content transform depths
-  --restyle <depth[,depth]>
-                          Transformation depth (rewrite/--preview only):
-                          sentence (default) = AI-pattern cleanup,
-                          voice = rewrite everything in the target voice/register,
-                          content = content-level re-planning (MPS becomes advisory).
-                          Comma list with --preview compares variants in-page (max 4 combos)
+                          with score/audit/diff/preview
   --jargon <policy[,policy]>
                           Technical-term policy (rewrite/--preview only):
                           keep (default), explain = add plain-language glosses,

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -111,11 +111,6 @@ export async function runDefault(parsed, logger) {
     : parsed.audit ? 'audit'
     : parsed.score ? 'score'
     : 'rewrite';
-  if (parsed.ouroboros) {
-    logger.warn('ouroboros.deprecated', {
-      message: '[patina] --ouroboros is deprecated and now runs --verify (rewrite + meaning-floor retry); the iterative loop has been removed.',
-    });
-  }
   const persona = resolvePersonaForRun({ parsed, config, mode, lang, repoRoot });
 
   const voiceSamplePath = mode === 'rewrite'
@@ -214,7 +209,6 @@ export async function runDefault(parsed, logger) {
       tone: toneResolution,
       promptMode,
       documentSignals: mode === 'rewrite' ? buildDocumentSignals({ text, lang }).signals : null,
-      restyle: parsed.restyle,
       jargon: parsed.jargon,
       rewriteHeadings: parsed.rewriteHeadings,
       persona,
@@ -680,7 +674,6 @@ async function runPreviewJob({
       scoring: scoring.body ? scoring : null,
       tone: toneResolution,
       promptMode,
-      restyle: parsed.restyle,
       jargon: parsed.jargon,
       rewriteHeadings: parsed.rewriteHeadings,
     };
@@ -734,7 +727,7 @@ async function runPreviewJob({
       .join('\n\n');
     const documentContext = buildDocumentSignals({ text: rewriteText, lang: config.language || 'ko' });
 
-    // Variant comparison (--restyle a,b / --jargon x,y): one rewrite call per
+    // Variant comparison (--jargon x,y / --tone a,b): one rewrite call per
     // variant, all baked into the preview page behind a scriptless toggle.
     // Calls run sequentially — local CLI backends carry concurrency caps of
     // 1-2, and a variant is a whole-document rewrite, not a cheap request.
@@ -744,7 +737,7 @@ async function runPreviewJob({
       throw runtimeError(
         'transform-variant comparison needs a page snapshot',
         'Plain-text file previews render as a single reading document, which cannot hold multiple toggleable variants.',
-        'Run the compare against a URL or .html input, or pick a single --restyle/--jargon value.'
+        'Run the compare against a URL or .html input, or pick a single --jargon/--tone value.'
       );
     }
     const variantBodies = [];
@@ -781,7 +774,6 @@ async function runPreviewJob({
             ...basePromptInputs,
             profile: variantProfile,
             tone: variantTone,
-            restyle: variant.restyle,
             jargon: variant.jargon,
             text: rewriteText,
             mode: 'rewrite',
@@ -887,7 +879,6 @@ async function runPreviewJob({
       const previewVariants = compareMode
         ? transformVariants.map((variant, index) => ({
           label: variant.label,
-          restyle: variant.restyle,
           jargon: variant.jargon,
           tone: variant.tone,
           rewrites: (index === 0 ? rewrites : alignOne(variantBodies[index], variant.label)).slice(0, blocks.length),

--- a/src/personas/schema.js
+++ b/src/personas/schema.js
@@ -253,7 +253,7 @@ export function validatePersona(frontmatter, ctx = {}) {
   }
 
   // Depth directive: content depth may relax emphasis/coverage only; it can
-  // NEVER make MPS/fidelity advisory (unlike legacy --restyle content).
+  // NEVER make MPS/fidelity advisory.
   const pdd = frontmatter.persona_depth_directive ?? {};
   if (asBool(pdd.mps_advisory, false) || asBool(pdd.fidelity_advisory, false)) {
     throw fail(
@@ -272,7 +272,6 @@ export function validatePersona(frontmatter, ctx = {}) {
   const bridge = frontmatter.legacy_profile_bridge ?? {};
   const legacyProfileBridge = {
     profiles: asStringArray(bridge.profiles),
-    restyleDefault: typeof bridge.restyle_default === 'string' ? bridge.restyle_default : null,
   };
 
   return {

--- a/src/preview/render.js
+++ b/src/preview/render.js
@@ -85,7 +85,7 @@ function renderWordDiffHtml(before, after) {
 }
 
 export function buildPreviewHtml({ html, blocks, rewrites, sourceUrl, explanationHtml = '', scoreChip = null, imageFindings = [], contextCardHtml = '', variants = null }) {
-  // Variant comparison (--preview --restyle a,b / --jargon x,y): every
+  // Variant comparison (--preview --jargon x,y / --tone a,b): every
   // variant's rewrite is baked into the same swap span and the bar gets a
   // scriptless radio toggle per variant — the snapshot stays inert, so the
   // switch must be CSS-only, exactly like the rewritten/original/both views.
@@ -219,21 +219,20 @@ function injectHead(html, sourceUrl) {
 }
 
 // Group baked variants for the two-level bar UI: one primary button per
-// distinct restyle depth (cleanup/voice/content) and, when a depth carries
-// more than one option (jargon/tone), a secondary chip row that appears only
-// while its depth is selected. Selection is two chained radio groups —
-// depth + per-depth option — so the page stays scriptless.
+// distinct jargon policy (cleanup/explain/remove) and, when a policy carries
+// more than one option (tone), a secondary chip row that appears only while
+// that policy is selected. Selection is two chained radio groups —
+// policy + per-policy option — so the page stays scriptless.
 function groupTransformVariants(variants) {
   const groups = [];
   variants.forEach((variant, index) => {
-    const key = variant.restyle ?? variant.label ?? `v${index + 1}`;
+    const key = variant.jargon ?? variant.label ?? `v${index + 1}`;
     let group = groups.find((g) => g.key === key);
     if (!group) {
-      group = { key, label: key === 'sentence' ? 'cleanup' : key, options: [] };
+      group = { key, label: key === 'keep' ? 'cleanup' : key, options: [] };
       groups.push(group);
     }
     const parts = [];
-    if (variant.jargon && variant.jargon !== 'keep') parts.push(variant.jargon);
     if (variant.tone) parts.push(variant.tone);
     group.options.push({ label: parts.join('·') || 'default', variantIndex: index + 1 });
   });

--- a/src/prompt-builder.js
+++ b/src/prompt-builder.js
@@ -124,9 +124,6 @@ function buildSeverityOverrideNote(config) {
  *   as ground truth for the Phase 0 document brief.
  * @param {boolean} [options.includeSelfAudit=true] Include the Phase 3 self-audit
  *   in rewrite instructions; ouroboros passes false to skip the token cost (#444).
- * @param {string} [options.restyle=sentence] Transformation depth
- *   (sentence|voice|content); non-default values add the opt-in
- *   transformation directive to rewrite prompts.
  * @param {string} [options.jargon=keep] Technical-term policy
  *   (keep|explain|remove); non-default values add the opt-in
  *   transformation directive to rewrite prompts.
@@ -155,7 +152,6 @@ export function buildPrompt(options) {
     // strips anyway; the loop's external scorers do the AI-tell/meaning checks
     // (#444). Default true keeps the standalone rewrite contract unchanged.
     includeSelfAudit = true,
-    restyle = 'sentence',
     jargon = 'keep',
     // #473: preserve Markdown ATX headings by default; --rewrite-headings opts in.
     rewriteHeadings = false,
@@ -166,7 +162,7 @@ export function buildPrompt(options) {
   // to rewrite mode where voice prior matters most. Profile body is still passed
   // through (Round 2 found Gemini ignored casual-conversation when omitted).
   if (promptMode === 'minimal' && mode === 'rewrite') {
-    return buildMinimalPrompt({ config, patterns, profile, voiceSample, persona, text, tone, documentSignals, restyle, jargon, rewriteHeadings });
+    return buildMinimalPrompt({ config, patterns, profile, voiceSample, persona, text, tone, documentSignals, jargon, rewriteHeadings });
   }
 
   const lang = config.language || 'ko';
@@ -259,7 +255,7 @@ export function buildPrompt(options) {
 
   if (mode === 'rewrite') {
     prompt += buildRewriteInstructions(structurePacks, lexicalPacks, { lang, includeSelfAudit, rewriteHeadings });
-    prompt += buildTransformDirective({ restyle, jargon, korean: false });
+    prompt += buildTransformDirective({ jargon, korean: false });
   } else if (mode === 'diff') {
     prompt += buildDiffInstructions();
   } else if (mode === 'audit') {
@@ -288,24 +284,15 @@ export function buildPrompt(options) {
   return prompt;
 }
 
-// Opt-in transformation directive (--restyle / --jargon). Everything else in
+// Opt-in transformation directive (--jargon). Everything else in
 // the rewrite prompt is deliberately conservative — minimal paraphrase, keep
 // each sentence's claim and framing — so when the user explicitly asks for a
 // deeper transformation, the directive must state that it overrides those
 // rules where they conflict. Facts, numbers, names, and causal claims remain
 // non-negotiable in every depth. Returns '' for the defaults so existing
 // prompts (and their golden snapshots) are byte-identical.
-function buildTransformDirective({ restyle = 'sentence', jargon = 'keep', korean = false } = {}) {
+function buildTransformDirective({ jargon = 'keep', korean = false } = {}) {
   const bullets = [];
-  if (restyle === 'voice') {
-    bullets.push(korean
-      ? `**전면 어투 전환 (--restyle voice)**: 의심 구간만 고치지 말고 글 전체를 목표 어투·화법(톤/프로필 섹션 기준)으로 다시 써. 문장 구조·리듬·어휘는 자유롭게 바꿔도 되지만, 모든 주장과 그 순서는 그대로 유지해.`
-      : `**Full voice transformation (--restyle voice)**: Rewrite the ENTIRE text in the target voice and register (per the tone/profile sections), not just AI-flagged zones. Sentence structure, rhythm, vocabulary, and phrasing may change freely; every claim and its ordering must survive.`);
-  } else if (restyle === 'content') {
-    bullets.push(korean
-      ? `**컨텐츠 재기획 (--restyle content)**: 컨텐츠 기획 수준에서 다시 짜. 섹션 재구성, 중복 통합·삭제, 논점 순서 변경, 독자에 맞춘 앵글 조정까지 허용. 핵심 사실은 지키되 다루는 범위와 강조점은 바뀌어도 돼. 의미 보존 점수(MPS)는 이번 실행에선 참고용이야 — 점수를 맞추려고 재작성을 제한하지 말고 정직하게 보고만 해.`
-      : `**Content-level re-planning (--restyle content)**: Re-plan the piece at the content level. You may restructure sections, merge or cut redundant passages, reorder arguments, and sharpen the angle for the document's audience. Coverage and emphasis may change; core claims must stay truthful. Treat the Meaning-Preservation Score as advisory for this run — report it honestly instead of constraining the rewrite to satisfy it.`);
-  }
   if (jargon === 'explain') {
     bullets.push(korean
       ? `**용어 설명 병기 (--jargon explain)**: 기술 용어는 유지하되, 처음 나올 때 짧고 쉬운 설명을 괄호로 덧붙여.`
@@ -640,7 +627,7 @@ export function isShortText(text) {
 // model's natural voice prior isn't overridden by analytical framing. Only
 // invoked for rewrite mode; score/audit/diff/ouroboros stay on the strict
 // path because they need precise pattern references.
-function buildMinimalPrompt({ config, patterns, profile, voiceSample, persona = null, text, tone, documentSignals = null, restyle = 'sentence', jargon = 'keep', rewriteHeadings = false }) {
+function buildMinimalPrompt({ config, patterns, profile, voiceSample, persona = null, text, tone, documentSignals = null, jargon = 'keep', rewriteHeadings = false }) {
   const lang = config.language || 'ko';
   const activePatterns = patterns.filter((p) => !p.isScoreOnly);
 
@@ -667,7 +654,7 @@ function buildMinimalPrompt({ config, patterns, profile, voiceSample, persona = 
   let prompt = `${instruction}\n\n${brief}\n\n`;
   const headingRule = buildHeadingPreservationRule(lang, rewriteHeadings);
   if (headingRule) prompt += `${headingRule}\n\n`;
-  prompt += buildTransformDirective({ restyle, jargon, korean: lang === 'ko' });
+  prompt += buildTransformDirective({ jargon, korean: lang === 'ko' });
 
   if (Array.isArray(documentSignals) && documentSignals.length > 0) {
     prompt += lang === 'ko' ? `## 문서 신호 (결정론 측정값)\n\n` : `## Document signals (measured)\n\n`;

--- a/tests/unit/persona-args.test.js
+++ b/tests/unit/persona-args.test.js
@@ -16,18 +16,17 @@ function assertPersonaAllowed(args) {
 }
 
 test('--persona rejects non-rewrite and preview surfaces', () => {
-  for (const flag of ['--score', '--audit', '--diff', '--ouroboros', '--preview']) {
+  for (const flag of ['--score', '--audit', '--diff', '--preview']) {
     assertPersonaInputError([flag, '--persona', 'preserve', 'draft.md']);
   }
 });
 
-test('--persona rejects legacy voice/content restyle depths', () => {
+test('removed --restyle / --ouroboros flags are rejected at parse time', () => {
   assertPersonaInputError(['--persona', 'preserve', '--restyle', 'voice', 'draft.md']);
-  assertPersonaInputError(['--persona', 'preserve', '--restyle', 'content', 'draft.md']);
+  assertPersonaInputError(['--persona', 'preserve', '--ouroboros', 'draft.md']);
 });
 
 test('--persona rejects comma-list transform variants', () => {
-  assertPersonaInputError(['--persona', 'preserve', '--restyle', 'sentence,voice', 'draft.md']);
   assertPersonaInputError(['--persona', 'preserve', '--jargon', 'keep,remove', 'draft.md']);
   assertPersonaInputError(['--persona', 'preserve', '--tone', 'casual,professional', 'draft.md']);
 });
@@ -43,8 +42,7 @@ test('--persona rejects non-Korean languages at parsed flag level', () => {
   }
 });
 
-test('--persona allows sentence restyle, single tone, profile, and voice sample', () => {
-  assertPersonaAllowed(['--persona', 'preserve', '--restyle', 'sentence', 'draft.md']);
+test('--persona allows single tone, profile, and voice sample', () => {
   assertPersonaAllowed(['--persona', 'preserve', '--tone', 'casual', 'draft.md']);
   assertPersonaAllowed(['--persona', 'preserve', '--profile', 'blog', 'draft.md']);
   assertPersonaAllowed(['--persona', 'preserve', '--voice-sample', 'sample.md', 'draft.md']);

--- a/tests/unit/transform-options.test.js
+++ b/tests/unit/transform-options.test.js
@@ -14,52 +14,44 @@ const BASE = {
   text: 'Sample body text for prompt construction.',
 };
 
-test('parseArgs accepts --restyle and --jargon values and rejects unknown ones', () => {
-  const parsed = parseArgs(['--restyle', 'content', '--jargon', 'remove', 'draft.md']);
-  assert.equal(parsed.restyle, 'content');
-  assert.equal(parsed.jargon, 'remove');
+test('parseArgs rejects the removed --restyle flag and still parses --jargon', () => {
+  assert.throws(() => parseArgs(['--restyle', 'voice', 'draft.md']), /--restyle was removed/);
+  assert.throws(() => parseArgs(['--restyle', 'sentence']), /--restyle was removed/);
 
-  assert.equal(parseArgs(['--restyle', 'voice']).restyle, 'voice');
-  assert.equal(parseArgs(['--restyle', 'sentence']).restyle, 'sentence');
+  assert.equal(parseArgs(['--jargon', 'remove', 'draft.md']).jargon, 'remove');
   assert.equal(parseArgs(['--jargon', 'explain']).jargon, 'explain');
+  assert.equal(parseArgs(['--jargon', 'keep']).jargon, 'keep');
 
-  assert.throws(() => parseArgs(['--restyle', 'rewrite-everything']), /unknown restyle depth/);
   assert.throws(() => parseArgs(['--jargon', 'simplify']), /unknown jargon policy/);
-  assert.throws(() => parseArgs(['--restyle']), /restyle/i);
+  assert.throws(() => parseArgs(['--jargon']), /jargon/i);
 });
 
 test('validateTransformRequest rejects non-rewrite modes only when a transform is active', () => {
   // Defaults (or explicit defaults) pass with every mode.
   validateTransformRequest({ score: true });
-  validateTransformRequest({ ouroboros: true, restyle: 'sentence', jargon: 'keep' });
+  validateTransformRequest({ jargon: 'keep' });
 
   // Active transform + non-rewrite mode is an input error.
-  assert.throws(() => validateTransformRequest({ restyle: 'voice', score: true }), /--restyle cannot be combined with --score/);
-  assert.throws(() => validateTransformRequest({ restyle: 'content', audit: true }), /--restyle cannot be combined with --audit/);
+  assert.throws(() => validateTransformRequest({ jargon: 'remove', score: true }), /--jargon cannot be combined with --score/);
+  assert.throws(() => validateTransformRequest({ jargon: 'explain', audit: true }), /--jargon cannot be combined with --audit/);
   assert.throws(() => validateTransformRequest({ jargon: 'remove', diff: true }), /--jargon cannot be combined with --diff/);
-  assert.throws(() => validateTransformRequest({ restyle: 'content', ouroboros: true }), /--restyle cannot be combined with --ouroboros/);
 
   // Plain rewrite and preview are the supported surfaces.
-  validateTransformRequest({ restyle: 'content', jargon: 'remove' });
-  validateTransformRequest({ restyle: 'voice', preview: true });
+  validateTransformRequest({ jargon: 'remove' });
+  validateTransformRequest({ jargon: 'explain', preview: true });
 });
 
 test('strict rewrite prompt carries the transformation directive only when opted in', () => {
   const base = buildPrompt({ ...BASE, mode: 'rewrite' });
   assert.ok(!base.includes('Transformation Directive'));
 
-  const explicitDefaults = buildPrompt({ ...BASE, mode: 'rewrite', restyle: 'sentence', jargon: 'keep' });
+  const explicitDefaults = buildPrompt({ ...BASE, mode: 'rewrite', jargon: 'keep' });
   assert.strictEqual(explicitDefaults, base);
 
-  const voice = buildPrompt({ ...BASE, mode: 'rewrite', restyle: 'voice' });
-  assert.ok(voice.includes('Transformation Directive'));
-  assert.ok(voice.includes('Full voice transformation (--restyle voice)'));
-  assert.ok(!voice.includes('Content-level re-planning'));
-
-  const content = buildPrompt({ ...BASE, mode: 'rewrite', restyle: 'content', jargon: 'remove' });
-  assert.ok(content.includes('Content-level re-planning (--restyle content)'));
-  assert.ok(content.includes('Meaning-Preservation Score as advisory'));
-  assert.ok(content.includes('Remove jargon (--jargon remove)'));
+  const remove = buildPrompt({ ...BASE, mode: 'rewrite', jargon: 'remove' });
+  assert.ok(remove.includes('Transformation Directive'));
+  assert.ok(remove.includes('Remove jargon (--jargon remove)'));
+  assert.ok(!remove.includes('Gloss technical terms'));
 
   const explain = buildPrompt({ ...BASE, mode: 'rewrite', jargon: 'explain' });
   assert.ok(explain.includes('Gloss technical terms (--jargon explain)'));
@@ -67,14 +59,14 @@ test('strict rewrite prompt carries the transformation directive only when opted
 
   // The directive must come after the conservative rewrite instructions it
   // overrides, and before the input text.
-  const directiveAt = content.indexOf('Transformation Directive');
-  assert.ok(directiveAt > content.indexOf('## Instructions'));
-  assert.ok(directiveAt < content.indexOf('## Input Text'));
+  const directiveAt = remove.indexOf('Transformation Directive');
+  assert.ok(directiveAt > remove.indexOf('## Instructions'));
+  assert.ok(directiveAt < remove.indexOf('## Input Text'));
 });
 
 test('non-rewrite strict prompts never carry the directive even if options leak through', () => {
   for (const mode of ['score', 'audit', 'diff']) {
-    const prompt = buildPrompt({ ...BASE, mode, restyle: 'content', jargon: 'remove' });
+    const prompt = buildPrompt({ ...BASE, mode, jargon: 'remove' });
     assert.ok(!prompt.includes('Transformation Directive'), `${mode} prompt must not carry the directive`);
   }
 });
@@ -85,39 +77,37 @@ test('minimal rewrite prompt carries a localized directive', () => {
     config: { language: 'ko', profile: 'default' },
     mode: 'rewrite',
     promptMode: 'minimal',
-    restyle: 'content',
     jargon: 'remove',
   });
   assert.ok(ko.includes('변환 지시 (사용자 요청)'));
-  assert.ok(ko.includes('컨텐츠 재기획 (--restyle content)'));
   assert.ok(ko.includes('개발 용어 제거 (--jargon remove)'));
 
-  const en = buildPrompt({ ...BASE, mode: 'rewrite', promptMode: 'minimal', restyle: 'voice' });
+  const en = buildPrompt({ ...BASE, mode: 'rewrite', promptMode: 'minimal', jargon: 'explain' });
   assert.ok(en.includes('Transformation Directive (user-requested)'));
-  assert.ok(en.includes('Full voice transformation (--restyle voice)'));
+  assert.ok(en.includes('Gloss technical terms (--jargon explain)'));
 
   const minimalDefault = buildPrompt({ ...BASE, mode: 'rewrite', promptMode: 'minimal' });
   assert.ok(!minimalDefault.includes('Transformation Directive'));
 });
 
 test('parseArgs accepts comma lists for compare mode and dedupes them', () => {
-  assert.equal(parseArgs(['--restyle', 'sentence,voice,content']).restyle, 'sentence,voice,content');
-  assert.equal(parseArgs(['--restyle', 'voice, voice ,content']).restyle, 'voice,content');
-  assert.equal(parseArgs(['--jargon', 'keep,remove']).jargon, 'keep,remove');
-  assert.throws(() => parseArgs(['--restyle', 'voice,everything']), /unknown restyle depth everything/);
-  assert.throws(() => parseArgs(['--restyle', ',,']), /--restyle expects a value/);
+  assert.equal(parseArgs(['--jargon', 'keep,explain,remove']).jargon, 'keep,explain,remove');
+  assert.equal(parseArgs(['--jargon', 'remove, remove ,explain']).jargon, 'remove,explain');
+  assert.equal(parseArgs(['--tone', 'casual,marketing']).tone, 'casual,marketing');
+  assert.throws(() => parseArgs(['--jargon', 'remove,everything']), /unknown jargon policy everything/);
+  assert.throws(() => parseArgs(['--jargon', ',,']), /--jargon expects a value/);
 });
 
 test('buildTransformVariants expands the cross product with labels and a cap', () => {
-  assert.deepStrictEqual(buildTransformVariants({}), [{ restyle: 'sentence', jargon: 'keep', tone: null, label: 'cleanup' }]);
-  assert.deepStrictEqual(buildTransformVariants({ restyle: 'sentence,voice', jargon: 'remove' }), [
-    { restyle: 'sentence', jargon: 'remove', tone: null, label: 'remove' },
-    { restyle: 'voice', jargon: 'remove', tone: null, label: 'voice+remove' },
+  assert.deepStrictEqual(buildTransformVariants({}), [{ jargon: 'keep', tone: null, label: 'cleanup' }]);
+  assert.deepStrictEqual(buildTransformVariants({ jargon: 'keep,remove' }), [
+    { jargon: 'keep', tone: null, label: 'cleanup' },
+    { jargon: 'remove', tone: null, label: 'remove' },
   ]);
-  assert.equal(buildTransformVariants({ restyle: 'sentence,voice,content' }).length, 3);
-  // 3 restyles × 2 jargons = 6 > cap of 4.
+  assert.equal(buildTransformVariants({ jargon: 'keep,explain,remove' }).length, 3);
+  // 3 jargons × 2 tones = 6 > cap of 4.
   assert.throws(
-    () => buildTransformVariants({ restyle: 'sentence,voice,content', jargon: 'keep,remove' }),
+    () => buildTransformVariants({ jargon: 'keep,explain,remove', tone: 'casual,professional' }),
     /too many transform variants/
   );
 });
@@ -127,22 +117,22 @@ test('tone joins the variant cross product with per-tone labels', () => {
   assert.throws(() => parseArgs(['--tone', 'casual,shouty']), /unknown tone shouty/);
 
   // Single tone: carried on the variant, absent from the label.
-  assert.deepStrictEqual(buildTransformVariants({ restyle: 'voice', tone: 'casual' }), [
-    { restyle: 'voice', jargon: 'keep', tone: 'casual', label: 'voice' },
+  assert.deepStrictEqual(buildTransformVariants({ jargon: 'remove', tone: 'casual' }), [
+    { jargon: 'remove', tone: 'casual', label: 'remove' },
   ]);
   // Multiple tones: tone appears in every label.
-  assert.deepStrictEqual(buildTransformVariants({ restyle: 'voice', tone: 'casual,professional' }), [
-    { restyle: 'voice', jargon: 'keep', tone: 'casual', label: 'voice·casual' },
-    { restyle: 'voice', jargon: 'keep', tone: 'professional', label: 'voice·professional' },
+  assert.deepStrictEqual(buildTransformVariants({ jargon: 'remove', tone: 'casual,professional' }), [
+    { jargon: 'remove', tone: 'casual', label: 'remove·casual' },
+    { jargon: 'remove', tone: 'professional', label: 'remove·professional' },
   ]);
   // Tone-only comparison: the tone IS the label.
   assert.deepStrictEqual(
     buildTransformVariants({ tone: 'casual,marketing' }).map((v) => v.label),
     ['casual', 'marketing']
   );
-  // Tone multiplies into the cap: 2 restyles × 1 jargon × 3 tones = 6 > 4.
+  // Tone multiplies into the cap: 2 jargons × 3 tones = 6 > 4.
   assert.throws(
-    () => buildTransformVariants({ restyle: 'sentence,voice', tone: 'casual,professional,marketing' }),
+    () => buildTransformVariants({ jargon: 'keep,remove', tone: 'casual,professional,marketing' }),
     /too many transform variants/
   );
   // Tone-only list still needs --preview, and the error names --tone.
@@ -159,15 +149,15 @@ test('tone joins the variant cross product with per-tone labels', () => {
 
 test('validateTransformRequest gates compare mode on --preview and rejects --ocr', () => {
   assert.throws(
-    () => validateTransformRequest({ restyle: 'sentence,voice' }),
+    () => validateTransformRequest({ jargon: 'keep,remove' }),
     /comparing transform variants requires --preview/
   );
   assert.throws(
-    () => validateTransformRequest({ restyle: 'sentence,voice', preview: true, ocr: true }),
+    () => validateTransformRequest({ jargon: 'keep,remove', preview: true, ocr: true }),
     /--ocr cannot be combined/
   );
-  validateTransformRequest({ restyle: 'sentence,voice,content', preview: true });
-  validateTransformRequest({ jargon: 'keep,remove', preview: true });
+  validateTransformRequest({ jargon: 'keep,explain,remove', preview: true });
+  validateTransformRequest({ tone: 'casual,marketing', preview: true });
 });
 
 test('buildPreviewHtml bakes variants behind a scriptless two-level radio toggle', () => {
@@ -176,8 +166,8 @@ test('buildPreviewHtml bakes variants behind a scriptless two-level radio toggle
   const start = html.indexOf(text);
   const blocks = [{ tag: 'p', start, end: start + text.length, raw: text, text }];
   const variants = [
-    { label: 'cleanup', restyle: 'sentence', jargon: 'keep', tone: null, rewrites: ['Cleaned up paragraph text, still recognizably the same claim.'] },
-    { label: 'voice+remove', restyle: 'voice', jargon: 'remove', tone: null, rewrites: ['Totally re-voiced paragraph for regular readers, same claim.'] },
+    { label: 'cleanup', jargon: 'keep', tone: null, rewrites: ['Cleaned up paragraph text, still recognizably the same claim.'] },
+    { label: 'remove', jargon: 'remove', tone: null, rewrites: ['De-jargoned paragraph for regular readers, same claim.'] },
   ];
   const { html: out, changedCount } = buildPreviewHtml({
     html, blocks, rewrites: variants[0].rewrites, variants, sourceUrl: 'https://example.com/',
@@ -188,17 +178,17 @@ test('buildPreviewHtml bakes variants behind a scriptless two-level radio toggle
   assert.ok(out.includes('class="ptna-after ptna-v1"'));
   assert.ok(out.includes('class="ptna-after ptna-v2"'));
   assert.ok(out.includes('Cleaned up paragraph text'));
-  assert.ok(out.includes('Totally re-voiced paragraph'));
+  assert.ok(out.includes('De-jargoned paragraph'));
   // Depth radios exist, come after the view radios, first one checked; each
   // depth carries its own (checked) option radio.
   assert.ok(out.includes('id="ptna-d-1" class="ptna-toggle-input" checked'));
   assert.ok(out.includes('id="ptna-d-2"'));
   assert.ok(out.indexOf('id="ptna-d-1"') > out.indexOf('id="ptna-v-both"'));
   assert.ok(out.includes('name="ptna-opt-2" id="ptna-do-2-1" class="ptna-toggle-input" checked'));
-  // Bar depth buttons carry the depth names; single-option depths render no
+  // Bar depth buttons carry the policy names; single-option depths render no
   // option chip row.
   assert.ok(out.includes('for="ptna-d-1">cleanup</label>'));
-  assert.ok(out.includes('for="ptna-d-2">voice</label>'));
+  assert.ok(out.includes('for="ptna-d-2">remove</label>'));
   assert.ok(!out.includes('ptna-opts-1"'));
   // Scriptless show rules chain view radio, depth radio, and option radio.
   assert.ok(out.includes('#ptna-v-rew:checked ~ #ptna-d-2:checked ~ #ptna-do-2-1:checked ~ * .ptna-blk .ptna-after.ptna-v2{display:inline !important;}'));
@@ -207,24 +197,24 @@ test('buildPreviewHtml bakes variants behind a scriptless two-level radio toggle
   assert.ok(!/<script\b/i.test(out));
 });
 
-test('depth buttons reveal per-depth option chips for tone/jargon variants', () => {
+test('depth buttons reveal per-depth option chips for tone variants', () => {
   const text = 'A paragraph long enough that four baked variants can rewrite it differently.';
   const html = `<html><body><p>${text}</p></body></html>`;
   const start = html.indexOf(text);
   const blocks = [{ tag: 'p', start, end: start + text.length, raw: text, text }];
   const variants = [
-    { label: 'voice·casual', restyle: 'voice', jargon: 'keep', tone: 'casual', rewrites: ['Casual voiced paragraph rewritten in a relaxed register for everyone.'] },
-    { label: 'voice·professional', restyle: 'voice', jargon: 'keep', tone: 'professional', rewrites: ['Professionally voiced paragraph rewritten in a formal register.'] },
-    { label: 'content·casual', restyle: 'content', jargon: 'keep', tone: 'casual', rewrites: ['Re-planned casual paragraph with a different structure entirely.'] },
-    { label: 'content·professional', restyle: 'content', jargon: 'keep', tone: 'professional', rewrites: ['Re-planned formal paragraph with a different structure entirely.'] },
+    { label: 'casual', jargon: 'keep', tone: 'casual', rewrites: ['Casual cleaned paragraph rewritten in a relaxed register for everyone.'] },
+    { label: 'professional', jargon: 'keep', tone: 'professional', rewrites: ['Professional cleaned paragraph rewritten in a formal register.'] },
+    { label: 'remove·casual', jargon: 'remove', tone: 'casual', rewrites: ['De-jargoned casual paragraph for a general audience entirely.'] },
+    { label: 'remove·professional', jargon: 'remove', tone: 'professional', rewrites: ['De-jargoned formal paragraph for a general audience entirely.'] },
   ];
   const { html: out } = buildPreviewHtml({
     html, blocks, rewrites: variants[0].rewrites, variants, sourceUrl: 'https://example.com/',
   });
 
   // Two depth buttons, each with a two-chip option row (tone names only).
-  assert.ok(out.includes('for="ptna-d-1">voice</label>'));
-  assert.ok(out.includes('for="ptna-d-2">content</label>'));
+  assert.ok(out.includes('for="ptna-d-1">cleanup</label>'));
+  assert.ok(out.includes('for="ptna-d-2">remove</label>'));
   assert.ok(out.includes('class="ptna-views ptna-opts ptna-opts-1"'));
   assert.ok(out.includes('class="ptna-views ptna-opts ptna-opts-2"'));
   assert.ok(out.includes('for="ptna-do-1-2">professional</label>'));
@@ -232,7 +222,7 @@ test('depth buttons reveal per-depth option chips for tone/jargon variants', () 
   // Option rows are hidden unless their depth is selected.
   assert.ok(out.includes('.ptna-opts{display:none !important;}'));
   assert.ok(out.includes('#ptna-d-2:checked ~ .ptna-bar .ptna-opts-2{display:inline-flex !important;}'));
-  // content·professional is variant 4 under depth 2, option 2.
+  // remove·professional is variant 4 under depth 2, option 2.
   assert.ok(out.includes('#ptna-v-rew:checked ~ #ptna-d-2:checked ~ #ptna-do-2-2:checked ~ * .ptna-blk .ptna-after.ptna-v4{display:inline !important;}'));
   // The diff view maps through the same three-radio chain.
   assert.ok(out.includes('#ptna-v-diff:checked ~ #ptna-d-1:checked ~ #ptna-do-1-2:checked ~ * .ptna-blk .ptna-diff.ptna-v2{display:inline !important;}'));
@@ -248,7 +238,7 @@ test('buildPreviewHtml counts a block as changed when ANY variant changes it', (
     html, blocks, rewrites: [text], sourceUrl: 'https://example.com/',
     variants: [
       { label: 'cleanup', rewrites: [text] },
-      { label: 'voice', rewrites: [text] },
+      { label: 'remove', rewrites: [text] },
     ],
   });
   assert.strictEqual(untouched.changedCount, 0);
@@ -258,7 +248,7 @@ test('buildPreviewHtml counts a block as changed when ANY variant changes it', (
     html, blocks, rewrites: [text], sourceUrl: 'https://example.com/',
     variants: [
       { label: 'cleanup', rewrites: [text] },
-      { label: 'voice', rewrites: ['A fully re-voiced second paragraph from the braver variant.'] },
+      { label: 'remove', rewrites: ['A fully de-jargoned second paragraph from the braver variant.'] },
     ],
   });
   assert.strictEqual(oneTouched.changedCount, 1);
@@ -331,7 +321,7 @@ test('variant compare pages carry one word-diff per variant', () => {
     html, blocks, rewrites: [text], sourceUrl: 'https://example.com/',
     variants: [
       { label: 'cleanup', rewrites: ['A paragraph that two variants will rewrite slightly differently today.'] },
-      { label: 'voice', rewrites: ['Completely re-voiced paragraph, rewritten beyond recognition today.'] },
+      { label: 'remove', rewrites: ['A de-jargoned paragraph, rewritten for a general audience today.'] },
     ],
   });
   assert.ok(out.includes('class="ptna-diff ptna-v1"'));

--- a/tests/unit/verify.test.js
+++ b/tests/unit/verify.test.js
@@ -145,20 +145,11 @@ test('validateVerifyRequest rejects non-rewrite and preview surfaces', () => {
   }
 });
 
-test('validateVerifyRequest rejects voice/content restyle depths', () => {
-  assert.throws(() => validateVerifyRequest({ verify: true, restyle: 'voice' }), /--verify cannot be combined with --restyle/);
-  assert.throws(() => validateVerifyRequest({ verify: true, restyle: 'content' }), /--verify cannot be combined with --restyle/);
-});
-
 test('validateVerifyRequest allows a plain verified rewrite and is a no-op without --verify', () => {
-  assert.doesNotThrow(() => validateVerifyRequest({ verify: true, restyle: 'sentence' }));
+  assert.doesNotThrow(() => validateVerifyRequest({ verify: true, jargon: 'remove' }));
   assert.doesNotThrow(() => validateVerifyRequest({}));
 });
 
-test('--ouroboros is a deprecated alias that turns on --verify', () => {
-  const parsed = parseArgs(['--ouroboros', 'draft.md']);
-  assert.equal(parsed.verify, true);
-  assert.equal(parsed.ouroboros, true);
-  // The alias must not self-conflict in the verify validator.
-  assert.doesNotThrow(() => validateVerifyRequest(parsed));
+test('the removed --ouroboros flag is rejected at parse time', () => {
+  assert.throws(() => parseArgs(['--ouroboros', 'draft.md']), /--ouroboros was removed/);
 });


### PR DESCRIPTION
Removes two overlapping CLI flags that no longer earn their keep. **Breaking change** (next release should be a major bump).

## `--ouroboros` (fully removed)
Phase 1 (#552) added `--verify`; Phase 2 (#553) aliased `--ouroboros` to it. This removes the flag entirely. Passing it now errors with a migration hint:

```
[patina] Error: --ouroboros was removed
         The iterative loop was replaced by --verify (rewrite, then verify MPS/fidelity with one conservative retry).
         → Use --verify instead.
```

**Kept on purpose:** `runOuroboros` (`src/ouroboros.js`) as the `npm run quality:rewrite-ab` research baseline; the `ouroboros.*` config namespace (shared scoring floors/weights used by `--verify`, `--score`, scoring.js, the web contract); the prompt-builder `ouroboros` mode (harness + snapshot); and the `/patina` **skill's** own loop (SKILL.md — the protected LLM pipeline, untouched).

## `--restyle` (fully removed)
`--restyle sentence` was the default and only meaning-preserving depth; `voice`/`content` were the two non-default depths the code itself flagged as "legacy" five times.

- `--restyle content` made the **Meaning-Preservation Score advisory** — it let one flag opt out of patina's core "we never change the claim" contract. Gone.
- `--restyle voice` (full voice/register rewrite) overlapped `--persona` / `--tone` / `--voice-sample`, which is why persona mode already rejected it. Voice changes go through those flags now.

Passing `--restyle` errors with a migration hint pointing at `--persona`/`--tone`. `--jargon` and the `--jargon`/`--tone` preview variant-comparison feature are unchanged.

## What changed
- **`src/cli/args.js`**: `--ouroboros`/`--restyle` → removed-flag errors; dropped `ouroboros` from `validateModeExclusivity`, `validateTransformRequest`, `validatePersonaRequest`, `validatePreviewRequest`; dropped all `restyle` handling from `buildTransformVariants`/`validateTransformRequest`/`validatePersonaRequest`/`validateVerifyRequest`; help text trimmed.
- **`src/prompt-builder.js`**: dropped the `restyle` param and the voice/content branches of `buildTransformDirective` (jargon directive kept).
- **`src/cli/run.js`**: removed the ouroboros deprecation warning and all `restyle` plumbing.
- **`src/preview/render.js`**: variant grouping now keys on **jargon policy** (cleanup/explain/remove) instead of the removed restyle depth; tone stays the secondary chip axis. Scriptless two-level CSS toggle unchanged.
- **`src/personas/schema.js` + `personas/ko/*.md`**: removed the dead `legacy_profile_bridge.restyle_default` field (parsed but never consumed — persona depth comes from `persona_depth_directive`, so personas never functionally depended on restyle).
- **Tests**: `transform-options`, `persona-args`, `verify` reworked onto jargon/tone; removed-flag rejections asserted.
- **Docs**: `CLI.md`, `README.md`, `FLAG-PARITY.md`, `GLOSSARY.md`, `PATTERNS.md`. (`agents.md`/`GLOSSARY` keep "ouroboros" where it refers to the still-present skill loop.)

## Verification
- `npm run lint` clean.
- `npm test` — full suite green (987 pass / 1 skip; includes the unchanged `ouroboros.test.js`, prompt-builder snapshot, threshold-parity, tone #523).
- Live (DeepSeek): `--ouroboros`/`--restyle voice` exit 2 with migration text; `--jargon remove` de-jargons correctly; `--verify` passes (MPS 100 / fidelity 75); `--help` no longer lists the removed flags.
