### PR TITLE
refactor(tone)!: --tone = register only, --profile = genre only

### DIFF
--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -13,11 +13,11 @@ output: rewrite           # rewrite | diff | audit | score
 # endpoints reject response_format — leave false unless your endpoint supports it.
 structured-output: false
 
-# Tone categorization (v3.10): named voice axis. Six v1 tones for ko/en.
+# Tone categorization (v3.10): register axis (casual/professional) for ko/en.
 # Resolution: explicit --tone > config tone > config profile.
 # auto = heuristic single-tone detection at SKILL.md Phase 4.5b.
 # Unset = profile-only legacy behavior (regression-safe default).
-tone:                       # one of: casual, professional, academic, narrative, marketing, instructional, auto
+tone:                       # one of: casual, professional, auto (register only)
                             # Override with CLI: --tone <name>
                             # zh/ja with explicit tone: warns and falls back to profile.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Then run the skill from Claude Code, Codex CLI, Cursor, or OpenCode:
 Useful skill calls:
 
 ```text
-/patina --tone narrative
+/patina --tone professional
 /patina --tone auto --lang en
 ```
 
@@ -193,7 +193,7 @@ version: "5.4.1"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score
-tone:                     # casual | professional | academic | narrative | marketing | instructional | auto
+tone:                     # casual | professional | auto  (register; genre = profile)
 ```
 
 Project `.patina.yaml` overrides defaults. Pattern packs are auto-discovered by language prefix. Additive list keys (`blocklist`, `allowlist`, `skip-patterns`) merge; other arrays replace.

--- a/SKILL.md
+++ b/SKILL.md
@@ -42,7 +42,7 @@ Glob .patina.default.yaml → Read
 - `--ouroboros`: ouroboros 모드 (반복 교정 + 점수 수렴)
 - `--strict`: 옵트인 다중 패스 엄격 모드. rewrite 출력 모드를 사용한다. `--lang`, `--tone`, `--profile`, `--ouroboros`와 함께 사용할 수 있다. `--audit`, `--diff`, `--score`와 함께 사용할 수 없다.
 - `--lang <code>`: 처리 언어 변경 (ko, en, zh, ja). 설정 파일의 `language` 값을 오버라이드한다.
-- `--tone <name>`: 톤 카테고리 지정. 유효값: `casual | professional | academic | narrative | marketing | instructional | auto`. 알 수 없는 값이면 즉시 오류: "Unknown tone '<name>'. Valid tones: casual, professional, academic, narrative, marketing, instructional, auto"
+- `--tone <name>`: 어투(레지스터) 지정. 유효값: `casual | professional | auto`. academic/marketing/narrative/instructional 은 장르이므로 `--profile <name>` 을 쓴다. 알 수 없는 값이면 즉시 오류: "Unknown tone '<name>'. Valid tones: casual, professional, auto"
 - `--batch <files>`: 여러 파일을 한꺼번에 처리 (glob 또는 명시적 경로 목록).
   - `--in-place`: 원본 파일을 교정된 텍스트로 덮어쓴다.
   - `--suffix <ext>`: 결과를 `{원본명}{ext}` 파일로 저장한다 (예: `--suffix .humanized`).
@@ -57,21 +57,14 @@ if resolved_tone == null and config.profile present:
   → "profile-only mode" (4.5b 단계 건너뜀; footer: tone=null, tone_source=profile_only)
 
 if resolved_tone == "auto":
-  → 4.5b 단계에서 휴리스틱 자동 감지 수행
+  → 4.5b 단계에서 휴리스틱 자동 감지 수행 (casual 또는 professional 로 확정)
 
-if resolved_tone in {casual, professional, academic, narrative, marketing, instructional}:
+if resolved_tone in {casual, professional}:
   → tone_source=user, tone_evidence=["user-specified"], tone_confidence=high
-  → 백본 프로필 매핑 (plan §1):
-      casual        → profiles/blog.md (primary) + profiles/social.md (secondary)
-      professional  → profiles/email.md (primary) + profiles/formal.md + profiles/legal.md + profiles/medical.md
-                      (legal/medical 는 fidelity 0.65 강제 — R2)
-      academic      → profiles/academic.md (primary) + profiles/technical.md
-      narrative     → profiles/narrative.md
-      marketing     → profiles/marketing.md
-      instructional → profiles/instructional.md
-  → 매핑된 프로필을 3단계에서 우선 로드한다 (--profile 오버라이드 이후 적용)
+  → 톤은 어투(레지스터)만 정한다. 장르 프로필은 `--profile` 로만 결정되며 톤은 프로필을 고르지 않는다 (백본 매핑 제거, 6.0).
+  → academic / narrative / marketing / instructional 은 더 이상 톤이 아니다 — 그건 장르이므로 `--profile <name>` 을 쓴다.
 
-if --lang in {zh, ja} and resolved_tone in 6-tone set:
+if --lang in {zh, ja} and resolved_tone != null:
   → footer에 경고 추가: tone "<name>" is en/ko-only in v1; falling back to default profile
   → tone_source=unsupported_language_fallback
   → profile-only 경로로 fallback
@@ -165,7 +158,7 @@ Read core/voice.md
 
 ## 4.5b단계: 톤 자동 감지 (Tone Auto-Detection)
 
-**실행 조건:** `resolved_tone == "auto"` 일 때만 실행한다. `resolved_tone`이 null이거나 6개 명시 톤 중 하나이면 이 단계를 건너뛴다.
+**실행 조건:** `resolved_tone == "auto"` 일 때만 실행한다. `resolved_tone`이 null이거나 명시 톤(`casual`/`professional`)이면 이 단계를 건너뛴다.
 
 **짧은 입력 예외:** 텍스트가 단락 < 2 OR 전체 문장 < 2이면 감지를 실행하지 않는다 → `professional` 톤으로 기록, `tone_source: skipped_short_input`, `tone_confidence: low`, `tone_evidence: ["input too short"]`. 이것은 폴백이 아니라 감지 시작 안 함이다 (A5 위배 아님). `skipped_short_input` 은 감지를 **건너뛴** 경우 전용 라벨이며, 감지가 실행되었으나 잔류 규칙으로 떨어진 경우(아래 잔류 규칙 항목)와 명확히 구분된다.
 
@@ -175,18 +168,6 @@ Read core/voice.md
 |------|------------|---------|
 | **어휘: casual-ko** | `진짜`, `솔직히`, `근데`, `뭐`, `어`, `걍`, `좀`, `그냥`, `ㅋ`, `ㅎ` 중 3개 이상 | casual |
 | **어휘: casual-en** | 축약형(`don't`, `I'm`, `it's`, `can't`, `won't`) 2개 이상 OR `honestly`, `actually`, `kinda`, `tbh` 등장 | casual |
-| **어휘: academic-ko** | `따라서`, `즉`, `결론적으로`, `분석`, `연구`, `검토`, `고찰`, `제안한다` 중 2개 이상 | academic |
-| **어휘: academic-en** | `therefore`, `thus`, `furthermore`, `analysis`, `evidence`, `research`, `suggests`, `findings` 중 2개 이상 | academic |
-| **어휘: instructional-ko** | 문장 첫머리 명령형 동사 (`하세요`, `하라`, `입력`, `실행`, `확인`, `설치`) 2개 이상 | instructional |
-| **어휘: instructional-en** | 문장 첫머리 명령형 동사(`Install`, `Run`, `Open`, `Click`, `Enter`, `Check`, `Go to`) 2개 이상 | instructional |
-| **어휘: marketing-ko** | `지금`, `바로`, `놓치지`, `단 하나`, `최고의`, `혜택`, `지금 바로`, `특별한` 중 2개 이상 | marketing |
-| **어휘: marketing-en** | `now`, `today`, `best`, `exclusive`, `limited`, `discover`, `unlock`, `transform` 중 2개 이상 OR CTA 동사(`Buy`, `Sign up`, `Try`) | marketing |
-| **어휘: narrative-ko** | 과거 시제 1인칭(`내가 ~했다`, `나는 ~했다`) 2개 이상 OR `그때`, `기억`, `느꼈다`, `눈물`, `웃음` 등장 | narrative |
-| **어휘: narrative-en** | 과거 시제 1인칭(`I was`, `I had`, `I felt`, `I remember`, `I noticed`) 2개 이상 | narrative |
-| **구조: numbered-list** | 번호 목록 행(`1.`, `2.`, `①` 등) 비율이 전체 줄의 30% 이상 | instructional |
-| **구조: short-impact** | 전체 문장 중 토큰 5개 이하 문장 비율 40% 이상 | marketing |
-| **구조: first-person-ratio** | 1인칭 대명사(`나`, `내`, `I`, `my`, `me`) 포함 문장 비율 50% 이상 | narrative |
-| **구조: no-first-person** | 1인칭 대명사 포함 문장 비율 5% 이하이고 긴 문장(토큰 15개 이상) 비율 40% 이상 | academic |
 
 **잔류(residual) 규칙:** 위 신호 중 어느 버킷도 임계값(1점)을 넘기지 못하면 → `professional` (중립 기본값).
 - `tone_source: auto` (감지는 실행되었음 — short-input 의 `skipped_short_input` 과 구분)
@@ -211,7 +192,7 @@ tone_confidence: high
 </detected-tone>
 ```
 
-감지 완료 후 해당 톤의 백본 프로필(1단계 매핑 표 참조)을 3단계 프로필 로드에 반영한다.
+감지 완료 후 결과 톤(`casual`/`professional`)은 어투(레지스터)에만 반영한다. 톤은 프로필을 고르지 않으며, 장르 프로필은 `--profile` 로만 결정된다 (백본 매핑 제거, 6.0).
 
 ---
 
@@ -656,10 +637,6 @@ FOR each anchor IN anchor_list:
    |------|-------------|-------------|
    | `casual` | 14:suppress, 15:reduce, 17:reduce, 18:amplify, 8:amplify | 14:suppress, 15:reduce, 17:reduce, 7:amplify, 8:amplify |
    | `professional` | 17:suppress, 25:reduce, 28:amplify | 17:suppress, 25:reduce, 28:amplify |
-   | `academic` | 17:suppress, 14:reduce, 8:reduce | 17:suppress, 14:reduce, 8:reduce |
-   | `narrative` | 14:suppress, 15:suppress, 25:suppress, 26:reduce, 27:reduce | 14:suppress, 15:suppress, 25:suppress, 26:reduce, 27:reduce |
-   | `marketing` | 17:allow, 14:reduce, 28:suppress | 17:allow, 14:reduce, 28:suppress |
-   | `instructional` | 25:allow, 15:allow, 22:reduce, 28:suppress, 14:reduce | 25:allow, 15:allow, 22:reduce, 28:suppress, 14:reduce |
 
    **legal/medical fidelity 강제 (R2):** resolved_tone=professional이고 config.profile이 `legal` 또는 `medical`이면, `ouroboros.combined-weights.legal` / `ouroboros.combined-weights.medical` (fidelity 0.65)을 강제 적용한다. 톤 오버라이드가 fidelity 하한을 낮추지 않도록 한다.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -132,12 +132,12 @@ With `--preview`, `--jargon` **and `--tone`** accept comma-separated lists; ever
 ```bash
 patina --preview --jargon keep,remove <url>                  # cleanup / de-jargoned side by side
 patina --preview --jargon remove --tone casual,professional <url>  # same policy, two voices
-patina --preview --tone casual,marketing <url>               # tone-only comparison
+patina --preview --tone casual,professional <url>           # register comparison
 ```
 
 - The bar groups variants two-level: one primary button per jargon policy (cleanup/explain/remove) and, when a policy carries multiple options (tone), a secondary chip row that appears only while that policy is selected — click **remove**, then pick **casual** or **professional**. Each policy remembers its own option selection. The switch is CSS-only (chained radio groups), so the snapshot stays scriptless and the page CSP keeps `script-src 'none'`.
 - The score chip shows each variant's deterministic score (`score 23 → cleanup 5 · remove 8`).
-- A comma-listed `--tone` joins the cross product: each variant resolves its own tone (and its backbone profile, unless `--profile` is explicit), exactly as a single run with that `--tone` would. Labels carry the tone when it varies (`remove·casual`).
+- A comma-listed `--tone` joins the cross product: each variant resolves its own register (genre profile is fixed by `--profile`), exactly as a single run with that `--tone` would. Labels carry the tone when it varies (`remove·casual`).
 - A block counts as changed when **any** variant changes it; a variant that left a block alone shows the original text under that button.
 - stdout carries the first variant's prose (pipe-safe); the explanation call is skipped in compare mode to keep the call budget at one per variant.
 - Compare mode needs a page snapshot (URL or `.html`) and is incompatible with `--ocr`; comma lists without `--preview` are an input error.
@@ -180,7 +180,7 @@ URL contract:
 Document context:
 - Rewrites run under a **document brief**: the prompt instructs the model to first identify what the document is, who is speaking to whom, the dominant register, and the recurring domain terms — and to keep that frame for every edit. All rewritten sentences are unified to the document's dominant register (register mixing is itself an AI tell).
 - For Korean text the dominant register is **measured deterministically** (sentence-ending distribution: 합쇼체/해요체/-다체) and injected into the prompt as ground truth; the "patina notes" panel shows the measurement in a *document context* card.
-- `--tone <casual|professional|academic|narrative|marketing|instructional|auto>` works with `--preview` and overrides the target tone; the register-unification rule still applies.
+- `--tone <casual|professional|auto>` works with `--preview` and overrides the target register; the register-unification rule still applies. (academic/marketing/narrative/instructional are genres — use `--profile`.)
 
 File contract (local `.html`):
 - A local `.html`/`.htm` file goes through the same snapshot pipeline as a fetched URL: prose blocks are extracted, rewritten, and swapped back in place. Markdown/text drafts are not accepted as preview input.

--- a/src/cli/args.js
+++ b/src/cli/args.js
@@ -91,8 +91,8 @@ export function parseArgs(rawArgs) {
         const t = readOptionValue(args, i, arg);
         i++;
         parsed.tone = parseTransformList(t, arg,
-          ['casual', 'professional', 'academic', 'narrative', 'marketing', 'instructional', 'auto'],
-          'Use `--tone auto` to let patina infer tone from the text. Comma-separate tones with --preview to compare variants.');
+          ['casual', 'professional', 'auto'],
+          'Use `--tone auto` to infer register from the text. academic/marketing/narrative/instructional are document genres now — use `--profile <name>`. Comma-separate tones with --preview to compare variants.');
         break;
       }
       case '--voice-sample':
@@ -722,9 +722,9 @@ LANGUAGE & PROFILE
                           social, email, legal, medical, marketing,
                           narrative, instructional, casual-conversation,
                           code-comment, commit-message, release-notes, namuwiki
-  --tone <name[,name]>    Tone: casual, professional, academic, narrative,
-                          marketing, instructional, auto. Resolution:
-                          --tone > config tone > config profile.
+  --tone <name[,name]>    Register: casual, professional, auto. (academic / marketing /
+                          narrative / instructional are genres now — use --profile.)
+                          Resolution: --tone > config tone > config profile.
                           Comma list with --preview compares tones as variants
   --voice-sample <path>   Use 1-3 user paragraphs as style-only voice anchors
   --persona <name>         Korean rewrite persona (default preserve); incompatible

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -5,7 +5,6 @@ import {
   loadProfile,
   loadCoreFile,
   loadVoiceSample,
-  toneToBackboneProfile,
 } from '../loader.js';
 import { buildPrompt } from '../prompt-builder.js';
 import { buildTransformVariants } from './args.js';
@@ -85,19 +84,7 @@ export async function runDefault(parsed, logger) {
     logger.warn('tone.warning', { message: `[patina] ${toneResolution.warning}` });
   }
 
-  // Backbone profile mapping: explicit user tone (not auto, not fallback) maps to a
-  // backbone profile. CLI --profile still wins on conflict (per Phase 1 spec — backbone
-  // is applied "after --profile override"). Only auto-map when user didn't specify --profile.
   let profileName = config.profile || 'default';
-  if (
-    !parsed.profile &&
-    toneResolution.tone_source === 'user' &&
-    toneResolution.tone &&
-    toneResolution.tone !== 'auto'
-  ) {
-    const backbone = toneToBackboneProfile(toneResolution.tone);
-    if (backbone) profileName = backbone;
-  }
   const resolvedProfileName = resolveProfileForLanguage(profileName, lang, logger);
   if (resolvedProfileName !== profileName) {
     profileName = resolvedProfileName;
@@ -755,24 +742,16 @@ async function runPreviewJob({
           message: `[patina] Rewriting variant ${variant.label} (${index + 1}/${transformVariants.length})…`,
         });
         // Per-variant tone: a comma-listed --tone makes each variant carry its
-        // own tone, so the resolution (and the backbone-profile mapping, when
-        // the user did not pass an explicit --profile) is re-derived here —
-        // mirroring exactly what a single run with that --tone would do.
+        // own register, re-resolved here to mirror a single run with that --tone.
+        // Profile (genre) is fixed across variants — tone no longer remaps it.
         let variantTone = toneResolution;
-        let variantProfile = basePromptInputs.profile;
         if (variant.tone && variant.tone !== firstCliTone) {
           variantTone = resolveTone({ cliTone: variant.tone, configTone: config.tone, lang: previewLang });
           if (variantTone.warning) {
             logger.warn('tone.warning', { message: `[patina] ${variantTone.warning}` });
           }
-          if (!parsed.profile && variantTone.tone_source === 'user' && variantTone.tone && variantTone.tone !== 'auto') {
-            const backbone = toneToBackboneProfile(variantTone.tone);
-            if (backbone) {
-              const loaded = loadProfile(repoRoot, resolveProfileForLanguage(backbone, previewLang, logger));
-              if (loaded.body) variantProfile = loaded;
-            }
-          }
         }
+        const variantProfile = basePromptInputs.profile;
         const variantRaw = await invokeBackendChain({
           ...invokeInputs,
           prompt: buildPrompt({

--- a/src/config.js
+++ b/src/config.js
@@ -110,7 +110,27 @@ export function getRepoRoot() {
   return REPO_ROOT;
 }
 
-const VALID_TONES = ['casual', 'professional', 'academic', 'narrative', 'marketing', 'instructional', 'auto'];
+const VALID_TONES = ['casual', 'professional', 'auto'];
+// Removed in 6.0: these named document genres, not register. --tone is register
+// only now (casual / professional / auto); the genre lives in --profile.
+const GENRE_TONES_MOVED_TO_PROFILE = ['academic', 'narrative', 'marketing', 'instructional'];
+
+function rejectTone(value, where) {
+  if (GENRE_TONES_MOVED_TO_PROFILE.includes(value)) {
+    throw inputError(
+      `'${value}' is no longer a tone`,
+      `${value} is a document genre, not register. --tone now only sets register: ${VALID_TONES.join(', ')}.`,
+      `Use \`--profile ${value}\` for the genre (optionally with \`--tone casual|professional\`).`
+    );
+  }
+  throw inputError(
+    where === 'config' ? `invalid tone '${value}' in config` : `unknown tone '${value}'`,
+    `${where === 'config' ? "The config 'tone'" : '--tone'} must be one of: ${VALID_TONES.join(', ')}.`,
+    where === 'config'
+      ? "Fix the tone value in your .patina.yaml (or remove it)."
+      : 'Pass a supported tone, or omit --tone for profile-only mode.'
+  );
+}
 
 // Resolve the effective tone from CLI flag and config (v3.10).
 // Priority: cliTone > configTone > unset. zh/ja + explicit tone → fallback path.
@@ -128,23 +148,11 @@ const VALID_TONES = ['casual', 'professional', 'academic', 'narrative', 'marketi
  * const tone = resolveTone({ cliTone: 'casual', lang: 'ko' });
  */
 export function resolveTone({ cliTone, configTone, lang }) {
-  if (cliTone !== undefined && cliTone !== null) {
-    if (!VALID_TONES.includes(cliTone)) {
-      throw inputError(
-        `unknown tone '${cliTone}'`,
-        `--tone must be one of: ${VALID_TONES.join(', ')}.`,
-        'Pass a supported tone, or omit --tone for profile-only mode.'
-      );
-    }
+  if (cliTone !== undefined && cliTone !== null && !VALID_TONES.includes(cliTone)) {
+    rejectTone(cliTone, 'cli');
   }
-  if (configTone !== undefined && configTone !== null && configTone !== '') {
-    if (!VALID_TONES.includes(configTone)) {
-      throw inputError(
-        `invalid tone '${configTone}' in config`,
-        `The config 'tone' must be one of: ${VALID_TONES.join(', ')}.`,
-        'Fix the tone value in your .patina.yaml (or remove it).'
-      );
-    }
+  if (configTone !== undefined && configTone !== null && configTone !== '' && !VALID_TONES.includes(configTone)) {
+    rejectTone(configTone, 'config');
   }
 
   const effective = cliTone || (configTone === '' ? null : configTone) || null;

--- a/src/loader.js
+++ b/src/loader.js
@@ -257,29 +257,3 @@ export function loadVoiceSample(path) {
     truncated: paragraphs.length > selected.length,
   };
 }
-
-// Tone → backbone profile mapping (v3.10, mirrors SKILL.md Phase 1).
-// Returns the *primary* backbone profile name for a resolved tone.
-// Multi-profile tones (e.g. professional → email + formal + legal + medical)
-// expose only the primary here; secondary profiles are documented in SKILL.md
-// and respected via legal/medical fidelity-floor enforcement at Phase 5b.
-const TONE_BACKBONE = {
-  casual: 'blog',                 // primary; social is a secondary backbone
-  professional: 'email',          // primary; formal/legal/medical secondary
-  academic: 'academic',           // primary; technical secondary
-  narrative: 'narrative',
-  marketing: 'marketing',
-  instructional: 'instructional',
-};
-
-/**
- * Map a resolved named tone to its primary backbone profile.
- *
- * @param {string} tone Tone name.
- * @returns {string|null} Profile name, or null when no mapping exists.
- * @example
- * const profile = toneToBackboneProfile('casual'); // blog
- */
-export function toneToBackboneProfile(tone) {
-  return TONE_BACKBONE[tone] || null;
-}

--- a/tests/unit/preview.test.js
+++ b/tests/unit/preview.test.js
@@ -397,13 +397,13 @@ test('resolveStreamedHtml keeps fallbacks whose segment never streamed', () => {
 test('buildContextCardHtml renders register and tone rows, empty without either', () => {
   const card = buildContextCardHtml({
     register: { register: 'polite', label: '해요체', shares: { formal: 0.1, polite: 0.8, plain: 0.1 }, classified: 20, sentenceCount: 22 },
-    tone: { tone: 'marketing', tone_source: 'user' },
+    tone: { tone: 'professional', tone_source: 'user' },
   });
   assert.ok(card.includes('ptna-ctx-card'));
   assert.ok(card.includes('document context'));
   assert.ok(card.includes('해요체'));
   assert.ok(card.includes('합쇼체 10% · 해요체 80% · -다체 10%'));
-  assert.ok(card.includes('marketing'));
+  assert.ok(card.includes('professional'));
 
   assert.strictEqual(buildContextCardHtml({}), '');
   assert.strictEqual(buildContextCardHtml({ tone: { tone: null, tone_source: 'profile_only' } }), '');

--- a/tests/unit/tone.test.js
+++ b/tests/unit/tone.test.js
@@ -2,13 +2,12 @@ import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 
 import { resolveTone } from '../../src/config.js';
-import { toneToBackboneProfile } from '../../src/loader.js';
 import { formatOutput } from '../../src/output.js';
 
 // --- resolveTone ---
 
 test('resolveTone: CLI tone wins over config tone', () => {
-  const r = resolveTone({ cliTone: 'casual', configTone: 'academic', lang: 'ko' });
+  const r = resolveTone({ cliTone: 'casual', configTone: 'professional', lang: 'ko' });
   assert.equal(r.tone, 'casual');
   assert.equal(r.tone_source, 'user');
 });
@@ -65,8 +64,8 @@ test('resolveTone: invalid configTone throws', () => {
   );
 });
 
-test('resolveTone: all 6 named tones accepted', () => {
-  for (const t of ['casual', 'professional', 'academic', 'narrative', 'marketing', 'instructional']) {
+test('resolveTone: register tones accepted', () => {
+  for (const t of ['casual', 'professional']) {
     const r = resolveTone({ cliTone: t, lang: 'en' });
     assert.equal(r.tone, t);
     assert.equal(r.tone_source, 'user');
@@ -74,20 +73,10 @@ test('resolveTone: all 6 named tones accepted', () => {
   }
 });
 
-// --- toneToBackboneProfile ---
-
-test('toneToBackboneProfile: maps known tones to backbone profiles', () => {
-  assert.equal(toneToBackboneProfile('casual'), 'blog');
-  assert.equal(toneToBackboneProfile('professional'), 'email');
-  assert.equal(toneToBackboneProfile('academic'), 'academic');
-  assert.equal(toneToBackboneProfile('narrative'), 'narrative');
-  assert.equal(toneToBackboneProfile('marketing'), 'marketing');
-  assert.equal(toneToBackboneProfile('instructional'), 'instructional');
-});
-
-test('toneToBackboneProfile: unknown tone returns null', () => {
-  assert.equal(toneToBackboneProfile('auto'), null);
-  assert.equal(toneToBackboneProfile('unknown'), null);
+test('resolveTone: removed genre tones are rejected with a --profile hint', () => {
+  for (const t of ['academic', 'narrative', 'marketing', 'instructional']) {
+    assert.throws(() => resolveTone({ cliTone: t, lang: 'en' }), new RegExp(`'${t}' is no longer a tone`));
+  }
 });
 
 // --- formatOutput tone footer ---

--- a/tests/unit/transform-options.test.js
+++ b/tests/unit/transform-options.test.js
@@ -93,7 +93,7 @@ test('minimal rewrite prompt carries a localized directive', () => {
 test('parseArgs accepts comma lists for compare mode and dedupes them', () => {
   assert.equal(parseArgs(['--jargon', 'keep,explain,remove']).jargon, 'keep,explain,remove');
   assert.equal(parseArgs(['--jargon', 'remove, remove ,explain']).jargon, 'remove,explain');
-  assert.equal(parseArgs(['--tone', 'casual,marketing']).tone, 'casual,marketing');
+  assert.equal(parseArgs(['--tone', 'casual,professional']).tone, 'casual,professional');
   assert.throws(() => parseArgs(['--jargon', 'remove,everything']), /unknown jargon policy everything/);
   assert.throws(() => parseArgs(['--jargon', ',,']), /--jargon expects a value/);
 });
@@ -113,7 +113,7 @@ test('buildTransformVariants expands the cross product with labels and a cap', (
 });
 
 test('tone joins the variant cross product with per-tone labels', () => {
-  assert.equal(parseArgs(['--tone', 'casual,marketing']).tone, 'casual,marketing');
+  assert.equal(parseArgs(['--tone', 'casual,professional']).tone, 'casual,professional');
   assert.throws(() => parseArgs(['--tone', 'casual,shouty']), /unknown tone shouty/);
 
   // Single tone: carried on the variant, absent from the label.
@@ -127,24 +127,24 @@ test('tone joins the variant cross product with per-tone labels', () => {
   ]);
   // Tone-only comparison: the tone IS the label.
   assert.deepStrictEqual(
-    buildTransformVariants({ tone: 'casual,marketing' }).map((v) => v.label),
-    ['casual', 'marketing']
+    buildTransformVariants({ tone: 'casual,professional' }).map((v) => v.label),
+    ['casual', 'professional']
   );
   // Tone multiplies into the cap: 2 jargons × 3 tones = 6 > 4.
   assert.throws(
-    () => buildTransformVariants({ jargon: 'keep,remove', tone: 'casual,professional,marketing' }),
+    () => buildTransformVariants({ jargon: 'keep,remove', tone: 'casual,professional,auto' }),
     /too many transform variants/
   );
   // Tone-only list still needs --preview, and the error names --tone.
   assert.throws(
-    () => validateTransformRequest({ tone: 'casual,marketing' }),
+    () => validateTransformRequest({ tone: 'casual,professional' }),
     /comparing transform variants requires --preview/
   );
   assert.throws(
-    () => validateTransformRequest({ tone: 'casual,marketing', preview: true, score: true }),
+    () => validateTransformRequest({ tone: 'casual,professional', preview: true, score: true }),
     /--tone cannot be combined with --score/
   );
-  validateTransformRequest({ tone: 'casual,marketing', preview: true });
+  validateTransformRequest({ tone: 'casual,professional', preview: true });
 });
 
 test('validateTransformRequest gates compare mode on --preview and rejects --ocr', () => {


### PR DESCRIPTION
Makes `--tone` mean **register only** and `--profile` mean **genre only**, so the two axes stop overlapping. **Breaking change** (folds into 6.0.0).

## Why
`--tone` and `--profile` were two muddled ways to say "how should this read":
- 4 tone names (`academic`, `marketing`, `narrative`, `instructional`) **duplicated profile names** — "academic tone" vs "academic profile" did almost the same thing.
- Every named tone secretly remapped to a backbone **profile** (`casual→blog`, `professional→email`, …), so picking a tone picked a genre.
- When both were set, tone "replaced" the profile's voice overrides — they fought over the same knob.

## What changed
- **`--tone` is register-only:** `casual`, `professional`, `auto`. The four genre names are removed. `--tone academic` (etc.) now errors with a migration hint pointing at `--profile academic`.
- **Backbone mapping deleted:** a tone no longer selects a profile. `--tone` adjusts register; `--profile` picks genre (default if unset); they are independent. Removed `TONE_BACKBONE` / `toneToBackboneProfile` (`loader.js`) and both mapping sites in `run.js` (main + preview-variant paths).
- **`auto` detection** naturally narrows to casual-vs-professional (the genre signal buckets — academic/marketing/narrative/instructional + the structural signals feeding them — are dropped from SKILL.md Phase 4.5b; residual stays `professional`).

## Files
- `src/config.js` — `VALID_TONES` → `casual/professional/auto`; `rejectTone` gives a `--profile` hint for the removed genre tones (CLI **and** config paths).
- `src/cli/args.js` — `--tone` token list narrowed + migration hint in the flag help.
- `src/loader.js` / `src/cli/run.js` — backbone mapping removed; profile is no longer derived from tone.
- `SKILL.md` — tone resolution, Phase 4.5b signal table, Phase 5b override table, and footer synced (CLI ↔ skill parity). `legal/medical` fidelity enforcement (R2, profile-driven) is unchanged.
- `.patina.default.yaml`, `docs/CLI.md`, `README.md` — tone lists/examples updated.
- Tests: `tone.test.js` (removed-tone rejection + register-only acceptance; dropped the deleted `toneToBackboneProfile` tests), `transform-options.test.js` / `preview.test.js` (removed-tone usages → `professional`).

## Verification
- `npm run lint` clean; `npm test` full suite green (990 pass / 1 skip).
- Live (DeepSeek): `--tone marketing`/`--tone academic` exit 2 with the `--profile` migration hint; `--tone professional` rewrites in a formal register without forcing a genre ("honestly we kinda crushed it…" → "We had a strong quarter and delivered a substantial amount of work."); `casual`/`professional`/`auto` parse fine.

Migration: `--tone academic|marketing|narrative|instructional` → use `--profile <name>` (optionally with `--tone casual|professional`).
