### PR TITLE
chore(release): 6.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "patina",
       "source": "./",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "description": "Strip the AI packaging, keep the meaning. Detect and rewrite AI writing patterns across KO/EN/ZH/JA with MPS/fidelity checks. Runs the root SKILL.md as the /patina skill.",
       "homepage": "https://github.com/devswha/patina",
       "repository": "https://github.com/devswha/patina",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
   "name": "patina",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese so text reads as if a human wrote it. Meaning-preservation (MPS) verified, audit-friendly. The root SKILL.md is loaded as the /patina skill.",
   "author": {
     "name": "devswha",

--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "6.0.0"
+version: "6.0.1"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
+## 6.0.1 — 2026-06-28
+
+**Playground overhaul: editorial restyle, interactive before/after examples, a real benchmark section, and more BYOK providers.**
+
+Semver rationale: patch — changes are scoped to the web playground (patina.vibetip.help) plus additive, OpenAI-compatible BYOK provider presets. No CLI flags, patterns, scoring, or schemas changed.
+
+### Added
+
+- **Playground benchmark section** with real fixture metrics (49 fixtures, 4 languages, Wilson CI) and a per-language table, framed as a regression gate rather than an authorship test (#560).
+- **Interactive examples panel** — language tabs (KO·EN·ZH·JA), a line-number gutter, and a persistent before→after word-level diff (in-tree LCS, CJK-aware) with copy/replay/try (#560).
+- **More BYOK providers** in the shared rewrite contract: Claude (Anthropic OpenAI-compat), DeepSeek, Kimi (Moonshot), and GLM (Zhipu), each with model presets. `openai` stays the free-tier default (#560).
+
+### Changed
+
+- **Editorial dark restyle** of the playground — neutral near-black canvas, a single restrained teal accent, and removal of the rainbow aurora / gradient text / heavy glow. The landing is restructured into a usage → samples → benchmark → wrap-up flow (#560).
+- **"New chat"** now starts a fresh conversation in place (with an empty state) instead of returning to the landing (#560).
+- BYOK mode is labelled **"API"**, with provider/model/key moved to a dedicated nav row so the header no longer wraps (#560).
+
+### Fixed
+
+- Chat output no longer leaks the `[BODY]`/`[SELF_AUDIT]` rewrite scaffolding; a floor-failed rewrite now renders the flagged text with MPS/fidelity scores and a clear, localized warning instead of a generic failure (#560).
+
 ## 6.0.0 — 2026-06-26
 
 **Voice-control consolidation: `--verify` replaces the ouroboros loop, `--tone` becomes register-only, `--profile` gains real deterministic pattern suppression.**

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 6.0.0" src="https://img.shields.io/badge/version-6.0.0-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 6.0.1" src="https://img.shields.io/badge/version-6.0.1-blue"></a>
 </p>
 
 <p align="center">
@@ -189,7 +189,7 @@ If meaning drifts, the change is retried or rolled back. Deterministic analysis 
 
 ```yaml
 # .patina.default.yaml
-version: "6.0.0"
+version: "6.0.1"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 6.0.0
+version: 6.0.1
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "6.0.0"
+    "patina-cli": "6.0.1"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cut 6.0.1. Bumps version across package.json, SKILL.md, .patina.default.yaml, README.md, the alias package, and the Claude plugin/marketplace manifests, plus a CHANGELOG entry.

Releases the playground overhaul from #560 (editorial restyle, interactive before/after examples, real benchmark section, new-chat-in-place, mark avatar, scaffolding/floor-failed render fix) and the additive OpenAI-compatible BYOK providers (Claude/DeepSeek/Kimi/GLM).

Semver: **patch** — web playground + additive provider presets only; no CLI flags, patterns, scoring, or schemas changed.

`npm run release:check` → Release metadata OK for 6.0.1. (npm publish is tag-triggered only; not tagging here.)