### PR TITLE
feat(playground): editorial overhaul, interactive examples, benchmark, API providers

### DIFF
--- a/playground/chatgpt.css
+++ b/playground/chatgpt.css
@@ -1,33 +1,33 @@
-/* patina — Lovable-style composition · dark patina×voltagent palette */
+/* patina — editorial dark: near-black canvas, white type, single restrained accent (no rainbow/aurora slop) */
 :root {
-  /* Surfaces — patina navy-black canvas (VoltAgent single-dark-surface) */
-  --bg: #020617;            /* patina icon canvas */
-  --bg-cream: #0f1a2c;      /* elevated dark surface (cards/bubbles/badges) */
-  --bg-side: #0a1120;       /* sidebar */
-  --bg-elev: #111a2b;       /* composer / prompt card */
+  /* Surfaces — neutral near-black (Lovable's warm-light, inverted to dark) */
+  --bg: #0a0a0b;            /* page canvas */
+  --bg-cream: #1b1b1f;      /* elevated surface (cards / badges / bar+foot) */
+  --bg-side: #0e0e10;       /* sidebar */
+  --bg-elev: #141417;       /* composer / prompt / editor panel */
   --bg-hover: rgba(255, 255, 255, 0.05);
   --bg-hover-2: rgba(255, 255, 255, 0.08);
 
-  /* Text */
-  --text: #e8eef7;
-  --text-dim: #aab6c6;      /* patina slate — raised for AA on navy */
-  --text-faint: #5f6b80;
+  /* Text — white on near-black */
+  --text: #fafafa;
+  --text-dim: #a1a1aa;
+  --text-faint: #7c7c84;
 
-  /* Borders */
-  --border: #1e293b;        /* patina hairline (logo border) */
-  --border-strong: #2a3a52;
+  /* Borders — neutral hairlines */
+  --border: #27272a;
+  --border-strong: #3f3f46;
 
-  /* Patina accents */
+  /* Patina semantic accents (kept for diff / signals) */
   --accent: #2dd4bf;        /* patina teal — single primary accent */
   --accent-soft: #5eead4;
   --accent-press: #14b8a6;
   --on-accent: #04181a;     /* dark text on a teal fill */
-  --copper: #c46a2a;        /* AI "packaging" / the "before" */
+  --copper: #d9772f;        /* AI "packaging" / the "before" */
   --gold: #ffe6a8;          /* preserved-meaning core */
 
-  /* High-emphasis pill (nav CTA): teal on dark */
-  --dark: #2dd4bf;
-  --on-dark: #04181a;
+  /* High-emphasis pill (nav CTA): white on near-black */
+  --dark: #fafafa;
+  --on-dark: #0a0a0b;
 
   --maxw: 768px;
   --page: 1120px;
@@ -35,14 +35,12 @@
   --mono: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 
   --inset: rgba(255, 255, 255, 0.08) 0 0.5px 0 0 inset, rgba(0, 0, 0, 0.35) 0 0 0 0.5px inset, rgba(0, 0, 0, 0.25) 0 1px 2px 0;
-  --focus-shadow: rgba(0, 0, 0, 0.45) 0 4px 16px;
+  --focus-shadow: rgba(0, 0, 0, 0.55) 0 4px 16px;
 
-  /* Aurora tuned for navy: subtle teal → violet → copper glow */
+  /* Restrained single-accent glow — editorial, no rainbow (StyleSeed: one accent, rest grayscale) */
   --aurora:
-    radial-gradient(58% 56% at 50% -12%, rgba(45, 212, 191, 0.11), transparent 70%),
-    radial-gradient(44% 42% at 14% 44%, rgba(120, 90, 255, 0.10), transparent 72%),
-    radial-gradient(48% 46% at 88% 54%, rgba(196, 106, 42, 0.08), transparent 72%),
-    radial-gradient(62% 54% at 50% 110%, rgba(45, 212, 191, 0.09), transparent 70%);
+    radial-gradient(60% 48% at 50% -10%, rgba(45, 212, 191, 0.07), transparent 72%),
+    radial-gradient(90% 60% at 50% 122%, rgba(255, 255, 255, 0.02), transparent 70%);
 }
 
 * { box-sizing: border-box; }
@@ -68,7 +66,7 @@ a { color: inherit; }
 /* ───────── top nav ───────── */
 .nav {
   position: sticky; top: 0; z-index: 20;
-  display: flex; align-items: center; gap: 20px;
+  display: flex; align-items: center; gap: 20px; flex-wrap: wrap;
   padding: 14px clamp(28px, 8vw, 120px);
   background: transparent;
 }
@@ -78,6 +76,8 @@ a { color: inherit; }
 .nav__links a { font-size: 15px; color: var(--text-dim); text-decoration: none; }
 .nav__links a:hover { color: var(--text); }
 .nav__end { margin-left: auto; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+.nav__byok { flex-basis: 100%; display: flex; align-items: center; justify-content: flex-end; gap: 10px; flex-wrap: wrap; margin-top: 2px; }
+.nav__byok[hidden] { display: none; }
 
 .ctl { display: flex; align-items: center; gap: 6px; }
 .ctl[hidden] { display: none; }
@@ -106,10 +106,7 @@ a { color: inherit; }
 .hero { position: relative; min-height: calc(100dvh - 63px); display: flex; flex-direction: column; justify-content: center; padding: 24px 24px 48px; overflow: hidden; }
 .hero__sky {
   position: absolute; inset: -10% -10% 0; z-index: 0;
-  background:
-    radial-gradient(1100px 540px at 50% 4%, rgba(45, 212, 191, 0.12), transparent 62%),
-    var(--aurora);
-  filter: saturate(1.05);
+  background: var(--aurora);
   pointer-events: none;
 }
 /* fine dot-grid texture — strongest behind the title, faded out toward the composer */
@@ -122,11 +119,7 @@ a { color: inherit; }
 }
 .hero__inner { position: relative; z-index: 1; width: 100%; max-width: 800px; margin: 0 auto; text-align: center; }
 .hero__title { font-size: clamp(40px, 6.4vw, 64px); font-weight: 600; line-height: 1.05; letter-spacing: -1.6px; margin: 0 0 14px; word-break: keep-all; text-wrap: balance; }
-.hero__title .grad {
-  background: linear-gradient(92deg, var(--copper), var(--accent) 55%, #7aa0ff);
-  -webkit-background-clip: text; background-clip: text; color: transparent;
-  white-space: nowrap;
-}
+.hero__title .grad { color: var(--accent); white-space: nowrap; }
 .hero__sub { font-size: 18px; color: var(--text-dim); margin: 0 auto 44px; max-width: 720px; text-wrap: balance; word-break: keep-all; }
 
 /* prompt card (the Lovable hero input) */
@@ -168,8 +161,9 @@ a { color: inherit; }
 .eyebrow span { flex: 0 0 auto; font-size: 12px; font-weight: 600; letter-spacing: .14em; text-transform: uppercase; color: var(--text-dim); background: var(--bg-cream); border: 1px solid var(--border-strong); border-radius: 8px; padding: 7px 12px; }
 .eyebrow::after { content: ""; flex: 1 1 auto; height: 1px; background: var(--border); }
 .sec__title { font-size: clamp(30px, 4.4vw, 44px); font-weight: 600; letter-spacing: -1.2px; margin: 0; }
+.sec__lede { margin: 14px 0 0; color: var(--text-dim); font-size: 16px; max-width: 640px; line-height: 1.6; text-wrap: balance; word-break: keep-all; }
 
-.how, .examples, .stats { max-width: var(--page); margin: 0 auto; padding: 104px 24px; }
+.how, .examples, .bench, .cta { max-width: var(--page); margin: 0 auto; padding: 104px 24px; }
 .how__grid { display: grid; grid-template-columns: 1.1fr 1fr; gap: 48px; align-items: center; }
 .how__preview {
   background: var(--bg-cream); border: 1px solid var(--border); border-radius: 16px;
@@ -186,19 +180,83 @@ a { color: inherit; }
 .how__steps h3 { font-size: 24px; font-weight: 600; margin: 0 0 4px; letter-spacing: -.4px; }
 .how__steps p { margin: 0; color: var(--text-dim); }
 
-.cards { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
-.xcard { background: var(--bg-elev); border: 1px solid var(--border); border-radius: 14px; padding: 18px; cursor: pointer; transition: border-color .15s, box-shadow .15s; }
-.xcard:hover { border-color: var(--border-strong); box-shadow: var(--focus-shadow); }
-.xcard__lang { font-family: var(--mono); font-size: 11px; color: var(--text-faint); text-transform: uppercase; letter-spacing: .08em; margin-bottom: 10px; }
-.xcard__row { display: flex; gap: 8px; padding: 6px 0; font-size: 14px; line-height: 1.5; }
-.xcard__k { flex: 0 0 46px; font-family: var(--mono); font-size: 11px; padding-top: 2px; }
-.xcard__row--b .xcard__k { color: var(--copper); }
-.xcard__row--a .xcard__k { color: var(--accent); }
+/* examples — editor panel (Resend/Linear-style chrome) */
+.editor { max-width: 920px; margin: 0 auto; background: var(--bg-elev); border: 1px solid var(--border); border-radius: 16px; overflow: hidden; box-shadow: 0 1px 2px rgba(0, 0, 0, .4), 0 12px 28px rgba(0, 0, 0, .18); }
+.editor__bar { display: flex; align-items: center; gap: 14px; padding: 11px 16px; border-bottom: 1px solid var(--border); background: var(--bg-cream); }
+.editor__dots { display: inline-flex; gap: 7px; flex: 0 0 auto; }
+.editor__dots i { width: 11px; height: 11px; border-radius: 50%; background: var(--border-strong); }
+.editor__tabs { display: flex; gap: 4px; flex: 1 1 auto; overflow-x: auto; scrollbar-width: none; }
+.editor__tabs::-webkit-scrollbar { display: none; }
+.editor__tab { font-family: inherit; font-size: 13px; color: var(--text-dim); background: transparent; border: 1px solid transparent; border-radius: 8px; padding: 6px 12px; cursor: pointer; white-space: nowrap; transition: background .15s, color .15s, border-color .15s; }
+.editor__tab:hover { color: var(--text); background: var(--bg-hover); }
+.editor__tab.is-active { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); background: color-mix(in srgb, var(--accent) 10%, transparent); }
+.editor__act { display: flex; align-items: center; gap: 10px; flex: 0 0 auto; }
+.editor__state { font-family: var(--mono); font-size: 11px; color: var(--text-faint); white-space: nowrap; }
+.editor__btn { font-family: var(--mono); font-size: 11px; border-radius: 8px; border: 1px solid var(--border); background: transparent; color: var(--text-dim); cursor: pointer; padding: 5px 11px; transition: border-color .15s, color .15s; }
+.editor__btn:hover { border-color: var(--border-strong); color: var(--text); }
+.editor__btn.is-ok { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
 
-.stats__grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin: 0; }
-.stat { background: var(--bg-cream); border: 1px solid var(--border); border-radius: 16px; padding: 28px 20px; text-align: center; }
-.stat dt { font-size: 48px; font-weight: 600; letter-spacing: -1.5px; line-height: 1; }
-.stat dd { margin: 10px 0 0; color: var(--text-dim); font-size: 14px; }
+.editor__body { display: flex; align-items: flex-start; min-height: 128px; background-image: radial-gradient(circle at 1px 1px, rgba(232, 238, 247, 0.035) 1px, transparent 1.5px); background-size: 22px 22px; }
+.editor__gutter { flex: 0 0 auto; display: flex; flex-direction: column; align-items: flex-end; padding: 18px 14px 18px 20px; border-right: 1px solid var(--border); font-family: var(--mono); font-size: 13px; line-height: 26px; color: var(--text-faint); user-select: none; }
+.editor__code { flex: 1 1 auto; min-width: 0; padding: 18px 24px; }
+
+.editor__foot { display: flex; align-items: center; gap: 12px; padding: 12px 16px; border-top: 1px solid var(--border); background: var(--bg-cream); }
+.editor__cap { font-size: 12px; color: var(--text-faint); flex: 1 1 auto; }
+.editor__footact { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }
+
+/* examples — persistent before/after diff (both stay visible) */
+.editor__seg { font-size: 15px; line-height: 26px; word-break: keep-all; }
+.editor__seg--before { color: var(--text-dim); }
+.editor__seg--before .dtok--rm { color: var(--copper); }
+.editor__seg--after { color: var(--text); }
+.editor__seg--after .dtok--add { color: var(--accent); }
+.editor__arrow { font-family: var(--mono); font-size: 12px; line-height: 26px; color: var(--accent); opacity: .75; letter-spacing: .04em; }
+.editor__gx { color: var(--accent); opacity: .55; }
+.dtok { transition: color .35s ease; }
+
+/* one-shot reveal flourish on the after block; the before block never moves */
+.editor.is-reveal .editor__arrow,
+.editor.is-reveal .editor__seg--after { animation: seg-in .6s ease both; }
+@keyframes seg-in { from { opacity: 0; transform: translateY(7px); } to { opacity: 1; transform: none; } }
+
+.xcard__replay, .xcard__try { font-family: inherit; font-size: 12px; border-radius: 9999px; padding: 6px 14px; cursor: pointer; transition: border-color .15s, background .15s, color .15s; }
+.xcard__replay { background: transparent; border: 1px solid var(--border); color: var(--text-dim); }
+.xcard__replay:hover { border-color: var(--border-strong); color: var(--text); }
+.xcard__try { background: transparent; border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border)); color: var(--accent); }
+.xcard__try:hover { background: color-mix(in srgb, var(--accent) 12%, transparent); }
+
+@media (prefers-reduced-motion: reduce) {
+  .editor.is-reveal .editor__arrow,
+  .editor.is-reveal .editor__seg--after { animation: none; }
+}
+
+.bench__cards { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin: 0 0 18px; }
+.bstat { background: var(--bg-cream); border: 1px solid var(--border); border-radius: 16px; padding: 26px 20px; }
+.bstat dt { font-size: 44px; font-weight: 600; letter-spacing: -1.5px; line-height: 1; }
+.bstat dd { margin: 10px 0 2px; color: var(--text); font-size: 14px; font-weight: 500; }
+.bstat small { display: block; color: var(--text-faint); font-size: 12px; font-family: var(--mono); }
+
+.bench__signals { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 24px; }
+.sigchip { font-family: var(--mono); font-size: 12px; color: var(--text-dim); background: var(--bg-elev); border: 1px solid var(--border); border-radius: 9999px; padding: 5px 12px; }
+
+.bench__tablewrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 16px; background: var(--bg-cream); }
+.bench__table { width: 100%; min-width: 440px; border-collapse: collapse; font-size: 14px; }
+.bench__table th, .bench__table td { padding: 13px 18px; text-align: right; }
+.bench__table th:first-child, .bench__table td:first-child { text-align: left; }
+.bench__table thead th { color: var(--text-faint); font-weight: 500; font-size: 11px; text-transform: uppercase; letter-spacing: .06em; border-bottom: 1px solid var(--border); }
+.bench__table tbody td { font-family: var(--mono); color: var(--text-dim); border-top: 1px solid var(--border); }
+.bench__table tbody tr:first-child td { border-top: 0; }
+.bench__table tbody td:first-child { color: var(--text); font-weight: 600; font-family: var(--font); }
+
+.bench__note { color: var(--text-faint); font-size: 13px; line-height: 1.65; margin: 20px 0 0; max-width: 740px; }
+.bench__link { display: inline-block; margin-top: 14px; color: var(--accent); font-size: 14px; text-decoration: none; }
+.bench__link:hover { text-decoration: underline; }
+
+.cta__inner { position: relative; overflow: hidden; background: var(--bg-cream); border: 1px solid var(--border); border-radius: 24px; padding: 60px 24px; text-align: center; }
+.cta__title { font-size: clamp(28px, 4vw, 40px); font-weight: 600; letter-spacing: -1px; margin: 0 0 12px; word-break: keep-all; text-wrap: balance; }
+.cta__sub { color: var(--text-dim); margin: 0 auto 28px; max-width: 520px; text-wrap: balance; word-break: keep-all; }
+.cta__btn { background: var(--accent); color: var(--on-accent); border: 0; border-radius: 9999px; padding: 14px 28px; font-size: 16px; font-weight: 600; font-family: inherit; cursor: pointer; box-shadow: var(--inset); transition: background .15s; }
+.cta__btn:hover { background: var(--accent-press); }
 
 .foot { max-width: var(--page); margin: 0 auto; padding: 40px 24px 56px; border-top: 1px solid var(--border); display: flex; align-items: center; gap: 20px; flex-wrap: wrap; }
 .foot__brand { display: flex; align-items: center; gap: 8px; font-weight: 700; }
@@ -233,7 +291,7 @@ a { color: inherit; }
 .histitem.active { background: var(--bg-hover-2); color: var(--text); }
 .sidebar__foot { padding: 14px 16px; border-top: 1px solid var(--border); }
 .brandmark { display: flex; align-items: center; gap: 8px; font-weight: 600; font-size: 15px; }
-.brandmark__dot { display: grid; place-items: center; width: 22px; height: 22px; border-radius: 7px; background: var(--accent); color: var(--on-accent); font-weight: 800; font-size: 13px; }
+.brandmark__icon, .foot__brand img { display: block; flex: 0 0 auto; }
 .sidebar__note { margin-top: 6px; font-size: 11px; color: var(--text-faint); line-height: 1.5; }
 
 .chatmain { flex: 1; display: flex; flex-direction: column; min-width: 0; }
@@ -244,6 +302,9 @@ a { color: inherit; }
 
 .thread { flex: 1; overflow-y: auto; scroll-behavior: smooth; }
 .thread__inner { max-width: var(--maxw); margin: 0 auto; padding: 24px 20px 8px; }
+.thread__empty { min-height: 46vh; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 14px; text-align: center; }
+.thread__empty img { opacity: .92; }
+.thread__empty-text { color: var(--text-dim); font-size: 15px; max-width: 420px; line-height: 1.55; text-wrap: balance; word-break: keep-all; margin: 0; }
 
 .msg { display: flex; gap: 16px; padding: 14px 0; }
 .msg__avatar { flex: 0 0 30px; width: 30px; height: 30px; border-radius: 50%; display: grid; place-items: center; font-weight: 700; font-size: 13px; margin-top: 2px; }
@@ -253,9 +314,11 @@ a { color: inherit; }
   background: var(--bg-cream); border: 1px solid var(--border);
   border-radius: 18px; padding: 10px 16px; max-width: 75%; white-space: pre-wrap; word-break: break-word;
 }
-.msg--patina .msg__avatar { background: var(--accent); color: var(--on-accent); }
+.msg--patina .msg__avatar { background: var(--bg-cream); border: 1px solid var(--border); overflow: hidden; }
+.msg__avatar img { width: 20px; height: 20px; display: block; }
 .msg--patina .msg__body { flex: 1; min-width: 0; }
 .msg__text { white-space: pre-wrap; word-break: break-word; }
+.msg__text--flagged { opacity: .72; }
 .msg__text.streaming::after { content: "▍"; color: var(--accent); margin-left: 1px; animation: blink 1s step-start infinite; }
 @keyframes blink { 50% { opacity: 0; } }
 
@@ -302,14 +365,18 @@ details.foldout[open] > summary::before { content: "▾ "; }
   .nav__links { display: none; }
   .ctl__label { display: none; }
   .how__grid { grid-template-columns: 1fr; gap: 28px; }
-  .stats__grid { grid-template-columns: repeat(2, 1fr); }
+  .bench__cards { grid-template-columns: repeat(2, 1fr); }
   .hero__title { letter-spacing: -1px; }
-  .how, .examples, .stats { padding: 72px 24px; }
+  .how, .examples, .bench, .cta { padding: 72px 24px; }
 }
 @media (max-width: 820px) {
   .sidebar { position: absolute; z-index: 30; height: 100%; box-shadow: 4px 0 24px rgba(0,0,0,.12); }
   .chat:not(.sidebar-open) .sidebar { margin-left: -260px; }
   .iconbtn { display: inline-block; }
-  .cards { grid-template-columns: 1fr; }
+  .editor__dots { display: none; }
+  .editor__state { display: none; }
+  .editor__code { padding: 16px; }
+  .editor__gutter { padding: 16px 10px; }
+  .bench__cards { grid-template-columns: 1fr; }
 }
 

--- a/playground/chatgpt.js
+++ b/playground/chatgpt.js
@@ -23,14 +23,13 @@ const els = {
   provider: /** @type {HTMLSelectElement} */ ($('#provider')),
   model: /** @type {HTMLSelectElement} */ ($('#model')),
   apiKey: /** @type {HTMLInputElement} */ ($('#api-key')),
-  providerCtl: $('#provider-ctl'),
-  modelCtl: $('#model-ctl'),
-  keyCtl: $('#key-ctl'),
+  byokRow: $('#byok-row'),
   homeLink: $('#home-link'),
   // landing hero
   heroForm: /** @type {HTMLFormElement} */ ($('#hero-form')),
   heroInput: /** @type {HTMLTextAreaElement} */ ($('#hero-input')),
   heroSend: /** @type {HTMLButtonElement} */ ($('#hero-send')),
+  ctaStart: /** @type {HTMLButtonElement} */ ($('#cta-start')),
 
   suggest: $('#suggest'),
   exampleCards: $('#example-cards'),
@@ -57,11 +56,25 @@ const I18N = {
     howTitle: 'Three steps',
     steps: [['1 · Paste', 'Drop in your AI-sounding draft. No code, no key.'], ['2 · Rewrite', 'patina clears ~160 patterns and rewrites it naturally.'], ['3 · Verify', 'Check MPS, fidelity, and the AI signal (before → after).']],
     examplesTitle: 'Before and after',
-    stats: ['catalogued patterns', 'languages · KO·EN·ZH·JA', 'deterministic signals', 'in-browser audit'],
+    xCaption: 'AI packaging, stripped',
+    xReplay: 'Replay',
+    xTry: 'Try this',
+    benchTitle: 'Numbers, in the open',
+    benchLede: 'A deterministic suspect-zone benchmark on a checked-in fixture corpus — auditable, not an authorship test.',
+    benchCards: [['overall accuracy', '95% CI 92.7–100%'], ['fixtures', 'AI vs. natural, labeled'], ['languages', 'KO · EN · ZH · JA'], ['false positives', 'at the 1% FPR budget']],
+    benchCols: ['lang', 'fixtures', 'accuracy', '95% CI', 'F1'],
+    benchNote: 'Measured on 49 deterministic fixtures as a regression gate — not a claim of generalization to new models, genres, or edited AI text, and not an authorship verdict.',
+    benchLink: 'Read the full report →',
+    ctaTitle: 'Paste your own and see',
+    ctaSub: 'Drop an AI-sounding draft into the box above. No code, no key.',
+    ctaBtn: 'Start at the top ↑',
     note: 'Deterministic humanizer —<br />same claim, numbers, tone.',
     hint: 'patina changes only the wording — never the claim, numbers, or causation. This demo rewrites via a local CLI; MPS/fidelity are preview values.',
     chatPh: 'Keep refining…  (Enter to send · Shift+Enter for newline)',
     newchat: 'New chat',
+    emptyChat: 'New chat — paste AI-sounding text below and patina cleans it up.',
+    floorWarn: 'This rewrite didn’t pass patina’s meaning-preservation floor (MPS / fidelity), so it’s flagged. Try again or pick a stronger model.',
+    failNote: 'Rewrite failed. Try again, or check the mode/key.',
   },
   ko: {
     title: 'AI 티 없이, <span class="grad">자연스럽게</span>',
@@ -70,11 +83,25 @@ const I18N = {
     howTitle: '세 단계면 끝',
     steps: [['1 · 붙여넣기', 'AI 티 나는 초안을 그대로 붙여넣어요. 코드도 키도 필요 없어요.'], ['2 · 다듬기', 'patina가 ~160개 패턴을 걷어내고 자연스럽게 고쳐요.'], ['3 · 검증', 'MPS·fidelity·AI 신호(전→후)로 의미 보존을 확인해요.']],
     examplesTitle: '이런 문장을, 이렇게',
-    stats: ['카탈로그 패턴', '지원 언어 · KO·EN·ZH·JA', '결정론 신호', '브라우저 audit'],
+    xCaption: 'AI 포장을 걷어내요',
+    xReplay: '다시 보기',
+    xTry: '이 문장으로 시작',
+    benchTitle: '숨김없는 벤치마크',
+    benchLede: '저장소에 포함된 fixture 코퍼스로 측정한 결정론적 의심구간 벤치마크 — 작성자 판별이 아니라, 감사 가능한 회귀 지표예요.',
+    benchCards: [['전체 정확도', '95% CI 92.7–100%'], ['fixtures', 'AI·자연 라벨 코퍼스'], ['지원 언어', 'KO · EN · ZH · JA'], ['오탐(FP)', '1% FPR 기준']],
+    benchCols: ['언어', 'fixtures', '정확도', '95% CI', 'F1'],
+    benchNote: '결정론 fixture 49개로 측정한 회귀 게이트 결과입니다. 새 모델·장르·편집된 AI 글로의 일반화나 작성자 판별을 뜻하지 않아요.',
+    benchLink: '전체 리포트 보기 →',
+    ctaTitle: '직접 붙여넣어 확인해 보세요',
+    ctaSub: 'AI 티 나는 초안을 위 입력칸에 붙여넣으면 끝. 코드도 키도 필요 없어요.',
+    ctaBtn: '맨 위로 가서 시작하기 ↑',
     note: '의미·숫자·톤을 바꾸지 않는<br />결정론적 휴머나이저.',
     hint: 'patina는 주장·수치·인과를 바꾸지 않고 표현만 다듬습니다. 데모는 로컬 CLI로 리라이트하며 MPS/fidelity는 프리뷰 값입니다.',
     chatPh: '이어서 다듬기…  (Enter 전송 · Shift+Enter 줄바꿈)',
     newchat: '새 대화',
+    emptyChat: '새 대화 — 아래에 AI 티 나는 문장을 붙여넣으면 patina가 다듬어요.',
+    floorWarn: '이 리라이트는 patina의 의미 보존 기준(MPS·fidelity)을 통과하지 못해 경고로 표시했어요. 다시 시도하거나 더 강한 모델을 골라보세요.',
+    failNote: '리라이트 실패. 다시 시도하거나 모드·키를 확인해 주세요.',
   },
   zh: {
     title: '让文字更<span class="grad">像人写的</span>',
@@ -83,11 +110,25 @@ const I18N = {
     howTitle: '三步搞定',
     steps: [['1 · 粘贴', '贴入有 AI 味的草稿，无需代码或密钥。'], ['2 · 改写', 'patina 清除约 160 种模式并自然地改写。'], ['3 · 校验', '查看 MPS、fidelity 和 AI 信号（前 → 后）。']],
     examplesTitle: '改写前后',
-    stats: ['收录模式', '支持语言 · KO·EN·ZH·JA', '确定性信号', '浏览器内审计'],
+    xCaption: '去掉 AI 包装',
+    xReplay: '重播',
+    xTry: '用这句试试',
+    benchTitle: '公开的基准',
+    benchLede: '基于仓库内 fixture 语料的确定性可疑区间基准 — 可审计，而非作者判定。',
+    benchCards: [['总体准确率', '95% CI 92.7–100%'], ['fixtures', 'AI 与自然，已标注'], ['支持语言', 'KO · EN · ZH · JA'], ['误报', '1% FPR 预算下']],
+    benchCols: ['语言', 'fixtures', '准确率', '95% CI', 'F1'],
+    benchNote: '在 49 个确定性 fixture 上作为回归门测得 — 不代表对新模型、体裁或经过编辑的 AI 文本的泛化，也不是作者判定。',
+    benchLink: '查看完整报告 →',
+    ctaTitle: '粘贴你的文字试试',
+    ctaSub: '把有 AI 味的草稿粘到上面的输入框，无需代码或密钥。',
+    ctaBtn: '回到顶部开始 ↑',
     note: '不改变主张·数字·语气的<br />确定性人性化工具。',
     hint: 'patina 只调整措辞，绝不改变主张、数字或因果。本演示通过本地 CLI 改写，MPS/fidelity 为预览值。',
     chatPh: '继续润色…  (Enter 发送 · Shift+Enter 换行)',
     newchat: '新对话',
+    emptyChat: '新对话 — 在下方粘贴有 AI 味的文字，patina 帮你润色。',
+    floorWarn: '该改写未通过 patina 的语义保留阈值（MPS·fidelity），已标记。请重试或选择更强的模型。',
+    failNote: '改写失败。请重试，或检查模式 / 密钥。',
   },
   ja: {
     title: 'AIっぽさを消して、<span class="grad">自然に</span>',
@@ -96,11 +137,25 @@ const I18N = {
     howTitle: '3ステップで完了',
     steps: [['1 · 貼り付け', 'AIっぽい下書きを貼るだけ。コードも鍵も不要。'], ['2 · 書き換え', 'patinaが約160のパターンを取り除き自然に書き換えます。'], ['3 · 検証', 'MPS・fidelity・AIシグナル（前 → 後）で意味の保持を確認。']],
     examplesTitle: 'ビフォー・アフター',
-    stats: ['収録パターン', '対応言語 · KO·EN·ZH·JA', '決定論シグナル', 'ブラウザ内監査'],
+    xCaption: 'AIの包装を外す',
+    xReplay: 'もう一度',
+    xTry: 'この文で試す',
+    benchTitle: '隠さないベンチマーク',
+    benchLede: 'リポジトリ同梱の fixture コーパスで測る決定論的サスペクトゾーンのベンチマーク — 監査可能で、作者判定ではありません。',
+    benchCards: [['全体精度', '95% CI 92.7–100%'], ['fixtures', 'AI・自然のラベル付き'], ['対応言語', 'KO · EN · ZH · JA'], ['誤検知', '1% FPR 基準']],
+    benchCols: ['言語', 'fixtures', '精度', '95% CI', 'F1'],
+    benchNote: '49 件の決定論 fixture で回帰ゲートとして測定 — 新しいモデルやジャンル、編集済み AI 文章への一般化や作者判定を意味しません。',
+    benchLink: '詳細レポートを見る →',
+    ctaTitle: '自分の文章で試す',
+    ctaSub: 'AIっぽい下書きを上の入力欄に貼るだけ。コードも鍵も不要。',
+    ctaBtn: '上に戻って始める ↑',
     note: '主張・数字・トーンを変えない<br />決定論的ヒューマナイザー。',
     hint: 'patinaは表現だけを整え、主張・数値・因果は変えません。デモはローカルCLIで書き換え、MPS/fidelityはプレビュー値です。',
     chatPh: 'さらに整える…  (Enter送信 · Shift+Enter改行)',
     newchat: '新しいチャット',
+    emptyChat: '新しいチャット — 下にAIっぽい文章を貼ると patina が整えます。',
+    floorWarn: 'この書き換えは patina の意味保持しきい値（MPS・fidelity）を満たさず、警告表示しています。再試行するか、より強力なモデルを選んでください。',
+    failNote: '書き換えに失敗しました。再試行するか、モード・キーを確認してください。',
   },
 };
 
@@ -128,10 +183,26 @@ const SAMPLES = {
 
 // Example cards (illustrative before → after, one per language).
 const EXAMPLES = [
-  { lang: 'ko', before: '본 솔루션은 혁신적인 시너지를 활용하여 전례 없는 가치를 원활하게 제공합니다.', after: '이 솔루션은 고객에게 실질적인 가치를 제공합니다.' },
-  { lang: 'en', before: 'Our cutting-edge solution leverages synergies to seamlessly deliver world-class value.', after: 'Our solution gives teams something that actually works.' },
-  { lang: 'zh', before: '本方案充分利用前沿协同效应，无缝赋能客户，释放前所未有的价值。', after: '这个方案帮客户真正解决问题。' },
-  { lang: 'ja', before: '本ソリューションは革新的なシナジーを活用し、かつてない価値を提供します。', after: 'このソリューションは、顧客に実際の価値を届けます。' },
+  {
+    lang: 'ko',
+    before: '오늘날 빠르게 변화하는 디지털 환경 속에서, 본 솔루션은 혁신적인 시너지를 활용하여 고객에게 전례 없는 가치를 원활하게 제공합니다. 이는 단순한 도구가 아니라, 팀의 잠재력을 극대화하는 패러다임의 전환입니다.',
+    after: '이 솔루션은 팀이 이미 쓰는 도구와 함께 작동해, 반복 작업을 줄이고 일을 더 빨리 끝내도록 돕습니다. 거창한 도구가 아니라 실제로 쓸 만한 도구예요.',
+  },
+  {
+    lang: 'en',
+    before: 'In today\'s fast-paced, ever-evolving digital landscape, our cutting-edge platform leverages synergies to seamlessly deliver world-class value at scale. It\'s not just a tool — it\'s a transformative solution that empowers teams to unlock their full potential.',
+    after: 'Our platform helps teams get more done with the tools they already use, and it cuts the busywork so you can ship faster.',
+  },
+  {
+    lang: 'zh',
+    before: '在当今瞬息万变的数字时代，本解决方案充分利用前沿协同效应，无缝赋能客户，释放前所未有的价值。这不仅仅是一个工具，更是一场彻底改变团队潜能的范式革命。',
+    after: '这个方案帮团队用现有的工具把活干得更快，省去重复劳动，真正解决问题。',
+  },
+  {
+    lang: 'ja',
+    before: '目まぐるしく変化する今日のデジタル時代において、本ソリューションは革新的なシナジーを活用し、お客様にかつてない価値をシームレスに提供します。これは単なるツールではなく、チームの潜在能力を最大限に引き出す変革的なソリューションです。',
+    after: 'このソリューションは、チームが今使っているツールのまま、無駄な作業を減らして仕事を速く終わらせるのを助けます。',
+  },
 ];
 
 /** @typedef {{id:string,title:string,messages:Array<{role:string,text:string,meta?:object}>,thread:ReturnType<typeof createRewriteThread>}} Convo */
@@ -165,7 +236,7 @@ function populateModels() {
 }
 function syncTier() {
   const byok = els.tier.value === WEB_TIERS.BYOK;
-  for (const c of [els.providerCtl, els.modelCtl, els.keyCtl]) c.hidden = !byok;
+  els.byokRow.hidden = !byok;
 }
 
 // ---------- landing: suggestions + examples ----------
@@ -179,23 +250,156 @@ function renderSuggest() {
     els.suggest.appendChild(pill);
   }
 }
+// Mixed-script tokenizer: CJK ideographs/kana/CJK-punct become single-char
+// tokens (char-level diff), while Latin/Hangul runs stay word-level. Whitespace
+// is its own token so spacing diffs cleanly.
+function isCJKChar(ch) {
+  const c = ch.codePointAt(0);
+  return (c >= 0x3040 && c <= 0x30ff)   // hiragana + katakana
+    || (c >= 0x3400 && c <= 0x4dbf)     // CJK ext A
+    || (c >= 0x4e00 && c <= 0x9fff)     // CJK unified
+    || (c >= 0xf900 && c <= 0xfaff)     // CJK compat
+    || (c >= 0x3001 && c <= 0x303f)     // CJK punctuation (U+3000 is whitespace)
+    || (c >= 0xff00 && c <= 0xffef);    // fullwidth forms
+}
+function tokenizeText(s) {
+  const toks = [];
+  let buf = '';
+  const flush = () => { if (buf) { toks.push(buf); buf = ''; } };
+  for (const ch of s) {
+    if (/\s/.test(ch)) { flush(); toks.push(ch); }
+    else if (isCJKChar(ch)) { flush(); toks.push(ch); }
+    else buf += ch;
+  }
+  flush();
+  return toks;
+}
+// LCS diff → ordered tokens tagged same | rm (before-only) | add (after-only).
+// before text = same+rm in order; after text = same+add in order.
+function diffSeq(a, b) {
+  const n = a.length, m = b.length;
+  const dp = Array.from({ length: n + 1 }, () => new Int32Array(m + 1));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const out = [];
+  let i = 0, j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) { out.push({ t: a[i], s: 'same' }); i++; j++; }
+    else if (dp[i + 1][j] >= dp[i][j + 1]) { out.push({ t: a[i], s: 'rm' }); i++; }
+    else { out.push({ t: b[j], s: 'add' }); j++; }
+  }
+  while (i < n) out.push({ t: a[i++], s: 'rm' });
+  while (j < m) out.push({ t: b[j++], s: 'add' });
+  return out;
+}
+// Render one side of the diff into a line node, skipping the opposite-side status.
+function fillLine(node, seq, skip) {
+  node.textContent = '';
+  for (const tok of seq) {
+    if (tok.s === skip) continue;
+    const cls = tok.s === 'rm' ? 'dtok dtok--rm' : tok.s === 'add' ? 'dtok dtok--add' : 'dtok';
+    node.appendChild(el('span', cls, tok.t));
+  }
+}
+
 function renderExamples() {
   els.exampleCards.innerHTML = '';
-  for (const ex of EXAMPLES) {
-    const card = el('div', 'xcard');
-    card.appendChild(el('div', 'xcard__lang', LANG_NAME[ex.lang] || ex.lang));
-    const b = el('div', 'xcard__row xcard__row--b');
-    b.appendChild(el('span', 'xcard__k', 'before')); b.appendChild(el('span', null, ex.before));
-    const a = el('div', 'xcard__row xcard__row--a');
-    a.appendChild(el('span', 'xcard__k', 'after')); a.appendChild(el('span', null, ex.after));
-    card.appendChild(b); card.appendChild(a);
-    card.addEventListener('click', () => {
-      els.lang.value = ex.lang; onLangChange();
-      loadIntoPrompt(ex.before);
+  const reduce = globalThis.matchMedia && globalThis.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-      globalThis.scrollTo({ top: 0, behavior: 'smooth' });
-    });
-    els.exampleCards.appendChild(card);
+  // editor chrome: window dots + language tabs + state label + copy
+  const editor = el('div', 'editor');
+  const bar = el('div', 'editor__bar');
+  const dots = el('span', 'editor__dots'); dots.setAttribute('aria-hidden', 'true');
+  dots.append(el('i'), el('i'), el('i'));
+  const tabs = el('div', 'editor__tabs'); tabs.setAttribute('role', 'tablist');
+  const actbar = el('div', 'editor__act');
+  const state = el('span', 'editor__state', 'before → after');
+  const copy = el('button', 'editor__btn', 'Copy'); copy.type = 'button'; copy.setAttribute('aria-label', 'Copy the rewritten text');
+  actbar.append(state, copy);
+  bar.append(dots, tabs, actbar);
+
+  // body: line-number gutter + persistent before/after diff (both stay visible)
+  const bodyEl = el('div', 'editor__body');
+  const gutter = el('div', 'editor__gutter'); gutter.setAttribute('aria-hidden', 'true');
+  const code = el('div', 'editor__code');
+  const before = el('div', 'editor__seg editor__seg--before');
+  const arrow = el('div', 'editor__arrow', '↓ patina');
+  const after = el('div', 'editor__seg editor__seg--after');
+  code.append(before, arrow, after);
+  bodyEl.append(gutter, code);
+
+  const foot = el('div', 'editor__foot');
+  const cap = el('span', 'editor__cap');
+  const footact = el('div', 'editor__footact');
+  const replay = el('button', 'xcard__replay'); replay.type = 'button';
+  const tryIt = el('button', 'xcard__try'); tryIt.type = 'button';
+  footact.append(replay, tryIt);
+  foot.append(cap, footact);
+
+  editor.append(bar, bodyEl, foot);
+
+  let active = EXAMPLES.find((e) => e.lang === els.lang.value) || EXAMPLES[0];
+
+  // line numbers run continuously: before block, a divider row, then after block.
+  const syncGutter = () => {
+    let lh = parseFloat(globalThis.getComputedStyle(before).lineHeight);
+    if (!Number.isFinite(lh)) lh = 26;
+    const b = Math.max(1, Math.round(before.scrollHeight / lh));
+    const a = Math.max(1, Math.round(after.scrollHeight / lh));
+    gutter.textContent = '';
+    for (let i = 1; i <= b; i++) gutter.appendChild(el('span', null, String(i)));
+    gutter.appendChild(el('span', 'editor__gx', '↓'));
+    for (let i = 1; i <= a; i++) gutter.appendChild(el('span', null, String(b + i)));
+  };
+  // one-shot flourish: the after block fades up; the before block never moves.
+  const reveal = () => {
+    if (reduce) return;
+    editor.classList.remove('is-reveal');
+    void editor.offsetWidth;
+    editor.classList.add('is-reveal');
+    globalThis.setTimeout(() => editor.classList.remove('is-reveal'), 800);
+  };
+  const setActive = (ex, doReveal) => {
+    active = ex;
+    const seq = diffSeq(tokenizeText(ex.before), tokenizeText(ex.after));
+    fillLine(before, seq, 'add');
+    fillLine(after, seq, 'rm');
+    for (const tab of tabs.children) tab.classList.toggle('is-active', tab.dataset.lang === ex.lang);
+    globalThis.requestAnimationFrame(syncGutter);
+    if (doReveal) reveal();
+  };
+
+  for (const ex of EXAMPLES) {
+    const tab = el('button', 'editor__tab', LANG_NAME[ex.lang] || ex.lang);
+    tab.type = 'button'; tab.dataset.lang = ex.lang; tab.setAttribute('role', 'tab');
+    tab.addEventListener('click', () => setActive(ex, true));
+    tabs.appendChild(tab);
+  }
+  replay.addEventListener('click', reveal);
+  tryIt.addEventListener('click', () => {
+    els.lang.value = active.lang; onLangChange();
+    loadIntoPrompt(active.before);
+    globalThis.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+  copy.addEventListener('click', async () => {
+    try {
+      await globalThis.navigator.clipboard.writeText(active.after);
+      copy.textContent = 'Copied'; copy.classList.add('is-ok');
+      globalThis.setTimeout(() => { copy.textContent = 'Copy'; copy.classList.remove('is-ok'); }, 1400);
+    } catch { /* clipboard unavailable */ }
+  });
+
+  els.exampleCards.appendChild(editor);
+  setActive(active, false);
+  globalThis.addEventListener('resize', syncGutter);
+  if (!reduce && ('IntersectionObserver' in globalThis)) {
+    const io = new globalThis.IntersectionObserver((entries, obs) => {
+      for (const en of entries) { if (en.isIntersecting) { reveal(); obs.unobserve(en.target); } }
+    }, { threshold: 0.4 });
+    io.observe(editor);
   }
 }
 function loadIntoPrompt(text) {
@@ -231,7 +435,7 @@ function renderThread() {
   const convo = activeConvo();
   els.thread.innerHTML = '';
   const inner = el('div', 'thread__inner');
-  if (convo) {
+  if (convo && convo.messages.length) {
     for (const m of convo.messages) {
       if (m.role === 'user') inner.appendChild(buildUserMsg(m.text));
       else {
@@ -241,9 +445,20 @@ function renderThread() {
         inner.appendChild(node);
       }
     }
+  } else {
+    inner.appendChild(buildThreadEmpty());
   }
   els.thread.appendChild(inner);
   scrollDown();
+}
+function buildThreadEmpty() {
+  const t = I18N[els.lang.value] || I18N.en;
+  const wrap = el('div', 'thread__empty');
+  const mark = document.createElement('img');
+  mark.src = '/assets/brand/patina-mark.svg'; mark.alt = ''; mark.width = 40; mark.height = 40;
+  wrap.appendChild(mark);
+  wrap.appendChild(el('p', 'thread__empty-text', t.emptyChat));
+  return wrap;
 }
 function threadInner() { return els.thread.querySelector('.thread__inner') || (() => { const i = el('div', 'thread__inner'); els.thread.appendChild(i); return i; })(); }
 
@@ -255,7 +470,11 @@ function buildUserMsg(text) {
 }
 function buildPatinaMsg() {
   const msg = el('div', 'msg msg--patina');
-  msg.appendChild(el('div', 'msg__avatar', 'p'));
+  const avatar = el('div', 'msg__avatar');
+  const mark = document.createElement('img');
+  mark.src = '/assets/brand/patina-mark.svg'; mark.alt = 'patina'; mark.width = 20; mark.height = 20;
+  avatar.appendChild(mark);
+  msg.appendChild(avatar);
   const body = el('div', 'msg__body');
   const textEl = el('div', 'msg__text');
   body.appendChild(textEl);
@@ -268,6 +487,17 @@ function buildTyping() {
   return t;
 }
 function fmt(v) { return Number.isFinite(v) ? String(Math.round(Number(v))) : '—'; }
+// Strip the rewrite prompt scaffolding ([BODY]…[/BODY] + [SELF_AUDIT]) so the
+// chat bubble only ever shows the rewritten body, never the internal format.
+function cleanStream(s) {
+  let out = String(s ?? '');
+  const sa = out.search(/\[SELF[_\s-]?AUDIT\]/i);
+  if (sa >= 0) out = out.slice(0, sa);
+  const bm = out.match(/\[BODY\]([\s\S]*?)(?:\[\/BODY\]|$)/i);
+  if (bm) out = bm[1];
+  out = out.replace(/\[\/?BODY\]/gi, '').replace(/\[\/?SELF[_\s-]?AUDIT\]/gi, '');
+  return out.trim();
+}
 function badge(label, value, ok) {
   const b = el('span', 'badge' + (ok ? ' badge--ok' : ''));
   b.appendChild(document.createTextNode(label + ' '));
@@ -354,6 +584,8 @@ async function submit(text) {
   convo.messages.push({ role: 'user', text: clean });
   if (convo.title === 'New chat') { convo.title = clean.slice(0, 40); renderSidebar(); }
   const inner = threadInner();
+  const emptyState = inner.querySelector('.thread__empty');
+  if (emptyState) emptyState.remove();
   inner.appendChild(buildUserMsg(clean));
 
   const { node, body, textEl } = buildPatinaMsg();
@@ -391,7 +623,7 @@ async function submit(text) {
       body: reqBody,
       signal: controller.signal,
       onStart: () => armIdle(),
-      onDelta: (_t, acc) => { armIdle(); start(); textEl.textContent = acc; scrollDown(); },
+      onDelta: (_t, acc) => { armIdle(); start(); textEl.textContent = cleanStream(acc); scrollDown(); },
       onDone: (frame) => {
         armIdle();
         start();
@@ -406,9 +638,23 @@ async function submit(text) {
     });
     if (!ok) {
       if (typing.parentElement) typing.remove();
-      textEl.style.display = ''; textEl.classList.remove('streaming');
-      const status = finalFrame?.status ? ` (HTTP ${finalFrame.status})` : '';
-      body.appendChild(el('div', 'error-note', `Rewrite failed${status}. Try again, or check the mode/key.`));
+      textEl.classList.remove('streaming');
+      const t = I18N[els.lang.value] || I18N.en;
+      const ff = finalFrame || {};
+      const attempt = typeof ff.rewrite === 'string' ? ff.rewrite.trim() : '';
+      const hasScores = ff.mps != null || ff.fidelity != null;
+      if (attempt || hasScores) {
+        // meaning floor not met: show the flagged attempt + scores + a clear warning (auditable, not silently shipped)
+        textEl.style.display = '';
+        textEl.textContent = attempt || cleanStream(textEl.textContent);
+        textEl.classList.add('msg__text--flagged');
+        body.appendChild(buildMeta({ mps: ff.mps, fidelity: ff.fidelity, signals: ff.signals, diff: ff.diff, floorFailed: true }));
+        body.appendChild(el('div', 'error-note', t.floorWarn));
+      } else {
+        textEl.style.display = 'none';
+        const status = ff.status ? ` (HTTP ${ff.status})` : '';
+        body.appendChild(el('div', 'error-note', t.failNote + status));
+      }
     }
   } catch (e) {
     if (typing.parentElement) typing.remove();
@@ -443,8 +689,20 @@ function applyI18n(lang) {
   const stepEls = document.querySelectorAll('.how__steps li');
   t.steps.forEach((s, i) => { const li = stepEls[i]; if (!li) return; const h = li.querySelector('h3'); const p = li.querySelector('p'); if (h) h.textContent = s[0]; if (p) p.textContent = s[1]; });
   set('.examples .sec__title', t.examplesTitle);
-  const dds = document.querySelectorAll('.stats .stat dd');
-  t.stats.forEach((s, i) => { if (dds[i]) dds[i].textContent = s; });
+  set('.editor__cap', t.xCaption);
+  set('.xcard__replay', t.xReplay);
+  set('.xcard__try', t.xTry);
+  set('.bench .sec__title', t.benchTitle);
+  set('.bench .sec__lede', t.benchLede);
+  const bcards = document.querySelectorAll('.bench__cards .bstat');
+  t.benchCards.forEach((c, i) => { const card = bcards[i]; if (!card) return; const dd = card.querySelector('dd'); const sm = card.querySelector('small'); if (dd) dd.textContent = c[0]; if (sm) sm.textContent = c[1]; });
+  const bcols = document.querySelectorAll('.bench__table thead th');
+  t.benchCols.forEach((c, i) => { if (bcols[i]) bcols[i].textContent = c; });
+  set('.bench__note', t.benchNote);
+  set('.bench__link', t.benchLink);
+  set('.cta__title', t.ctaTitle);
+  set('.cta__sub', t.ctaSub);
+  set('#cta-start', t.ctaBtn);
   setHtml('.sidebar__note', t.note);
   set('.composer__hint', t.hint);
   els.input.setAttribute('placeholder', t.chatPh);
@@ -471,9 +729,10 @@ els.composer.addEventListener('submit', (e) => { e.preventDefault(); submit(els.
 els.input.addEventListener('input', () => { autoGrow(els.input); updateChatSend(); });
 els.input.addEventListener('keydown', (e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submit(els.input.value); } });
 
-els.newChat.addEventListener('click', () => { newConvo(); showLanding(); els.heroInput.value = ''; autoGrow(els.heroInput); updateHeroSend(); closeMobileSidebar(); els.heroInput.focus(); });
+els.newChat.addEventListener('click', () => { newConvo(); showChat(); els.input.value = ''; autoGrow(els.input); updateChatSend(); closeMobileSidebar(); els.input.focus(); });
 els.toggleSidebar.addEventListener('click', () => { els.chat.classList.toggle('sidebar-open'); });
 els.homeLink.addEventListener('click', (e) => { e.preventDefault(); showLanding(); globalThis.scrollTo({ top: 0, behavior: 'smooth' }); });
+els.ctaStart && els.ctaStart.addEventListener('click', () => { globalThis.scrollTo({ top: 0, behavior: 'smooth' }); els.heroInput.focus(); });
 
 els.lang.addEventListener('change', onLangChange);
 els.tier.addEventListener('change', syncTier);

--- a/playground/index.html
+++ b/playground/index.html
@@ -39,25 +39,27 @@
           <span class="ctl__label">Mode</span>
           <select id="tier" class="ctl__select">
             <option value="free">Free</option>
-            <option value="byok">BYOK</option>
+            <option value="byok">API</option>
           </select>
-        </label>
-        <label class="ctl ctl--byok" id="provider-ctl" hidden>
-          <span class="ctl__label">Provider</span>
-          <select id="provider" class="ctl__select"></select>
-        </label>
-        <label class="ctl ctl--byok" id="model-ctl" hidden>
-          <span class="ctl__label">Model</span>
-          <select id="model" class="ctl__select"></select>
-        </label>
-        <label class="ctl ctl--byok ctl--key" id="key-ctl" hidden>
-          <span class="ctl__label">API key</span>
-          <input id="api-key" class="ctl__input" type="password" autocomplete="off" placeholder="sk-… (kept in your browser)" />
         </label>
         <a class="btn btn--gh" href="https://github.com/devswha/patina" aria-label="patina on GitHub">
           <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path fill="currentColor" fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
           <span>GitHub</span>
         </a>
+      </div>
+      <div class="nav__byok" id="byok-row" hidden>
+        <label class="ctl ctl--byok" id="provider-ctl">
+          <span class="ctl__label">Provider</span>
+          <select id="provider" class="ctl__select"></select>
+        </label>
+        <label class="ctl ctl--byok" id="model-ctl">
+          <span class="ctl__label">Model</span>
+          <select id="model" class="ctl__select"></select>
+        </label>
+        <label class="ctl ctl--byok ctl--key" id="key-ctl">
+          <span class="ctl__label">API key</span>
+          <input id="api-key" class="ctl__input" type="password" autocomplete="off" placeholder="sk-… (kept in your browser)" />
+        </label>
       </div>
     </header>
 
@@ -84,7 +86,7 @@
 
       <section class="how">
         <div class="sec__head">
-          <p class="eyebrow"><span>how it works</span></p>
+          <p class="eyebrow"><span>how to use</span></p>
           <h2 class="sec__title">Three steps</h2>
         </div>
         <div class="how__grid">
@@ -104,27 +106,57 @@
 
       <section class="examples" id="examples">
         <div class="sec__head">
-          <p class="eyebrow"><span>examples</span></p>
+          <p class="eyebrow"><span>samples</span></p>
           <h2 class="sec__title">Before and after</h2>
         </div>
-        <div class="cards" id="example-cards"></div>
+        <div id="example-cards"></div>
       </section>
 
-      <section class="stats">
+      <section class="bench" id="benchmark">
         <div class="sec__head">
-          <p class="eyebrow"><span>patina in numbers</span></p>
-          <h2 class="sec__title">By the numbers</h2>
+          <p class="eyebrow"><span>benchmark</span></p>
+          <h2 class="sec__title">Numbers, in the open</h2>
+          <p class="sec__lede">A deterministic suspect-zone benchmark on a checked-in fixture corpus — auditable, not an authorship test.</p>
         </div>
-        <dl class="stats__grid">
-          <div class="stat"><dt>~160</dt><dd>catalogued patterns</dd></div>
-          <div class="stat"><dt>4</dt><dd>languages · KO·EN·ZH·JA</dd></div>
-          <div class="stat"><dt>4</dt><dd>deterministic signals</dd></div>
-          <div class="stat"><dt>100%</dt><dd>in-browser audit</dd></div>
+        <dl class="bench__cards">
+          <div class="bstat"><dt>100%</dt><dd>overall accuracy</dd><small>95% CI 92.7–100%</small></div>
+          <div class="bstat"><dt>49</dt><dd>fixtures</dd><small>AI vs. natural, labeled</small></div>
+          <div class="bstat"><dt>4</dt><dd>languages</dd><small>KO · EN · ZH · JA</small></div>
+          <div class="bstat"><dt>0</dt><dd>false positives</dd><small>at the 1% FPR budget</small></div>
         </dl>
+        <div class="bench__signals">
+          <span class="sigchip">burstiness</span>
+          <span class="sigchip">MATTR</span>
+          <span class="sigchip">AI-lexicon</span>
+          <span class="sigchip">KO diagnostics</span>
+        </div>
+        <div class="bench__tablewrap">
+          <table class="bench__table">
+            <thead>
+              <tr><th>lang</th><th>fixtures</th><th>accuracy</th><th>95% CI</th><th>F1</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>EN</td><td>13</td><td>100%</td><td>77.2–100%</td><td>1.00</td></tr>
+              <tr><td>JA</td><td>12</td><td>100%</td><td>75.8–100%</td><td>1.00</td></tr>
+              <tr><td>KO</td><td>12</td><td>100%</td><td>75.8–100%</td><td>1.00</td></tr>
+              <tr><td>ZH</td><td>12</td><td>100%</td><td>75.8–100%</td><td>1.00</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="bench__note">Measured on 49 deterministic fixtures as a regression gate — not a claim of generalization to new models, genres, or edited AI text, and not an authorship verdict.</p>
+        <a class="bench__link" href="https://github.com/devswha/patina/blob/main/docs/benchmarks/latest.md">Read the full report →</a>
+      </section>
+
+      <section class="cta">
+        <div class="cta__inner">
+          <h2 class="cta__title">Paste your own and see</h2>
+          <p class="cta__sub">Drop an AI-sounding draft into the box above. No code, no key.</p>
+          <button class="cta__btn" id="cta-start" type="button">Start at the top ↑</button>
+        </div>
       </section>
 
       <footer class="foot">
-        <div class="foot__brand"><span class="nav__dot">p</span> patina</div>
+        <div class="foot__brand"><img class="foot__icon" src="/assets/brand/patina-mark.svg" alt="" width="20" height="20" /> patina</div>
         <nav class="foot__links" aria-label="Footer">
           <a href="https://github.com/devswha/patina">GitHub</a>
           <a href="https://github.com/devswha/patina/blob/main/docs/ETHICS.md">Ethics</a>
@@ -146,7 +178,7 @@
         </div>
         <nav class="sidebar__history" id="history" aria-label="Conversations"></nav>
         <div class="sidebar__foot">
-          <div class="brandmark"><span class="brandmark__dot">p</span> patina</div>
+          <div class="brandmark"><img class="brandmark__icon" src="/assets/brand/patina-mark.svg" alt="" width="22" height="22" /> patina</div>
           <div class="sidebar__note">Deterministic humanizer —<br />same claim, numbers, tone.</div>
         </div>
       </aside>

--- a/src/web-rewrite-contract.js
+++ b/src/web-rewrite-contract.js
@@ -73,6 +73,22 @@ export const PROVIDER_PRESETS = Object.freeze({
     baseURL: 'https://api.openai.com/v1',
     models: Object.freeze(['gpt-5.5', 'gpt-5.1', 'gpt-4.1', 'gpt-4.1-mini']),
   }),
+  claude: Object.freeze({
+    baseURL: 'https://api.anthropic.com/v1',
+    models: Object.freeze(['claude-sonnet-4-5', 'claude-opus-4-1', 'claude-haiku-4-5']),
+  }),
+  deepseek: Object.freeze({
+    baseURL: 'https://api.deepseek.com/v1',
+    models: Object.freeze(['deepseek-v4-pro', 'deepseek-v4-flash', 'deepseek-chat', 'deepseek-reasoner']),
+  }),
+  kimi: Object.freeze({
+    baseURL: 'https://api.moonshot.ai/v1',
+    models: Object.freeze(['kimi-latest', 'moonshot-v1-128k', 'moonshot-v1-32k']),
+  }),
+  glm: Object.freeze({
+    baseURL: 'https://open.bigmodel.cn/api/paas/v4',
+    models: Object.freeze(['glm-4.6', 'glm-4.5', 'glm-4.5-air']),
+  }),
 });
 
 /**


### PR DESCRIPTION
## What

Playground (patina.vibetip.help) overhaul — landing structure, an interactive examples panel, a real benchmark section, an editorial restyle, chat polish, and more BYOK providers.

### Landing
- Restructure below the hero into a 4-part flow: **사용법 / 고친 샘플들 / 벤치마크 / 마무리**.
- **Benchmark** section with real fixture numbers (49 fixtures · 4 langs · 100% [92.7–100% CI] · 0 FP) + per-language table and an honest *"regression gate, not an authorship test"* caveat.

### Examples → editor panel
- Language tabs (KO·EN·ZH·JA), line-number gutter, copy / replay / "try this".
- **Persistent before↔after word-level diff** (in-tree LCS, CJK-aware tokenizer) — both versions stay visible (no fast-vanishing morph).

### Theme
- Editorial dark system: neutral near-black canvas, white type, **single restrained teal accent**. Removed the rainbow aurora + gradient text + heavy glow (the AI-slop tells catalogued in `ai-slop-taxonomy.md`); softened shadows.

### Chat
- **New chat** starts fresh in place (empty state) instead of jumping back to the landing.
- patina **mark icon** as the assistant avatar; sidebar/footer brand marks too.
- Strip `[BODY]`/`[SELF_AUDIT]` prompt scaffolding from streamed output; clean **floor-failed** rendering (flagged text + MPS/Fidelity + localized warning) instead of leaking raw text.

### BYOK / API
- Rename the BYOK mode label to **"API"**; move provider/model/key to a **dedicated second nav row** so the top bar no longer wraps/breaks.
- Add OpenAI-compatible providers to `PROVIDER_PRESETS`: **claude, deepseek, kimi, glm** (with models). `openai` stays the free default; allowlist + base URLs verified.

## Files
- `playground/index.html`, `playground/chatgpt.js`, `playground/chatgpt.css`
- `src/web-rewrite-contract.js` (provider presets)

## Test plan
- `npm run lint` (syntax + eslint + typecheck + spellcheck) — clean
- `npm test` — **987 pass / 0 fail / 1 skip**
- Live BYOK against a real DeepSeek key, end-to-end via the dev server **and** the browser UI (rewrite + MPS/fidelity scoring + floor enforcement). DeepSeek models (chat / v4-pro / v4-flash / reasoner) all return rewrites.

## Notes
- Floor failures observed with DeepSeek are the meaning-preservation guard working (DeepSeek-as-judge scores conservatively), not a regression. Optional follow-up: pin a stronger judge model or expose a "skip scoring" BYOK option.
- `playground/DESIGN.md` still documents the older navy×voltagent tokens; it should be refreshed once the visual direction is final (left as a follow-up to avoid churn).
