### PR TITLE
chore(release): 6.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "patina",
       "source": "./",
-      "version": "5.4.1",
+      "version": "6.0.0",
       "description": "Strip the AI packaging, keep the meaning. Detect and rewrite AI writing patterns across KO/EN/ZH/JA with MPS/fidelity checks. Runs the root SKILL.md as the /patina skill.",
       "homepage": "https://github.com/devswha/patina",
       "repository": "https://github.com/devswha/patina",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
   "name": "patina",
-  "version": "5.4.1",
+  "version": "6.0.0",
   "description": "Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese so text reads as if a human wrote it. Meaning-preservation (MPS) verified, audit-friendly. The root SKILL.md is loaded as the /patina skill.",
   "author": {
     "name": "devswha",

--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "5.4.1"
+version: "6.0.0"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,32 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
+## 6.0.0 — 2026-06-26
+
+**Voice-control consolidation: `--verify` replaces the ouroboros loop, `--tone` becomes register-only, `--profile` gains real deterministic pattern suppression.**
+
+Semver rationale: major — removes the `--ouroboros` and `--restyle` CLI flags, drops four `--tone` values, and changes `--tone`/`--profile` semantics (tone no longer selects a profile). Existing commands that used the removed flags/tones now error with a migration hint.
+
+### Added
+
+- **`--verify`** — folds a meaning check into the rewrite: scores MPS and fidelity, runs one conservative retry from the original when either is below the floor, and fails closed to the highest-fidelity candidate. Works through any selected backend (HTTP or local CLI) (#552).
+- **Deterministic meaning guard** — every rewrite warns on stderr when source numbers go missing, with no model call (#552).
+- **Profile `pattern-overrides … suppress` is now enforced deterministically** — a profile (e.g. `legal`) that suppresses a genre-appropriate pattern (passive voice, formal vocabulary) drops it from the rewrite/audit/score prompt instead of documenting intent the model may ignore. `reduce`/`amplify` remain advisory (#556).
+
+### Changed (breaking)
+
+- **`--tone` is register-only** (`casual`, `professional`, `auto`). `academic`, `marketing`, `narrative`, and `instructional` were document genres, not register — they move to `--profile <name>` and now error with that hint (#557).
+- **Tone no longer maps to a profile backbone.** `--tone` sets register and `--profile` sets genre as independent axes; picking a tone no longer switches the profile (#557).
+
+### Removed (breaking)
+
+- **`--ouroboros`** — the iterative loop is replaced by `--verify`. The flag errors with a migration hint. (`runOuroboros` survives only as the `quality:rewrite-ab` research baseline; the `/patina` skill keeps its own loop) (#553, #554).
+- **`--restyle`** — voice/register changes are `--persona` / `--tone` / `--voice-sample`; content-level re-planning is out of scope for a meaning-preserving humanizer. `--restyle content` had made the meaning-preservation score advisory, which contradicted patina's core contract (#554).
+
+### Internal
+
+- Removed dead `legacy_profile_bridge` persona metadata and the orphaned `ouroboros` prompt/output mode (no runtime path produced it after #553) (#555).
+
 ## 5.4.1 — 2026-06-26
 
 **Web playground and install reliability fixes: rewrites no longer hang, language is auto-detected, the mobile Korean hero wraps cleanly, and fresh installs get their runtime dependency.**

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 5.4.1" src="https://img.shields.io/badge/version-5.4.1-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 6.0.0" src="https://img.shields.io/badge/version-6.0.0-blue"></a>
 </p>
 
 <p align="center">
@@ -189,7 +189,7 @@ If meaning drifts, the change is retried or rolled back. Deterministic analysis 
 
 ```yaml
 # .patina.default.yaml
-version: "5.4.1"
+version: "6.0.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 5.4.1
+version: 6.0.0
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "5.4.1",
+  "version": "6.0.0",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "5.4.1",
+  "version": "6.0.0",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "5.4.1"
+    "patina-cli": "6.0.0"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump **5.4.1 → 6.0.0** (major) and CHANGELOG for the voice-control consolidation shipped in #552–#557.

## Why major
Breaking CLI surface changes:
- Removed `--ouroboros` (#553/#554) and `--restyle` (#554) — both error with a migration hint.
- `--tone` is register-only; `academic`/`marketing`/`narrative`/`instructional` moved to `--profile` (#557).
- `--tone` no longer selects a profile backbone — tone (register) and profile (genre) are independent (#557).

Plus features: `--verify` meaning-floor rewrite + deterministic guard (#552), profile `pattern-overrides … suppress` now enforced deterministically (#556).

## Version sync (8 surfaces, gated by `release:check`)
`package.json`, `SKILL.md`, `.patina.default.yaml`, `README.md` (config example + badge), `CHANGELOG.md`, `packages/patina-humanizer/package.json` (+ its exact `patina-cli` dep), `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` — all at `6.0.0`.

## Local gate run (mirrors release.yml verify)
- `npm run release:check` → `Release metadata OK for 6.0.0`
- `npm test` → 990 pass / 1 skip / 0 fail
- `npm run check:no-private-assets` → OK (0 forbidden paths)
- `npm run dogfood` → all surfaces under the score gate
- `npm run benchmark:report && npm run benchmark:compare` → `docs/benchmarks` clean (no drift)

Merging this, then pushing tag `v6.0.0`, triggers the npm publish of `patina-cli` + `patina-humanizer`.
