### PR TITLE
feat(profile): honor pattern-overrides 'suppress' deterministically

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ See [docs/HARNESS.md](docs/HARNESS.md) for the full measurement-tool map.
 
 Profiles live in `profiles/{name}.md`. Copy an existing one (e.g. `blog.md`) and adjust:
 - `voice-overrides`: which voice dimensions to amplify/suppress
-- `pattern-overrides`: per-language pattern severity adjustments
+- `pattern-overrides`: per-language, per-pattern-id actions. `suppress` is applied deterministically (the pattern is dropped from the prompt for that language); `reduce`/`amplify` are advisory and reinforced only by the prose body.
 
 ## Pattern Staleness
 

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -134,6 +134,8 @@ patina --lang en --profile my-newsletter post.md
 
 Voice-override values are `amplify` / `allow` / `reduce` / `suppress`; pattern IDs and their meanings are in [`PATTERNS.md`](PATTERNS.md).
 
+> **What actually runs:** a `pattern-overrides` entry set to **`suppress`** is applied deterministically — patina drops that pattern from the rewrite / audit / score prompt for the profile's language, so the model never flags it (e.g. `legal` suppresses Korean passive-voice #27). `reduce` / `amplify` are **advisory** for now: they document intent and are reinforced by the profile's prose body, but the engine does not yet adjust their weight.
+
 ---
 
 ## 6. Pre-commit hook wrapper *(optional)*

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -1,6 +1,7 @@
 import { loadConfig, getRepoRoot, resolveTone } from '../config.js';
 import {
   loadPatterns,
+  applyProfilePatternOverrides,
   loadProfile,
   loadCoreFile,
   loadVoiceSample,
@@ -103,8 +104,12 @@ export async function runDefault(parsed, logger) {
     config.profile = 'default';
   }
 
-  const patterns = loadPatterns(repoRoot, lang, config['skip-patterns'] || []);
   const profile = loadProfile(repoRoot, profileName);
+  const patterns = applyProfilePatternOverrides(
+    loadPatterns(repoRoot, lang, config['skip-patterns'] || []),
+    profile,
+    lang,
+  );
   const voice = loadCoreFile(repoRoot, 'voice.md');
   const scoring = loadCoreFile(repoRoot, 'scoring.md');
   const mode = parsed.diff ? 'diff'

--- a/src/loader.js
+++ b/src/loader.js
@@ -101,6 +101,56 @@ export function loadProfile(repoRoot, profileName) {
 }
 
 /**
+ * Strip the individual pattern sections a profile marks `suppress` from loaded
+ * pattern packs, so the rewrite/audit/score prompt never carries those rules.
+ *
+ * `pattern-overrides` in a profile's frontmatter is keyed by language then
+ * numeric pattern id, with action `suppress` or `reduce`. v1 honors `suppress`
+ * deterministically (the LLM cannot flag a rule it was never given); `reduce`
+ * has no weight knob yet and is intentionally left in place. Packs without a
+ * matching override are returned unchanged (same object identity).
+ *
+ * @param {Array<{body: string}>} packs Loaded pattern packs from loadPatterns.
+ * @param {{frontmatter: object|null}|null} profile Loaded profile (loadProfile).
+ * @param {string} lang Active language code.
+ * @returns {Array<{body: string}>} Packs with suppressed sections removed.
+ * @example
+ * const packs = applyProfilePatternOverrides(loadPatterns(root, 'ko'), loadProfile(root, 'legal'), 'ko');
+ */
+export function applyProfilePatternOverrides(packs, profile, lang) {
+  const overrides = profile?.frontmatter?.['pattern-overrides']?.[lang];
+  if (!overrides || typeof overrides !== 'object') return packs;
+  const suppressIds = Object.entries(overrides)
+    .filter(([, action]) => action === 'suppress')
+    .map(([id]) => String(id).trim())
+    .filter(Boolean);
+  if (suppressIds.length === 0) return packs;
+  return packs.map((pack) => {
+    const body = stripPatternSections(pack.body, suppressIds);
+    return body === pack.body ? pack : { ...pack, body };
+  });
+}
+
+// Remove each "### <id>. …" section — heading through the body up to the next
+// "### " heading or end of pack — including the blank/`---` separator that
+// trails a removed section, then normalize the seams left behind.
+function stripPatternSections(body, ids) {
+  const idSet = new Set(ids.map((id) => String(id)));
+  const kept = [];
+  let skipping = false;
+  for (const line of body.split('\n')) {
+    const heading = line.match(/^###\s+(\d+)\./);
+    if (heading) skipping = idSet.has(heading[1]);
+    if (!skipping) kept.push(line);
+  }
+  return kept
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/\n+---\s*$/g, '')
+    .trim();
+}
+
+/**
  * Load a Markdown file from the core/ directory.
  *
  * @param {string} repoRoot Repository root path.

--- a/tests/unit/profile-pattern-overrides.test.js
+++ b/tests/unit/profile-pattern-overrides.test.js
@@ -1,0 +1,103 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { applyProfilePatternOverrides, loadPatterns, loadProfile } from '../../src/loader.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+// A tiny synthetic pack mirroring the real "### N. title" + `---` layout, so the
+// stripping logic is tested independently of the live pattern catalog numbering.
+const PACK_BODY = [
+  '# Pack title',
+  '',
+  '### 1. First pattern',
+  '',
+  'Body of one.',
+  '',
+  '---',
+  '',
+  '### 2. Second pattern',
+  '',
+  'Body of two.',
+  '',
+  '---',
+  '',
+  '### 12. Twelfth pattern',
+  '',
+  'Body of twelve.',
+  '',
+  '---',
+  '',
+  '### 27. Last pattern',
+  '',
+  'Body of twenty-seven.',
+].join('\n');
+
+function pack(body) {
+  return [{ file: 'xx-test.md', frontmatter: { pack: 'xx-test' }, body, isStructure: false, isScoreOnly: false }];
+}
+
+function profileWith(overrides) {
+  return { frontmatter: { 'pattern-overrides': overrides }, body: 'doc' };
+}
+
+test('suppress removes the exact section and leaves neighbours intact', () => {
+  const [out] = applyProfilePatternOverrides(pack(PACK_BODY), profileWith({ xx: { 27: 'suppress' } }), 'xx');
+  assert.match(out.body, /^### 1\. /m);
+  assert.match(out.body, /^### 2\. /m);
+  assert.match(out.body, /^### 12\. /m);
+  assert.doesNotMatch(out.body, /^### 27\. /m);
+  assert.ok(!out.body.includes('Body of twenty-seven'));
+  assert.ok(out.body.includes('Body of twelve.'));
+});
+
+test('suppress never matches a substring id (12 ≠ 2, 27 ≠ 7)', () => {
+  const [out] = applyProfilePatternOverrides(pack(PACK_BODY), profileWith({ xx: { 12: 'suppress' } }), 'xx');
+  assert.doesNotMatch(out.body, /^### 12\. /m);
+  assert.match(out.body, /^### 2\. /m, '#2 must survive when #12 is suppressed');
+  assert.match(out.body, /^### 1\. /m);
+});
+
+test('multiple suppress ids are removed in one pass and seams stay clean', () => {
+  const [out] = applyProfilePatternOverrides(pack(PACK_BODY), profileWith({ xx: { 1: 'suppress', 12: 'suppress' } }), 'xx');
+  assert.doesNotMatch(out.body, /^### 1\. /m);
+  assert.doesNotMatch(out.body, /^### 12\. /m);
+  assert.match(out.body, /^### 2\. /m);
+  assert.match(out.body, /^### 27\. /m);
+  assert.ok(!/\n{3,}/.test(out.body), 'no triple-newline gaps left behind');
+});
+
+test('reduce is left in place (only suppress is wired in v1)', () => {
+  const [out] = applyProfilePatternOverrides(pack(PACK_BODY), profileWith({ xx: { 12: 'reduce' } }), 'xx');
+  assert.match(out.body, /^### 12\. /m, 'reduce must not remove the section');
+});
+
+test('no overrides for the language is an identity passthrough (same refs)', () => {
+  const packs = pack(PACK_BODY);
+  assert.equal(applyProfilePatternOverrides(packs, profileWith({ ko: { 1: 'suppress' } }), 'xx'), packs);
+  assert.equal(applyProfilePatternOverrides(packs, profileWith({}), 'xx'), packs);
+  assert.equal(applyProfilePatternOverrides(packs, { frontmatter: null, body: '' }, 'xx'), packs);
+  assert.equal(applyProfilePatternOverrides(packs, null, 'xx'), packs);
+});
+
+test('integration: --profile legal suppresses ko patterns 12/18/27 deterministically', () => {
+  const raw = loadPatterns(REPO_ROOT, 'ko');
+  const legal = loadProfile(REPO_ROOT, 'legal');
+  const filtered = applyProfilePatternOverrides(raw, legal, 'ko');
+  const after = filtered.map((p) => p.body).join('\n\n');
+
+  for (const id of [12, 18, 27]) {
+    assert.doesNotMatch(after, new RegExp(`^### ${id}\\. `, 'm'), `legal must suppress ko #${id}`);
+  }
+  // A non-suppressed pattern and the reduce-only ones survive.
+  assert.match(after, /^### 7\. /m);
+  for (const id of [22, 23, 8]) {
+    assert.match(after, new RegExp(`^### ${id}\\. `, 'm'), `reduce/untouched ko #${id} must survive`);
+  }
+
+  // default profile changes nothing.
+  const def = loadProfile(REPO_ROOT, 'default');
+  assert.equal(applyProfilePatternOverrides(raw, def, 'ko'), raw);
+});


### PR DESCRIPTION
Makes a profile's `pattern-overrides … suppress` **actually do something**. Until now `loadProfile` parsed the frontmatter but nothing read `pattern-overrides`/`voice-overrides` — so e.g. `legal` "documented" that it suppresses Korean passive-voice (#27), but patina still fed that rule to the model and flagged it anyway. The table was decorative.

## What changed
- **`src/loader.js`** — new `applyProfilePatternOverrides(packs, profile, lang)`. For each pattern id the active profile marks `suppress` in `pattern-overrides[lang]`, it strips that `### <id>. …` section out of the pattern-pack body (heading through the next `### ` heading / end of pack, plus the dangling `---` separator). The model can't flag a rule it was never given, so the suppression is deterministic — no reliance on the LLM reading the prose body. Packs with no matching override are returned by identity.
- **`src/cli/run.js`** — load the profile first, then run loaded patterns through `applyProfilePatternOverrides` before they reach `buildPrompt`. Single chokepoint, so every prompt surface (rewrite/diff/audit/score/preview) inherits it.
- **Docs** — `COOKBOOK.md` / `CONTRIBUTING.md` now state plainly that **only `suppress` is wired**; `reduce`/`amplify` remain advisory (intent doc + prose body), not yet weight-adjusting.

## Scope (deliberately small — first slice)
- Only `suppress` (full drop). `reduce`/`amplify` are left in place untouched — a follow-up if we want weighted detection.
- **No benchmark impact:** these 160 patterns are LLM-prompt rules; the gated deterministic engine (`analyzeText`, `src/features/*`) does not key off them, so the calibration corpus / 67.3% number is unaffected. This only changes what the LLM-side rewrite/audit/score is told to look for.

## Verification
- New `tests/unit/profile-pattern-overrides.test.js` (6 tests): exact-section removal, substring-id safety (`12 ≠ 2`, `27 ≠ 7`), multi-id one pass with clean seams, `reduce` left in place, identity passthrough when no override, and an integration assertion that `--profile legal` suppresses ko #12/#18/#27 while #7/#8/#22/#23 survive.
- End-to-end (deterministic): a `legal` ko rewrite prompt no longer contains `수동태 남용` (#27) or `과도한 한자어` (#18); the `default` prompt still does.
- `npm run lint` clean; `npm test` full suite green (991 pass / 1 skip).
