### PR TITLE
feat(pro): disabled-by-default Pro monetization layer (open-core)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -15,6 +15,22 @@ Private assets (NOT included)
 No private corpora, reinforced lexicons/patterns, prompts, or hosted-server
 assets are included in this repository or its npm packages.
 
+Trademark & brand
+-----------------
+The MIT License covers the code; it does NOT grant any right to the "patina"
+name or brand. "patina" is a trademark of devswha (Korean trademark filing in
+progress with KIPO). You may use, fork, modify, and redistribute the code under
+the MIT License, but you may not use the "patina" name, logo, or branding in a
+way that implies affiliation with or endorsement by the patina project, nor to
+market a competing hosted service as "patina". Rebrand forks under your own name.
+
+Hosted Pro (separate from this open baseline)
+---------------------------------------------
+The hosted Pro tier (the enhanced Korean engine and related server assets) is a
+private, non-distributed offering. This repository ships only the open baseline
+plus the public Pro client contract, gating, and a non-enhancing stub engine;
+the enhanced engine itself is never included here.
+
 Acknowledgements
 ----------------
 Inspired by oh-my-zsh's plugin architecture, Wikipedia's "Signs of AI writing"

--- a/api/lemon-webhook.js
+++ b/api/lemon-webhook.js
@@ -1,0 +1,99 @@
+// @ts-check
+// Lemon Squeezy webhook endpoint. Thin glue over src/lemon-webhook.js.
+//
+// CRITICAL: the signature is computed over the RAW request bytes, so this
+// handler must read the unparsed body (do not rely on a framework JSON parse,
+// which would re-serialize and break verification). Configure the platform to
+// disable body parsing for this route.
+
+import { createRestKv } from './rewrite.js';
+import { createMemoryKv, isProductionPosture } from '../src/rate-limit.js';
+import { createLemonWebhookProcessor } from '../src/lemon-webhook.js';
+import { hashLicenseKey } from '../src/pro-entitlements.js';
+import { byteLength } from '../src/web-rewrite-contract.js';
+
+/** Case-insensitive single header lookup. */
+function headerValue(headers, name) {
+  const lower = name.toLowerCase();
+  for (const [k, v] of Object.entries(headers || {})) {
+    if (k.toLowerCase() === lower) return Array.isArray(v) ? v[0] : v;
+  }
+  return undefined;
+}
+
+/**
+ * Read the raw request body (string or stream), capped to bound abuse.
+ * @param {any} req
+ * @returns {Promise<string|Buffer>}
+ */
+async function readRawBody(req) {
+  const MAX_BODY_BYTES = 64 * 1024;
+  if (typeof req.body === 'string') {
+    if (byteLength(req.body) > MAX_BODY_BYTES) throw new Error('payload too large');
+    return req.body;
+  }
+  if (Buffer.isBuffer(req.rawBody)) {
+    if (req.rawBody.length > MAX_BODY_BYTES) throw new Error('payload too large');
+    return req.rawBody;
+  }
+  /** @type {Buffer[]} */
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of req) {
+    total += chunk.length;
+    if (total > 64 * 1024) throw new Error('payload too large');
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
+ * @param {{env?: Record<string,string|undefined>, kv?: any, logger?: {info?: Function, warn?: Function}, now?: () => number}} [options]
+ */
+export function createLemonWebhookApiHandler({ env = /** @type {Record<string,string|undefined>} */ (process.env), kv: injectedKv, logger = console, now = () => Date.now() } = {}) {
+  const restKv = createRestKv(env);
+  const kv = injectedKv ?? (isProductionPosture(env) ? restKv : (restKv ?? createMemoryKv()));
+
+  return async function handler(req, res) {
+    const send = (status, payload) => {
+      res.statusCode = status;
+      res.setHeader?.('Content-Type', 'application/json');
+      res.setHeader?.('Cache-Control', 'no-store');
+      res.end?.(JSON.stringify(payload));
+      logger.info?.('lemon.webhook', { route: '/api/lemon-webhook', status });
+    };
+
+    if (req.method && req.method !== 'POST') return send(405, { error: 'method not allowed' });
+    if (!kv) return send(503, { error: 'webhook storage unavailable' });
+
+    let rawBody;
+    try {
+      rawBody = await readRawBody(req);
+    } catch {
+      return send(413, { error: 'payload too large' });
+    }
+
+    const processor = createLemonWebhookProcessor({
+      kv,
+      webhookSecret: env.PATINA_LEMON_WEBHOOK_SECRET || '',
+      licenseHmacSecret: env.PATINA_PRO_HMAC_SECRET || '',
+      hashKey: hashLicenseKey,
+      now,
+      logger,
+    });
+
+    let result;
+    try {
+      result = await processor.process({ rawBody, signature: headerValue(req.headers, 'x-signature') });
+    } catch {
+      return send(503, { error: 'webhook processing unavailable' });
+    }
+
+    if ('applied' in result) return send(200, { ok: true, applied: result.applied });
+    return send(result.status, { error: result.reason });
+  };
+}
+
+export default async function handler(req, res) {
+  return createLemonWebhookApiHandler()(req, res);
+}

--- a/api/pro-session.js
+++ b/api/pro-session.js
@@ -1,0 +1,96 @@
+// @ts-check
+// Pro session exchange endpoint: POST a raw Lemon license key ONCE, receive an
+// opaque short-lived Pro session token. Thin glue over src/pro-session.js — the
+// security logic lives there; this wires request/response, KV selection,
+// production fail-closed posture, no-store headers, and sanitized logging.
+
+import { createRestKv } from './rewrite.js';
+import { createMemoryKv, isProductionPosture } from '../src/rate-limit.js';
+import { createProSessionExchange } from '../src/pro-session.js';
+import { hashLicenseKey } from '../src/pro-entitlements.js';
+import { byteLength } from '../src/web-rewrite-contract.js';
+
+/**
+ * Read and JSON-parse a request body. Honors a pre-parsed `req.body` (Vercel)
+ * and otherwise drains the stream. Caps the payload so a giant body cannot DoS.
+ *
+ * @param {any} req
+ * @returns {Promise<unknown>}
+ */
+async function readJsonBody(req) {
+  const MAX_BODY_BYTES = 16 * 1024;
+  if (req && typeof req.body === 'string') {
+    if (byteLength(req.body) > MAX_BODY_BYTES) throw new Error('payload too large');
+    return req.body.length > 0 ? JSON.parse(req.body) : {};
+  }
+  // A pre-parsed object body (Vercel) is returned as-is; the exchange reads only
+  // an OWN `licenseKey` string, so a polluted prototype cannot smuggle a key.
+  if (req && req.body != null && typeof req.body === 'object') return req.body;
+  /** @type {Buffer[]} */
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of req) {
+    total += chunk.length;
+    if (total > 16 * 1024) throw new Error('payload too large');
+    chunks.push(chunk);
+  }
+  if (chunks.length === 0) return {};
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+}
+
+/**
+ * @param {{env?: Record<string,string|undefined>, kv?: any, verifyLicense?: (raw:string)=>Promise<object|null>, logger?: {info?: Function, warn?: Function}, now?: () => number}} [options]
+ */
+export function createProSessionApiHandler({ env = /** @type {Record<string,string|undefined>} */ (process.env), kv: injectedKv, verifyLicense, logger = console, now = () => Date.now() } = {}) {
+  const restKv = createRestKv(env);
+  // Production must use the durable REST KV; never silently fall back to the
+  // in-memory store (which would lose sessions and fail open across instances).
+  const kv = injectedKv ?? (isProductionPosture(env) ? restKv : (restKv ?? createMemoryKv()));
+
+  return async function handler(req, res) {
+    res.setHeader?.('Cache-Control', 'no-store');
+    res.setHeader?.('Content-Type', 'application/json');
+
+    const send = (status, payload) => {
+      res.statusCode = status;
+      res.end?.(JSON.stringify(payload));
+      // Sanitized log ONLY: status code, never the raw key/email/token/body.
+      logger.info?.('pro-session.exchange', { route: '/api/pro-session', status });
+    };
+
+    if (req.method && req.method !== 'POST') return send(405, { error: 'method not allowed' });
+    if (!kv) return send(503, { error: 'pro session storage unavailable' });
+
+    let body;
+    try {
+      body = await readJsonBody(req);
+    } catch {
+      return send(400, { error: 'invalid request body' });
+    }
+
+    const exchange = createProSessionExchange({
+      kv,
+      hmacSecret: env.PATINA_PRO_HMAC_SECRET || '',
+      verifyLicense,
+      hashKey: hashLicenseKey,
+      now,
+    });
+
+    let result;
+    try {
+      result = await exchange.exchange(/** @type {any} */ (body));
+    } catch {
+      // A KV/provider outage must fail closed as a sanitized 503, never an
+      // uncaught framework error that leaks a stack or skips the no-store path.
+      return send(503, { error: 'pro session storage unavailable' });
+    }
+    if ('proSessionToken' in result) {
+      return send(200, { proSessionToken: result.proSessionToken, expiresAt: result.expiresAt, status: result.status });
+    }
+    return send(result.status, { error: result.reason });
+  };
+}
+
+export default async function handler(req, res) {
+  return createProSessionApiHandler()(req, res);
+}

--- a/api/rewrite.js
+++ b/api/rewrite.js
@@ -1,9 +1,12 @@
 // @ts-check
 import { createRateLimiter, createMemoryKv, isProductionPosture } from '../src/rate-limit.js';
 import { createRewriteHandler } from '../src/rewrite-handler.js';
-import { encodeStreamFrame, WEB_TIERS } from '../src/web-rewrite-contract.js';
+import { encodeStreamFrame, WEB_TIERS, STREAM_FRAME_TYPES } from '../src/web-rewrite-contract.js';
 import { buildRewriteMetric } from '../src/web-observability.js';
 import { runWebRewriteStream } from '../src/web-rewrite-stream.js';
+import { createStubEnhancedEngine } from '../src/enhanced-rewrite-engine-contract.js';
+import { createProMetering } from '../src/pro-metering.js';
+import { hashSessionToken, sessionKey, entitlementKey, verifyProSession } from '../src/pro-session.js';
 
 /**
  * @param {unknown} value
@@ -26,7 +29,7 @@ function parseKvNumber(value) {
  * Create a dependency-free Upstash/Vercel KV REST adapter.
  *
  * @param {Record<string,string|undefined>} env
- * @returns {null|{get(key: string): Promise<unknown>, incr(key: string, options?: {ttlMs?: number}): Promise<number>}}
+ * @returns {null|{get(key: string): Promise<unknown>, set(key: string, val: string, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>}}
  */
 export function createRestKv(env = {}) {
   const base = env.KV_REST_API_URL;
@@ -35,11 +38,15 @@ export function createRestKv(env = {}) {
   const root = base.replace(/\/+$/, '');
   const headers = { Authorization: `Bearer ${token}` };
 
-  async function read(path) {
-    const response = await globalThis.fetch(`${root}${path}`, { headers });
+  async function request(path, { method = 'GET', body = undefined } = {}) {
+    /** @type {RequestInit} */
+    const init = { method, headers };
+    if (body != null) init.body = body;
+    const response = await globalThis.fetch(`${root}${path}`, init);
     if (!response.ok) throw new Error('kv request failed');
     return response.json();
   }
+  const read = (path) => request(path);
 
   return {
     async get(key) {
@@ -57,15 +64,111 @@ export function createRestKv(env = {}) {
       }
       return value;
     },
+    async set(key, val, { ttlMs } = {}) {
+      // Shared store contract (memory KV + this REST KV):
+      //  - VALUES ARE STRINGS. Callers serialize objects themselves; a
+      //    non-string is rejected (fail loud) instead of being implicitly
+      //    JSON.stringify'd, so memory and REST never diverge on value shape.
+      //  - KEYS MUST BE OPAQUE/HMAC ids (no raw license key, email, or token).
+      //    The key is URL-encoded into the path while the value travels in the
+      //    POST body, so a secret value is never exposed in request URLs/logs.
+      //  - TTL granularity: a positive ttlMs is rounded UP to whole seconds
+      //    (Redis EX). Contract TTLs are >= 1s, so memory (ms) and REST (s)
+      //    agree at second granularity; sub-second TTLs are out of contract.
+      if (typeof val !== 'string') throw new TypeError('kv set value must be a string');
+      const encoded = encodeURIComponent(key);
+      const seconds = (typeof ttlMs === 'number' && ttlMs > 0) ? Math.max(1, Math.ceil(ttlMs / 1000)) : undefined;
+      const path = seconds ? `/set/${encoded}?EX=${seconds}` : `/set/${encoded}`;
+      await request(path, { method: 'POST', body: val });
+    },
   };
 }
 
 /**
- * @param {{env?: Record<string,string|undefined>, runWebRewriteStreamImpl?: typeof runWebRewriteStream, logger?: {info?: Function, warn?: Function, error?: Function, debug?: Function}, now?: () => number}} [options]
+ * @param {{env?: Record<string,string|undefined>, kv?: any, runWebRewriteStreamImpl?: typeof runWebRewriteStream, enhancedEngine?: {kind?:string, isAvailable:Function, rewrite:Function}, logger?: {info?: Function, warn?: Function, error?: Function, debug?: Function}, now?: () => number}} [options]
  */
-export function createRewriteApiHandler({ env = /** @type {Record<string,string|undefined>} */ (process.env), runWebRewriteStreamImpl = runWebRewriteStream, logger = console, now = () => Date.now() } = {}) {
+export function createRewriteApiHandler({ env = /** @type {Record<string,string|undefined>} */ (process.env), kv: injectedKv, runWebRewriteStreamImpl = runWebRewriteStream, enhancedEngine = createStubEnhancedEngine(), logger = console, now = () => Date.now() } = {}) {
   const restKv = createRestKv(env);
-  const kv = isProductionPosture(env) ? restKv : (restKv ?? createMemoryKv());
+  const kv = injectedKv ?? (isProductionPosture(env) ? restKv : (restKv ?? createMemoryKv()));
+  const proMetering = createProMetering({ kv, now });
+  /** @param {unknown} v */
+  const parseRecord = (v) => {
+    if (v == null) return null;
+    if (typeof v === 'object') return v;
+    if (typeof v !== 'string') return null;
+    try { const p = JSON.parse(v); return p && typeof p === 'object' ? p : null; } catch { return null; }
+  };
+  /** @type {Record<string, number>} */
+  const PRO_SESSION_STATUS = { no_session: 401, expired: 401, absolute_expired: 401, entitlement_revoked: 402 };
+
+  // Pro path: gate-on requests (G001 only emits tier 'pro' when the gate is on)
+  // are verified by opaque session token (G004) -> entitlement (G003) -> Pro
+  // metering (G006) -> the enhanced engine adapter. Every failure is explicit
+  // and fail-closed; it never falls back to free/BYOK or the shared LLM.
+  async function runProRewrite({ res, request }) {
+    const denyMetric = (status) => logger.info?.('rewrite.metric', buildRewriteMetric({
+      tier: 'pro', provider: 'enhanced', model: enhancedEngine.kind || 'enhanced', status,
+      latencyMs: 0, quotaDecision: 'denied', charCount: typeof request.text === 'string' ? request.text.length : 0,
+    }));
+    const jsonErr = (status, error) => {
+      res.statusCode = status;
+      res.setHeader?.('Content-Type', 'application/json');
+      res.setHeader?.('Cache-Control', 'no-store');
+      res.end?.(JSON.stringify({ error }));
+      denyMetric(status);
+    };
+
+    const proSecret = env.PATINA_PRO_HMAC_SECRET;
+    if (!proSecret) return jsonErr(503, 'pro service unavailable');
+
+    let tokenHash;
+    try {
+      tokenHash = hashSessionToken(proSecret, request.proSessionToken);
+    } catch {
+      return jsonErr(401, 'invalid pro session');
+    }
+    let sessionRecord;
+    let entitlement;
+    try {
+      sessionRecord = parseRecord(await kv.get(sessionKey(tokenHash)));
+      entitlement = sessionRecord && typeof /** @type {any} */ (sessionRecord).entitlementId === 'string'
+        ? parseRecord(await kv.get(entitlementKey(/** @type {any} */ (sessionRecord).entitlementId)))
+        : null;
+    } catch {
+      // A KV outage during the Pro lookup fails closed as an explicit 503 (the
+      // pro path never degrades to a generic 500 or to free/BYOK).
+      return jsonErr(503, 'pro session storage unavailable');
+    }
+    const verdict = verifyProSession({ sessionRecord: /** @type {any} */ (sessionRecord), entitlement, now: now() });
+    if (!verdict.ok) return jsonErr(PRO_SESSION_STATUS[verdict.reason ?? 'no_session'] ?? 401, 'pro session not valid');
+
+    const meter = await proMetering.check({ entitlementId: /** @type {any} */ (sessionRecord).entitlementId });
+    if (!meter.allowed) {
+      const denied = /** @type {{status:number, reason:string}} */ (meter);
+      return jsonErr(denied.status, denied.reason);
+    }
+
+    if (!enhancedEngine.isAvailable(env)) return jsonErr(503, 'pro engine unavailable');
+    let result;
+    try {
+      result = await enhancedEngine.rewrite({ text: request.text, lang: request.lang, mode: request.mode, original: request.original, history: request.history });
+    } catch {
+      return jsonErr(503, 'pro engine error');
+    }
+
+    res.statusCode = 200;
+    res.setHeader?.('Content-Type', 'application/x-ndjson');
+    res.setHeader?.('Cache-Control', 'no-store');
+    const startedAt = now();
+    res.write?.(encodeStreamFrame({ type: STREAM_FRAME_TYPES.START }));
+    res.write?.(encodeStreamFrame({ type: STREAM_FRAME_TYPES.DELTA, text: result.text }));
+    res.write?.(encodeStreamFrame({ type: STREAM_FRAME_TYPES.DONE, scores: result.scores }));
+    res.end?.();
+    logger.info?.('rewrite.metric', buildRewriteMetric({
+      tier: 'pro', provider: 'enhanced', model: enhancedEngine.kind || 'enhanced', status: 200,
+      latencyMs: now() - startedAt, quotaDecision: 'allowed', charCount: typeof request.text === 'string' ? request.text.length : 0,
+    }));
+  }
   return createRewriteHandler({
     rateLimiter: createRateLimiter({
       kv,
@@ -73,6 +176,7 @@ export function createRewriteApiHandler({ env = /** @type {Record<string,string|
       env,
     }),
     runRewrite: async ({ res, request }) => {
+      if (request.tier === WEB_TIERS.PRO) return runProRewrite({ res, request });
       // Resolve the effective LLM key server-side: BYOK uses the caller's key;
       // free uses the server's own provider key (never the request, which has
       // no key on the free tier). Fail closed if the free service is unconfigured.

--- a/docs/PRO.md
+++ b/docs/PRO.md
@@ -1,0 +1,135 @@
+# patina Open Core vs Pro
+
+patina is **open core**. The baseline is fully open (MIT) and works on its own;
+a hosted **Pro** tier adds a server-side enhanced Korean engine. This page
+documents the boundary, how Pro is accessed (no account required), and the
+billing/cancellation/refund policy.
+
+> Status: the Pro tier ships **disabled by default** (`PATINA_PRO_ENABLED` is
+> off). Checkout is not open until the enhanced engine meets its quality bar.
+> Everything below describes the gated infrastructure, not a live paywall.
+
+## What is open (MIT) vs what is Pro
+
+| | Open baseline (this repo, `patina-cli`) | Hosted Pro |
+|---|---|---|
+| Deterministic detector (`src/features/*`), patterns, lexicon, profiles | ✅ open | — |
+| CLI, free web rewrite proxy, BYOK (your own LLM key) | ✅ open | — |
+| Enhanced Korean rewrite engine (private corpus/lexicon/pipeline) | ❌ never shipped | ✅ server-only |
+| Higher limits, batch, history convenience | — | ✅ |
+
+The open baseline keeps working forever without Pro. The **only** thing behind
+Pro is the server-side enhanced engine and higher limits — and that engine is
+never distributed in npm/git (a leak gate, `scripts/check-no-private-assets.mjs`,
+enforces zero private assets in the published package).
+
+## How Pro is accessed — no account, just a license key
+
+There is **no account, login, or password**. After buying a Pro subscription
+you receive a Lemon Squeezy **license key**. The flow:
+
+1. You paste the license key **once** into the app (`exchangeProLicense`).
+2. The server verifies it and returns an **opaque, short-lived Pro session
+   token** (30-minute sliding window, 2-hour absolute cap). The raw license key
+   is never stored or re-sent; only a hash is kept server-side.
+3. Rewrite requests send that opaque token (`tier: "pro"`, `proSessionToken`) —
+   never the raw key, and never a caller-chosen provider/model/key.
+4. If the entitlement is cancelled/refunded/expired, the next request fails
+   closed (the server re-checks the entitlement every request).
+
+Tokens are held in-memory/session by default; persistent storage is opt-in with
+a clear warning and a delete control.
+
+## Billing, cancellation & refunds (Korean)
+
+Payment is handled by **Lemon Squeezy as the Merchant of Record** (it handles
+tax/VAT, receipts, and refunds). The cancellation/refund policy below is shown
+**identically** at checkout, in the receipt/email, and in the license guide —
+its single source of truth is `src/pro-legal-copy.js` (`PRO_LEGAL_COPY_BLOCK_KO`):
+
+- 구독은 언제든 해지할 수 있으며, 해지하면 다음 결제부터 청구되지 않습니다.
+- 결제 후 7일 이내에는 고객지원을 통해 환불을 요청할 수 있습니다.
+- 다만 디지털 서비스 특성상 Pro 기능을 상당히 사용한 경우, 전자상거래법상 청약철회가 제한될 수 있습니다.
+- 결제·영수증·환불은 판매대행사(Merchant of Record)인 Lemon Squeezy가 처리합니다.
+- 환불·결제 문의는 고객지원으로, 구독 해지·결제수단 변경은 Lemon Squeezy 고객 포털에서 할 수 있습니다.
+
+## License & trademark
+
+The code is **MIT** and stays MIT — fork, modify, and redistribute freely. The
+code license does **not** grant rights to the **"patina"** name or brand
+("patina" is a trademark of devswha; a Korean KIPO filing is in progress). Do
+not market a competing hosted service as "patina"; rebrand forks under your own
+name. See `NOTICE` and `LICENSE` for the authoritative terms.
+
+## Deployment (Vercel)
+
+The web surface (free playground + `/api/*`) deploys to Vercel from `vercel.json`.
+There are two safe deploy levels; paid checkout (level C) stays closed until the
+`docs/RELEASE-CHECKLIST.md` gates pass.
+
+### Prerequisites
+
+- A Vercel project linked to this repo (`vercel link`).
+- A KV store (Upstash Redis / Vercel KV) for rate-limit + Pro state. In a
+  production posture the handler **fails closed without KV**.
+- Secrets are set via the Vercel dashboard or `vercel env add` — **never** in a
+  tracked file (`.env.*` is gitignored). Generate HMAC secrets with
+  `openssl rand -hex 32`.
+
+### Level A — free tier only (Pro disabled)
+
+Leave `PATINA_PRO_ENABLED` unset. Required env:
+
+| env | purpose | required |
+|---|---|---|
+| `PATINA_FREE_API_KEY` | server LLM key for the free tier (503 without it) | yes (for free) |
+| `PATINA_FREE_PROVIDER` | free provider preset (default `openai`) | optional |
+| `PATINA_FREE_MODEL` | free model (default = preset's first model) | optional |
+| `KV_REST_API_URL` + `KV_REST_API_TOKEN` | KV REST endpoint (rate limit) | yes in production |
+| `PATINA_QUOTA_HMAC_SECRET` | rate-limit token HMAC | yes in production |
+
+```bash
+vercel link                                  # once
+vercel env add PATINA_FREE_API_KEY production
+# ...add KV + PATINA_QUOTA_HMAC_SECRET...
+vercel --prod
+```
+
+BYOK needs no server key (the user supplies their own).
+
+### Level B — Pro infrastructure (checkout hidden, stub engine)
+
+Adds the Pro plumbing without opening payment. The default engine is the
+deterministic **stub** (no quality gain), so checkout must stay hidden.
+Additional env on top of level A:
+
+| env | purpose |
+|---|---|
+| `PATINA_PRO_ENABLED=true` | turns on the Pro tier route |
+| `PATINA_PRO_HMAC_SECRET` | shared secret: hashes license keys + session tokens + webhook license ids (`openssl rand -hex 32`) |
+| `PATINA_PRO_PROVIDER` | Pro provider preset (must be in `PROVIDER_PRESETS`, e.g. `openai`) |
+| `PATINA_PRO_MODEL` | Pro model — must be set explicitly AND allowlisted in that preset (no fallback) |
+| `PATINA_LEMON_WEBHOOK_SECRET` | Lemon Squeezy webhook signing secret |
+
+Serverless functions deploy automatically from `api/`: `/api/rewrite`,
+`/api/pro-session`, `/api/lemon-webhook`.
+
+Lemon Squeezy setup:
+
+1. Create a store + a $9.99/mo subscription product with license keys enabled.
+2. Add a webhook targeting `https://<your-domain>/api/lemon-webhook`.
+3. Set its signing secret equal to `PATINA_LEMON_WEBHOOK_SECRET`.
+
+Verify the Pro path locally with no money and no real key — the
+`tests/unit/rewrite-pro-path.test.js` flow seeds an `active` entitlement + a
+session in a mock KV, POSTs `{tier:"pro", proSessionToken}`, and expects a
+streamed `start/delta/done`. A bogus token returns 401; gate-off returns 403.
+
+### Level C — open paid checkout
+
+Only after **all** `docs/RELEASE-CHECKLIST.md` gates pass (1–11 in CI here, plus
+the private CROSS-TRACK gate 12: the real enhanced ko engine passes the same
+`EnhancedRewriteEngine` contract and wins a paired ko benchmark with no
+false-positive regression). Then swap `createStubEnhancedEngine()` for the
+private engine and enable checkout. File/confirm the KIPO 'patina' trademark
+first.

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -1,0 +1,34 @@
+# patina Pro — payment-open release checklist
+
+The hosted Pro tier ships **disabled by default** (`PATINA_PRO_ENABLED` off) and
+the public checkout flag stays **off** until every gate below passes. This
+prevents the order-inversion failure: never sell Pro before the enhanced engine
+is real and demonstrably better than free.
+
+> Rule: **`PAYMENT_OPEN` (public checkout) is enabled ONLY after all gates pass.**
+> A deployment that cannot show the CROSS-TRACK quality artifact must fail its
+> payment-open readiness check and keep checkout hidden.
+
+## THIS-PLAN gates (public repo — verifiable here)
+
+1. **Gate-off no-regression** — `PATINA_PRO_ENABLED=false`: free/BYOK validation, rate limiter, provider resolution, and the deterministic `src/features/*` are unchanged. (`npm test`)
+2. **Shared KV store contract** — memory KV and REST KV pass the same get/set/incr/TTL contract; production fails closed without KV; no raw secret in a URL/value. (`kv-store-contract*`)
+3. **Entitlement state machine** — transitions, idempotency, out-of-order/stale rejection, terminal-resurrection prevention, malformed-expiry fail-closed. (`pro-entitlements*`)
+4. **Opaque Pro session token** — license key exchanged once → opaque token; sliding + absolute expiry; revoke cuts access; raw key/token never stored/logged. (`pro-session*`)
+5. **Lemon webhook mirror** — timing-safe signature, idempotency, mirror-before-marker ordering, correct refund/cancel subscription scoping. (`lemon-webhook*`)
+6. **EnhancedRewriteEngine contract + stub** — the public stub and the private engine pass the SAME contract; the stub makes no quality claim (floor scores). (`enhanced-rewrite-engine*`)
+7. **Pro metering** — per-entitlement day/hour/minute caps; malformed counter/outage fail-closed. (`pro-metering*`)
+8. **Pro rewrite path** — session → entitlement → metering → engine; every failure is explicit (401/402/429/503); never falls back to free/BYOK. (`rewrite-pro-path*`)
+9. **Client + legal copy** — pro requests carry only the opaque token; the raw key is never retained; ko refund/cancel copy is a single source (7-day + digital limit + Lemon MoR). (`rewrite-client-pro*`)
+10. **Leak gate** — `npm run check:no-private-assets` is clean; planted private/enhanced/reinforced/corpus/server fixtures are caught. No raw key/email/secret in the package or logs.
+11. **Full regression + lint** — `npm test` green and `npm run lint` (syntax/eslint/typecheck/spellcheck) clean.
+
+## CROSS-TRACK gate (private — NOT verifiable in this repo)
+
+12. **Enhanced ko engine quality** — the private engine passes the SAME `EnhancedRewriteEngine` contract AND a paired ko benchmark shows a statistically significant win over the free baseline with no FP regression. Until this artifact exists, payment-open readiness fails.
+
+## Open only after 1–12
+
+Only when gates 1–11 pass in CI AND the CROSS-TRACK quality artifact (gate 12)
+is attached may the public checkout flag be enabled. Trademark: file/confirm the
+KIPO 'patina' mark and keep the NOTICE brand policy current before public sale.

--- a/playground/rewrite-client.js
+++ b/playground/rewrite-client.js
@@ -49,10 +49,10 @@ export function createRewriteThread({ lang }) {
      * Build a request body WITHOUT mutating thread state. State is only
      * committed on an accepted rewrite (see commit), so a failed/floor-rejected
      * turn never poisons the next request's original/history (fail-closed UX).
-     * @param {{text:string, tier:string, provider?:string, model?:string, apiKey?:string}} input
+     * @param {{text:string, tier:string, provider?:string, model?:string, apiKey?:string, proSessionToken?:string}} input
      * @returns {Record<string, unknown>}
      */
-    buildRequest({ text, tier, provider, model, apiKey }) {
+    buildRequest({ text, tier, provider, model, apiKey, proSessionToken }) {
       const cleanText = String(text ?? '');
       const isRefine = original != null;
       const body = {
@@ -70,6 +70,11 @@ export function createRewriteThread({ lang }) {
         if (provider != null) body.provider = provider;
         if (model != null) body.model = model;
         if (apiKey != null) body.apiKey = apiKey;
+      } else if (tier === WEB_TIERS.PRO) {
+        // Pro sends ONLY the opaque session token (never the raw license key,
+        // and never a caller-chosen provider/model/apiKey — the server picks
+        // the enhanced route). Mirrors the G001 contract.
+        if (proSessionToken != null) body.proSessionToken = proSessionToken;
       }
 
       return body;
@@ -198,4 +203,46 @@ export async function streamRewrite({
   const frame = { type: STREAM_FRAME_TYPES.ERROR, error: 'stream ended before done' };
   onError?.(frame);
   return { ok: false, finalFrame: frame };
+}
+
+/**
+ * Exchange a raw Lemon Squeezy license key for an opaque, short-lived Pro
+ * session token (POST /api/pro-session). The raw key is sent ONCE, in the body,
+ * and is never retained by this helper — the caller stores only the returned
+ * opaque token (recommended: in-memory/session, not persistent). On any
+ * non-2xx the returned error carries the server message but never the raw key.
+ *
+ * @param {{licenseKey:string, fetchImpl?:typeof fetch, url?:string, signal?:AbortSignal}} input
+ * @returns {Promise<{ok:true, proSessionToken:string, expiresAt:number, status:string}|{ok:false, status:number, error:string}>}
+ */
+export async function exchangeProLicense({ licenseKey, fetchImpl = globalThis.fetch, url = '/api/pro-session', signal }) {
+  if (typeof licenseKey !== 'string' || licenseKey.trim().length === 0) {
+    return { ok: false, status: 400, error: 'licenseKey required' };
+  }
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ licenseKey }),
+      signal,
+    });
+  } catch {
+    return { ok: false, status: 0, error: 'network error' };
+  }
+  let data = null;
+  try {
+    data = await response.json();
+  } catch {
+    data = null;
+  }
+  if (!response.ok || !data || typeof data.proSessionToken !== 'string') {
+    // Scrub the submitted raw key from any server-provided error text before
+    // returning it: a buggy/hostile server that echoes the key back must never
+    // cause this helper to retain the raw license key in its result.
+    const raw = (data && typeof data.error === 'string') ? data.error : 'pro exchange failed';
+    const error = raw.split(licenseKey).join('[REDACTED]');
+    return { ok: false, status: response.status || 502, error };
+  }
+  return { ok: true, proSessionToken: data.proSessionToken, expiresAt: data.expiresAt, status: data.status };
 }

--- a/scripts/check-no-private-assets.mjs
+++ b/scripts/check-no-private-assets.mjs
@@ -29,7 +29,7 @@ export const FORBIDDEN_GLOBS = Object.freeze([
   '**/enhanced/**', // any `enhanced/` directory (reinforced assets)
   '**/reinforced/**', // any `reinforced/` directory (reinforced assets)
   '**/corpus/**', // private corpus directories
-  'server/**', // private service/server implementation
+  '**/server/**', // private service/server implementation (any depth, incl. nested packages)
 ]);
 
 /**
@@ -62,7 +62,10 @@ export function globToRegExp(glob) {
       re += c;
     }
   }
-  return new RegExp(`${re}$`);
+  // Case-insensitive: a private marker must be caught regardless of case
+  // (e.g. `.PRIVATE.` must match `**/*.private.*`), since case-only renames
+  // must not bypass the leak boundary.
+  return new RegExp(`${re}$`, 'i');
 }
 
 const FORBIDDEN_MATCHERS = FORBIDDEN_GLOBS.map((glob) => ({ glob, re: globToRegExp(glob) }));

--- a/src/enhanced-rewrite-engine-contract.js
+++ b/src/enhanced-rewrite-engine-contract.js
@@ -1,0 +1,105 @@
+// @ts-check
+// EnhancedRewriteEngine adapter contract (open-core boundary).
+//
+// The PUBLIC repo ships only this contract + a deterministic STUB adapter for
+// plumbing/e2e. The real enhanced ko engine is a PRIVATE cross-track asset that
+// MUST implement the SAME contract and pass the SAME contract test before
+// payment-open. Keeping the contract public + the implementation private is the
+// open-core moat: the wire shape is known, the quality is not shippable.
+//
+// A conforming engine exposes:
+//   isAvailable(env): boolean        — whether this adapter can serve a request
+//   async rewrite(request): Result   — { text, scores:{mps,fidelity} }
+// and throws a typed EnhancedEngineError for invalid input / unavailability.
+// It must never embed or emit a private asset (corpus/lexicon/pattern bodies).
+
+import { MPS_FLOOR, FIDELITY_FLOOR, SUPPORTED_LANGS } from './web-rewrite-contract.js';
+
+/** Typed error so callers can fail closed on a known shape. */
+export class EnhancedEngineError extends Error {
+  /** @param {string} code @param {string} message */
+  constructor(code, message) {
+    super(message);
+    this.name = 'EnhancedEngineError';
+    this.code = code;
+  }
+}
+
+/**
+ * Validate an enhanced-rewrite request shape (shared by every adapter).
+ * @param {any} request
+ * @returns {{text:string, lang:string, mode:string}}
+ */
+export function assertValidEnhancedRequest(request) {
+  if (!request || typeof request !== 'object') throw new EnhancedEngineError('bad_request', 'request must be an object');
+  const { text, lang, mode } = request;
+  if (typeof text !== 'string' || text.trim().length === 0) throw new EnhancedEngineError('bad_request', 'text required');
+  if (!SUPPORTED_LANGS.includes(lang)) throw new EnhancedEngineError('bad_request', 'unsupported lang');
+  if (mode !== 'first' && mode !== 'refine') throw new EnhancedEngineError('bad_request', 'mode must be first|refine');
+  return { text, lang, mode };
+}
+
+/**
+ * Create the PUBLIC stub enhanced engine. It is deterministic, carries NO
+ * private asset, and is for plumbing/e2e only — it does NOT humanize. It
+ * returns the input text unchanged with floor-passing scores so the rewrite
+ * pipeline (gate -> entitlement -> metering -> engine -> response) can be
+ * exercised end to end without the private engine.
+ *
+ * @param {{kind?:string}} [opts]
+ */
+export function createStubEnhancedEngine({ kind = 'stub' } = {}) {
+  return {
+    kind,
+    /** @param {Record<string,string|undefined>} [_env] */
+    isAvailable(_env) {
+      return true;
+    },
+    /**
+     * @param {any} request
+     * @returns {Promise<{text:string, scores:{mps:number, fidelity:number}, engine:string}>}
+     */
+    async rewrite(request) {
+      const { text } = assertValidEnhancedRequest(request);
+      // Plumbing only: echo the input unchanged. A stub MUST NOT claim to have
+      // improved anything; scores are exactly at the floor so the pipeline does
+      // not treat stub output as a quality win.
+      return { text, scores: { mps: MPS_FLOOR, fidelity: FIDELITY_FLOOR }, engine: kind };
+    },
+  };
+}
+
+/**
+ * Shared contract test. Both the public stub and the private enhanced engine
+ * MUST pass this. `assert` is injected (node:assert) so this module stays
+ * dependency-free and usable from any test runner.
+ *
+ * @param {() => {isAvailable:Function, rewrite:Function}} makeEngine
+ * @param {{ equal:Function, ok:Function, rejects:Function, match?:Function }} assert
+ */
+export async function runEnhancedEngineContract(makeEngine, assert) {
+  const engine = makeEngine();
+
+  // isAvailable returns a boolean.
+  assert.equal(typeof engine.isAvailable(), 'boolean');
+  assert.equal(typeof engine.isAvailable({}), 'boolean');
+
+  // A valid request yields { text, scores{mps,fidelity} } at or above floor.
+  const ok = await engine.rewrite({ text: '안녕하세요 테스트', lang: 'ko', mode: 'first' });
+  assert.equal(typeof ok.text, 'string');
+  assert.ok(ok.text.length > 0);
+  assert.ok(Number.isFinite(ok.scores.mps) && ok.scores.mps >= MPS_FLOOR);
+  assert.ok(Number.isFinite(ok.scores.fidelity) && ok.scores.fidelity >= FIDELITY_FLOOR);
+
+  // Invalid inputs throw the typed error (fail-closed, no silent default).
+  await assert.rejects(() => engine.rewrite(null), /request must be an object/);
+  await assert.rejects(() => engine.rewrite({ text: '', lang: 'ko', mode: 'first' }), /text required/);
+  await assert.rejects(() => engine.rewrite({ text: 'x', lang: 'xx', mode: 'first' }), /unsupported lang/);
+  await assert.rejects(() => engine.rewrite({ text: 'x', lang: 'ko', mode: 'bogus' }), /first\|refine/);
+
+  // The output must not embed private-asset markers (open-core leak guard).
+  const out = JSON.stringify(ok);
+  for (const marker of ['.private.', '.enhanced.', '.reinforced.', 'corpus/']) {
+    assert.ok(!out.includes(marker), `engine output leaked a private marker: ${marker}`);
+  }
+}

--- a/src/lemon-webhook.js
+++ b/src/lemon-webhook.js
@@ -1,0 +1,266 @@
+// @ts-check
+// Lemon Squeezy webhook -> entitlement mirror (server-side only).
+//
+// Verifies the webhook signature (timing-safe), maps the provider event to an
+// entitlement status, and folds it into the durable entitlement mirror through
+// the G003 state machine (idempotent, ordered, fail-closed). The mirror is
+// keyed by the SAME opaque id the session exchange (G004) uses —
+// hashLicenseKey(rawLicenseKey) — so a webhook update is immediately visible to
+// the next session verify (no separate session index needed: a Pro request
+// re-derives the entitlement by id every time, so a revoke/cancel takes effect
+// on the next request).
+//
+// PURE where possible; the processor takes an injected KV + hashKey + clock.
+// Raw license key/email never enter a store key, URL, log, or returned object.
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import {
+  applyEntitlementEvent,
+  deriveEntitlementState,
+  shouldInvalidateSessions,
+  ENTITLEMENT_STATES,
+} from './pro-entitlements.js';
+import { entitlementKey } from './pro-session.js';
+
+/** Idempotency marker TTL: a re-delivered event id is ignored for 30 days. */
+export const WEBHOOK_IDEMPOTENCY_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+/** Entitlement mirror TTL: long-lived; refreshed on every applied event. */
+export const ENTITLEMENT_MIRROR_TTL_MS = 400 * 24 * 60 * 60 * 1000;
+
+/** @param {string} eventId */
+export function idempotencyKey(eventId) {
+  return `whevt:${eventId}`;
+}
+
+/**
+ * Subscription "object" events whose `data.id` is the subscription id. Every
+ * other subscription_* event (payment_success/failed/recovered/refunded) is a
+ * Subscription INVOICE object whose `data.id` is the invoice id, so the
+ * subscription must be read from `attributes.subscription_id` instead.
+ * @type {ReadonlySet<string>}
+ */
+const SUBSCRIPTION_OBJECT_EVENTS = new Set([
+  'subscription_created', 'subscription_updated', 'subscription_cancelled',
+  'subscription_resumed', 'subscription_expired', 'subscription_paused', 'subscription_unpaused',
+]);
+
+/**
+ * Timing-safe verification of a Lemon Squeezy webhook signature. Lemon signs
+ * the raw request body with HMAC-SHA256 (hex) using the store webhook secret
+ * and sends it in the `X-Signature` header.
+ *
+ * @param {string|Buffer} rawBody exact bytes received (NOT re-serialized JSON)
+ * @param {string|undefined} signatureHex value of the X-Signature header
+ * @param {string} secret webhook signing secret
+ * @returns {boolean}
+ */
+export function verifyWebhookSignature(rawBody, signatureHex, secret) {
+  if (typeof secret !== 'string' || secret.length === 0) return false;
+  if (typeof signatureHex !== 'string' || !/^[0-9a-f]+$/i.test(signatureHex)) return false;
+  const expected = createHmac('sha256', secret).update(rawBody).digest();
+  let provided;
+  try {
+    provided = Buffer.from(signatureHex, 'hex');
+  } catch {
+    return false;
+  }
+  // Length must match for timingSafeEqual; a mismatch is a clean reject.
+  if (provided.length !== expected.length) return false;
+  return timingSafeEqual(provided, expected);
+}
+
+/**
+ * Map a Lemon event name + subscription/order status to an entitlement status.
+ * Unmappable events return null (ignored, not an error).
+ *
+ * @param {string} eventName e.g. "subscription_created", "subscription_updated"
+ * @param {string} [providerStatus] e.g. "active", "on_trial", "past_due", "cancelled", "expired"
+ * @returns {string|null}
+ */
+export function mapLemonEventToStatus(eventName, providerStatus) {
+  const S = ENTITLEMENT_STATES;
+  // Refund/chargeback/fraud → hard revoke (sticky terminal).
+  if (eventName === 'subscription_payment_refunded' || eventName === 'order_refunded' || eventName === 'license_key_revoked') {
+    return S.REVOKED;
+  }
+  // Subscription lifecycle: trust the carried provider status when present.
+  if (eventName && eventName.startsWith('subscription_')) {
+    switch (providerStatus) {
+      case 'active': return S.ACTIVE;
+      case 'on_trial': case 'trialing': return S.TRIALING;
+      case 'past_due': return S.PAST_DUE;
+      case 'cancelled': case 'canceled': return S.CANCELLED;
+      case 'expired': return S.EXPIRED;
+      case 'unpaid': return S.PAST_DUE;
+      case 'paused': return S.PAST_DUE;
+      default: break;
+    }
+    if (eventName === 'subscription_created' || eventName === 'subscription_resumed' || eventName === 'subscription_payment_success') return S.ACTIVE;
+    if (eventName === 'subscription_cancelled') return S.CANCELLED;
+    if (eventName === 'subscription_expired') return S.EXPIRED;
+    if (eventName === 'subscription_payment_failed') return S.PAST_DUE;
+    return null;
+  }
+  if (eventName === 'order_created' || eventName === 'license_key_created') return S.ACTIVE;
+  if (eventName === 'license_key_updated') {
+    switch (providerStatus) {
+      case 'active': return S.ACTIVE;
+      case 'disabled': case 'inactive': return S.REVOKED;
+      case 'expired': return S.EXPIRED;
+      default: return null;
+    }
+  }
+  return null;
+}
+
+/** Parse a finite ms-epoch from an ISO string or number; null if unusable. */
+function toEpochMs(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const t = Date.parse(value);
+    return Number.isFinite(t) ? t : null;
+  }
+  return null;
+}
+
+/**
+ * Build a G003 entitlement event from a verified, parsed Lemon payload.
+ * Returns null when the payload is unmappable or missing required fields.
+ *
+ * Expected shape (Lemon): { meta: { event_name, custom_data? }, data: { id, attributes: {...} } }
+ * The raw license key must be supplied to derive the mirror id; it is taken
+ * from `meta.custom_data.license_key` or `data.attributes.key`.
+ *
+ * @param {any} payload parsed webhook JSON
+ * @param {(secret:string, raw:string)=>string} hashKey
+ * @param {string} licenseHmacSecret
+ * @returns {{entitlementId:string, event:{id:string,status:string,effectiveAt:number,version?:number,subscriptionId?:string,expiresAt?:number}}|null}
+ */
+export function buildEntitlementEvent(payload, hashKey, licenseHmacSecret) {
+  if (!payload || typeof payload !== 'object') return null;
+  const meta = payload.meta && typeof payload.meta === 'object' ? payload.meta : {};
+  const data = payload.data && typeof payload.data === 'object' ? payload.data : {};
+  const attrs = data.attributes && typeof data.attributes === 'object' ? data.attributes : {};
+
+  const eventName = typeof meta.event_name === 'string' ? meta.event_name : '';
+  const status = mapLemonEventToStatus(eventName, attrs.status);
+  if (!status) return null;
+
+  // The raw license key (carried by license/order events) keys the mirror.
+  const rawLicenseKey = (meta.custom_data && typeof meta.custom_data.license_key === 'string')
+    ? meta.custom_data.license_key
+    : (typeof attrs.key === 'string' ? attrs.key : null);
+  if (!rawLicenseKey || !licenseHmacSecret) return null;
+
+  const eventId = typeof meta.event_id === 'string' && meta.event_id
+    ? meta.event_id
+    : (data.id != null ? `${eventName}:${data.id}:${attrs.updated_at ?? attrs.created_at ?? ''}` : null);
+  if (!eventId) return null;
+
+  const effectiveAt = toEpochMs(attrs.updated_at) ?? toEpochMs(attrs.created_at);
+  if (effectiveAt == null) return null;
+
+  // subscriptionId scoping. Lemon has TWO payload families under subscription_*:
+  //  - Subscription OBJECT events (created/updated/cancelled/resumed/expired/
+  //    paused/unpaused): data.id IS the subscription id.
+  //  - Subscription INVOICE events (payment_success/failed/recovered/refunded):
+  //    data.id is the INVOICE id; the subscription is attributes.subscription_id.
+  // Orders/licenses likewise put their own id in data.id, not the subscription.
+  // So: prefer an explicit attributes.subscription_id; use data.id ONLY for the
+  // subscription-object events; otherwise omit (the event then applies to the
+  // current entitlement, so e.g. a refund revoke lands via the same-sub path).
+  // Using data.id blindly would let an active subscription ignore a refund
+  // (scoped to an invoice id) as "other_subscription".
+  const subscriptionId = attrs.subscription_id != null
+    ? String(attrs.subscription_id)
+    : (SUBSCRIPTION_OBJECT_EVENTS.has(eventName) && data.id != null ? String(data.id) : undefined);
+  const expiresAt = toEpochMs(attrs.renews_at) ?? toEpochMs(attrs.ends_at) ?? undefined;
+
+  /** @type {{id:string,status:string,effectiveAt:number,version?:number,subscriptionId?:string,expiresAt?:number}} */
+  const event = { id: eventId, status, effectiveAt };
+  if (subscriptionId != null) event.subscriptionId = subscriptionId;
+  if (typeof expiresAt === 'number') event.expiresAt = expiresAt;
+
+  return { entitlementId: hashKey(licenseHmacSecret, rawLicenseKey), event };
+}
+
+function parseRecord(value) {
+  if (value == null) return null;
+  if (typeof value === 'object') return value;
+  if (typeof value !== 'string') return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create the webhook processor. Verifies signature, enforces idempotency, maps
+ * the event, and folds it into the entitlement mirror via the G003 state
+ * machine. Fail-closed on a bad signature or storage error.
+ *
+ * @param {{
+ *   kv: {get(key:string):Promise<unknown>, set(key:string, val:string, opts?:{ttlMs?:number}):Promise<void>},
+ *   webhookSecret: string,
+ *   licenseHmacSecret: string,
+ *   hashKey: (secret:string, raw:string)=>string,
+ *   now?: ()=>number,
+ *   logger?: {info?:Function, warn?:Function},
+ * }} deps
+ */
+export function createLemonWebhookProcessor({ kv, webhookSecret, licenseHmacSecret, hashKey, now = () => Date.now(), logger = console }) {
+  return {
+    /**
+     * @param {{rawBody:string|Buffer, signature:string|undefined}} input
+     * @returns {Promise<{ok:true, applied:boolean, reason?:string}|{ok:false, status:number, reason:string}>}
+     */
+    async process({ rawBody, signature }) {
+      // Missing config is a fail-closed 503, never a silent unmapped/no-op that
+      // would hide a misconfiguration and let mirrors go stale.
+      if (!webhookSecret) return { ok: false, status: 503, reason: 'webhook secret unavailable' };
+      if (!licenseHmacSecret) return { ok: false, status: 503, reason: 'entitlement secret unavailable' };
+      if (!verifyWebhookSignature(rawBody, signature, webhookSecret)) {
+        return { ok: false, status: 401, reason: 'invalid signature' };
+      }
+      let payload;
+      try {
+        payload = JSON.parse(typeof rawBody === 'string' ? rawBody : rawBody.toString('utf8'));
+      } catch {
+        return { ok: false, status: 400, reason: 'invalid payload' };
+      }
+
+      const built = buildEntitlementEvent(payload, hashKey, licenseHmacSecret);
+      if (!built) return { ok: true, applied: false, reason: 'unmapped_event' };
+
+      // Idempotency: a re-delivered event id is applied at most once.
+      const idemKey = idempotencyKey(built.event.id);
+      const seen = await kv.get(idemKey);
+      if (seen != null) return { ok: true, applied: false, reason: 'duplicate_event' };
+
+      const current = parseRecord(await kv.get(entitlementKey(built.entitlementId)));
+      const tNow = now();
+      const result = applyEntitlementEvent(current, built.event, tNow);
+
+      // Apply the entitlement change FIRST, then write the idempotency marker
+      // LAST. If the mirror write fails, the marker is not set, so a Lemon retry
+      // re-applies the event (a revoke/cancel can never be permanently skipped
+      // by a partial KV failure).
+      if (result.changed) {
+        await kv.set(entitlementKey(built.entitlementId), JSON.stringify(result.record), { ttlMs: ENTITLEMENT_MIRROR_TTL_MS });
+      }
+      await kv.set(idemKey, '1', { ttlMs: WEBHOOK_IDEMPOTENCY_TTL_MS });
+
+      if (!result.changed) return { ok: true, applied: false, reason: 'reason' in result ? result.reason : 'ignored' };
+
+      // Sanitized log: never the raw license key/email — only the opaque id and
+      // the state transition. Session enforcement is automatic (the next Pro
+      // request re-derives this entitlement and sees the new state).
+      if (shouldInvalidateSessions(result.prevState, deriveEntitlementState(result.record, tNow))) {
+        logger.info?.('lemon.webhook.invalidate', { entitlement: built.entitlementId.slice(0, 12), from: result.prevState, to: result.nextState });
+      }
+      return { ok: true, applied: true, reason: result.nextState };
+    },
+  };
+}

--- a/src/pro-entitlements.js
+++ b/src/pro-entitlements.js
@@ -1,0 +1,250 @@
+// @ts-check
+// Pro entitlement state machine (server-side only).
+//
+// Single source of truth for "is this entitlement allowed to use Pro right
+// now, and how does a newly observed Lemon Squeezy event change the stored
+// record?". PURE: no network/fs/KV/LLM — deterministic functions over plain
+// records and events, plus an HMAC helper for hashing raw license keys into
+// opaque store ids. The webhook layer (G005) maps provider event types onto
+// `status` and verifies authenticity; this module owns ordering, idempotency,
+// out-of-order/stale rejection, terminal-state resurrection prevention,
+// per-subscription scoping, cache TTLs, and session invalidation.
+//
+// Fail-closed everywhere: an unknown/missing/malformed record or event never
+// grants Pro. Only `active` and (policy-allowed) `trialing` are Pro-allowed.
+// Authority ordering is effectiveAt-primary (the provider event time), with an
+// optional explicit numeric `version` used ONLY as a same-time tiebreaker —
+// timestamps are never used as versions and an explicit `version: 0` is a
+// legitimate low tiebreaker, not "missing".
+
+import { createHmac } from 'node:crypto';
+
+/** The closed set of entitlement states. */
+export const ENTITLEMENT_STATES = Object.freeze({
+  NONE: 'none',
+  TRIALING: 'trialing',
+  ACTIVE: 'active',
+  PAST_DUE: 'past_due',
+  CANCELLED: 'cancelled',
+  REVOKED: 'revoked',
+  EXPIRED: 'expired',
+});
+
+/** Pro-granting states (frozen, immutable). `trialing` is allowed by policy. */
+export const PRO_ALLOWED_STATES = Object.freeze([ENTITLEMENT_STATES.ACTIVE, ENTITLEMENT_STATES.TRIALING]);
+/** Terminal states: a record here only leaves via an explicit newer reissue (frozen). */
+export const TERMINAL_STATES = Object.freeze([ENTITLEMENT_STATES.CANCELLED, ENTITLEMENT_STATES.REVOKED, ENTITLEMENT_STATES.EXPIRED]);
+
+/** Positive cache TTL (Pro-allowed states); mirrors the plan's 10-minute floor. */
+export const POSITIVE_ENTITLEMENT_TTL_MS = 10 * 60 * 1000;
+/** Negative cache TTL (not Pro-allowed); short so a new purchase propagates fast. */
+export const NEGATIVE_ENTITLEMENT_TTL_MS = 60 * 1000;
+
+// Private membership sets. Exported constants are frozen arrays so the
+// access policy can never be mutated process-wide (Object.freeze does NOT make
+// a Set's add/delete inert, so we never export the Sets themselves).
+/** @type {ReadonlySet<string>} */
+const STATE_VALUES = new Set(Object.values(ENTITLEMENT_STATES));
+/** @type {ReadonlySet<string>} */
+const PRO_ALLOWED = new Set(PRO_ALLOWED_STATES);
+/** @type {ReadonlySet<string>} */
+const TERMINAL = new Set(TERMINAL_STATES);
+
+/**
+ * Hash a raw license key into an opaque, log-safe store id. The raw key never
+ * becomes a KV key or appears in a URL/log; only this HMAC digest does.
+ *
+ * @param {string} secret server-side HMAC secret
+ * @param {string} rawLicenseKey
+ * @returns {string} hex digest
+ */
+export function hashLicenseKey(secret, rawLicenseKey) {
+  if (typeof secret !== 'string' || secret.length === 0) throw new Error('entitlement hash secret unavailable');
+  if (typeof rawLicenseKey !== 'string' || rawLicenseKey.length === 0) throw new Error('license key required');
+  return createHmac('sha256', secret).update(rawLicenseKey).digest('hex');
+}
+
+/**
+ * @typedef {Object} EntitlementRecord
+ * @property {string} status one of ENTITLEMENT_STATES
+ * @property {number} effectiveAt provider event effective time (ms epoch)
+ * @property {number} version same-time tiebreaker (0 when none was supplied)
+ * @property {string} [lastEventId] last applied provider event id (idempotency)
+ * @property {string} [subscriptionId] provider subscription/license identity
+ * @property {number} [expiresAt] hard expiry (ms epoch); missing/non-finite/past = not allowed
+ */
+
+/**
+ * @typedef {Object} EntitlementEvent
+ * @property {string} id provider event id (idempotency key)
+ * @property {string} status mapped target status (one of ENTITLEMENT_STATES)
+ * @property {number} effectiveAt provider effective time (ms epoch)
+ * @property {number} [version] same-time tiebreaker; finite number when present
+ * @property {string} [subscriptionId] subscription/license identity (non-empty string)
+ * @property {number} [expiresAt] hard expiry to store (finite number when present)
+ */
+
+/** A finite-number guard used for every numeric field that affects access. */
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+/**
+ * Derive the effective state of a stored record at time `now`. A Pro-allowed
+ * record whose `expiresAt` is present but NOT a finite future timestamp
+ * (NaN/Infinity/string/past) is reported `expired` — malformed expiry denies
+ * Pro fail-closed. Missing record → `none`.
+ *
+ * @param {EntitlementRecord|null|undefined} record
+ * @param {number} [now]
+ * @returns {string} one of ENTITLEMENT_STATES
+ */
+export function deriveEntitlementState(record, now = Date.now()) {
+  if (!record || typeof record !== 'object') return ENTITLEMENT_STATES.NONE;
+  const status = STATE_VALUES.has(record.status) ? record.status : ENTITLEMENT_STATES.NONE;
+  if (PRO_ALLOWED.has(status) && record.expiresAt != null) {
+    // A present expiry MUST be a finite future timestamp; anything else denies Pro.
+    if (!isFiniteNumber(record.expiresAt) || record.expiresAt <= now) return ENTITLEMENT_STATES.EXPIRED;
+  }
+  return status;
+}
+
+/**
+ * Whether a record grants Pro right now. Fail-closed: only `active`/`trialing`
+ * (and not past/at a hard expiry, and not malformed) qualify.
+ *
+ * @param {EntitlementRecord|null|undefined} record
+ * @param {number} [now]
+ * @returns {boolean}
+ */
+export function isProAllowed(record, now = Date.now()) {
+  return PRO_ALLOWED.has(deriveEntitlementState(record, now));
+}
+
+/**
+ * Cache TTL for a derived state: Pro-allowed → 10m positive; else → 60s negative.
+ *
+ * @param {string} state
+ * @returns {number} ttl in ms
+ */
+export function cacheTtlForState(state) {
+  return PRO_ALLOWED.has(state) ? POSITIVE_ENTITLEMENT_TTL_MS : NEGATIVE_ENTITLEMENT_TTL_MS;
+}
+
+/**
+ * Whether a transition must invalidate cached positive entitlement and active
+ * Pro session tokens. Leaving a Pro-allowed state, or entering any terminal
+ * state, invalidates (defensive: revoke after cancel still invalidates).
+ *
+ * @param {string} prevState
+ * @param {string} nextState
+ * @returns {boolean}
+ */
+export function shouldInvalidateSessions(prevState, nextState) {
+  const wasAllowed = PRO_ALLOWED.has(prevState);
+  const isAllowed = PRO_ALLOWED.has(nextState);
+  return (wasAllowed && !isAllowed) || (!isAllowed && TERMINAL.has(nextState) && prevState !== nextState);
+}
+
+/** Effective tiebreaker version for ordering: explicit finite number, else 0. */
+function versionOf(obj) {
+  return isFiniteNumber(obj.version) ? obj.version : 0;
+}
+
+/**
+ * Strict "event is newer than the stored record" by (effectiveAt, version).
+ * effectiveAt is primary; version is only a same-time tiebreaker. Timestamps
+ * are never treated as versions.
+ */
+function isStrictlyNewer(event, record) {
+  if (event.effectiveAt !== record.effectiveAt) return event.effectiveAt > record.effectiveAt;
+  return versionOf(event) > versionOf(record);
+}
+
+function ignored(reason) {
+  return { changed: /** @type {const} */ (false), ignored: /** @type {const} */ (true), reason };
+}
+
+/**
+ * Apply a provider event to the current entitlement record, enforcing field
+ * validation, idempotency, ordering, per-subscription scoping, revoke
+ * stickiness, and terminal-resurrection prevention. Pure: returns a new record,
+ * never mutates inputs. `now` is used only for time-aware terminal detection
+ * (a time-expired Pro record is treated as terminal for resurrection rules).
+ *
+ * @param {EntitlementRecord|null|undefined} current
+ * @param {EntitlementEvent} event
+ * @param {number} [now]
+ * @returns {{changed:true, record:EntitlementRecord, prevState:string, nextState:string}|{changed:false, ignored:true, reason:string}}
+ */
+export function applyEntitlementEvent(current, event, now = Date.now()) {
+  // --- event field validation (malformed → ignored fail-closed) ---
+  if (!event || typeof event !== 'object') return ignored('invalid_event');
+  if (typeof event.id !== 'string' || event.id.length === 0) return ignored('invalid_event');
+  if (!STATE_VALUES.has(event.status)) return ignored('invalid_event');
+  if (!isFiniteNumber(event.effectiveAt)) return ignored('invalid_event');
+  if (event.version != null && !isFiniteNumber(event.version)) return ignored('invalid_event');
+  if (event.expiresAt != null && !isFiniteNumber(event.expiresAt)) return ignored('invalid_event');
+  if (event.subscriptionId != null && (typeof event.subscriptionId !== 'string' || event.subscriptionId.length === 0)) return ignored('invalid_event');
+
+  const cur = current && typeof current === 'object' ? current : null;
+  const prevStored = cur && STATE_VALUES.has(cur.status) ? cur.status : ENTITLEMENT_STATES.NONE;
+
+  // Idempotency: a re-delivered event id is a no-op.
+  if (cur && cur.lastEventId && cur.lastEventId === event.id) return ignored('duplicate_event');
+
+  // A `none` event never creates a record.
+  if (event.status === ENTITLEMENT_STATES.NONE) return ignored('noop_none');
+
+  if (cur) {
+    const newer = isStrictlyNewer(event, cur);
+    const curSub = typeof cur.subscriptionId === 'string' ? cur.subscriptionId : null;
+    const evSub = typeof event.subscriptionId === 'string' ? event.subscriptionId : null;
+
+    if (curSub != null && evSub != null && evSub !== curSub) {
+      // The event concerns a DIFFERENT subscription than the stored one. Only a
+      // strictly-newer Pro-allowed reissue replaces the record; anything else
+      // (e.g. a stale/replayed revoke for an old subscription) is ignored, so
+      // it can never revoke or disturb the current subscription's access.
+      if (PRO_ALLOWED.has(event.status) && newer) {
+        // reissue → fall through to build the new record
+      } else {
+        return ignored('other_subscription');
+      }
+    } else {
+      // Same subscription (or one side unspecified).
+      const revokeOverride = event.status === ENTITLEMENT_STATES.REVOKED && prevStored !== ENTITLEMENT_STATES.REVOKED;
+      if (!newer && !revokeOverride) return ignored('stale_event');
+
+      // Revoked is sticky: a same-subscription event can never un-revoke.
+      if (prevStored === ENTITLEMENT_STATES.REVOKED) return ignored('revoked_sticky');
+
+      // Resurrection prevention (time-aware): a terminal record — including a
+      // time-expired Pro record — only returns to Pro via either a different
+      // subscription reissue (handled above) or a genuine renewal that carries
+      // a finite FUTURE expiry. A bare same-subscription "active" with no new
+      // period cannot resurrect access.
+      const prevDerived = deriveEntitlementState(cur, now);
+      if (TERMINAL.has(prevDerived) && PRO_ALLOWED.has(event.status)) {
+        const renewal = isFiniteNumber(event.expiresAt) && event.expiresAt > now && newer;
+        if (!renewal) return ignored('no_resurrection');
+      }
+    }
+  }
+
+  /** @type {EntitlementRecord} */
+  const record = {
+    status: event.status,
+    effectiveAt: event.effectiveAt,
+    version: versionOf(event),
+    lastEventId: event.id,
+    ...(event.subscriptionId != null
+      ? { subscriptionId: event.subscriptionId }
+      : (cur && cur.subscriptionId != null ? { subscriptionId: cur.subscriptionId } : {})),
+    // expiresAt is taken ONLY from the event (never inherited): the event is the
+    // authority on the current period. Absent = no hard expiry stated.
+    ...(isFiniteNumber(event.expiresAt) ? { expiresAt: event.expiresAt } : {}),
+  };
+
+  return { changed: true, record, prevState: prevStored, nextState: event.status };
+}

--- a/src/pro-legal-copy.js
+++ b/src/pro-legal-copy.js
@@ -1,0 +1,34 @@
+// @ts-check
+// Single source of truth for the Korean Pro billing legal copy.
+//
+// The SAME strings must appear at three touchpoints — the pre-purchase
+// checkout screen, the receipt/email, and the license guide — so a buyer sees
+// one consistent cancellation/refund policy everywhere (a G005/closure-panel
+// requirement). Reflects Korean e-commerce expectations: a 7-day withdrawal
+// window with the digital-service limitation, and that Lemon Squeezy is the
+// Merchant of Record that actually processes payment/refunds.
+
+/** Conditional refund window (days) surfaced in the ko copy. */
+export const PRO_REFUND_WINDOW_DAYS = 7;
+
+/** Individual ko legal lines (stable keys for UI binding). */
+export const PRO_LEGAL_COPY_KO = Object.freeze({
+  cancelAnytime: '구독은 언제든 해지할 수 있으며, 해지하면 다음 결제부터 청구되지 않습니다.',
+  refundWindow: `결제 후 ${PRO_REFUND_WINDOW_DAYS}일 이내에는 고객지원을 통해 환불을 요청할 수 있습니다.`,
+  digitalLimit: '다만 디지털 서비스 특성상 Pro 기능을 상당히 사용한 경우, 전자상거래법상 청약철회가 제한될 수 있습니다.',
+  merchantOfRecord: '결제·영수증·환불은 판매대행사(Merchant of Record)인 Lemon Squeezy가 처리합니다.',
+  support: '환불·결제 문의는 고객지원으로, 구독 해지·결제수단 변경은 Lemon Squeezy 고객 포털에서 할 수 있습니다.',
+});
+
+/**
+ * The exact ordered policy block, rendered IDENTICALLY at checkout, in the
+ * receipt/email, and in the license guide. Bind this single value everywhere;
+ * never hand-write the policy at a touchpoint.
+ */
+export const PRO_LEGAL_COPY_BLOCK_KO = [
+  PRO_LEGAL_COPY_KO.cancelAnytime,
+  PRO_LEGAL_COPY_KO.refundWindow,
+  PRO_LEGAL_COPY_KO.digitalLimit,
+  PRO_LEGAL_COPY_KO.merchantOfRecord,
+  PRO_LEGAL_COPY_KO.support,
+].join('\n');

--- a/src/pro-metering.js
+++ b/src/pro-metering.js
@@ -1,0 +1,85 @@
+// @ts-check
+// Pro usage metering (server-side only).
+//
+// Bounds Pro cost/abuse with per-entitlement day/hour/minute request caps over
+// the shared KV store contract (G002). A "month" subscription is sold as
+// fair-use, NOT literally unlimited: these caps make a shared/scripted key
+// unable to run LLM spend far past revenue. Fail-closed: a malformed counter or
+// a storage failure denies the request rather than failing open on an abuse
+// boundary (mirrors src/rate-limit.js). Keys are opaque (the entitlement id is
+// already an HMAC hash); no raw key/email is ever a metering key.
+
+const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
+const MINUTE_MS = 60_000;
+
+/** Per-entitlement Pro caps (the plan's recommended values). */
+export const PRO_LIMITS = Object.freeze({ reqPerDay: 100, reqPerHour: 20, reqPerMinute: 6, maxChars: 12000 });
+
+/**
+ * Cost-alert thresholds (USD). The metering layer emits a sanitized alert event
+ * when an entitlement's estimated spend crosses a warning/throttle line, and a
+ * global operator alert for total daily/monthly spend. These are advisory
+ * signals for observability; the hard request caps above are the enforcement.
+ */
+export const COST_ALERT = Object.freeze({
+  keyDayWarnUsd: 2, keyMonthWarnUsd: 15,
+  keyDayThrottleUsd: 3, keyMonthThrottleUsd: 25,
+  globalDayUsd: 25, globalMonthUsd: 300,
+});
+
+/** @param {string} id opaque entitlement id @param {string} window @param {number} bucket */
+function meterKey(id, window, bucket) {
+  return `prometer:${window}:${id}:${bucket}`;
+}
+
+/**
+ * Create the Pro metering checker.
+ *
+ * @param {{
+ *   kv: {incr(key:string, opts?:{ttlMs?:number}):Promise<number>},
+ *   now?: () => number,
+ *   limits?: typeof PRO_LIMITS,
+ * }} deps
+ */
+export function createProMetering({ kv, now = () => Date.now(), limits = PRO_LIMITS }) {
+  return {
+    /**
+     * Count one Pro request against the day/hour/minute caps. Fail-closed.
+     *
+     * @param {{entitlementId:string}} input
+     * @returns {Promise<{allowed:true, remainingDay:number}|{allowed:false, status:number, reason:string}>}
+     */
+    async check({ entitlementId }) {
+      if (typeof entitlementId !== 'string' || entitlementId.length === 0) {
+        return { allowed: false, status: 403, reason: 'no entitlement' };
+      }
+      if (!kv || typeof kv.incr !== 'function') {
+        return { allowed: false, status: 503, reason: 'metering storage unavailable' };
+      }
+
+      const t = now();
+      const dayBucket = Math.floor(t / DAY_MS);
+      const hourBucket = Math.floor(t / HOUR_MS);
+      const minuteBucket = Math.floor(t / MINUTE_MS);
+
+      try {
+        const dayCount = await kv.incr(meterKey(entitlementId, 'd', dayBucket), { ttlMs: (dayBucket + 1) * DAY_MS - t });
+        if (!Number.isSafeInteger(dayCount) || dayCount < 1) return { allowed: false, status: 503, reason: 'metering storage unavailable' };
+        if (dayCount > limits.reqPerDay) return { allowed: false, status: 429, reason: 'daily cap exceeded' };
+
+        const hourCount = await kv.incr(meterKey(entitlementId, 'h', hourBucket), { ttlMs: (hourBucket + 1) * HOUR_MS - t });
+        if (!Number.isSafeInteger(hourCount) || hourCount < 1) return { allowed: false, status: 503, reason: 'metering storage unavailable' };
+        if (hourCount > limits.reqPerHour) return { allowed: false, status: 429, reason: 'hourly cap exceeded' };
+
+        const minuteCount = await kv.incr(meterKey(entitlementId, 'm', minuteBucket), { ttlMs: (minuteBucket + 1) * MINUTE_MS - t });
+        if (!Number.isSafeInteger(minuteCount) || minuteCount < 1) return { allowed: false, status: 503, reason: 'metering storage unavailable' };
+        if (minuteCount > limits.reqPerMinute) return { allowed: false, status: 429, reason: 'rate too high' };
+
+        return { allowed: true, remainingDay: Math.max(0, limits.reqPerDay - dayCount) };
+      } catch {
+        return { allowed: false, status: 503, reason: 'metering storage unavailable' };
+      }
+    },
+  };
+}

--- a/src/pro-session.js
+++ b/src/pro-session.js
@@ -1,0 +1,207 @@
+// @ts-check
+// Pro session token exchange (server-side only).
+//
+// A raw Lemon Squeezy license key is presented ONCE, at the exchange endpoint,
+// over a POST body. It is hashed (HMAC) into an opaque entitlement id, checked
+// against the durable entitlement mirror (written by the G005 webhook) — or a
+// provider verify fallback — and, only if the entitlement is Pro-allowed
+// (G003), exchanged for an opaque, short-lived Pro session token. The rewrite
+// path (G006) then sends that token, never the raw key, on every request
+// (G001 contract). Only the token's HMAC hash is stored; the raw token, raw
+// license key, and email never enter a store key, URL, log, or returned object.
+//
+// Fail-closed: any missing/expired/revoked/not-allowed condition denies a
+// session and never downgrades to free/BYOK silently.
+
+import { createHmac, randomBytes } from 'node:crypto';
+import { isProAllowed, deriveEntitlementState } from './pro-entitlements.js';
+
+/** Sliding session lifetime: a token is good for 30 minutes since (re)issue. */
+export const PRO_SESSION_TTL_MS = 30 * 60 * 1000;
+/** Absolute cap: a token can never live beyond 2 hours from first issue. */
+export const PRO_SESSION_ABSOLUTE_TTL_MS = 2 * 60 * 60 * 1000;
+
+/**
+ * Max accepted raw license key length (chars). A real Lemon license key is
+ * short; a longer value is rejected at the security boundary so an oversized
+ * key (from any body shape, incl. a pre-parsed object that bypassed a transport
+ * byte cap) can never reach HMAC/KV/provider verification.
+ */
+export const MAX_LICENSE_KEY_CHARS = 512;
+
+/** KV key namespaces (opaque hashes only — never raw key/email/token). */
+export const ENTITLEMENT_KEY_PREFIX = 'ent:';
+export const SESSION_KEY_PREFIX = 'sess:';
+
+/** @param {string} entitlementId opaque HMAC id */
+export function entitlementKey(entitlementId) {
+  return `${ENTITLEMENT_KEY_PREFIX}${entitlementId}`;
+}
+/** @param {string} tokenHash opaque HMAC of the session token */
+export function sessionKey(tokenHash) {
+  return `${SESSION_KEY_PREFIX}${tokenHash}`;
+}
+
+/**
+ * Generate an opaque 256-bit Pro session token (hex). Returned to the client
+ * exactly once; only its hash is persisted.
+ *
+ * @param {(n:number)=>Buffer} [randomImpl]
+ * @returns {string}
+ */
+export function generateProSessionToken(randomImpl = randomBytes) {
+  return randomImpl(32).toString('hex');
+}
+
+/**
+ * HMAC-hash a session token for storage/lookup. The raw token is never stored.
+ *
+ * @param {string} secret
+ * @param {string} token
+ * @returns {string} hex digest
+ */
+export function hashSessionToken(secret, token) {
+  if (typeof secret !== 'string' || secret.length === 0) throw new Error('session hmac secret unavailable');
+  if (typeof token !== 'string' || token.length === 0) throw new Error('session token required');
+  return createHmac('sha256', secret).update(token).digest('hex');
+}
+
+/**
+ * @typedef {Object} ProSessionRecord
+ * @property {string} entitlementId opaque HMAC id this session is bound to
+ * @property {number} issuedAt ms epoch
+ * @property {number} expiresAt sliding expiry (ms epoch)
+ * @property {number} absoluteExpiresAt hard cap (ms epoch)
+ */
+
+/**
+ * Build a session record for an allowed entitlement. Fail-closed: a non-allowed
+ * entitlement yields no session.
+ *
+ * @param {{entitlement:object|null, entitlementId:string, now?:number}} input
+ * @returns {{ok:true, record:ProSessionRecord}|{ok:false, reason:string}}
+ */
+export function issueProSession({ entitlement, entitlementId, now = Date.now() }) {
+  if (typeof entitlementId !== 'string' || entitlementId.length === 0) return { ok: false, reason: 'no_entitlement_id' };
+  if (!isProAllowed(entitlement, now)) return { ok: false, reason: 'not_allowed' };
+  return {
+    ok: true,
+    record: {
+      entitlementId,
+      issuedAt: now,
+      expiresAt: now + PRO_SESSION_TTL_MS,
+      absoluteExpiresAt: now + PRO_SESSION_ABSOLUTE_TTL_MS,
+    },
+  };
+}
+
+/**
+ * Verify a stored session record against the current entitlement. Fail-closed
+ * on a missing/malformed record, a passed sliding or absolute expiry, or an
+ * entitlement that is no longer Pro-allowed (cancelled/revoked/expired).
+ *
+ * @param {{sessionRecord:ProSessionRecord|null|undefined, entitlement:object|null, now?:number}} input
+ * @returns {{ok:boolean, reason?:string}}
+ */
+export function verifyProSession({ sessionRecord, entitlement, now = Date.now() }) {
+  if (!sessionRecord || typeof sessionRecord !== 'object') return { ok: false, reason: 'no_session' };
+  const { expiresAt, absoluteExpiresAt } = sessionRecord;
+  if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt) || expiresAt <= now) return { ok: false, reason: 'expired' };
+  if (typeof absoluteExpiresAt !== 'number' || !Number.isFinite(absoluteExpiresAt) || absoluteExpiresAt <= now) return { ok: false, reason: 'absolute_expired' };
+  if (!isProAllowed(entitlement, now)) return { ok: false, reason: 'entitlement_revoked' };
+  return { ok: true };
+}
+
+/**
+ * Slide a session's expiry forward (bounded by the absolute cap) — only while
+ * the session is still valid and the entitlement is still allowed.
+ *
+ * @param {{sessionRecord:ProSessionRecord, entitlement:object|null, now?:number}} input
+ * @returns {{ok:true, record:ProSessionRecord}|{ok:false, reason?:string}}
+ */
+export function refreshProSession({ sessionRecord, entitlement, now = Date.now() }) {
+  const v = verifyProSession({ sessionRecord, entitlement, now });
+  if (!v.ok) return { ok: false, reason: v.reason };
+  const expiresAt = Math.min(now + PRO_SESSION_TTL_MS, sessionRecord.absoluteExpiresAt);
+  return { ok: true, record: { ...sessionRecord, expiresAt } };
+}
+
+/** Parse a JSON string store value into an object, or null on any failure. */
+function parseRecord(value) {
+  if (value == null) return null;
+  if (typeof value === 'object') return value; // memory KV may return the object
+  if (typeof value !== 'string') return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create the license -> opaque session token exchange. Dependencies are
+ * injected so it is unit-testable with a mock KV and a mock provider verifier.
+ *
+ * @param {{
+ *   kv: {get(key:string):Promise<unknown>, set(key:string, val:string, opts?:{ttlMs?:number}):Promise<void>},
+ *   hmacSecret: string,
+ *   verifyLicense?: (rawLicenseKey:string)=>Promise<object|null>,
+ *   hashKey: (secret:string, raw:string)=>string,
+ *   now?: ()=>number,
+ *   randomImpl?: (n:number)=>Buffer,
+ * }} deps
+ */
+export function createProSessionExchange({ kv, hmacSecret, verifyLicense, hashKey, now = () => Date.now(), randomImpl = randomBytes }) {
+  return {
+    /**
+     * Exchange a raw license key for an opaque Pro session token.
+     * Returns a masked result; never echoes the raw key/email/token in errors.
+     *
+     * @param {{licenseKey?:unknown}} body
+     * @returns {Promise<{ok:true, proSessionToken:string, expiresAt:number, status:string}|{ok:false, status:number, reason:string}>}
+     */
+    async exchange(body) {
+      if (!hmacSecret) return { ok: false, status: 503, reason: 'pro session secret unavailable' };
+      // Read ONLY an own `licenseKey` property: an inherited/prototype-polluted
+      // value (e.g. Object.create({ licenseKey })) must not smuggle a key.
+      const rawLicenseKey = (body && typeof body === 'object' && Object.hasOwn(body, 'licenseKey'))
+        ? /** @type {any} */ (body).licenseKey
+        : undefined;
+      if (typeof rawLicenseKey !== 'string' || rawLicenseKey.trim().length === 0) {
+        return { ok: false, status: 400, reason: 'licenseKey required' };
+      }
+      if (rawLicenseKey.length > MAX_LICENSE_KEY_CHARS) {
+        return { ok: false, status: 400, reason: 'licenseKey too long' };
+      }
+
+      const entitlementId = hashKey(hmacSecret, rawLicenseKey);
+      const tNow = now();
+
+      // Prefer the durable entitlement mirror; fall back to a provider verify.
+      let entitlement = parseRecord(await kv.get(entitlementKey(entitlementId)));
+      if (!entitlement && typeof verifyLicense === 'function') {
+        entitlement = parseRecord(await verifyLicense(rawLicenseKey));
+      }
+
+      if (!isProAllowed(entitlement, tNow)) {
+        // 402 Payment Required: the key is not (or no longer) a paying entitlement.
+        return { ok: false, status: 402, reason: 'entitlement not active' };
+      }
+
+      const issued = issueProSession({ entitlement, entitlementId, now: tNow });
+      if (!issued.ok) return { ok: false, status: 402, reason: 'entitlement not active' };
+
+      const token = generateProSessionToken(randomImpl);
+      const tokenHash = hashSessionToken(hmacSecret, token);
+      await kv.set(sessionKey(tokenHash), JSON.stringify(issued.record), { ttlMs: PRO_SESSION_ABSOLUTE_TTL_MS });
+
+      return {
+        ok: true,
+        proSessionToken: token, // returned to the client exactly once
+        expiresAt: issued.record.expiresAt,
+        status: deriveEntitlementState(entitlement, tNow),
+      };
+    },
+  };
+}

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -110,7 +110,10 @@ export function isProductionPosture(env = {}) {
 export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.now(), limits = TIER_LIMITS }) {
   return {
     async check({ tier, ip }) {
-      if (tier === WEB_TIERS.BYOK) return { allowed: true, tier };
+      // BYOK uses the caller's own provider quota; Pro is bounded separately by
+      // src/pro-metering.js (per-entitlement caps), so both bypass the free
+      // shared-proxy IP quota here.
+      if (tier === WEB_TIERS.BYOK || tier === WEB_TIERS.PRO) return { allowed: true, tier };
 
       const production = isProductionPosture(env);
       if (production && (!kv || kv.__memory)) return { allowed: false, status: 503, reason: 'quota storage unavailable' };

--- a/src/web-rewrite-contract.js
+++ b/src/web-rewrite-contract.js
@@ -15,8 +15,8 @@
 /** Languages the rewrite pipeline supports. */
 export const SUPPORTED_LANGS = Object.freeze(['ko', 'en', 'zh', 'ja']);
 
-/** Service tiers. `free` is the abuse-bounded shared proxy; `byok` uses the user's own key. */
-export const WEB_TIERS = Object.freeze({ FREE: 'free', BYOK: 'byok' });
+/** Service tiers. `free` is the abuse-bounded shared proxy; `byok` uses the user's own key; `pro` is the hosted paid tier, gated by PATINA_PRO_ENABLED (disabled by default). */
+export const WEB_TIERS = Object.freeze({ FREE: 'free', BYOK: 'byok', PRO: 'pro' });
 
 /** Turn kinds. `first` is the one-shot rewrite; `refine` is a conversational follow-up. */
 export const REWRITE_MODES = Object.freeze({ FIRST: 'first', REFINE: 'refine' });
@@ -37,13 +37,36 @@ export const FIDELITY_FLOOR = 70;
 export const TIER_LIMITS = Object.freeze({
   free: Object.freeze({ maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 2 }),
   byok: Object.freeze({ maxChars: 20000, maxConcurrent: 2 }),
+  pro: Object.freeze({ maxChars: 12000, maxConcurrent: 2, reqPerDay: 100, burstPerHour: 20, requestsPerMinute: 6 }),
 });
+
+/**
+ * Whether the hosted Pro tier is enabled in this environment. Pro is DISABLED
+ * BY DEFAULT: only an explicit `PATINA_PRO_ENABLED === 'true'` opens the gate.
+ * Every Pro entitlement/routing/metering path is closed together behind this
+ * single flag, so a partially-wired Pro tier can never alter the free/BYOK
+ * request path. checkout/payment-open is a SEPARATE flag, not implied by this.
+ *
+ * @param {Record<string,string|undefined>} [env]
+ * @returns {boolean}
+ */
+export function isProEnabled(env = {}) {
+  return env.PATINA_PRO_ENABLED === 'true';
+}
 
 /**
  * Conversation context caps. The client holds the thread (no-store server); the
  * server re-caps every request to `maxTurns` recent turns and `maxBytes` total.
  */
 export const CONTEXT_LIMITS = Object.freeze({ maxTurns: 6, maxBytes: 12 * 1024 });
+
+/**
+ * Max length of an opaque Pro session token. Tokens are server-issued opaque
+ * random identifiers, so a legitimate token is short; a longer value is
+ * rejected to bound the abuse/DoS surface (a Pro request must not carry a
+ * giant blob in the token field).
+ */
+export const MAX_PRO_SESSION_TOKEN_CHARS = 512;
 
 /**
  * Stream frame protocol. The handler streams newline-delimited JSON ("NDJSON")
@@ -99,7 +122,7 @@ export const PROVIDER_PRESETS = Object.freeze({
  * the safe failure for a key-handling boundary.
  */
 const SECRET_KEY_MARKERS = Object.freeze([
-  'apikey', 'token', 'secret', 'password', 'passwd', 'credential', 'authorization', 'bearer',
+  'apikey', 'token', 'secret', 'password', 'passwd', 'credential', 'authorization', 'bearer', 'license', 'signature',
 ]);
 function isSecretKey(key) {
   const norm = String(key).toLowerCase().replace(/[_-]/g, '');
@@ -177,6 +200,21 @@ export function resolveProviderModel({ tier, provider, model } = {}, env = {}) {
     if (!preset.models.includes(model)) return { ok: false, error: 'model not allowlisted' };
     return { ok: true, tier, provider, model, baseURL: preset.baseURL };
   }
+  if (tier === WEB_TIERS.PRO) {
+    // Pro is gated: when disabled, Pro never resolves a route (fail-closed).
+    if (!isProEnabled(env)) return { ok: false, error: 'pro tier unavailable' };
+    // Pro provider/model/baseURL come ONLY from server env (the enhanced
+    // route), never from the request body. Callers cannot choose them.
+    const p = env.PATINA_PRO_PROVIDER;
+    const preset = presetFor(p);
+    if (!preset) return { ok: false, error: 'pro provider not configured' };
+    // PATINA_PRO_MODEL must be set explicitly: no preset fallback, so a
+    // provider-only (model-missing) misconfiguration fails closed instead of
+    // silently routing to an arbitrary preset model.
+    const m = env.PATINA_PRO_MODEL;
+    if (!m || !preset.models.includes(m)) return { ok: false, error: 'pro model not configured' };
+    return { ok: true, tier, provider: p, model: m, baseURL: preset.baseURL };
+  }
   return { ok: false, error: 'unknown tier' };
 }
 
@@ -230,8 +268,13 @@ export function validateRewriteRequest(body, env = {}) {
   if (!SUPPORTED_LANGS.includes(lang)) {
     return { ok: false, status: 400, error: `lang must be one of ${SUPPORTED_LANGS.join(', ')}` };
   }
-  if (tier !== WEB_TIERS.FREE && tier !== WEB_TIERS.BYOK) {
-    return { ok: false, status: 400, error: 'tier must be "free" or "byok"' };
+  if (tier !== WEB_TIERS.FREE && tier !== WEB_TIERS.BYOK && tier !== WEB_TIERS.PRO) {
+    return { ok: false, status: 400, error: 'tier must be "free", "byok", or "pro"' };
+  }
+  if (tier === WEB_TIERS.PRO && !isProEnabled(env)) {
+    // Pro disabled by default: reject explicitly (fail-closed), never silently
+    // downgrade to free/BYOK. The free/BYOK validation below is unchanged.
+    return { ok: false, status: 403, error: 'pro tier unavailable' };
   }
   if (typeof text !== 'string' || text.trim().length === 0) {
     return { ok: false, status: 400, error: 'text must be a non-empty string' };
@@ -253,6 +296,26 @@ export function validateRewriteRequest(body, env = {}) {
     }
   }
 
+  // Pro requests carry an opaque short-lived session token, never the raw Lemon
+  // license key (that is exchanged once at the session endpoint). Pro also
+  // cannot choose provider/model/apiKey — the server picks the enhanced route.
+  let proSessionToken;
+  if (tier === WEB_TIERS.PRO) {
+    if (/** @type {any} */ (body).licenseKey != null) {
+      return { ok: false, status: 400, error: 'rewrite requests must use proSessionToken, not a raw licenseKey' };
+    }
+    if (/** @type {any} */ (body).provider != null || /** @type {any} */ (body).model != null) {
+      return { ok: false, status: 400, error: 'pro tier must not include provider/model' };
+    }
+    proSessionToken = /** @type {any} */ (body).proSessionToken;
+    if (typeof proSessionToken !== 'string' || proSessionToken.trim().length === 0) {
+      return { ok: false, status: 400, error: 'pro tier requires a proSessionToken' };
+    }
+    if (proSessionToken.length > MAX_PRO_SESSION_TOKEN_CHARS) {
+      return { ok: false, status: 400, error: 'proSessionToken is too long' };
+    }
+  }
+
   const provider = /** @type {any} */ (body).provider;
   const model = /** @type {any} */ (body).model;
   const resolved = resolveProviderModel({ tier, provider, model }, env);
@@ -264,8 +327,8 @@ export function validateRewriteRequest(body, env = {}) {
       return { ok: false, status: 400, error: 'byok tier requires an apiKey' };
     }
   } else if (apiKey != null) {
-    // Free tier must never carry a caller key; reject rather than silently drop.
-    return { ok: false, status: 400, error: 'free tier must not include an apiKey' };
+    // Only BYOK carries a caller key; free/pro must not. Reject, don't drop.
+    return { ok: false, status: 400, error: `${tier} tier must not include an apiKey` };
   }
 
   const normHistory = normalizeHistory(history);
@@ -284,6 +347,7 @@ export function validateRewriteRequest(body, env = {}) {
       model: resolved.model,
       baseURL: resolved.baseURL,
       apiKey: tier === WEB_TIERS.BYOK ? apiKey : undefined,
+      proSessionToken: tier === WEB_TIERS.PRO ? proSessionToken : undefined,
     },
   };
 }

--- a/tests/unit/enhanced-rewrite-engine.test.js
+++ b/tests/unit/enhanced-rewrite-engine.test.js
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createStubEnhancedEngine,
+  runEnhancedEngineContract,
+  assertValidEnhancedRequest,
+  EnhancedEngineError,
+} from '../../src/enhanced-rewrite-engine-contract.js';
+import { MPS_FLOOR, FIDELITY_FLOOR } from '../../src/web-rewrite-contract.js';
+
+test('the public stub engine passes the shared EnhancedRewriteEngine contract', async () => {
+  await runEnhancedEngineContract(() => createStubEnhancedEngine(), assert);
+});
+
+test('the stub echoes input at floor scores (plumbing only, makes no quality claim)', async () => {
+  const engine = createStubEnhancedEngine();
+  const r = await engine.rewrite({ text: '안녕하세요', lang: 'ko', mode: 'first' });
+  assert.equal(r.text, '안녕하세요');
+  assert.equal(r.scores.mps, MPS_FLOOR);
+  assert.equal(r.scores.fidelity, FIDELITY_FLOOR);
+  assert.equal(r.engine, 'stub');
+});
+
+test('assertValidEnhancedRequest throws typed EnhancedEngineError on bad input', () => {
+  assert.throws(() => assertValidEnhancedRequest(null), EnhancedEngineError);
+  assert.throws(() => assertValidEnhancedRequest({ text: '', lang: 'ko', mode: 'first' }), /text required/);
+  assert.throws(() => assertValidEnhancedRequest({ text: 'x', lang: 'de', mode: 'first' }), /unsupported lang/);
+  assert.throws(() => assertValidEnhancedRequest({ text: 'x', lang: 'ko', mode: 'nope' }), /first\|refine/);
+});
+
+test('the stub output carries no private-asset marker', async () => {
+  const r = await createStubEnhancedEngine().rewrite({ text: 'hello', lang: 'en', mode: 'first' });
+  const dump = JSON.stringify(r);
+  for (const m of ['.private.', '.enhanced.', '.reinforced.', 'corpus/']) assert.ok(!dump.includes(m));
+});

--- a/tests/unit/kv-store-contract.redteam.test.js
+++ b/tests/unit/kv-store-contract.redteam.test.js
@@ -1,0 +1,240 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createMemoryKv, createRateLimiter } from '../../src/rate-limit.js';
+import { WEB_TIERS } from '../../src/web-rewrite-contract.js';
+import { createRestKv } from '../../api/rewrite.js';
+
+function makeRestKvMock({ failures = new Map(), incrResults = [] } = {}) {
+  const store = new Map();
+  const calls = [];
+  let clock = 1_000_000;
+  const origFetch = globalThis.fetch;
+
+  const live = (key) => {
+    const entry = store.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= clock) {
+      store.delete(key);
+      return undefined;
+    }
+    return entry;
+  };
+
+  globalThis.fetch = async (url, init = {}) => {
+    const href = String(url);
+    const u = new URL(href);
+    const segs = u.pathname.split('/').filter(Boolean);
+    const op = segs[0];
+    const rawKeySegment = segs[1] ?? '';
+    const key = decodeURIComponent(rawKeySegment);
+    const body = init.body == null ? undefined : String(init.body);
+    calls.push({ url: href, method: init.method ?? 'GET', body, op, rawKeySegment, key });
+
+    const failure = failures.get(op) ?? failures.get(href);
+    if (failure) {
+      return { ok: false, status: failure.status ?? 500, async json() { return failure.body ?? { error: 'boom' }; } };
+    }
+
+    let result;
+    if (op === 'get') {
+      result = live(key)?.value ?? null;
+    } else if (op === 'set') {
+      const ex = u.searchParams.get('EX');
+      const expiresAt = ex == null ? Number.POSITIVE_INFINITY : clock + Number(ex) * 1000;
+      store.set(key, { value: body ?? '', expiresAt });
+      result = 'OK';
+    } else if (op === 'incr') {
+      if (incrResults.length) {
+        result = incrResults.shift();
+      } else {
+        const current = Number(live(key)?.value ?? 0);
+        result = current + 1;
+        const prior = store.get(key);
+        store.set(key, { value: String(result), expiresAt: prior?.expiresAt ?? Number.POSITIVE_INFINITY });
+      }
+    } else if (op === 'expire') {
+      const seconds = Number(segs[2]);
+      const entry = store.get(key);
+      if (entry) entry.expiresAt = clock + seconds * 1000;
+      result = entry ? 1 : 0;
+    } else {
+      result = null;
+    }
+    return { ok: true, async json() { return { result }; } };
+  };
+
+  return {
+    kv: createRestKv({ KV_REST_API_URL: 'https://kv.example.com', KV_REST_API_TOKEN: 'tok' }),
+    calls,
+    advance(ms) { clock += ms; },
+    restore() { globalThis.fetch = origFetch; },
+  };
+}
+
+function withFakeDateNow(startMs = 1_000_000) {
+  const original = Date.now;
+  let now = startMs;
+  Date.now = () => now;
+  return {
+    advance(ms) { now += ms; },
+    restore() { Date.now = original; },
+  };
+}
+
+test('REST set keeps URL-hostile secret values out of every request URL and only in POST body', async () => {
+  const mock = makeRestKvMock();
+  try {
+    const secret = 's3cr3t?/&=%#'.repeat(32) + '\nline-two\nemoji-🚨-끝';
+    await mock.kv.set('quota:key', secret, { ttlMs: 2_500 });
+    await mock.kv.get('quota:key');
+    await mock.kv.incr('counter:key', { ttlMs: 1_001 });
+
+    const setCall = mock.calls.find((call) => call.op === 'set');
+    assert.equal(setCall?.method, 'POST');
+    assert.equal(setCall?.body, secret);
+    for (const call of mock.calls) {
+      assert.ok(!call.url.includes(secret), `raw secret leaked into URL: ${call.url}`);
+      assert.ok(!call.url.includes(encodeURIComponent(secret)), `encoded secret leaked into URL: ${call.url}`);
+      assert.ok(!call.url.includes('line-two'), `secret substring leaked into URL: ${call.url}`);
+      assert.ok(!call.url.includes('%F0%9F%9A%A8'), `emoji secret leaked into URL: ${call.url}`);
+    }
+  } finally {
+    mock.restore();
+  }
+});
+
+test('REST keys with separators, spaces, colon, and unicode are percent-encoded in one path segment', async () => {
+  const mock = makeRestKvMock();
+  try {
+    const key = 'tenant/word space:유니코드/../escape';
+    const counterKey = `${key}:counter`;
+    await mock.kv.set(key, 'value');
+    await mock.kv.get(key);
+    await mock.kv.incr(counterKey, { ttlMs: 1_000 });
+
+    const expectedKeys = new Set([encodeURIComponent(key), encodeURIComponent(counterKey)]);
+    for (const call of mock.calls) {
+      assert.ok(expectedKeys.has(call.rawKeySegment), call.rawKeySegment);
+      assert.equal(call.key, call.op === 'incr' || call.op === 'expire' ? counterKey : key);
+      assert.ok(!call.url.includes('/../'));
+      assert.ok(!call.url.includes('tenant/word'));
+    }
+  } finally {
+    mock.restore();
+  }
+});
+
+test('REST fetch failures throw and rate limiter converts them to fail-closed storage unavailable', async () => {
+  for (const [op, status] of [['get', 404], ['set', 500], ['incr', 503]]) {
+    const mock = makeRestKvMock({ failures: new Map([[op, { status }]]) });
+    try {
+      await assert.rejects(
+        op === 'get' ? mock.kv.get('k') : op === 'set' ? mock.kv.set('k', 'v') : mock.kv.incr('k'),
+        /kv request failed/,
+      );
+    } finally {
+      mock.restore();
+    }
+  }
+
+  const mock = makeRestKvMock({ failures: new Map([['incr', { status: 500 }]]) });
+  try {
+    const limiter = createRateLimiter({
+      kv: mock.kv,
+      hmacSecret: 'secret',
+      env: { NODE_ENV: 'production' },
+      limits: { [WEB_TIERS.FREE]: { reqPerDay: 10, burstPerHour: 5 } },
+    });
+    assert.deepEqual(await limiter.check({ tier: WEB_TIERS.FREE, ip: '203.0.113.9' }), {
+      allowed: false,
+      status: 503,
+      reason: 'quota storage unavailable',
+    });
+  } finally {
+    mock.restore();
+  }
+});
+
+test('REST incr rejects malformed counters instead of returning unsafe values', async () => {
+  for (const bad of [undefined, Number.NaN, {}, '2.5', 'not-a-number']) {
+    const mock = makeRestKvMock({ incrResults: [bad] });
+    try {
+      await assert.rejects(mock.kv.incr('counter'), /kv incr returned invalid counter/);
+    } finally {
+      mock.restore();
+    }
+  }
+});
+
+test('REST TTL EX boundaries: any positive ttlMs rounds UP to whole seconds (min 1), expiry flips after boundary', async () => {
+  const mock = makeRestKvMock();
+  try {
+    // Documented contract: a positive ttlMs is rounded UP to whole seconds
+    // (Redis EX, min 1). Sub-second TTLs are out of contract and still yield
+    // EX=1 rather than silently omitting the TTL (fail-safe: no immortal key).
+    await mock.kv.set('sub-second', 'v', { ttlMs: 0.5 });
+    assert.ok(mock.calls.at(-1).url.endsWith('/set/sub-second?EX=1'), mock.calls.at(-1).url);
+
+    await mock.kv.set('fractional', 'temp', { ttlMs: 1_001 });
+    const setUrl = mock.calls.at(-1).url;
+    assert.ok(setUrl.endsWith('/set/fractional?EX=2'), setUrl);
+    mock.advance(1_999);
+    assert.equal(await mock.kv.get('fractional'), 'temp');
+    mock.advance(1);
+    assert.equal(await mock.kv.get('fractional'), null);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('memory TTL boundary matches millisecond contract for sub-second expiry', async () => {
+  const time = withFakeDateNow();
+  try {
+    const kv = createMemoryKv();
+    await kv.set('fractional', 'temp', { ttlMs: 1.5 });
+    time.advance(1);
+    assert.equal(await kv.get('fractional'), 'temp');
+    time.advance(0.5);
+    assert.equal((await kv.get('fractional')) ?? null, null);
+  } finally {
+    time.restore();
+  }
+});
+
+test('memory and REST return identical results for the same normal store sequence after nullish normalization', async () => {
+  const mock = makeRestKvMock();
+  try {
+    const memory = createMemoryKv();
+    const rest = mock.kv;
+    const memoryResults = [];
+    const restResults = [];
+
+    const recordBoth = async (fn) => {
+      memoryResults.push((await fn(memory)) ?? null);
+      restResults.push((await fn(rest)) ?? null);
+    };
+
+    await recordBoth((kv) => kv.get('missing'));
+    await recordBoth(async (kv) => { await kv.set('same:key', 'value', { ttlMs: 60_000 }); return kv.get('same:key'); });
+    await recordBoth((kv) => kv.incr('same:counter'));
+    await recordBoth((kv) => kv.incr('same:counter', { ttlMs: 60_000 }));
+    await recordBoth(async (kv) => { await kv.set('same:key', 'next'); return kv.get('same:key'); });
+
+    assert.deepEqual(restResults, memoryResults);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('missing values are nullish for both stores: memory undefined and REST null', async () => {
+  const mock = makeRestKvMock();
+  try {
+    const memoryMissing = await createMemoryKv().get('absent');
+    const restMissing = await mock.kv.get('absent');
+    assert.equal(memoryMissing, undefined);
+    assert.equal(restMissing, null);
+    assert.equal(memoryMissing ?? null, restMissing ?? null);
+  } finally {
+    mock.restore();
+  }
+});

--- a/tests/unit/kv-store-contract.test.js
+++ b/tests/unit/kv-store-contract.test.js
@@ -1,0 +1,179 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createMemoryKv } from '../../src/rate-limit.js';
+import { createRestKv } from '../../api/rewrite.js';
+
+// G002: the in-memory KV (tests/local) and the Upstash/Vercel REST KV must
+// satisfy ONE shared store contract — get / set / incr / TTL — so the
+// entitlement, session-token, idempotency, and metering layers (G003-G006)
+// can target a single interface. The REST adapter additionally must never put
+// a raw secret value in the request URL (the value goes in the POST body) and
+// must key only by opaque/URL-encoded ids.
+
+/**
+ * Build a deterministic in-memory mock of the Upstash REST surface that
+ * createRestKv talks to, capturing every requested URL so we can assert no raw
+ * value is ever placed in the URL path/query.
+ */
+function makeRestKvMock() {
+  /** @type {Map<string,{value:string, expiresAt:number}>} */
+  const store = new Map();
+  const urls = [];
+  let clock = 1_000_000;
+  const live = (k) => {
+    const e = store.get(k);
+    if (!e) return undefined;
+    if (e.expiresAt <= clock) { store.delete(k); return undefined; }
+    return e;
+  };
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    urls.push(String(url));
+    const u = new URL(String(url));
+    const segs = u.pathname.split('/').filter(Boolean); // [op, key, ...]
+    const op = segs[0];
+    const key = decodeURIComponent(segs[1] ?? '');
+    let result;
+    if (op === 'get') {
+      result = live(key)?.value ?? null;
+    } else if (op === 'set') {
+      const ex = u.searchParams.get('EX');
+      const ttlMs = ex ? Number(ex) * 1000 : Infinity;
+      // The value is in the body, NOT the URL — mirror real Upstash behavior.
+      const body = init.body == null ? '' : String(init.body);
+      store.set(key, { value: body, expiresAt: ex ? clock + ttlMs : Number.POSITIVE_INFINITY });
+      result = 'OK';
+    } else if (op === 'incr') {
+      const cur = Number(live(key)?.value ?? 0);
+      const next = cur + 1;
+      const prev = store.get(key);
+      store.set(key, { value: String(next), expiresAt: prev?.expiresAt ?? Number.POSITIVE_INFINITY });
+      result = next;
+    } else if (op === 'expire') {
+      const seconds = Number(segs[2]);
+      const e = store.get(key);
+      if (e) e.expiresAt = clock + seconds * 1000;
+      result = 1;
+    } else {
+      result = null;
+    }
+    return { ok: true, async json() { return { result }; } };
+  };
+  return {
+    kv: createRestKv({ KV_REST_API_URL: 'https://kv.example.com', KV_REST_API_TOKEN: 'tok' }),
+    urls,
+    advance(ms) { clock += ms; },
+    restore() { globalThis.fetch = origFetch; },
+  };
+}
+
+/**
+ * Shared contract assertions. `getNull` normalizes the "missing" sentinel
+ * (memory returns undefined; REST returns null) so both pass one contract.
+ */
+async function runStoreContract(kv) {
+  // set/get string roundtrip
+  await kv.set('k:opaque:1', 'value-one');
+  assert.equal(await kv.get('k:opaque:1'), 'value-one');
+
+  // overwrite
+  await kv.set('k:opaque:1', 'value-two');
+  assert.equal(await kv.get('k:opaque:1'), 'value-two');
+
+  // missing key is nullish (undefined OR null)
+  assert.equal((await kv.get('k:absent')) ?? null, null);
+
+  // incr sequence
+  assert.equal(await kv.incr('c:opaque:1'), 1);
+  assert.equal(await kv.incr('c:opaque:1'), 2);
+  assert.equal(await kv.incr('c:opaque:1', { ttlMs: 60_000 }), 3);
+
+  // set with ttl is accepted and the value is readable before expiry
+  await kv.set('k:ttl', 'temp', { ttlMs: 60_000 });
+  assert.equal(await kv.get('k:ttl'), 'temp');
+}
+
+test('memory KV satisfies the shared store contract (get/set/incr/ttl)', async () => {
+  await runStoreContract(createMemoryKv());
+});
+
+test('memory KV honors TTL expiry', async () => {
+  const kv = createMemoryKv();
+  await kv.set('k:short', 'gone-soon', { ttlMs: 1 });
+  await new Promise((r) => setTimeout(r, 10));
+  assert.equal((await kv.get('k:short')) ?? null, null);
+});
+
+test('REST KV satisfies the same shared store contract', async () => {
+  const mock = makeRestKvMock();
+  try {
+    await runStoreContract(mock.kv);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('REST KV honors TTL expiry via EX', async () => {
+  const mock = makeRestKvMock();
+  try {
+    await mock.kv.set('k:short', 'gone-soon', { ttlMs: 5_000 });
+    assert.equal(await mock.kv.get('k:short'), 'gone-soon');
+    mock.advance(6_000);
+    assert.equal(await mock.kv.get('k:short'), null);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('REST KV never places the raw value in the request URL (value goes in the body)', async () => {
+  const mock = makeRestKvMock();
+  try {
+    const secretish = 'hashed-entitlement-payload-abc123';
+    await mock.kv.set('ent:9f8a', secretish, { ttlMs: 600_000 });
+    // Every captured URL must be value-free; the value only ever travels in the body.
+    for (const url of mock.urls) {
+      assert.ok(!url.includes(secretish), `value leaked into URL: ${url}`);
+    }
+    // The set URL carries the opaque key + EX, not the value.
+    const setUrl = mock.urls.find((u) => u.includes('/set/'));
+    assert.ok(setUrl.includes('ent%3A9f8a') || setUrl.includes('ent:9f8a'));
+    assert.ok(setUrl.includes('EX=600'));
+  } finally {
+    mock.restore();
+  }
+});
+
+test('REST KV URL-encodes keys (opaque ids only, no raw separators leaking)', async () => {
+  const mock = makeRestKvMock();
+  try {
+    await mock.kv.get('a/b c:weird');
+    const getUrl = mock.urls.find((u) => u.includes('/get/'));
+    assert.ok(getUrl.includes('a%2Fb%20c%3Aweird'));
+  } finally {
+    mock.restore();
+  }
+});
+
+test('createRestKv is null without KV env (production fail-closed handoff)', () => {
+  assert.equal(createRestKv({}), null);
+  assert.equal(createRestKv({ KV_REST_API_URL: 'https://x' }), null);
+  assert.equal(createRestKv({ KV_REST_API_TOKEN: 'tok' }), null);
+});
+
+test('REST KV set requires a string value (no implicit JSON serialization divergence)', async () => {
+  const mock = makeRestKvMock();
+  try {
+    // The shared store contract is string-only: callers serialize objects
+    // themselves. REST rejects a non-string loudly instead of implicitly
+    // JSON.stringify'ing it (which would diverge from memory KV, where an
+    // object would round-trip as an object). This keeps memory and REST
+    // observably identical for the contract's value type.
+    for (const bad of [{ a: 1 }, [1, 2], 42, true, null, undefined]) {
+      await assert.rejects(() => mock.kv.set('k:bad', /** @type {any} */ (bad)), /value must be a string/);
+    }
+    await mock.kv.set('k:ok', 'a-string');
+    assert.equal(await mock.kv.get('k:ok'), 'a-string');
+  } finally {
+    mock.restore();
+  }
+});

--- a/tests/unit/lemon-webhook-api.test.js
+++ b/tests/unit/lemon-webhook-api.test.js
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
+import { createLemonWebhookApiHandler } from '../../api/lemon-webhook.js';
+import { entitlementKey } from '../../src/pro-session.js';
+import { hashLicenseKey } from '../../src/pro-entitlements.js';
+
+const WEBHOOK_SECRET = 'wh-secret';
+const LICENSE_SECRET = 'lic-secret';
+const RAW_KEY = 'LEMON-API-KEY';
+const NOW = Date.parse('2026-06-15T00:00:00Z');
+
+const sign = (body) => createHmac('sha256', WEBHOOK_SECRET).update(body).digest('hex');
+
+function body(eventId) {
+  return JSON.stringify({
+    meta: { event_name: 'order_created', event_id: eventId, custom_data: { license_key: RAW_KEY } },
+    data: { id: 'sub_1', attributes: { status: 'active', updated_at: '2026-06-01T00:00:00Z', created_at: '2026-06-01T00:00:00Z', renews_at: '2026-12-01T00:00:00Z' } },
+  });
+}
+
+function mockKv() {
+  const map = new Map();
+  return { map, async get(k) { return map.has(k) ? map.get(k) : null; }, async set(k, v) { map.set(k, v); } };
+}
+function mockRes() {
+  return { statusCode: 0, headers: {}, body: undefined, setHeader(k, v) { this.headers[k.toLowerCase()] = v; }, end(p) { this.body = p; } };
+}
+function makeHandler(kv = mockKv()) {
+  return {
+    kv,
+    handler: createLemonWebhookApiHandler({
+      env: { PATINA_LEMON_WEBHOOK_SECRET: WEBHOOK_SECRET, PATINA_PRO_HMAC_SECRET: LICENSE_SECRET },
+      kv,
+      logger: { info() {} },
+      now: () => NOW,
+    }),
+  };
+}
+
+test('a correctly-signed POST applies the entitlement and returns 200 (no-store)', async () => {
+  const { kv, handler } = makeHandler();
+  const b = body('api-e1');
+  const res = mockRes();
+  await handler({ method: 'POST', headers: { 'X-Signature': sign(b) }, body: b }, res);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.headers['cache-control'], 'no-store');
+  assert.equal(JSON.parse(res.body).applied, true);
+  assert.ok(kv.map.has(entitlementKey(hashLicenseKey(LICENSE_SECRET, RAW_KEY))));
+});
+
+test('an invalid signature is rejected 401 and writes nothing', async () => {
+  const { kv, handler } = makeHandler();
+  const b = body('api-e2');
+  const res = mockRes();
+  await handler({ method: 'POST', headers: { 'x-signature': 'deadbeef' }, body: b }, res);
+  assert.equal(res.statusCode, 401);
+  assert.equal([...kv.map.keys()].some((k) => k.startsWith('ent:')), false);
+});
+
+test('non-POST is 405', async () => {
+  const { handler } = makeHandler();
+  const res = mockRes();
+  await handler({ method: 'GET', headers: {} }, res);
+  assert.equal(res.statusCode, 405);
+});
+
+test('production without a REST KV fails closed with 503', async () => {
+  const handler = createLemonWebhookApiHandler({
+    env: { PATINA_LEMON_WEBHOOK_SECRET: WEBHOOK_SECRET, PATINA_PRO_HMAC_SECRET: LICENSE_SECRET, VERCEL_ENV: 'production' },
+    now: () => NOW,
+  });
+  const res = mockRes();
+  await handler({ method: 'POST', headers: {}, body: body('api-e3') }, res);
+  assert.equal(res.statusCode, 503);
+});

--- a/tests/unit/lemon-webhook.redteam.test.js
+++ b/tests/unit/lemon-webhook.redteam.test.js
@@ -1,0 +1,279 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
+import { Readable } from 'node:stream';
+import { createLemonWebhookProcessor, idempotencyKey } from '../../src/lemon-webhook.js';
+import { createLemonWebhookApiHandler } from '../../api/lemon-webhook.js';
+import { entitlementKey } from '../../src/pro-session.js';
+import { ENTITLEMENT_STATES, hashLicenseKey, isProAllowed } from '../../src/pro-entitlements.js';
+
+const WEBHOOK_SECRET = 'redteam-webhook-secret';
+const OTHER_WEBHOOK_SECRET = 'attacker-secret';
+const LICENSE_SECRET = 'redteam-license-secret';
+const RAW_KEY = 'LEMON-REDTEAM-RAW-KEY';
+const OTHER_RAW_KEY = 'LEMON-REDTEAM-OTHER-KEY';
+const EMAIL = 'victim@example.test';
+const NOW = Date.parse('2026-06-15T00:00:00Z');
+const FUTURE_RENEWS = '2026-12-01T00:00:00Z';
+
+const sign = (body, secret = WEBHOOK_SECRET) => createHmac('sha256', secret).update(body).digest('hex');
+
+const payload = ({
+  event = 'subscription_created',
+  status = 'active',
+  id = 'sub_redteam',
+  eventId = 'evt-redteam',
+  updated = '2026-06-01T00:00:00Z',
+  renews = FUTURE_RENEWS,
+  licenseKey = RAW_KEY,
+  email = EMAIL,
+  extraMeta = {},
+  extraAttrs = {},
+} = {}) => ({
+  meta: {
+    event_name: event,
+    event_id: eventId,
+    custom_data: licenseKey == null ? { ...extraMeta } : { license_key: licenseKey, ...extraMeta },
+  },
+  data: {
+    id,
+    attributes: {
+      status,
+      updated_at: updated,
+      created_at: updated,
+      renews_at: renews,
+      user_email: email,
+      email,
+      ...extraAttrs,
+    },
+  },
+});
+
+const mockKv = () => {
+  const map = new Map();
+  const writes = [];
+  return {
+    map,
+    writes,
+    get: async (key) => (map.has(key) ? map.get(key) : null),
+    set: async (key, value, options) => {
+      assert.equal(typeof value, 'string');
+      writes.push({ key, value, options });
+      map.set(key, value);
+    },
+  };
+};
+
+const processorWith = ({ kv = mockKv(), logs = [] } = {}) => ({
+  kv,
+  logs,
+  proc: createLemonWebhookProcessor({
+    kv,
+    webhookSecret: WEBHOOK_SECRET,
+    licenseHmacSecret: LICENSE_SECRET,
+    hashKey: hashLicenseKey,
+    now: () => NOW,
+    logger: { info: (message, meta) => logs.push({ message, meta }), warn: (message, meta) => logs.push({ message, meta }) },
+  }),
+});
+
+const mockRes = () => ({
+  statusCode: 0,
+  headers: {},
+  body: undefined,
+  setHeader(key, value) { this.headers[key.toLowerCase()] = value; },
+  end(payloadText) { this.body = payloadText; },
+});
+
+const apiHandlerWith = ({ kv = mockKv(), env = {}, logs = [] } = {}) => ({
+  kv,
+  logs,
+  handler: createLemonWebhookApiHandler({
+    env: { PATINA_LEMON_WEBHOOK_SECRET: WEBHOOK_SECRET, PATINA_PRO_HMAC_SECRET: LICENSE_SECRET, ...env },
+    kv,
+    logger: { info: (message, meta) => logs.push({ message, meta }), warn: (message, meta) => logs.push({ message, meta }) },
+    now: () => NOW,
+  }),
+});
+
+const storedEntitlement = (kv, rawKey = RAW_KEY) => {
+  const id = hashLicenseKey(LICENSE_SECRET, rawKey);
+  const value = kv.map.get(entitlementKey(id));
+  return value == null ? null : JSON.parse(value);
+};
+
+const allStoredText = (kv) => JSON.stringify({ keys: [...kv.map.keys()], values: [...kv.map.values()], writes: kv.writes });
+
+const assertNoMirrorWrites = (kv) => {
+  assert.equal([...kv.map.keys()].some((key) => key.startsWith('ent:')), false);
+};
+
+test('forged signatures are rejected 401 and never write the entitlement mirror', async () => {
+  const attackCases = [
+    { name: 'wrong hex signature', signature: '00'.repeat(32), mutate: (body) => body },
+    { name: 'signature from another secret', signature: null, signer: OTHER_WEBHOOK_SECRET, mutate: (body) => body },
+    { name: 'empty signature', signature: '', mutate: (body) => body },
+    { name: 'non-hex signature', signature: 'not-a-hex-signature', mutate: (body) => body },
+    { name: 'length mismatch', signature: 'abcd', mutate: (body) => body },
+    { name: 'tampered body after signing', signature: null, mutate: (body) => body.replace('active', 'cancelled'), signBody: true },
+  ];
+
+  for (const attack of attackCases) {
+    const { kv, proc } = processorWith();
+    const originalBody = JSON.stringify(payload({ eventId: `forged-${attack.name}` }));
+    const rawBody = attack.mutate(originalBody);
+    const signature = attack.signature ?? sign(attack.signBody ? originalBody : rawBody, attack.signer ?? WEBHOOK_SECRET);
+    const result = await proc.process({ rawBody, signature });
+
+    assert.equal(result.ok, false, attack.name);
+    assert.equal(result.status, 401, attack.name);
+    assertNoMirrorWrites(kv);
+    assert.equal(kv.map.size, 0, attack.name);
+  }
+});
+
+test('replay of a valid signed event is idempotent and applies only once', async () => {
+  const { kv, proc } = processorWith();
+  const body = JSON.stringify(payload({ event: 'order_created', eventId: 'replay-once' }));
+
+  const first = await proc.process({ rawBody: body, signature: sign(body) });
+  const second = await proc.process({ rawBody: body, signature: sign(body) });
+
+  assert.equal(first.applied, true);
+  assert.equal(second.applied, false);
+  assert.equal(second.reason, 'duplicate_event');
+  assert.equal(kv.writes.filter((write) => write.key.startsWith('ent:')).length, 1);
+  assert.ok(kv.map.has(idempotencyKey('replay-once')));
+  assert.equal(isProAllowed(storedEntitlement(kv), NOW), true);
+});
+
+test('ordering attack cannot resurrect Pro after revoke with a same-subscription active event', async () => {
+  const { kv, proc } = processorWith();
+  const activeBody = JSON.stringify(payload({ eventId: 'order-1', updated: '2026-06-01T00:00:00Z' }));
+  const revokeBody = JSON.stringify(payload({ event: 'license_key_revoked', status: 'cancelled', eventId: 'order-2', updated: '2026-06-02T00:00:00Z' }));
+  const attackerActiveBody = JSON.stringify(payload({ event: 'subscription_updated', status: 'active', eventId: 'order-3', updated: '2026-06-03T00:00:00Z' }));
+
+  assert.equal((await proc.process({ rawBody: activeBody, signature: sign(activeBody) })).applied, true);
+  assert.equal((await proc.process({ rawBody: revokeBody, signature: sign(revokeBody) })).applied, true);
+  const attack = await proc.process({ rawBody: attackerActiveBody, signature: sign(attackerActiveBody) });
+
+  assert.equal(attack.applied, false);
+  assert.equal(attack.reason, 'revoked_sticky');
+  const record = storedEntitlement(kv);
+  assert.equal(record.status, ENTITLEMENT_STATES.REVOKED);
+  assert.equal(isProAllowed(record, NOW), false);
+});
+
+test('different license keys are isolated into different entitlement ids', async () => {
+  const { kv, proc } = processorWith();
+  const firstBody = JSON.stringify(payload({ eventId: 'isolate-1', licenseKey: RAW_KEY, id: 'sub_a' }));
+  const secondBody = JSON.stringify(payload({ eventId: 'isolate-2', licenseKey: OTHER_RAW_KEY, id: 'sub_b' }));
+
+  await proc.process({ rawBody: firstBody, signature: sign(firstBody) });
+  await proc.process({ rawBody: secondBody, signature: sign(secondBody) });
+
+  const firstId = hashLicenseKey(LICENSE_SECRET, RAW_KEY);
+  const secondId = hashLicenseKey(LICENSE_SECRET, OTHER_RAW_KEY);
+  assert.notEqual(firstId, secondId);
+  assert.ok(kv.map.has(entitlementKey(firstId)));
+  assert.ok(kv.map.has(entitlementKey(secondId)));
+  assert.equal(JSON.parse(kv.map.get(entitlementKey(firstId))).subscriptionId, 'sub_a');
+  assert.equal(JSON.parse(kv.map.get(entitlementKey(secondId))).subscriptionId, 'sub_b');
+});
+
+test('unmapped events and missing license keys are applied:false and never write a mirror', async () => {
+  const cases = [
+    JSON.stringify(payload({ event: 'unknown_event', eventId: 'unmapped-event' })),
+    JSON.stringify(payload({ eventId: 'missing-key', licenseKey: null })),
+  ];
+
+  for (const body of cases) {
+    const { kv, proc } = processorWith();
+    const result = await proc.process({ rawBody: body, signature: sign(body) });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.applied, false);
+    assert.equal(result.reason, 'unmapped_event');
+    assertNoMirrorWrites(kv);
+  }
+});
+
+test('malformed JSON with a valid signature is rejected 400', async () => {
+  const { kv, proc } = processorWith();
+  const body = '{"meta":';
+  const result = await proc.process({ rawBody: body, signature: sign(body) });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 400);
+  assert.equal(kv.map.size, 0);
+});
+
+test('raw license keys and emails never leak into store keys, stored values, logs, or return objects', async () => {
+  const logs = [];
+  const { kv, proc } = processorWith({ logs });
+  const createBody = JSON.stringify(payload({ eventId: 'leak-create', email: EMAIL }));
+  const cancelBody = JSON.stringify(payload({ event: 'subscription_updated', status: 'cancelled', eventId: 'leak-cancel', updated: '2026-07-01T00:00:00Z', email: EMAIL }));
+
+  const createResult = await proc.process({ rawBody: createBody, signature: sign(createBody) });
+  const cancelResult = await proc.process({ rawBody: cancelBody, signature: sign(cancelBody) });
+  const combined = JSON.stringify({ store: allStoredText(kv), logs, createResult, cancelResult });
+
+  assert.equal(combined.includes(RAW_KEY), false);
+  assert.equal(combined.includes(EMAIL), false);
+  assert.equal(createResult.applied, true);
+  assert.equal(cancelResult.applied, true);
+});
+
+test('api rejects non-POST with 405 and always marks responses no-store', async () => {
+  const { handler } = apiHandlerWith();
+  const res = mockRes();
+
+  await handler({ method: 'GET', headers: {} }, res);
+
+  assert.equal(res.statusCode, 405);
+  assert.equal(res.headers['cache-control'], 'no-store');
+  assert.deepEqual(JSON.parse(res.body), { error: 'method not allowed' });
+});
+
+test('api fails closed with 503 in production when REST KV is unavailable', async () => {
+  const logs = [];
+  const handler = createLemonWebhookApiHandler({
+    env: { PATINA_LEMON_WEBHOOK_SECRET: WEBHOOK_SECRET, PATINA_PRO_HMAC_SECRET: LICENSE_SECRET, VERCEL_ENV: 'production' },
+    logger: { info: (message, meta) => logs.push({ message, meta }) },
+    now: () => NOW,
+  });
+  const res = mockRes();
+
+  await handler({ method: 'POST', headers: { 'x-signature': '00'.repeat(32) }, body: '{}' }, res);
+
+  assert.equal(res.statusCode, 503);
+  assert.equal(res.headers['cache-control'], 'no-store');
+  assert.deepEqual(JSON.parse(res.body), { error: 'webhook storage unavailable' });
+});
+
+test('api caps streaming request bodies over 64KB with 413', async () => {
+  const { kv, handler } = apiHandlerWith();
+  const oversized = Buffer.alloc((64 * 1024) + 1, 0x61);
+  const req = Readable.from([oversized]);
+  req.method = 'POST';
+  req.headers = { 'x-signature': sign(oversized) };
+  const res = mockRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 413);
+  assert.equal(res.headers['cache-control'], 'no-store');
+  assertNoMirrorWrites(kv);
+});
+
+test('prototype-pollution payload is parsed safely and does not poison Object.prototype', async () => {
+  const { kv, proc } = processorWith();
+  const body = `{"meta":{"event_name":"subscription_created","event_id":"pollution","custom_data":{"license_key":"${RAW_KEY}","__proto__":{"polluted":true}}},"data":{"id":"sub_redteam","attributes":{"status":"active","updated_at":"2026-06-01T00:00:00Z","created_at":"2026-06-01T00:00:00Z","renews_at":"${FUTURE_RENEWS}","constructor":{"prototype":{"polluted":true}}}}}`;
+
+  const result = await proc.process({ rawBody: body, signature: sign(body) });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.applied, true);
+  assert.equal(Object.prototype.polluted, undefined);
+  assert.equal(isProAllowed(storedEntitlement(kv), NOW), true);
+});

--- a/tests/unit/lemon-webhook.test.js
+++ b/tests/unit/lemon-webhook.test.js
@@ -1,0 +1,242 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
+import {
+  verifyWebhookSignature,
+  mapLemonEventToStatus,
+  buildEntitlementEvent,
+  idempotencyKey,
+  createLemonWebhookProcessor,
+} from '../../src/lemon-webhook.js';
+import { entitlementKey } from '../../src/pro-session.js';
+import { ENTITLEMENT_STATES, hashLicenseKey, isProAllowed } from '../../src/pro-entitlements.js';
+
+const S = ENTITLEMENT_STATES;
+const WEBHOOK_SECRET = 'wh-secret';
+const LICENSE_SECRET = 'lic-secret';
+const RAW_KEY = 'LEMON-LICENSE-XYZ';
+// A clock inside the fixtures' entitlement window (effective 2026-06-01, renews 2026-12-01).
+const NOW = Date.parse('2026-06-15T00:00:00Z');
+
+const sign = (body, secret = WEBHOOK_SECRET) => createHmac('sha256', secret).update(body).digest('hex');
+
+function lemonPayload({ event = 'subscription_created', status = 'active', id = 'sub_1', updated = '2026-06-01T00:00:00Z', renews = '2026-12-01T00:00:00Z', licenseKey = RAW_KEY, eventId = 'evt-1' } = {}) {
+  return {
+    meta: { event_name: event, event_id: eventId, custom_data: { license_key: licenseKey } },
+    data: { id, attributes: { status, updated_at: updated, created_at: updated, renews_at: renews } },
+  };
+}
+
+function mockKv() {
+  const map = new Map();
+  return {
+    map,
+    async get(k) { return map.has(k) ? map.get(k) : null; },
+    async set(k, v) { assert.equal(typeof v, 'string'); map.set(k, v); },
+  };
+}
+
+function processorWith({ kv = mockKv(), now = NOW, logs = [] } = {}) {
+  return {
+    kv, logs,
+    proc: createLemonWebhookProcessor({
+      kv, webhookSecret: WEBHOOK_SECRET, licenseHmacSecret: LICENSE_SECRET,
+      hashKey: hashLicenseKey, now: () => now, logger: { info: (m, meta) => logs.push({ m, meta }) },
+    }),
+  };
+}
+
+// --- signature --------------------------------------------------------------
+test('verifyWebhookSignature accepts a correct HMAC and rejects everything else (timing-safe)', () => {
+  const body = JSON.stringify({ a: 1 });
+  assert.equal(verifyWebhookSignature(body, sign(body), WEBHOOK_SECRET), true);
+  assert.equal(verifyWebhookSignature(body, sign(body, 'wrong'), WEBHOOK_SECRET), false);
+  assert.equal(verifyWebhookSignature(body + 'tamper', sign(body), WEBHOOK_SECRET), false);
+  assert.equal(verifyWebhookSignature(body, 'not-hex-!!', WEBHOOK_SECRET), false);
+  assert.equal(verifyWebhookSignature(body, 'abcd', WEBHOOK_SECRET), false); // length mismatch
+  assert.equal(verifyWebhookSignature(body, sign(body), ''), false); // missing secret
+  assert.equal(verifyWebhookSignature(body, undefined, WEBHOOK_SECRET), false);
+});
+
+// --- event mapping ----------------------------------------------------------
+test('mapLemonEventToStatus maps lifecycle + refund/revoke and returns null for unknown', () => {
+  assert.equal(mapLemonEventToStatus('subscription_created', 'active'), S.ACTIVE);
+  assert.equal(mapLemonEventToStatus('subscription_updated', 'on_trial'), S.TRIALING);
+  assert.equal(mapLemonEventToStatus('subscription_updated', 'past_due'), S.PAST_DUE);
+  assert.equal(mapLemonEventToStatus('subscription_updated', 'cancelled'), S.CANCELLED);
+  assert.equal(mapLemonEventToStatus('subscription_updated', 'expired'), S.EXPIRED);
+  assert.equal(mapLemonEventToStatus('subscription_payment_failed'), S.PAST_DUE);
+  assert.equal(mapLemonEventToStatus('order_created'), S.ACTIVE);
+  assert.equal(mapLemonEventToStatus('license_key_revoked'), S.REVOKED);
+  assert.equal(mapLemonEventToStatus('order_refunded'), S.REVOKED);
+  assert.equal(mapLemonEventToStatus('some_unrelated_event'), null);
+});
+
+// --- build event ------------------------------------------------------------
+test('buildEntitlementEvent derives the mirror id from the license key and maps fields', () => {
+  const built = buildEntitlementEvent(lemonPayload(), hashLicenseKey, LICENSE_SECRET);
+  assert.ok(built);
+  assert.equal(built.entitlementId, hashLicenseKey(LICENSE_SECRET, RAW_KEY));
+  assert.equal(built.event.status, S.ACTIVE);
+  assert.equal(built.event.id, 'evt-1');
+  assert.equal(built.event.subscriptionId, 'sub_1');
+  assert.equal(typeof built.event.effectiveAt, 'number');
+  assert.equal(typeof built.event.expiresAt, 'number');
+});
+
+test('buildEntitlementEvent returns null when unmappable or missing a license key', () => {
+  assert.equal(buildEntitlementEvent({ meta: { event_name: 'nope' }, data: {} }, hashLicenseKey, LICENSE_SECRET), null);
+  const noKey = { meta: { event_name: 'subscription_created', event_id: 'e' }, data: { id: 's', attributes: { status: 'active', updated_at: '2026-01-01T00:00:00Z' } } };
+  assert.equal(buildEntitlementEvent(noKey, hashLicenseKey, LICENSE_SECRET), null);
+  assert.equal(buildEntitlementEvent(null, hashLicenseKey, LICENSE_SECRET), null);
+});
+
+// --- processor: signature + apply + idempotency -----------------------------
+test('process rejects an invalid signature (401) and applies a valid order to the mirror', async () => {
+  const { kv, proc } = processorWith();
+  const body = JSON.stringify(lemonPayload({ event: 'order_created', eventId: 'e1' }));
+
+  assert.equal((await proc.process({ rawBody: body, signature: 'deadbeef' })).status, 401);
+
+  const res = await proc.process({ rawBody: body, signature: sign(body) });
+  assert.equal(res.ok, true);
+  assert.equal(res.applied, true);
+  assert.equal(res.reason, S.ACTIVE);
+
+  const eid = hashLicenseKey(LICENSE_SECRET, RAW_KEY);
+  const stored = JSON.parse(kv.map.get(entitlementKey(eid)));
+  assert.equal(stored.status, S.ACTIVE);
+  assert.equal(isProAllowed(stored, NOW), true);
+  // no raw license key in any store key
+  for (const k of kv.map.keys()) assert.ok(!k.includes(RAW_KEY));
+});
+
+test('process is idempotent: a re-delivered event id is not applied twice', async () => {
+  const { kv, proc } = processorWith();
+  const body = JSON.stringify(lemonPayload({ event: 'order_created', eventId: 'e-dup' }));
+  await proc.process({ rawBody: body, signature: sign(body) });
+  const again = await proc.process({ rawBody: body, signature: sign(body) });
+  assert.equal(again.applied, false);
+  assert.equal(again.reason, 'duplicate_event');
+  assert.ok(kv.map.has(idempotencyKey('e-dup')));
+});
+
+test('process folds a cancel and then a refund(revoke) through the state machine', async () => {
+  const { kv, proc } = processorWith();
+  const eid = hashLicenseKey(LICENSE_SECRET, RAW_KEY);
+
+  const create = JSON.stringify(lemonPayload({ event: 'subscription_created', status: 'active', eventId: 'c1', updated: '2026-06-01T00:00:00Z' }));
+  await proc.process({ rawBody: create, signature: sign(create) });
+
+  const cancel = JSON.stringify(lemonPayload({ event: 'subscription_updated', status: 'cancelled', eventId: 'c2', updated: '2026-07-01T00:00:00Z' }));
+  await proc.process({ rawBody: cancel, signature: sign(cancel) });
+  assert.equal(JSON.parse(kv.map.get(entitlementKey(eid))).status, S.CANCELLED);
+
+  const refund = JSON.stringify(lemonPayload({ event: 'order_refunded', status: 'cancelled', eventId: 'c3', updated: '2026-08-01T00:00:00Z' }));
+  await proc.process({ rawBody: refund, signature: sign(refund) });
+  assert.equal(JSON.parse(kv.map.get(entitlementKey(eid))).status, S.REVOKED);
+});
+
+test('process ignores an unmapped event without error and never writes a mirror', async () => {
+  const { kv, proc } = processorWith();
+  const body = JSON.stringify({ meta: { event_name: 'unrelated', event_id: 'u1' }, data: {} });
+  const res = await proc.process({ rawBody: body, signature: sign(body) });
+  assert.equal(res.ok, true);
+  assert.equal(res.applied, false);
+  assert.equal(res.reason, 'unmapped_event');
+  assert.equal([...kv.map.keys()].some((k) => k.startsWith('ent:')), false);
+});
+
+test('process rejects a malformed (but correctly-signed) payload with 400', async () => {
+  const { proc } = processorWith();
+  const body = '{not json';
+  const res = await proc.process({ rawBody: body, signature: sign(body) });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 400);
+});
+
+test('the sanitized invalidation log never carries the raw license key', async () => {
+  const { kv, proc, logs } = processorWith();
+  const create = JSON.stringify(lemonPayload({ event: 'subscription_created', status: 'active', eventId: 'l1', updated: '2026-06-01T00:00:00Z' }));
+  await proc.process({ rawBody: create, signature: sign(create) });
+  const cancel = JSON.stringify(lemonPayload({ event: 'subscription_updated', status: 'cancelled', eventId: 'l2', updated: '2026-07-01T00:00:00Z' }));
+  await proc.process({ rawBody: cancel, signature: sign(cancel) });
+  assert.ok(!JSON.stringify(logs).includes(RAW_KEY));
+  void kv;
+});
+
+// --- G005 review hardening regressions --------------------------------------
+test('a refund (order payload, no subscription_id) revokes the active subscription, not "other_subscription"', async () => {
+  const { kv, proc } = processorWith();
+  const eid = hashLicenseKey(LICENSE_SECRET, RAW_KEY);
+  const create = JSON.stringify(lemonPayload({ event: 'subscription_created', status: 'active', id: 'sub_1', eventId: 'r1', updated: '2026-06-01T00:00:00Z' }));
+  await proc.process({ rawBody: create, signature: sign(create) });
+  assert.equal(JSON.parse(kv.map.get(entitlementKey(eid))).status, S.ACTIVE);
+
+  // order_refunded: data.id is an ORDER id (not the subscription); no subscription_id.
+  const refund = JSON.stringify({
+    meta: { event_name: 'order_refunded', event_id: 'r2', custom_data: { license_key: RAW_KEY } },
+    data: { id: 'ord_9', attributes: { updated_at: '2026-07-01T00:00:00Z', created_at: '2026-07-01T00:00:00Z' } },
+  });
+  const res = await proc.process({ rawBody: refund, signature: sign(refund) });
+  assert.equal(res.applied, true);
+  assert.equal(JSON.parse(kv.map.get(entitlementKey(eid))).status, S.REVOKED);
+});
+
+test('license_key_updated maps disabled->revoked and expired->expired', async () => {
+  const { kv, proc } = processorWith();
+  const eid = hashLicenseKey(LICENSE_SECRET, RAW_KEY);
+  const disabled = JSON.stringify({
+    meta: { event_name: 'license_key_updated', event_id: 'lk1', custom_data: { license_key: RAW_KEY } },
+    data: { id: 'lic_1', attributes: { status: 'disabled', updated_at: '2026-06-01T00:00:00Z' } },
+  });
+  await proc.process({ rawBody: disabled, signature: sign(disabled) });
+  assert.equal(JSON.parse(kv.map.get(entitlementKey(eid))).status, S.REVOKED);
+});
+
+test('a missing entitlement/webhook secret fails closed with 503 (not a silent no-op)', async () => {
+  const noSecret = createLemonWebhookProcessor({
+    kv: mockKv(), webhookSecret: WEBHOOK_SECRET, licenseHmacSecret: '', hashKey: hashLicenseKey, now: () => NOW, logger: { info() {} },
+  });
+  const body = JSON.stringify(lemonPayload({ eventId: 's1' }));
+  const res = await noSecret.process({ rawBody: body, signature: sign(body) });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 503);
+});
+
+test('the entitlement mirror is written BEFORE the idempotency marker (a partial KV failure cannot drop a revoke)', async () => {
+  const map = new Map();
+  const flakyKv = {
+    map,
+    async get(k) { return map.has(k) ? map.get(k) : null; },
+    async set(k, v) {
+      if (k.startsWith('whevt:')) throw new Error('idempotency write failed');
+      map.set(k, v);
+    },
+  };
+  const proc = createLemonWebhookProcessor({
+    kv: flakyKv, webhookSecret: WEBHOOK_SECRET, licenseHmacSecret: LICENSE_SECRET, hashKey: hashLicenseKey, now: () => NOW, logger: { info() {} },
+  });
+  const create = JSON.stringify(lemonPayload({ event: 'subscription_created', status: 'active', eventId: 'p1' }));
+  await assert.rejects(() => proc.process({ rawBody: create, signature: sign(create) }), /idempotency write failed/);
+  // The mirror change persisted even though the idempotency write threw, so a
+  // Lemon retry (idem marker absent) will safely re-apply rather than lose it.
+  assert.ok(map.has(entitlementKey(hashLicenseKey(LICENSE_SECRET, RAW_KEY))));
+});
+
+test('subscription_payment_refunded (Invoice object: data.id=invoice) still revokes the active subscription', async () => {
+  const { kv, proc } = processorWith();
+  const eid = hashLicenseKey(LICENSE_SECRET, RAW_KEY);
+  const create = JSON.stringify(lemonPayload({ event: 'subscription_created', status: 'active', id: 'sub_1', eventId: 'pr1', updated: '2026-06-01T00:00:00Z' }));
+  await proc.process({ rawBody: create, signature: sign(create) });
+  assert.equal(JSON.parse(kv.map.get(entitlementKey(eid))).status, S.ACTIVE);
+
+  // Invoice-shaped payload: data.id is the INVOICE id; subscription_id is in attributes.
+  const refund = JSON.stringify({
+    meta: { event_name: 'subscription_payment_refunded', event_id: 'pr2', custom_data: { license_key: RAW_KEY } },
+    data: { id: 'inv_9', attributes: { subscription_id: 'sub_1', updated_at: '2026-07-01T00:00:00Z', created_at: '2026-07-01T00:00:00Z' } },
+  });
+  const res = await proc.process({ rawBody: refund, signature: sign(refund) });
+  assert.equal(res.applied, true);
+  assert.equal(JSON.parse(kv.map.get(entitlementKey(eid))).status, S.REVOKED);
+});

--- a/tests/unit/monetization-leak-guard.redteam.test.js
+++ b/tests/unit/monetization-leak-guard.redteam.test.js
@@ -1,0 +1,135 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  globToRegExp,
+  matchForbidden,
+  runGate,
+} from '../../scripts/check-no-private-assets.mjs';
+
+const hitByPath = (paths) => new Map(matchForbidden(paths).map((hit) => [hit.path, hit.pattern]));
+
+describe('monetization leak guard red-team: private asset placement', () => {
+  it('catches monetization private assets across nested source, corpus, and server paths', () => {
+    const planted = [
+      'src/paywall/private/persona-license.js',
+      'src/x/private/y.js',
+      'revenue/corpus/premium-ko/seed.jsonl',
+      'packages/patina-humanizer/corpus/deep/monetization/train.jsonl',
+      'server/billing/entitlements.js',
+    ];
+
+    assert.deepEqual(hitByPath(planted), new Map([
+      ['src/paywall/private/persona-license.js', '**/private/**'],
+      ['src/x/private/y.js', '**/private/**'],
+      ['revenue/corpus/premium-ko/seed.jsonl', '**/corpus/**'],
+      ['packages/patina-humanizer/corpus/deep/monetization/train.jsonl', '**/corpus/**'],
+      ['server/billing/entitlements.js', '**/server/**'],
+    ]));
+  });
+
+  it('treats explicitly private filename markers as case-insensitive leak shapes', () => {
+    const upperPrivate = 'src/payments/pro-pricing.PRIVATE.js';
+
+    assert.deepEqual(matchForbidden([upperPrivate]), [
+      { path: upperPrivate, pattern: '**/*.private.*' },
+    ]);
+  });
+});
+
+describe('monetization leak guard red-team: false-positive probes', () => {
+  it('does not catch safe paths that merely contain server-like text', () => {
+    const benignServerWords = [
+      'observer/x.js',
+      'src/serverless.js',
+      'src/features/observer-score.js',
+      'docs/integrations/serverless.md',
+    ];
+
+    assert.deepEqual(matchForbidden(benignServerWords), []);
+  });
+
+  it('does not catch benign public monetization modules', () => {
+    const benignMonetization = [
+      'src/features/pricing.js',
+      'src/personas/license-gates.js',
+      'docs/integrations/stripe-public.md',
+      'packages/patina-humanizer/src/billing-public.js',
+    ];
+
+    assert.deepEqual(matchForbidden(benignMonetization), []);
+  });
+});
+
+describe('monetization leak guard red-team: packed and tracked sources', () => {
+  it('fails runGate when monetization private assets leak through package and git sources', () => {
+    const result = runGate({
+      packedFiles: [
+        'src/index.js',
+        'packages/patina-humanizer/src/paywall.private.js',
+      ],
+      trackedFiles: [
+        'README.md',
+        'src/monetization/private/keys.js',
+      ],
+    });
+
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.counts, { packed: 2, tracked: 2 });
+    assert.deepEqual(result.violations, [
+      {
+        path: 'packages/patina-humanizer/src/paywall.private.js',
+        pattern: '**/*.private.*',
+        source: 'package',
+      },
+      {
+        path: 'src/monetization/private/keys.js',
+        pattern: '**/private/**',
+        source: 'git',
+      },
+    ]);
+  });
+
+  it('passes runGate for empty and benign-only inputs', () => {
+    assert.deepEqual(runGate(), {
+      ok: true,
+      violations: [],
+      counts: { packed: 0, tracked: 0 },
+    });
+
+    assert.deepEqual(runGate({
+      packedFiles: ['src/index.js', 'packages/patina-humanizer/bin/patina-humanizer.js'],
+      trackedFiles: ['README.md', 'src/features/pricing.js'],
+    }), {
+      ok: true,
+      violations: [],
+      counts: { packed: 2, tracked: 2 },
+    });
+  });
+});
+
+describe('monetization leak guard red-team: enhanced engine shapes', () => {
+  it('catches each reinforced/enhanced/corpus shape independently', () => {
+    const engineShapes = [
+      'src/engines/pricing.enhanced.js',
+      'src/engines/persona.reinforced.json',
+      'src/engines/enhanced/paywall.js',
+      'src/engines/reinforced/scorer.js',
+      'src/engines/corpus/premium.jsonl',
+    ];
+
+    assert.deepEqual(hitByPath(engineShapes), new Map([
+      ['src/engines/pricing.enhanced.js', '**/*.enhanced.*'],
+      ['src/engines/persona.reinforced.json', '**/*.reinforced.*'],
+      ['src/engines/enhanced/paywall.js', '**/enhanced/**'],
+      ['src/engines/reinforced/scorer.js', '**/reinforced/**'],
+      ['src/engines/corpus/premium.jsonl', '**/corpus/**'],
+    ]));
+  });
+
+  it('keeps glob compilation anchored to complete path segments', () => {
+    const serverGlob = globToRegExp('server/**');
+    assert.equal(serverGlob.test('server/billing.js'), true);
+    assert.equal(serverGlob.test('observer/server/billing.js'), false);
+    assert.equal(serverGlob.test('src/serverless.js'), false);
+  });
+});

--- a/tests/unit/monetization-leak-guard.test.js
+++ b/tests/unit/monetization-leak-guard.test.js
@@ -1,0 +1,96 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { matchForbidden } from '../../scripts/check-no-private-assets.mjs';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+/**
+ * Shapes that indicate a baked secret in source. Monetization sources must
+ * read every secret from env/params; a literal key/token/secret is a leak.
+ */
+const BAKED_SECRET_PATTERNS = [
+  /\bsk-[A-Za-z0-9_-]{12,}/,                                                  // OpenAI-style key incl. sk-proj-
+  /['"][0-9a-fA-F]{32,}['"]/,                                                 // long hex literal (HMAC/digest), any case
+  /PATINA_[A-Z0-9_]*(?:SECRET|TOKEN|KEY)\s*(?:[:=]|\|\||\?\?)\s*['"][^'"]+['"]/, // env secret with a NON-empty baked fallback/assignment
+  /\b[A-Z][A-Z0-9]*_(?:SECRET|TOKEN|APIKEY|API_KEY)\b\s*[:=]\s*['"][^'"]+['"]/, // UPPER_SECRET/TOKEN/APIKEY = "literal"
+];
+
+// G008: the leak gate must catch monetization-shaped private assets, and the
+// PUBLIC monetization modules added by G001-G007 must themselves be clean —
+// open-core boundary (no enhanced engine, corpus, or baked secret ships here).
+
+test('the leak gate flags monetization-shaped private/enhanced/corpus/server paths', () => {
+  const plantedPrivate = [
+    'src/pro-enhanced-engine.private.js',          // *.private.*
+    'src/enhanced/ko-pro-pipeline.js',             // enhanced/
+    'lexicon/ko-pro.reinforced.md',                // *.reinforced.*
+    'corpus/lemon-license-keys.jsonl',             // corpus/
+    'private/pro-hmac-secret.json',                // private/
+    'server/lemon-webhook-secret.js',              // server/
+  ];
+  const hits = matchForbidden(plantedPrivate);
+  assert.equal(hits.length, plantedPrivate.length, 'every monetization-private path must be flagged');
+});
+
+test('the actual PUBLIC monetization modules are NOT flagged (they ship in the open baseline)', () => {
+  const publicModules = [
+    'src/web-rewrite-contract.js',
+    'src/pro-entitlements.js',
+    'src/pro-session.js',
+    'src/pro-metering.js',
+    'src/pro-legal-copy.js',
+    'src/lemon-webhook.js',
+    'src/enhanced-rewrite-engine-contract.js',
+    'api/pro-session.js',
+    'api/lemon-webhook.js',
+    'api/rewrite.js',
+    'playground/rewrite-client.js',
+    'docs/PRO.md',
+    'docs/RELEASE-CHECKLIST.md',
+  ];
+  assert.deepEqual(matchForbidden(publicModules), []);
+});
+
+test('no monetization source file bakes in a secret or raw key', () => {
+  const files = [
+    'src/pro-entitlements.js', 'src/pro-session.js', 'src/pro-metering.js',
+    'src/lemon-webhook.js', 'src/enhanced-rewrite-engine-contract.js',
+    'api/pro-session.js', 'api/lemon-webhook.js', 'api/rewrite.js',
+    'playground/rewrite-client.js',
+  ];
+  for (const rel of files) {
+    const body = readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+    // Secrets must come from env/params, never a baked literal. These mirror
+    // (and broaden) the secret shapes the contract already redacts.
+    for (const re of BAKED_SECRET_PATTERNS) {
+      assert.ok(!re.test(body), `${rel} appears to bake a secret (matched ${re})`);
+    }
+  }
+});
+
+test('the baked-secret patterns actually catch real secret shapes (not vacuous)', () => {
+  const positives = [
+    "const k = 'sk-proj-Abc123_def-456789xyz';",
+    "const sig = 'deadBEEFdeadbeefdeadbeefdeadbeefdeadbeef';",            // 40 hex, mixed case
+    "const s = env.PATINA_PRO_HMAC_SECRET || 'dev-fallback-secret';",      // non-empty fallback
+    "PATINA_LEMON_WEBHOOK_SECRET = 'baked-value-123';",
+    "LEMON_API_KEY = 'live_abcdef';",
+  ];
+  for (const sample of positives) {
+    assert.ok(BAKED_SECRET_PATTERNS.some((re) => re.test(sample)), `expected a pattern to flag: ${sample}`);
+  }
+  // ...and benign shapes used by the real modules are NOT flagged.
+  const benign = [
+    "const apiKey = env.PATINA_FREE_API_KEY;",
+    "webhookSecret: env.PATINA_LEMON_WEBHOOK_SECRET || '',",                // empty fallback ok
+    "export const ENTITLEMENT_KEY_PREFIX = 'ent:';",
+    "model: enhancedEngine.kind || 'enhanced',",
+    "return { ok: false, status: 503, reason: 'pro session secret unavailable' };",
+  ];
+  for (const sample of benign) {
+    assert.ok(!BAKED_SECRET_PATTERNS.some((re) => re.test(sample)), `false positive on benign: ${sample}`);
+  }
+});

--- a/tests/unit/pro-entitlements.redteam.test.js
+++ b/tests/unit/pro-entitlements.redteam.test.js
@@ -1,0 +1,192 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ENTITLEMENT_STATES,
+  applyEntitlementEvent,
+  deriveEntitlementState,
+  hashLicenseKey,
+  isProAllowed,
+} from '../../src/pro-entitlements.js';
+
+const S = ENTITLEMENT_STATES;
+const NOW = 10_000;
+
+const event = (overrides = {}) => ({
+  id: 'evt-1',
+  status: S.ACTIVE,
+  effectiveAt: 1_000,
+  version: 1,
+  subscriptionId: 'sub-1',
+  ...overrides,
+});
+
+const mustRecord = (result) => {
+  assert.equal(result.changed, true);
+  return result.record;
+};
+
+const assertNotAllowedResult = (result, label) => {
+  assert.equal(result.changed, false, `${label}: event must be ignored`);
+  assert.equal(isProAllowed(result.record, NOW), false, `${label}: ignored result must not expose an allowed record`);
+};
+
+const assertNoThrow = (callback, label) => {
+  assert.doesNotThrow(callback, label);
+};
+
+test('revoke cannot be bypassed by same-subscription active events in arbitrary order, duplicates, higher versions, or future effectiveAt', () => {
+  const active = mustRecord(applyEntitlementEvent(null, event({ id: 'active-1', effectiveAt: 5_000, version: 5 })));
+  const revoked = mustRecord(applyEntitlementEvent(active, event({ id: 'revoke-older', status: S.REVOKED, effectiveAt: 1_000, version: 1 })));
+
+  assert.equal(revoked.status, S.REVOKED);
+  assert.equal(isProAllowed(revoked, NOW), false);
+
+  const attacks = [
+    ['same event duplicate revoke', event({ id: 'revoke-older', status: S.REVOKED, effectiveAt: 1_000, version: 1 })],
+    ['same-sub active higher version', event({ id: 'active-v999', status: S.ACTIVE, effectiveAt: 6_000, version: 999 })],
+    ['same-sub trialing higher version', event({ id: 'trial-v1000', status: S.TRIALING, effectiveAt: 7_000, version: 1_000 })],
+    ['same-sub active future effectiveAt', event({ id: 'active-future', status: S.ACTIVE, effectiveAt: 99_999_999, version: 1_001 })],
+    ['same-sub active no subscription id', event({ id: 'active-no-sub', status: S.ACTIVE, effectiveAt: 100_000_000, version: 1_002, subscriptionId: undefined })],
+  ];
+
+  for (const [label, attack] of attacks) {
+    const result = applyEntitlementEvent(revoked, attack);
+    assert.equal(result.changed, false, label);
+    assert.equal(isProAllowed(revoked, NOW), false, `${label}: original revoked record remains denied`);
+  }
+});
+
+test('cancelled and expired terminal records cannot be resurrected by same-subscription active events', () => {
+  for (const terminal of [S.CANCELLED, S.EXPIRED]) {
+    const record = mustRecord(applyEntitlementEvent(null, event({ id: `make-${terminal}`, status: terminal, effectiveAt: 1_000, version: 1 })));
+    const attack = applyEntitlementEvent(record, event({ id: `resurrect-${terminal}`, status: S.ACTIVE, effectiveAt: 2_000, version: 2 }));
+
+    assert.equal(attack.changed, false, terminal);
+    assert.equal(attack.reason, 'no_resurrection');
+    assert.equal(isProAllowed(record, NOW), false);
+  }
+});
+
+test('null or undefined subscriptionId cannot disguise terminal same-subscription resurrection as a reissue', () => {
+  for (const terminal of [S.CANCELLED, S.EXPIRED, S.REVOKED]) {
+    const record = mustRecord(applyEntitlementEvent(null, event({ id: `terminal-${terminal}`, status: terminal, effectiveAt: 1_000, version: 1, subscriptionId: 'sub-original' })));
+
+    for (const missingSubscriptionId of [null, undefined]) {
+      const attack = applyEntitlementEvent(record, event({
+        id: `missing-sub-${terminal}-${missingSubscriptionId}`,
+        status: S.ACTIVE,
+        effectiveAt: 2_000,
+        version: 2,
+        subscriptionId: missingSubscriptionId,
+      }));
+
+      assert.equal(attack.changed, false, `${terminal}/${missingSubscriptionId}`);
+      assert.equal(isProAllowed(record, NOW), false);
+    }
+  }
+});
+
+test('duplicate event id cannot double-apply or bypass ordering with changed payload', () => {
+  const first = mustRecord(applyEntitlementEvent(null, event({ id: 'shared-id', status: S.ACTIVE, effectiveAt: 1_000, version: 1 })));
+  const duplicateCancel = applyEntitlementEvent(first, event({ id: 'shared-id', status: S.CANCELLED, effectiveAt: 9_000, version: 9 }));
+
+  assert.equal(duplicateCancel.changed, false);
+  assert.equal(duplicateCancel.reason, 'duplicate_event');
+  assert.equal(isProAllowed(first, NOW), true);
+
+  const cancelled = mustRecord(applyEntitlementEvent(first, event({ id: 'cancel-unique', status: S.CANCELLED, effectiveAt: 10_000, version: 10 })));
+  const duplicateActive = applyEntitlementEvent(cancelled, event({ id: 'cancel-unique', status: S.ACTIVE, effectiveAt: 11_000, version: 11 }));
+
+  assert.equal(duplicateActive.changed, false);
+  assert.equal(duplicateActive.reason, 'duplicate_event');
+  assert.equal(isProAllowed(cancelled, NOW), false);
+});
+
+test('version/effectiveAt ties are not newer and cannot override state', () => {
+  const active = mustRecord(applyEntitlementEvent(null, event({ id: 'active', status: S.ACTIVE, effectiveAt: 5_000, version: 5 })));
+
+  const tieCancel = applyEntitlementEvent(active, event({ id: 'tie-cancel', status: S.CANCELLED, effectiveAt: 5_000, version: 5 }));
+  assert.equal(tieCancel.changed, false);
+  assert.equal(tieCancel.reason, 'stale_event');
+  assert.equal(isProAllowed(active, NOW), true);
+
+  const sameVersionLaterEffective = applyEntitlementEvent(active, event({ id: 'later-effective', status: S.PAST_DUE, effectiveAt: 5_001, version: 5 }));
+  assert.equal(sameVersionLaterEffective.changed, true);
+  assert.equal(sameVersionLaterEffective.record.status, S.PAST_DUE);
+  assert.equal(isProAllowed(sameVersionLaterEffective.record, NOW), false);
+});
+
+test('deriveEntitlementState/isProAllowed fail closed at expiry boundaries and malformed expiresAt values', () => {
+  assert.equal(deriveEntitlementState({ status: S.ACTIVE, expiresAt: NOW + 1 }, NOW), S.ACTIVE);
+  assert.equal(isProAllowed({ status: S.ACTIVE, expiresAt: NOW + 1 }, NOW), true);
+
+  for (const expiresAt of [NOW, NOW - 1, -1, 0, Number.NaN, Number.POSITIVE_INFINITY, '20000']) {
+    const record = { status: S.ACTIVE, expiresAt };
+    assert.equal(deriveEntitlementState(record, NOW), S.EXPIRED, `expiresAt=${String(expiresAt)} should derive expired`);
+    assert.equal(isProAllowed(record, NOW), false, `expiresAt=${String(expiresAt)} should deny Pro`);
+  }
+});
+
+test('prototype-pollution and type-confusion inputs are handled without throwing or granting Pro', () => {
+  const pollutedRecord = JSON.parse('{"status":"active","expiresAt":0,"__proto__":{"status":"active"}}');
+  const confusedRecords = [
+    pollutedRecord,
+    [],
+    42,
+    'active',
+    { status: ['active'] },
+    { status: 1 },
+    { status: new String(S.ACTIVE) },
+  ];
+
+  for (const record of confusedRecords) {
+    assertNoThrow(() => deriveEntitlementState(record, NOW), `derive should not throw for ${Object.prototype.toString.call(record)}`);
+    assertNoThrow(() => isProAllowed(record, NOW), `isProAllowed should not throw for ${Object.prototype.toString.call(record)}`);
+    assert.equal(isProAllowed(record, NOW), false, `confused record ${Object.prototype.toString.call(record)} must deny Pro`);
+  }
+
+  const validCurrent = mustRecord(applyEntitlementEvent(null, event({ id: 'seed', status: S.CANCELLED, effectiveAt: 1_000, version: 1 })));
+  const confusedEvents = [
+    JSON.parse('{"id":"polluted","status":"active","effectiveAt":2000,"version":2,"subscriptionId":"sub-1","__proto__":{"subscriptionId":"sub-2"}}'),
+    [],
+    42,
+    'event',
+    { id: 'array-status', status: ['active'], effectiveAt: 2_000, version: 2 },
+    { id: 'string-object-status', status: new String(S.ACTIVE), effectiveAt: 2_000, version: 2 },
+  ];
+
+  for (const candidate of confusedEvents) {
+    assertNoThrow(() => applyEntitlementEvent(validCurrent, candidate), `apply should not throw for ${Object.prototype.toString.call(candidate)}`);
+    const result = applyEntitlementEvent(validCurrent, candidate);
+    assertNotAllowedResult(result, `confused event ${Object.prototype.toString.call(candidate)}`);
+  }
+});
+
+test('hashLicenseKey does not echo raw keys and throws without a secret', () => {
+  const raw = 'LEMON-SUPER-SECRET-RAW-KEY';
+  const digest = hashLicenseKey('server-secret', raw);
+
+  assert.match(digest, /^[0-9a-f]{64}$/);
+  assert.equal(digest.includes(raw), false);
+  assert.throws(() => hashLicenseKey('', raw), /secret/);
+});
+
+test('applyEntitlementEvent never mutates input record or event objects', () => {
+  const current = Object.freeze({
+    status: S.CANCELLED,
+    effectiveAt: 1_000,
+    version: 1,
+    lastEventId: 'cancelled',
+    subscriptionId: 'sub-1',
+    expiresAt: 2_000,
+  });
+  const candidate = Object.freeze(event({ id: 'attempt', status: S.ACTIVE, effectiveAt: 2_000, version: 2 }));
+  const currentSnapshot = JSON.stringify(current);
+  const eventSnapshot = JSON.stringify(candidate);
+
+  const result = applyEntitlementEvent(current, candidate);
+
+  assert.equal(result.changed, false);
+  assert.equal(JSON.stringify(current), currentSnapshot);
+  assert.equal(JSON.stringify(candidate), eventSnapshot);
+});

--- a/tests/unit/pro-entitlements.test.js
+++ b/tests/unit/pro-entitlements.test.js
@@ -1,0 +1,244 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ENTITLEMENT_STATES,
+  PRO_ALLOWED_STATES,
+  TERMINAL_STATES,
+  POSITIVE_ENTITLEMENT_TTL_MS,
+  NEGATIVE_ENTITLEMENT_TTL_MS,
+  hashLicenseKey,
+  deriveEntitlementState,
+  isProAllowed,
+  cacheTtlForState,
+  shouldInvalidateSessions,
+  applyEntitlementEvent,
+} from '../../src/pro-entitlements.js';
+
+const S = ENTITLEMENT_STATES;
+
+function ev(overrides = {}) {
+  return { id: 'evt-1', status: S.ACTIVE, effectiveAt: 1000, ...overrides };
+}
+
+// --- hashing ----------------------------------------------------------------
+test('hashLicenseKey is a deterministic opaque HMAC and never echoes the raw key', () => {
+  const a = hashLicenseKey('secret', 'LEMON-RAW-KEY');
+  const b = hashLicenseKey('secret', 'LEMON-RAW-KEY');
+  assert.equal(a, b);
+  assert.match(a, /^[0-9a-f]{64}$/);
+  assert.ok(!a.includes('LEMON-RAW-KEY'));
+  assert.notEqual(a, hashLicenseKey('secret', 'OTHER-KEY'));
+  assert.notEqual(a, hashLicenseKey('other-secret', 'LEMON-RAW-KEY'));
+});
+
+test('hashLicenseKey fails closed without a secret or key', () => {
+  assert.throws(() => hashLicenseKey('', 'k'), /secret/);
+  assert.throws(() => hashLicenseKey('s', ''), /license key/);
+});
+
+// --- derive + isProAllowed --------------------------------------------------
+test('deriveEntitlementState reports none for missing/garbage and the stored status otherwise', () => {
+  assert.equal(deriveEntitlementState(null), S.NONE);
+  assert.equal(deriveEntitlementState(undefined), S.NONE);
+  assert.equal(deriveEntitlementState({}), S.NONE);
+  assert.equal(deriveEntitlementState({ status: 'bogus' }), S.NONE);
+  assert.equal(deriveEntitlementState({ status: S.ACTIVE }), S.ACTIVE);
+  assert.equal(deriveEntitlementState({ status: S.PAST_DUE }), S.PAST_DUE);
+});
+
+test('deriveEntitlementState reports expired when a Pro-allowed record is past its hard expiry', () => {
+  const rec = { status: S.ACTIVE, effectiveAt: 0, expiresAt: 500 };
+  assert.equal(deriveEntitlementState(rec, 400), S.ACTIVE);
+  assert.equal(deriveEntitlementState(rec, 600), S.EXPIRED);
+});
+
+test('isProAllowed is true only for active and trialing (and not past expiry)', () => {
+  assert.equal(isProAllowed({ status: S.ACTIVE }), true);
+  assert.equal(isProAllowed({ status: S.TRIALING }), true);
+  for (const s of [S.NONE, S.PAST_DUE, S.CANCELLED, S.REVOKED, S.EXPIRED]) {
+    assert.equal(isProAllowed({ status: s }), false, `expected ${s} not allowed`);
+  }
+  assert.equal(isProAllowed(null), false);
+  assert.equal(isProAllowed({ status: S.ACTIVE, expiresAt: 100 }, 200), false);
+});
+
+test('PRO_ALLOWED_STATES is exactly {active, trialing}', () => {
+  assert.deepEqual([...PRO_ALLOWED_STATES].sort(), [S.ACTIVE, S.TRIALING].sort());
+});
+
+// --- cache ttl + session invalidation ---------------------------------------
+test('cacheTtlForState: positive 10m for allowed, negative 60s otherwise', () => {
+  assert.equal(cacheTtlForState(S.ACTIVE), POSITIVE_ENTITLEMENT_TTL_MS);
+  assert.equal(cacheTtlForState(S.TRIALING), POSITIVE_ENTITLEMENT_TTL_MS);
+  for (const s of [S.NONE, S.PAST_DUE, S.CANCELLED, S.REVOKED, S.EXPIRED]) {
+    assert.equal(cacheTtlForState(s), NEGATIVE_ENTITLEMENT_TTL_MS);
+  }
+});
+
+test('shouldInvalidateSessions fires when leaving allowed or entering a terminal state', () => {
+  assert.equal(shouldInvalidateSessions(S.ACTIVE, S.PAST_DUE), true);
+  assert.equal(shouldInvalidateSessions(S.ACTIVE, S.CANCELLED), true);
+  assert.equal(shouldInvalidateSessions(S.TRIALING, S.REVOKED), true);
+  assert.equal(shouldInvalidateSessions(S.CANCELLED, S.REVOKED), true); // defensive: revoke after cancel
+  assert.equal(shouldInvalidateSessions(S.ACTIVE, S.ACTIVE), false);
+  assert.equal(shouldInvalidateSessions(S.TRIALING, S.ACTIVE), false);
+  assert.equal(shouldInvalidateSessions(S.NONE, S.ACTIVE), false);
+});
+
+// --- applyEntitlementEvent: creation + idempotency --------------------------
+test('applyEntitlementEvent creates a record from no prior state', () => {
+  const r = applyEntitlementEvent(null, ev({ subscriptionId: 'sub_1', expiresAt: 9999 }));
+  assert.equal(r.changed, true);
+  assert.equal(r.record.status, S.ACTIVE);
+  assert.equal(r.record.lastEventId, 'evt-1');
+  assert.equal(r.record.subscriptionId, 'sub_1');
+  assert.equal(r.record.expiresAt, 9999);
+  assert.equal(r.prevState, S.NONE);
+  assert.equal(r.nextState, S.ACTIVE);
+});
+
+test('applyEntitlementEvent ignores a duplicate event id (idempotent)', () => {
+  const first = applyEntitlementEvent(null, ev()).record;
+  const dup = applyEntitlementEvent(first, ev());
+  assert.equal(dup.changed, false);
+  assert.equal(dup.reason, 'duplicate_event');
+});
+
+test('applyEntitlementEvent ignores malformed events fail-closed', () => {
+  for (const bad of [null, {}, { id: 'x' }, { id: 'x', status: 'nope', effectiveAt: 1 }, { id: 'x', status: S.ACTIVE, effectiveAt: 'soon' }]) {
+    const r = applyEntitlementEvent(null, /** @type {any} */ (bad));
+    assert.equal(r.changed, false);
+    assert.equal(r.reason, 'invalid_event');
+  }
+});
+
+test('applyEntitlementEvent treats a none-status event as a no-op', () => {
+  const r = applyEntitlementEvent(null, ev({ status: S.NONE }));
+  assert.equal(r.changed, false);
+  assert.equal(r.reason, 'noop_none');
+});
+
+// --- ordering / out-of-order / stale ----------------------------------------
+test('applyEntitlementEvent applies a strictly-newer event and ignores an older one', () => {
+  const active = applyEntitlementEvent(null, ev({ id: 'e1', status: S.ACTIVE, effectiveAt: 1000, subscriptionId: 'sub_1' })).record;
+  const pastDue = applyEntitlementEvent(active, ev({ id: 'e2', status: S.PAST_DUE, effectiveAt: 2000, subscriptionId: 'sub_1' }));
+  assert.equal(pastDue.changed, true);
+  assert.equal(pastDue.record.status, S.PAST_DUE);
+
+  // An older event arriving late must not overwrite the newer state.
+  const stale = applyEntitlementEvent(pastDue.record, ev({ id: 'e0', status: S.ACTIVE, effectiveAt: 500, subscriptionId: 'sub_1' }));
+  assert.equal(stale.changed, false);
+  assert.equal(stale.reason, 'stale_event');
+});
+
+test('authority is effectiveAt-primary with version as a same-time tiebreaker', () => {
+  // A later effectiveAt wins regardless of version (no timestamp/version mixing).
+  const a = applyEntitlementEvent(null, ev({ id: 'e1', status: S.ACTIVE, effectiveAt: 1000, version: 5, subscriptionId: 'sub_1' })).record;
+  const later = applyEntitlementEvent(a, ev({ id: 'e2', status: S.PAST_DUE, effectiveAt: 2000, version: 1, subscriptionId: 'sub_1' }));
+  assert.equal(later.changed, true);
+  assert.equal(later.record.status, S.PAST_DUE);
+
+  // At EQUAL effectiveAt, the higher version wins and a lower/equal one is stale.
+  const b = applyEntitlementEvent(null, ev({ id: 'e3', status: S.ACTIVE, effectiveAt: 1000, version: 2, subscriptionId: 'sub_1' })).record;
+  const lowerV = applyEntitlementEvent(b, ev({ id: 'e4', status: S.CANCELLED, effectiveAt: 1000, version: 1, subscriptionId: 'sub_1' }));
+  assert.equal(lowerV.changed, false);
+  assert.equal(lowerV.reason, 'stale_event');
+  const higherV = applyEntitlementEvent(b, ev({ id: 'e5', status: S.CANCELLED, effectiveAt: 1000, version: 3, subscriptionId: 'sub_1' }));
+  assert.equal(higherV.changed, true);
+  assert.equal(higherV.record.status, S.CANCELLED);
+
+  // An explicit version: 0 is a legitimate low tiebreaker, never "missing".
+  const z = applyEntitlementEvent(null, ev({ id: 'e6', status: S.ACTIVE, effectiveAt: 1000, version: 0, subscriptionId: 'sub_1' })).record;
+  assert.equal(z.version, 0);
+});
+
+test('malformed or non-future expiresAt on a Pro record denies Pro fail-closed (no fail-open)', () => {
+  const base = { status: S.ACTIVE, effectiveAt: 0, version: 0 };
+  assert.equal(isProAllowed({ ...base, expiresAt: 1000 }, 500), true); // finite future → allowed
+  assert.equal(isProAllowed({ ...base, expiresAt: 500 }, 500), false); // boundary (<=) → expired
+  assert.equal(isProAllowed({ ...base, expiresAt: 400 }, 500), false); // past → expired
+  for (const bad of [NaN, Infinity, -Infinity, '20000', {}, []]) {
+    const rec = { ...base, expiresAt: /** @type {any} */ (bad) };
+    assert.equal(isProAllowed(rec, 500), false, `expiresAt=${String(bad)} must deny Pro`);
+    assert.equal(deriveEntitlementState(rec, 500), S.EXPIRED);
+  }
+});
+
+test('a stale/replayed revoke for an OLD subscription cannot revoke the current one', () => {
+  const active2 = applyEntitlementEvent(null, ev({ id: 'e1', status: S.ACTIVE, effectiveAt: 5000, subscriptionId: 'sub_2' })).record;
+  const oldRevoke = applyEntitlementEvent(active2, ev({ id: 'e0', status: S.REVOKED, effectiveAt: 1000, subscriptionId: 'sub_1' }));
+  assert.equal(oldRevoke.changed, false);
+  assert.equal(oldRevoke.reason, 'other_subscription');
+  assert.equal(isProAllowed(active2), true);
+});
+
+test('a time-expired active record only renews via a newer event carrying a future expiry', () => {
+  const now = 10_000;
+  const expired = { status: S.ACTIVE, effectiveAt: 1000, version: 0, subscriptionId: 'sub_1', expiresAt: 2000 };
+  assert.equal(deriveEntitlementState(expired, now), S.EXPIRED);
+  const bare = applyEntitlementEvent(expired, ev({ id: 'e2', status: S.ACTIVE, effectiveAt: 3000, subscriptionId: 'sub_1' }), now);
+  assert.equal(bare.changed, false);
+  assert.equal(bare.reason, 'no_resurrection');
+  const renew = applyEntitlementEvent(expired, ev({ id: 'e3', status: S.ACTIVE, effectiveAt: 3000, subscriptionId: 'sub_1', expiresAt: 99_999 }), now);
+  assert.equal(renew.changed, true);
+  assert.equal(renew.record.status, S.ACTIVE);
+  assert.equal(renew.record.expiresAt, 99_999);
+});
+
+test('exported state constants are frozen (immutable access policy)', () => {
+  assert.ok(Object.isFrozen(PRO_ALLOWED_STATES));
+  assert.ok(Object.isFrozen(TERMINAL_STATES));
+  assert.throws(() => { /** @type {any} */ (PRO_ALLOWED_STATES).push('hacked'); });
+});
+
+// --- revoke override + sticky -----------------------------------------------
+test('a revoke wins even when it arrives out of order (monotonic terminal override)', () => {
+  const active = applyEntitlementEvent(null, ev({ id: 'e1', status: S.ACTIVE, effectiveAt: 5000, subscriptionId: 'sub_1' })).record;
+  const revoke = applyEntitlementEvent(active, ev({ id: 'e2', status: S.REVOKED, effectiveAt: 1000, subscriptionId: 'sub_1' }));
+  assert.equal(revoke.changed, true);
+  assert.equal(revoke.record.status, S.REVOKED);
+});
+
+test('revoked is sticky: a same-subscription active cannot un-revoke', () => {
+  const revoked = applyEntitlementEvent(null, ev({ id: 'e1', status: S.REVOKED, effectiveAt: 1000, subscriptionId: 'sub_1' })).record;
+  const tryActive = applyEntitlementEvent(revoked, ev({ id: 'e2', status: S.ACTIVE, effectiveAt: 2000, subscriptionId: 'sub_1' }));
+  assert.equal(tryActive.changed, false);
+  assert.equal(tryActive.reason, 'revoked_sticky');
+});
+
+test('revoked can only be left by a newer reissue for a different subscription', () => {
+  const revoked = applyEntitlementEvent(null, ev({ id: 'e1', status: S.REVOKED, effectiveAt: 1000, subscriptionId: 'sub_1' })).record;
+  const reissue = applyEntitlementEvent(revoked, ev({ id: 'e2', status: S.ACTIVE, effectiveAt: 2000, subscriptionId: 'sub_2' }));
+  assert.equal(reissue.changed, true);
+  assert.equal(reissue.record.status, S.ACTIVE);
+  assert.equal(reissue.record.subscriptionId, 'sub_2');
+});
+
+// --- resurrection prevention (cancelled/expired) ----------------------------
+test('a cancelled record is not resurrected to active by the same subscription', () => {
+  const cancelled = applyEntitlementEvent(null, ev({ id: 'e1', status: S.CANCELLED, effectiveAt: 1000, subscriptionId: 'sub_1' })).record;
+  const sameSub = applyEntitlementEvent(cancelled, ev({ id: 'e2', status: S.ACTIVE, effectiveAt: 2000, subscriptionId: 'sub_1' }));
+  assert.equal(sameSub.changed, false);
+  assert.equal(sameSub.reason, 'no_resurrection');
+});
+
+test('a cancelled record CAN be replaced by a new subscription (reissue)', () => {
+  const cancelled = applyEntitlementEvent(null, ev({ id: 'e1', status: S.CANCELLED, effectiveAt: 1000, subscriptionId: 'sub_1' })).record;
+  const reissue = applyEntitlementEvent(cancelled, ev({ id: 'e2', status: S.ACTIVE, effectiveAt: 2000, subscriptionId: 'sub_2' }));
+  assert.equal(reissue.changed, true);
+  assert.equal(reissue.record.subscriptionId, 'sub_2');
+});
+
+test('past_due can recover to active for the same subscription (not terminal)', () => {
+  const pastDue = applyEntitlementEvent(null, ev({ id: 'e1', status: S.PAST_DUE, effectiveAt: 1000, subscriptionId: 'sub_1' })).record;
+  const recovered = applyEntitlementEvent(pastDue, ev({ id: 'e2', status: S.ACTIVE, effectiveAt: 2000, subscriptionId: 'sub_1' }));
+  assert.equal(recovered.changed, true);
+  assert.equal(recovered.record.status, S.ACTIVE);
+});
+
+test('inputs are never mutated', () => {
+  const current = applyEntitlementEvent(null, ev({ id: 'e1', subscriptionId: 'sub_1' })).record;
+  const snapshot = JSON.stringify(current);
+  applyEntitlementEvent(current, ev({ id: 'e2', status: S.CANCELLED, effectiveAt: 2000, subscriptionId: 'sub_1' }));
+  assert.equal(JSON.stringify(current), snapshot);
+});

--- a/tests/unit/pro-metering.test.js
+++ b/tests/unit/pro-metering.test.js
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createProMetering, PRO_LIMITS } from '../../src/pro-metering.js';
+
+/** A counter KV (incr only), like the rate limiter uses. */
+function counterKv() {
+  const map = new Map();
+  return { map, async incr(k) { const n = (map.get(k) ?? 0) + 1; map.set(k, n); return n; } };
+}
+
+test('PRO_LIMITS pins the agreed caps', () => {
+  assert.deepEqual(PRO_LIMITS, { reqPerDay: 100, reqPerHour: 20, reqPerMinute: 6, maxChars: 12000 });
+});
+
+test('allows up to the per-minute cap, then 429s the burst', async () => {
+  const meter = createProMetering({ kv: counterKv(), now: () => 1_000_000 });
+  for (let i = 0; i < PRO_LIMITS.reqPerMinute; i++) {
+    const r = await meter.check({ entitlementId: 'eid' });
+    assert.equal(r.allowed, true, `request ${i + 1} should be allowed`);
+  }
+  const over = await meter.check({ entitlementId: 'eid' });
+  assert.equal(over.allowed, false);
+  assert.equal(over.status, 429);
+  assert.match(over.reason, /rate too high/);
+});
+
+test('enforces the daily cap independently (injected low limit)', async () => {
+  let t = 0;
+  const meter = createProMetering({
+    kv: counterKv(),
+    now: () => t,
+    limits: { reqPerDay: 3, reqPerHour: 1000, reqPerMinute: 1000, maxChars: 12000 },
+  });
+  for (let i = 0; i < 3; i++) {
+    assert.equal((await meter.check({ entitlementId: 'eid' })).allowed, true);
+    t += 60_000; // advance a minute so we are clearly testing the day cap
+  }
+  const over = await meter.check({ entitlementId: 'eid' });
+  assert.equal(over.allowed, false);
+  assert.equal(over.status, 429);
+  assert.match(over.reason, /daily cap/);
+});
+
+test('different entitlements are metered independently', async () => {
+  const meter = createProMetering({ kv: counterKv(), now: () => 1_000_000, limits: { reqPerDay: 1, reqPerHour: 1, reqPerMinute: 1, maxChars: 12000 } });
+  assert.equal((await meter.check({ entitlementId: 'a' })).allowed, true);
+  assert.equal((await meter.check({ entitlementId: 'b' })).allowed, true); // separate counters
+  assert.equal((await meter.check({ entitlementId: 'a' })).allowed, false); // a is now over
+});
+
+test('fails closed: no entitlement -> 403, missing/garbage counter -> 503', async () => {
+  const meter = createProMetering({ kv: counterKv(), now: () => 1_000_000 });
+  assert.equal((await meter.check({ entitlementId: '' })).status, 403);
+  assert.equal((await meter.check({})).status, 403);
+
+  const badKv = { async incr() { return undefined; } };
+  const badMeter = createProMetering({ kv: /** @type {any} */ (badKv), now: () => 1_000_000 });
+  assert.equal((await badMeter.check({ entitlementId: 'eid' })).status, 503);
+
+  const noKv = createProMetering({ kv: /** @type {any} */ ({}), now: () => 1_000_000 });
+  assert.equal((await noKv.check({ entitlementId: 'eid' })).status, 503);
+
+  const throwKv = { async incr() { throw new Error('kv down'); } };
+  const throwMeter = createProMetering({ kv: /** @type {any} */ (throwKv), now: () => 1_000_000 });
+  assert.equal((await throwMeter.check({ entitlementId: 'eid' })).status, 503);
+});

--- a/tests/unit/pro-session-api.test.js
+++ b/tests/unit/pro-session-api.test.js
@@ -1,0 +1,116 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createProSessionApiHandler } from '../../api/pro-session.js';
+import { entitlementKey, hashSessionToken, sessionKey } from '../../src/pro-session.js';
+import { ENTITLEMENT_STATES, hashLicenseKey } from '../../src/pro-entitlements.js';
+
+const S = ENTITLEMENT_STATES;
+const SECRET = 'api-test-secret';
+const activeEntitlement = { status: S.ACTIVE, effectiveAt: 0, version: 0, subscriptionId: 'sub_1' };
+
+function mockKv() {
+  const map = new Map();
+  return {
+    map,
+    async get(key) { return map.has(key) ? map.get(key) : null; },
+    async set(key, val) { assert.equal(typeof val, 'string'); map.set(key, val); },
+  };
+}
+
+/** A mock res capturing status/headers/body. */
+function mockRes() {
+  return {
+    statusCode: 0,
+    headers: {},
+    body: undefined,
+    setHeader(k, v) { this.headers[k.toLowerCase()] = v; },
+    end(payload) { this.body = payload; },
+  };
+}
+
+function makeHandler({ kv = mockKv(), env = {}, verifyLicense, logs = [] } = {}) {
+  const handler = createProSessionApiHandler({
+    env: { PATINA_PRO_HMAC_SECRET: SECRET, ...env },
+    kv,
+    verifyLicense,
+    logger: { info: (msg, meta) => logs.push({ msg, meta }) },
+    now: () => 1_000_000,
+  });
+  return { handler, kv, logs };
+}
+
+test('POST with an active mirror entitlement returns 200 + an opaque token (no-store)', async () => {
+  const { handler, kv } = makeHandler();
+  const rawKey = 'LEMON-RAW-API';
+  kv.map.set(entitlementKey(hashLicenseKey(SECRET, rawKey)), JSON.stringify(activeEntitlement));
+
+  const res = mockRes();
+  await handler({ method: 'POST', body: { licenseKey: rawKey } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.headers['cache-control'], 'no-store');
+  const out = JSON.parse(res.body);
+  assert.match(out.proSessionToken, /^[0-9a-f]{64}$/);
+  assert.equal(out.status, S.ACTIVE);
+  // session stored under the token HASH; raw key/token absent from store keys
+  assert.ok(kv.map.has(sessionKey(hashSessionToken(SECRET, out.proSessionToken))));
+  for (const key of kv.map.keys()) assert.ok(!key.includes(rawKey));
+});
+
+test('non-POST is 405', async () => {
+  const { handler } = makeHandler();
+  const res = mockRes();
+  await handler({ method: 'GET' }, res);
+  assert.equal(res.statusCode, 405);
+});
+
+test('missing licenseKey is 400', async () => {
+  const { handler } = makeHandler();
+  const res = mockRes();
+  await handler({ method: 'POST', body: {} }, res);
+  assert.equal(res.statusCode, 400);
+});
+
+test('a non-allowed entitlement is 402 (fail-closed, no token)', async () => {
+  const { handler, kv } = makeHandler();
+  kv.map.set(entitlementKey(hashLicenseKey(SECRET, 'k')), JSON.stringify({ status: S.CANCELLED, effectiveAt: 0, version: 0 }));
+  const res = mockRes();
+  await handler({ method: 'POST', body: { licenseKey: 'k' } }, res);
+  assert.equal(res.statusCode, 402);
+  assert.ok(!JSON.parse(res.body).proSessionToken);
+});
+
+test('production without a REST KV fails closed with 503 (no memory fallback)', async () => {
+  // isProductionPosture true via VERCEL_ENV; no KV_REST_API_* env → restKv null.
+  const handler = createProSessionApiHandler({
+    env: { PATINA_PRO_HMAC_SECRET: SECRET, VERCEL_ENV: 'production' },
+    now: () => 1_000_000,
+  });
+  const res = mockRes();
+  await handler({ method: 'POST', body: { licenseKey: 'k' } }, res);
+  assert.equal(res.statusCode, 503);
+});
+
+test('the sanitized log never carries the raw license key or token', async () => {
+  const { handler, kv, logs } = makeHandler();
+  const rawKey = 'SECRET-RAW-LICENSE';
+  kv.map.set(entitlementKey(hashLicenseKey(SECRET, rawKey)), JSON.stringify(activeEntitlement));
+  const res = mockRes();
+  await handler({ method: 'POST', body: { licenseKey: rawKey } }, res);
+  const dump = JSON.stringify(logs);
+  assert.ok(!dump.includes(rawKey));
+  assert.ok(!dump.includes(JSON.parse(res.body).proSessionToken));
+});
+
+test('a KV outage during exchange fails closed as a sanitized 503 (no uncaught error)', async () => {
+  const throwingKv = { async get() { throw new Error('kv down'); }, async set() {} };
+  const handler = createProSessionApiHandler({
+    env: { PATINA_PRO_HMAC_SECRET: SECRET },
+    kv: throwingKv,
+    now: () => 1_000_000,
+  });
+  const res = mockRes();
+  await handler({ method: 'POST', body: { licenseKey: 'k' } }, res);
+  assert.equal(res.statusCode, 503);
+  assert.equal(res.headers['cache-control'], 'no-store');
+});

--- a/tests/unit/pro-session.redteam.test.js
+++ b/tests/unit/pro-session.redteam.test.js
@@ -1,0 +1,258 @@
+import { Readable } from 'node:stream';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PRO_SESSION_ABSOLUTE_TTL_MS,
+  PRO_SESSION_TTL_MS,
+  createProSessionExchange,
+  entitlementKey,
+  hashSessionToken,
+  issueProSession,
+  refreshProSession,
+  sessionKey,
+  verifyProSession,
+} from '../../src/pro-session.js';
+import { ENTITLEMENT_STATES, hashLicenseKey } from '../../src/pro-entitlements.js';
+import { createProSessionApiHandler } from '../../api/pro-session.js';
+
+const S = ENTITLEMENT_STATES;
+const SECRET = 'redteam-hmac-secret';
+const RAW_LICENSE = 'RAW-LEMON-REDTEAM-LICENSE';
+const RAW_TOKEN_MARKER = 'RAW-PRO-SESSION-TOKEN';
+const EMAIL = 'victim@example.test';
+const NOW = 1_000_000;
+
+const activeEntitlement = (overrides = {}) => ({
+  status: S.ACTIVE,
+  effectiveAt: 0,
+  version: 0,
+  subscriptionId: 'sub_redteam',
+  ...overrides,
+});
+
+const inactiveStatuses = [S.CANCELLED, S.REVOKED, S.EXPIRED, S.PAST_DUE, S.NONE];
+
+const seqRandom = () => {
+  let n = 0;
+  return (len) => Buffer.alloc(len, (n++ % 254) + 1);
+};
+
+const fixedRandom = (text) => (len) => Buffer.from(text.padEnd(len, 'x')).subarray(0, len);
+
+const mockKv = () => {
+  const map = new Map();
+  return {
+    map,
+    async get(key) { return map.has(key) ? map.get(key) : null; },
+    async set(key, val, opts = {}) {
+      assert.equal(typeof val, 'string', 'KV value must be a string');
+      map.set(key, val);
+      map.set(`__ttl__${key}`, opts.ttlMs);
+    },
+  };
+};
+
+const exchangeWith = ({ kv = mockKv(), verifyLicense, now = NOW, randomImpl = seqRandom() } = {}) => ({
+  kv,
+  ex: createProSessionExchange({
+    kv,
+    hmacSecret: SECRET,
+    verifyLicense,
+    hashKey: hashLicenseKey,
+    now: () => now,
+    randomImpl,
+  }),
+});
+
+const mockRes = () => ({
+  statusCode: 0,
+  headers: {},
+  body: undefined,
+  setHeader(key, val) { this.headers[key.toLowerCase()] = val; },
+  end(payload) { this.body = payload; },
+});
+
+const streamReq = (body, method = 'POST') => {
+  const req = Readable.from([body]);
+  req.method = method;
+  return req;
+};
+
+const makeApiHandler = ({ kv = mockKv(), env = {}, verifyLicense, logs = [] } = {}) => ({
+  kv,
+  logs,
+  handler: createProSessionApiHandler({
+    env: { PATINA_PRO_HMAC_SECRET: SECRET, ...env },
+    kv,
+    verifyLicense,
+    logger: { info: (msg, meta) => logs.push({ msg, meta }) },
+    now: () => NOW,
+  }),
+});
+
+const dumpStore = (kv) => JSON.stringify([...kv.map.entries()]);
+
+const assertNoSecretLeak = ({ kv, result, rawLicense = RAW_LICENSE, rawToken, email = EMAIL, allowReturnedToken = false }) => {
+  const storeDump = dumpStore(kv);
+  const resultDump = JSON.stringify(result);
+  for (const forbidden of [rawLicense, email].filter(Boolean)) {
+    assert.equal(storeDump.includes(forbidden), false, `secret leaked into KV: ${forbidden}`);
+    assert.equal(resultDump.includes(forbidden), false, `secret leaked into result: ${forbidden}`);
+  }
+  if (rawToken) {
+    assert.equal(storeDump.includes(rawToken), false, `raw token leaked into KV: ${rawToken}`);
+    if (!allowReturnedToken) assert.equal(resultDump.includes(rawToken), false, `raw token leaked into result: ${rawToken}`);
+  }
+};
+
+test('inactive entitlements never exchange into a session token', async () => {
+  for (const status of inactiveStatuses) {
+    const { kv, ex } = exchangeWith();
+    const entitlementId = hashLicenseKey(SECRET, `${RAW_LICENSE}-${status}`);
+    kv.map.set(entitlementKey(entitlementId), JSON.stringify({ status, effectiveAt: 0, version: 0 }));
+
+    const result = await ex.exchange({ licenseKey: `${RAW_LICENSE}-${status}` });
+
+    assert.equal(result.ok, false, `${status} must fail closed`);
+    assert.equal(result.status, 402, `${status} must be Payment Required`);
+    assert.equal('proSessionToken' in result, false, `${status} must not return a token`);
+    for (const key of kv.map.keys()) assert.equal(key.startsWith('sess:'), false, `${status} must not create a session`);
+  }
+});
+
+test('missing, blank, and non-string licenseKey bodies cannot obtain sessions', async () => {
+  const invalidBodies = [undefined, null, {}, { licenseKey: '' }, { licenseKey: '   ' }, { licenseKey: 123 }, { licenseKey: true }, { licenseKey: ['k'] }, { licenseKey: { toString: () => RAW_LICENSE } }];
+
+  for (const body of invalidBodies) {
+    const { kv, ex } = exchangeWith();
+    const result = await ex.exchange(body);
+
+    assert.equal(result.ok, false, `invalid body must fail: ${JSON.stringify(body)}`);
+    assert.equal(result.status, 400, `invalid body must be 400: ${JSON.stringify(body)}`);
+    assert.equal([...kv.map.keys()].some((key) => key.startsWith('sess:')), false);
+  }
+});
+
+test('exchange only returns the raw token as the intended success bearer and does not leak raw license, token, or email elsewhere', async () => {
+  const rawToken = fixedRandom(RAW_TOKEN_MARKER)(32).toString('hex');
+  const { kv, ex } = exchangeWith({
+    randomImpl: fixedRandom(RAW_TOKEN_MARKER),
+    verifyLicense: async (raw) => (raw === RAW_LICENSE ? activeEntitlement({ email: EMAIL, licenseKey: RAW_LICENSE }) : null),
+  });
+
+  const result = await ex.exchange({ licenseKey: RAW_LICENSE });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.proSessionToken, rawToken);
+  assert.ok(kv.map.has(sessionKey(hashSessionToken(SECRET, rawToken))), 'session must be stored by token hash');
+  assert.equal(kv.map.has(sessionKey(rawToken)), false, 'raw token must not be a store key');
+  assertNoSecretLeak({ kv, result, rawToken, allowReturnedToken: true });
+
+  const denied = await ex.exchange({ licenseKey: `${RAW_LICENSE}-DENIED` });
+  assert.equal(denied.ok, false);
+  assertNoSecretLeak({ kv, result: denied, rawLicense: `${RAW_LICENSE}-DENIED`, rawToken, email: EMAIL });
+});
+
+test('expired sliding and absolute sessions fail verification', () => {
+  const issued = issueProSession({ entitlement: activeEntitlement(), entitlementId: 'eid-redteam', now: NOW }).record;
+
+  assert.equal(verifyProSession({ sessionRecord: issued, entitlement: activeEntitlement(), now: NOW + PRO_SESSION_TTL_MS + 1 }).ok, false);
+  assert.equal(verifyProSession({ sessionRecord: issued, entitlement: activeEntitlement(), now: NOW + PRO_SESSION_TTL_MS + 1 }).reason, 'expired');
+
+  const absoluteExpired = { ...issued, expiresAt: NOW + PRO_SESSION_ABSOLUTE_TTL_MS + 10_000 };
+  assert.equal(verifyProSession({ sessionRecord: absoluteExpired, entitlement: activeEntitlement(), now: NOW + PRO_SESSION_ABSOLUTE_TTL_MS + 1 }).ok, false);
+  assert.equal(verifyProSession({ sessionRecord: absoluteExpired, entitlement: activeEntitlement(), now: NOW + PRO_SESSION_ABSOLUTE_TTL_MS + 1 }).reason, 'absolute_expired');
+});
+
+test('revoked entitlement immediately invalidates an otherwise fresh session', () => {
+  const issued = issueProSession({ entitlement: activeEntitlement(), entitlementId: 'eid-redteam', now: NOW }).record;
+
+  const result = verifyProSession({
+    sessionRecord: issued,
+    entitlement: { status: S.REVOKED, effectiveAt: 0, version: 1 },
+    now: NOW + 1,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'entitlement_revoked');
+});
+
+test('refresh cannot extend beyond the absolute cap or refresh forever', () => {
+  let record = issueProSession({ entitlement: activeEntitlement(), entitlementId: 'eid-redteam', now: NOW }).record;
+  let cursor = NOW;
+
+  while (cursor < NOW + PRO_SESSION_ABSOLUTE_TTL_MS - 1) {
+    cursor = Math.min(cursor + PRO_SESSION_TTL_MS - 1, NOW + PRO_SESSION_ABSOLUTE_TTL_MS - 1);
+    const refreshed = refreshProSession({ sessionRecord: record, entitlement: activeEntitlement(), now: cursor });
+    assert.equal(refreshed.ok, true);
+    assert.ok(refreshed.record.expiresAt <= record.absoluteExpiresAt, 'refresh must respect absolute cap');
+    record = refreshed.record;
+    if (record.expiresAt === record.absoluteExpiresAt) break;
+  }
+
+  assert.equal(record.expiresAt, record.absoluteExpiresAt);
+  assert.equal(refreshProSession({ sessionRecord: record, entitlement: activeEntitlement(), now: record.absoluteExpiresAt }).ok, false);
+});
+
+test('two exchanges for the same license receive distinct opaque token hashes', async () => {
+  const { kv, ex } = exchangeWith();
+  kv.map.set(entitlementKey(hashLicenseKey(SECRET, RAW_LICENSE)), JSON.stringify(activeEntitlement()));
+
+  const first = await ex.exchange({ licenseKey: RAW_LICENSE });
+  const second = await ex.exchange({ licenseKey: RAW_LICENSE });
+
+  assert.equal(first.ok, true);
+  assert.equal(second.ok, true);
+  assert.notEqual(first.proSessionToken, second.proSessionToken);
+  assert.notEqual(hashSessionToken(SECRET, first.proSessionToken), hashSessionToken(SECRET, second.proSessionToken));
+  assert.match(first.proSessionToken, /^[0-9a-f]{64}$/);
+  assert.match(second.proSessionToken, /^[0-9a-f]{64}$/);
+});
+
+test('API rejects non-POST, giant bodies, malformed JSON, missing production KV, and always no-stores', async () => {
+  const { handler } = makeApiHandler();
+
+  const getRes = mockRes();
+  await handler({ method: 'GET' }, getRes);
+  assert.equal(getRes.statusCode, 405);
+  assert.equal(getRes.headers['cache-control'], 'no-store');
+
+  const giantRes = mockRes();
+  await handler(streamReq('{"licenseKey":"'.padEnd(16 * 1024 + 2, 'A')), giantRes);
+  assert.equal(giantRes.statusCode, 400);
+  assert.equal(giantRes.headers['cache-control'], 'no-store');
+
+  const malformedRes = mockRes();
+  await handler(streamReq('{"licenseKey":'), malformedRes);
+  assert.equal(malformedRes.statusCode, 400);
+  assert.equal(malformedRes.headers['cache-control'], 'no-store');
+
+  const prodHandler = createProSessionApiHandler({
+    env: { PATINA_PRO_HMAC_SECRET: SECRET, VERCEL_ENV: 'production' },
+    now: () => NOW,
+    logger: { info: () => {} },
+  });
+  const prodRes = mockRes();
+  await prodHandler({ method: 'POST', body: { licenseKey: RAW_LICENSE } }, prodRes);
+  assert.equal(prodRes.statusCode, 503);
+  assert.equal(prodRes.headers['cache-control'], 'no-store');
+});
+
+test('prototype-polluted and type-confused bodies cannot smuggle a licenseKey', async () => {
+  const inherited = Object.create({ licenseKey: RAW_LICENSE });
+  const { kv, ex } = exchangeWith();
+  kv.map.set(entitlementKey(hashLicenseKey(SECRET, RAW_LICENSE)), JSON.stringify(activeEntitlement()));
+
+  const exchangeResult = await ex.exchange(inherited);
+
+  assert.equal(exchangeResult.ok, false, 'exchange must ignore inherited licenseKey values');
+  assert.equal(exchangeResult.status, 400);
+  assert.equal([...kv.map.keys()].some((key) => key.startsWith('sess:')), false);
+
+  const { handler } = makeApiHandler({ kv });
+  const apiRes = mockRes();
+  await handler({ method: 'POST', body: inherited }, apiRes);
+
+  assert.equal(apiRes.statusCode, 400, 'API must ignore inherited licenseKey values');
+  assert.equal(JSON.parse(apiRes.body).proSessionToken, undefined);
+});

--- a/tests/unit/pro-session.test.js
+++ b/tests/unit/pro-session.test.js
@@ -1,0 +1,219 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PRO_SESSION_TTL_MS,
+  PRO_SESSION_ABSOLUTE_TTL_MS,
+  entitlementKey,
+  sessionKey,
+  generateProSessionToken,
+  hashSessionToken,
+  issueProSession,
+  verifyProSession,
+  refreshProSession,
+  createProSessionExchange,
+} from '../../src/pro-session.js';
+import { ENTITLEMENT_STATES, hashLicenseKey } from '../../src/pro-entitlements.js';
+
+const S = ENTITLEMENT_STATES;
+const SECRET = 'test-hmac-secret';
+
+const activeEntitlement = (over = {}) => ({ status: S.ACTIVE, effectiveAt: 0, version: 0, subscriptionId: 'sub_1', ...over });
+
+/** A deterministic random impl: distinct bytes per call so tokens differ. */
+function seqRandom() {
+  let n = 0;
+  return (len) => Buffer.alloc(len, (n++ % 254) + 1);
+}
+
+/** A tiny mock of the shared string KV store. */
+function mockKv() {
+  const map = new Map();
+  return {
+    map,
+    async get(key) { return map.has(key) ? map.get(key) : null; },
+    async set(key, val, { ttlMs } = {}) {
+      assert.equal(typeof val, 'string', 'KV value must be a string (store contract)');
+      map.set(key, val);
+      map.set(`__ttl__${key}`, ttlMs);
+    },
+  };
+}
+
+// --- token primitives -------------------------------------------------------
+test('generateProSessionToken is opaque hex and uses the injected random source', () => {
+  const t = generateProSessionToken(seqRandom());
+  assert.match(t, /^[0-9a-f]{64}$/);
+  assert.notEqual(generateProSessionToken(seqRandom()), generateProSessionToken(() => Buffer.alloc(32, 9)));
+});
+
+test('hashSessionToken is deterministic and fails closed without a secret/token', () => {
+  assert.equal(hashSessionToken(SECRET, 'tok'), hashSessionToken(SECRET, 'tok'));
+  assert.match(hashSessionToken(SECRET, 'tok'), /^[0-9a-f]{64}$/);
+  assert.notEqual(hashSessionToken(SECRET, 'tok'), 'tok');
+  assert.throws(() => hashSessionToken('', 'tok'), /secret/);
+  assert.throws(() => hashSessionToken(SECRET, ''), /token/);
+});
+
+test('key namespaces are opaque-prefixed', () => {
+  assert.equal(entitlementKey('abc'), 'ent:abc');
+  assert.equal(sessionKey('def'), 'sess:def');
+});
+
+// --- issue / verify / refresh ----------------------------------------------
+test('issueProSession builds a record only for an allowed entitlement', () => {
+  const ok = issueProSession({ entitlement: activeEntitlement(), entitlementId: 'eid', now: 1000 });
+  assert.equal(ok.ok, true);
+  assert.equal(ok.record.entitlementId, 'eid');
+  assert.equal(ok.record.expiresAt, 1000 + PRO_SESSION_TTL_MS);
+  assert.equal(ok.record.absoluteExpiresAt, 1000 + PRO_SESSION_ABSOLUTE_TTL_MS);
+
+  for (const s of [S.CANCELLED, S.REVOKED, S.EXPIRED, S.PAST_DUE, S.NONE]) {
+    const r = issueProSession({ entitlement: { status: s, effectiveAt: 0, version: 0 }, entitlementId: 'eid', now: 1000 });
+    assert.equal(r.ok, false, `${s} must not issue a session`);
+  }
+  assert.equal(issueProSession({ entitlement: activeEntitlement(), entitlementId: '', now: 1000 }).ok, false);
+});
+
+test('verifyProSession fails closed on missing/expired/absolute-expired/revoked', () => {
+  const now = 1_000_000;
+  const fresh = issueProSession({ entitlement: activeEntitlement(), entitlementId: 'eid', now }).record;
+  assert.equal(verifyProSession({ sessionRecord: fresh, entitlement: activeEntitlement(), now }).ok, true);
+
+  // sliding expiry passed
+  assert.equal(verifyProSession({ sessionRecord: fresh, entitlement: activeEntitlement(), now: now + PRO_SESSION_TTL_MS + 1 }).reason, 'expired');
+  // entitlement revoked while session still time-valid
+  assert.equal(verifyProSession({ sessionRecord: fresh, entitlement: { status: S.REVOKED, effectiveAt: 0, version: 0 }, now: now + 1000 }).reason, 'entitlement_revoked');
+  // malformed
+  assert.equal(verifyProSession({ sessionRecord: null, entitlement: activeEntitlement(), now }).reason, 'no_session');
+  assert.equal(verifyProSession({ sessionRecord: { expiresAt: 'soon', absoluteExpiresAt: now + 1 }, entitlement: activeEntitlement(), now }).reason, 'expired');
+
+  // absolute cap beats a slid sliding expiry
+  const nearCap = { entitlementId: 'eid', issuedAt: now, expiresAt: now + PRO_SESSION_TTL_MS, absoluteExpiresAt: now + 1000 };
+  assert.equal(verifyProSession({ sessionRecord: nearCap, entitlement: activeEntitlement(), now: now + 2000 }).reason, 'absolute_expired');
+});
+
+test('refreshProSession slides expiry but never past the absolute cap, and only while valid', () => {
+  const now = 1_000_000;
+  const rec = issueProSession({ entitlement: activeEntitlement(), entitlementId: 'eid', now }).record;
+  const later = now + 20 * 60 * 1000; // 20 min later, still valid
+  const refreshed = refreshProSession({ sessionRecord: rec, entitlement: activeEntitlement(), now: later });
+  assert.equal(refreshed.ok, true);
+  // A 20-min-in refresh slides to later+TTL, still well under the 2h cap.
+  assert.equal(refreshed.record.expiresAt, later + PRO_SESSION_TTL_MS);
+  assert.ok(refreshed.record.expiresAt <= rec.absoluteExpiresAt);
+
+  // The absolute cap binds when the slide would exceed it.
+  const nearCap = { entitlementId: 'eid', issuedAt: now, expiresAt: now + 5000, absoluteExpiresAt: now + 5000 };
+  const capped = refreshProSession({ sessionRecord: nearCap, entitlement: activeEntitlement(), now: now + 1000 });
+  assert.equal(capped.ok, true);
+  assert.equal(capped.record.expiresAt, nearCap.absoluteExpiresAt, 'expiry is clamped to the absolute cap');
+
+  // cannot refresh once the entitlement is revoked
+  assert.equal(refreshProSession({ sessionRecord: rec, entitlement: { status: S.REVOKED, effectiveAt: 0, version: 0 }, now: later }).ok, false);
+});
+
+// --- exchange ---------------------------------------------------------------
+function exchangeWith({ kv = mockKv(), verifyLicense, now = 1_000_000 } = {}) {
+  return {
+    kv,
+    ex: createProSessionExchange({
+      kv,
+      hmacSecret: SECRET,
+      verifyLicense,
+      hashKey: hashLicenseKey,
+      now: () => now,
+      randomImpl: seqRandom(),
+    }),
+  };
+}
+
+test('exchange issues a token for an active mirror entitlement and stores ONLY hashes', async () => {
+  const { kv, ex } = exchangeWith();
+  const rawKey = 'LEMON-LICENSE-RAW';
+  const eid = hashLicenseKey(SECRET, rawKey);
+  kv.map.set(entitlementKey(eid), JSON.stringify(activeEntitlement()));
+
+  const res = await ex.exchange({ licenseKey: rawKey });
+  assert.equal(res.ok, true);
+  assert.match(res.proSessionToken, /^[0-9a-f]{64}$/);
+  assert.equal(res.status, S.ACTIVE);
+
+  // The session is stored under the HASH of the token, not the token itself,
+  // and the raw license key never appears in any store key.
+  const tokenHash = hashSessionToken(SECRET, res.proSessionToken);
+  assert.ok(kv.map.has(sessionKey(tokenHash)));
+  for (const key of kv.map.keys()) {
+    assert.ok(!key.includes(rawKey), `raw license key leaked into store key: ${key}`);
+    assert.ok(!key.includes(res.proSessionToken), `raw token leaked into store key: ${key}`);
+  }
+  // session record carries no raw key/token, and a TTL was set
+  const stored = JSON.parse(kv.map.get(sessionKey(tokenHash)));
+  assert.equal(stored.entitlementId, eid);
+  assert.ok(!JSON.stringify(stored).includes(rawKey));
+  assert.equal(kv.map.get(`__ttl__${sessionKey(tokenHash)}`), PRO_SESSION_ABSOLUTE_TTL_MS);
+});
+
+test('exchange falls back to a provider verify when the mirror is empty', async () => {
+  let seen;
+  const { ex } = exchangeWith({
+    verifyLicense: async (raw) => { seen = raw; return activeEntitlement(); },
+  });
+  const res = await ex.exchange({ licenseKey: 'RAW-2' });
+  assert.equal(res.ok, true);
+  assert.equal(seen, 'RAW-2');
+});
+
+test('exchange fails closed (402) for a non-allowed entitlement and never downgrades', async () => {
+  for (const s of [S.CANCELLED, S.REVOKED, S.EXPIRED, S.PAST_DUE]) {
+    const { kv, ex } = exchangeWith();
+    const eid = hashLicenseKey(SECRET, 'k');
+    kv.map.set(entitlementKey(eid), JSON.stringify({ status: s, effectiveAt: 0, version: 0 }));
+    const res = await ex.exchange({ licenseKey: 'k' });
+    assert.equal(res.ok, false);
+    assert.equal(res.status, 402, `${s} must be 402`);
+  }
+});
+
+test('exchange fails closed for an unknown key (no mirror, no verify)', async () => {
+  const { ex } = exchangeWith();
+  const res = await ex.exchange({ licenseKey: 'never-seen' });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 402);
+});
+
+test('exchange rejects a missing/blank licenseKey (400) and a missing secret (503)', async () => {
+  const { ex } = exchangeWith();
+  assert.equal((await ex.exchange({})).status, 400);
+  assert.equal((await ex.exchange({ licenseKey: '   ' })).status, 400);
+
+  const ex503 = createProSessionExchange({ kv: mockKv(), hmacSecret: '', hashKey: hashLicenseKey });
+  assert.equal((await ex503.exchange({ licenseKey: 'k' })).status, 503);
+});
+
+test('exchange error results never echo the raw license key', async () => {
+  const { ex } = exchangeWith();
+  const res = await ex.exchange({ licenseKey: 'SUPER-SECRET-RAW-KEY' });
+  assert.ok(!JSON.stringify(res).includes('SUPER-SECRET-RAW-KEY'));
+});
+
+test('exchange ignores an INHERITED licenseKey (prototype pollution cannot smuggle a key)', async () => {
+  const { kv, ex } = exchangeWith();
+  const rawKey = 'INHERITED-RAW';
+  kv.map.set(entitlementKey(hashLicenseKey(SECRET, rawKey)), JSON.stringify(activeEntitlement()));
+  // licenseKey lives on the prototype, not as an own property.
+  const polluted = Object.create({ licenseKey: rawKey });
+  const res = await ex.exchange(polluted);
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 400);
+  // and no session was created
+  assert.equal([...kv.map.keys()].some((k) => k.startsWith('sess:')), false);
+});
+
+test('exchange rejects an oversized licenseKey at the boundary (any body shape)', async () => {
+  const { kv, ex } = exchangeWith();
+  const res = await ex.exchange({ licenseKey: 'x'.repeat(600) });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 400);
+  assert.match(res.reason, /too long/);
+  assert.equal([...kv.map.keys()].some((k) => k.startsWith('sess:')), false);
+});

--- a/tests/unit/rewrite-client-pro.redteam.test.js
+++ b/tests/unit/rewrite-client-pro.redteam.test.js
@@ -1,0 +1,148 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRewriteThread, exchangeProLicense } from '../../playground/rewrite-client.js';
+import { PRO_LEGAL_COPY_BLOCK_KO, PRO_LEGAL_COPY_KO, PRO_REFUND_WINDOW_DAYS } from '../../src/pro-legal-copy.js';
+
+const rawKey = 'LEMON-RAW-SECRET-REDTEAM';
+
+const assertDoesNotContain = (value, needle, message) => {
+  assert.equal(JSON.stringify(value).includes(needle), false, message);
+};
+
+const makeJsonResponse = ({ ok = true, status = 200, payload = {} } = {}) => ({
+  ok,
+  status,
+  json: async () => payload,
+});
+
+const countOccurrences = (haystack, needle) => haystack.split(needle).length - 1;
+
+test('pro buildRequest ignores caller BYOK credentials and sends only the opaque pro token', () => {
+  const thread = createRewriteThread({ lang: 'ko' });
+  const body = thread.buildRequest({
+    text: '공격 입력',
+    tier: 'pro',
+    provider: 'attacker-provider',
+    model: 'attacker-model',
+    apiKey: 'sk-attacker-key',
+    proSessionToken: 'opaque-pro-token',
+  });
+
+  assert.equal(body.proSessionToken, 'opaque-pro-token');
+  assert.equal(Object.hasOwn(body, 'provider'), false);
+  assert.equal(Object.hasOwn(body, 'model'), false);
+  assert.equal(Object.hasOwn(body, 'apiKey'), false);
+  assert.deepEqual(Object.keys(body).sort(), ['lang', 'mode', 'proSessionToken', 'text', 'tier'].sort());
+});
+
+test('pro buildRequest without a pro token omits the proSessionToken key so the server rejects it', () => {
+  const thread = createRewriteThread({ lang: 'ko' });
+  const body = thread.buildRequest({ text: '토큰 없는 pro 요청', tier: 'pro' });
+
+  assert.equal(body.tier, 'pro');
+  assert.equal(Object.hasOwn(body, 'proSessionToken'), false);
+  assert.equal(Object.hasOwn(body, 'provider'), false);
+  assert.equal(Object.hasOwn(body, 'model'), false);
+  assert.equal(Object.hasOwn(body, 'apiKey'), false);
+});
+
+test('exchangeProLicense never retains the raw license key in success, failure, or network-error results', async () => {
+  const success = await exchangeProLicense({
+    licenseKey: rawKey,
+    fetchImpl: async () => makeJsonResponse({ payload: { proSessionToken: 'opaque-token', expiresAt: 123, status: 'active' } }),
+  });
+  assert.equal(success.ok, true);
+  assertDoesNotContain(success, rawKey, 'success result must not retain the raw license key');
+
+  const failure = await exchangeProLicense({
+    licenseKey: rawKey,
+    fetchImpl: async () => makeJsonResponse({ ok: false, status: 402, payload: { error: `denied ${rawKey}` } }),
+  });
+  assert.equal(failure.ok, false);
+  assertDoesNotContain(failure, rawKey, 'failure result must not echo or retain the raw license key');
+
+  const network = await exchangeProLicense({
+    licenseKey: rawKey,
+    fetchImpl: async () => { throw new Error(`offline ${rawKey}`); },
+  });
+  assert.equal(network.ok, false);
+  assert.equal(network.status, 0);
+  assertDoesNotContain(network, rawKey, 'network-error result must not retain the raw license key');
+});
+
+test('exchangeProLicense fails closed for tokenless 200 and non-2xx responses', async () => {
+  const tokenlessOk = await exchangeProLicense({
+    licenseKey: rawKey,
+    fetchImpl: async () => makeJsonResponse({ payload: { status: 'active', expiresAt: 123 } }),
+  });
+  assert.deepEqual(tokenlessOk, { ok: false, status: 200, error: 'pro exchange failed' });
+
+  const non2xx = await exchangeProLicense({
+    licenseKey: rawKey,
+    fetchImpl: async () => makeJsonResponse({ ok: false, status: 403, payload: { error: 'forbidden' } }),
+  });
+  assert.deepEqual(non2xx, { ok: false, status: 403, error: 'forbidden' });
+});
+
+test('exchangeProLicense returns ok:false status:0 on network throws', async () => {
+  const result = await exchangeProLicense({
+    licenseKey: rawKey,
+    fetchImpl: async () => { throw new Error('network down'); },
+  });
+
+  assert.deepEqual(result, { ok: false, status: 0, error: 'network error' });
+});
+
+test('exchangeProLicense rejects empty and non-string license keys before calling fetch', async () => {
+  const rejectedInputs = ['', '   ', null, undefined, 0, false, {}, []];
+
+  for (const licenseKey of rejectedInputs) {
+    let called = false;
+    const result = await exchangeProLicense({
+      licenseKey,
+      fetchImpl: async () => {
+        called = true;
+        return makeJsonResponse({ payload: { proSessionToken: 'should-not-happen' } });
+      },
+    });
+
+    assert.deepEqual(result, { ok: false, status: 400, error: 'licenseKey required' });
+    assert.equal(called, false, `fetch must not be called for ${String(licenseKey)}`);
+  }
+});
+
+test('exchangeProLicense sends the raw license key exactly once in the body and never in URL or headers', async () => {
+  let capturedUrl;
+  let capturedInit;
+  const result = await exchangeProLicense({
+    licenseKey: rawKey,
+    url: `/api/pro-session?probe=${encodeURIComponent('not-the-key')}`,
+    fetchImpl: async (url, init) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return makeJsonResponse({ payload: { proSessionToken: 'opaque-token', expiresAt: 456, status: 'active' } });
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(countOccurrences(String(capturedInit.body), rawKey), 1);
+  assert.equal(JSON.parse(capturedInit.body).licenseKey, rawKey);
+  assert.equal(String(capturedUrl).includes(rawKey), false);
+  assert.equal(JSON.stringify(capturedInit.headers).includes(rawKey), false);
+});
+
+test('ko legal copy is a single source block containing 7-day withdrawal and Lemon MoR lines', () => {
+  assert.equal(PRO_REFUND_WINDOW_DAYS, 7);
+  assert.match(PRO_LEGAL_COPY_BLOCK_KO, /7일/);
+  assert.match(PRO_LEGAL_COPY_BLOCK_KO, /청약철회/);
+  assert.match(PRO_LEGAL_COPY_BLOCK_KO, /Lemon Squeezy/);
+  assert.match(PRO_LEGAL_COPY_BLOCK_KO, /Merchant of Record/);
+
+  const blockLines = PRO_LEGAL_COPY_BLOCK_KO.split('\n');
+  const sourceLines = Object.values(PRO_LEGAL_COPY_KO);
+  assert.deepEqual(blockLines, sourceLines);
+
+  for (const line of sourceLines) {
+    assert.equal(blockLines.includes(line), true, `legal block must contain source line: ${line}`);
+  }
+});

--- a/tests/unit/rewrite-client-pro.test.js
+++ b/tests/unit/rewrite-client-pro.test.js
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRewriteThread, exchangeProLicense } from '../../playground/rewrite-client.js';
+import { PRO_LEGAL_COPY_BLOCK_KO, PRO_LEGAL_COPY_KO, PRO_REFUND_WINDOW_DAYS } from '../../src/pro-legal-copy.js';
+
+// --- buildRequest pro tier --------------------------------------------------
+test('buildRequest for the pro tier carries ONLY the opaque session token', () => {
+  const thread = createRewriteThread({ lang: 'ko' });
+  const body = thread.buildRequest({ text: '안녕하세요', tier: 'pro', proSessionToken: 'opaque-tok', provider: 'claude', model: 'x', apiKey: 'sk-x' });
+  assert.equal(body.tier, 'pro');
+  assert.equal(body.proSessionToken, 'opaque-tok');
+  // pro must not smuggle a caller-chosen provider/model/apiKey
+  assert.equal(body.provider, undefined);
+  assert.equal(body.model, undefined);
+  assert.equal(body.apiKey, undefined);
+});
+
+test('buildRequest for free/byok is unchanged by the pro addition', () => {
+  const thread = createRewriteThread({ lang: 'en' });
+  const free = thread.buildRequest({ text: 'hi', tier: 'free' });
+  assert.equal(free.tier, 'free');
+  assert.equal(free.proSessionToken, undefined);
+  const byok = thread.buildRequest({ text: 'hi', tier: 'byok', provider: 'openai', model: 'gpt-4.1', apiKey: 'sk-1' });
+  assert.equal(byok.apiKey, 'sk-1');
+  assert.equal(byok.proSessionToken, undefined);
+});
+
+// --- exchangeProLicense -----------------------------------------------------
+function fetchOk(payload) {
+  return async () => ({ ok: true, status: 200, async json() { return payload; } });
+}
+function fetchErr(status, payload) {
+  return async () => ({ ok: false, status, async json() { return payload; } });
+}
+
+test('exchangeProLicense returns the opaque token on success and sends the key once in the body', async () => {
+  let sentBody;
+  const fetchImpl = async (_url, init) => { sentBody = init.body; return { ok: true, status: 200, async json() { return { proSessionToken: 't0k', expiresAt: 123, status: 'active' }; } }; };
+  const res = await exchangeProLicense({ licenseKey: 'LEMON-RAW', fetchImpl });
+  assert.equal(res.ok, true);
+  assert.equal(res.proSessionToken, 't0k');
+  assert.equal(res.status, 'active');
+  // the raw key travels once, in the POST body
+  assert.equal(JSON.parse(sentBody).licenseKey, 'LEMON-RAW');
+});
+
+test('exchangeProLicense rejects a blank key without calling the network', async () => {
+  let called = false;
+  const fetchImpl = async () => { called = true; return { ok: true, status: 200, async json() { return {}; } }; };
+  const res = await exchangeProLicense({ licenseKey: '   ', fetchImpl });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 400);
+  assert.equal(called, false);
+});
+
+test('exchangeProLicense surfaces a server error without leaking the raw key', async () => {
+  const res = await exchangeProLicense({ licenseKey: 'SECRET-RAW', fetchImpl: fetchErr(402, { error: 'entitlement not active' }) });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 402);
+  assert.equal(res.error, 'entitlement not active');
+  assert.ok(!JSON.stringify(res).includes('SECRET-RAW'));
+});
+
+test('exchangeProLicense fails closed on a malformed success body (no token)', async () => {
+  const res = await exchangeProLicense({ licenseKey: 'k', fetchImpl: fetchOk({ notAToken: true }) });
+  assert.equal(res.ok, false);
+});
+
+test('exchangeProLicense fails closed on a network error', async () => {
+  const res = await exchangeProLicense({ licenseKey: 'k', fetchImpl: async () => { throw new Error('offline'); } });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 0);
+});
+
+// --- ko legal copy single source --------------------------------------------
+test('the ko refund/cancel copy is a single ordered block with the 7-day window', () => {
+  assert.equal(PRO_REFUND_WINDOW_DAYS, 7);
+  for (const line of Object.values(PRO_LEGAL_COPY_KO)) {
+    assert.ok(PRO_LEGAL_COPY_BLOCK_KO.includes(line), 'every line must appear in the shared block');
+  }
+  assert.match(PRO_LEGAL_COPY_BLOCK_KO, /7일/);
+  assert.match(PRO_LEGAL_COPY_BLOCK_KO, /Lemon Squeezy/);
+  assert.match(PRO_LEGAL_COPY_BLOCK_KO, /청약철회/);
+});
+
+test('exchangeProLicense scrubs the raw key even if a hostile server echoes it in the error', async () => {
+  const raw = 'LEMON-RAW-ECHOED';
+  const fetchImpl = async () => ({ ok: false, status: 403, async json() { return { error: `denied for ${raw}` }; } });
+  const res = await exchangeProLicense({ licenseKey: raw, fetchImpl });
+  assert.equal(res.ok, false);
+  assert.ok(!JSON.stringify(res).includes(raw), 'raw key must be scrubbed from the returned error');
+  assert.match(res.error, /\[REDACTED\]/);
+});

--- a/tests/unit/rewrite-pro-path.redteam.test.js
+++ b/tests/unit/rewrite-pro-path.redteam.test.js
@@ -1,0 +1,285 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRewriteApiHandler } from '../../api/rewrite.js';
+import { parseStreamFrame, STREAM_FRAME_TYPES, MPS_FLOOR, FIDELITY_FLOOR } from '../../src/web-rewrite-contract.js';
+import { hashSessionToken, sessionKey, entitlementKey, PRO_SESSION_TTL_MS, PRO_SESSION_ABSOLUTE_TTL_MS } from '../../src/pro-session.js';
+import { ENTITLEMENT_STATES } from '../../src/pro-entitlements.js';
+
+const S = ENTITLEMENT_STATES;
+const SECRET = 'redteam-pro-secret';
+const TOKEN = 'redteam-opaque-pro-token';
+const RAW_KEY = 'sk-redteam-raw-key-should-not-leak';
+const EMAIL = 'victim@example.test';
+const NOW = 1_000_000;
+const PRO_ENV = Object.freeze({
+  PATINA_PRO_ENABLED: 'true',
+  PATINA_PRO_PROVIDER: 'openai',
+  PATINA_PRO_MODEL: 'gpt-5.5',
+  PATINA_PRO_HMAC_SECRET: SECRET,
+  PATINA_FREE_API_KEY: 'sk-free-redteam',
+});
+
+const mockKv = ({ incrImpl } = {}) => {
+  const map = new Map();
+  return {
+    map,
+    get: async (k) => (map.has(k) ? map.get(k) : null),
+    set: async (k, v) => { map.set(k, v); },
+    incr: async (k, opts) => {
+      if (incrImpl) return incrImpl(k, opts, map);
+      const n = (map.get(k) ?? 0) + 1;
+      map.set(k, n);
+      return n;
+    },
+  };
+};
+
+const seed = (kv, {
+  token = TOKEN,
+  entitlementId = 'eid-redteam',
+  status = S.ACTIVE,
+  session = {},
+  entitlement = {},
+} = {}) => {
+  kv.map.set(entitlementKey(entitlementId), JSON.stringify({
+    status,
+    effectiveAt: 0,
+    version: 0,
+    subscriptionId: 'sub_redteam',
+    ...entitlement,
+  }));
+  kv.map.set(sessionKey(hashSessionToken(SECRET, token)), JSON.stringify({
+    entitlementId,
+    issuedAt: NOW,
+    expiresAt: NOW + PRO_SESSION_TTL_MS,
+    absoluteExpiresAt: NOW + PRO_SESSION_ABSOLUTE_TTL_MS,
+    ...session,
+  }));
+};
+
+const req = (body) => ({
+  method: 'POST',
+  headers: { 'x-real-ip': '1.2.3.4' },
+  async *[Symbol.asyncIterator]() { yield Buffer.from(JSON.stringify(body), 'utf8'); },
+});
+
+const proBody = (overrides = {}) => ({
+  mode: 'first',
+  lang: 'ko',
+  tier: 'pro',
+  text: '안녕하세요 redteam',
+  proSessionToken: TOKEN,
+  ...overrides,
+});
+
+const mockRes = () => ({
+  statusCode: 0,
+  headers: {},
+  chunks: [],
+  setHeader(k, v) { this.headers[k.toLowerCase()] = v; },
+  write(c) { this.chunks.push(String(c)); return true; },
+  end(c) { if (c != null) this.chunks.push(String(c)); },
+  body() { return this.chunks.join(''); },
+  frames() { return this.body().split('\n').filter(Boolean).map(parseStreamFrame).filter(Boolean); },
+  json() { try { return JSON.parse(this.body()); } catch { return null; } },
+});
+
+const createLogger = () => {
+  const entries = [];
+  return {
+    entries,
+    info: (...args) => { entries.push(['info', ...args]); },
+    warn: (...args) => { entries.push(['warn', ...args]); },
+    error: (...args) => { entries.push(['error', ...args]); },
+    text: () => JSON.stringify(entries),
+  };
+};
+
+const makeHandler = ({ kv = mockKv(), env = PRO_ENV, enhancedEngine, runWebRewriteStreamImpl, logger = createLogger() } = {}) => ({
+  kv,
+  logger,
+  handler: createRewriteApiHandler({ env, kv, enhancedEngine, runWebRewriteStreamImpl, logger, now: () => NOW }),
+});
+
+const assertNoStream = (res) => {
+  assert.equal(res.headers['content-type'], 'application/json');
+  assert.ok(!res.frames().some((f) => f.type === STREAM_FRAME_TYPES.START || f.type === STREAM_FRAME_TYPES.DELTA || f.type === STREAM_FRAME_TYPES.DONE));
+};
+
+const assertNoLeak = (res, logger, forbidden = [TOKEN, RAW_KEY, EMAIL, SECRET]) => {
+  const observed = `${res.body()}\n${logger.text()}`;
+  for (const secret of forbidden) assert.ok(!observed.includes(secret), `leaked ${secret}`);
+};
+
+test('invalid, forged, and empty proSessionToken cannot obtain enhanced output', async () => {
+  for (const body of [proBody(), proBody({ proSessionToken: 'forged-token' }), proBody({ proSessionToken: '' })]) {
+    const kv = mockKv();
+    if (body.proSessionToken !== TOKEN) seed(kv);
+    const logger = createLogger();
+    const { handler } = makeHandler({ kv, logger });
+    const res = mockRes();
+    await handler(req(body), res);
+    assert.equal(res.statusCode, body.proSessionToken === '' ? 400 : 401);
+    assertNoStream(res);
+    assertNoLeak(res, logger);
+  }
+});
+
+test('sliding-expired and absolute-expired sessions fail closed with 401', async () => {
+  for (const session of [{ expiresAt: NOW }, { absoluteExpiresAt: NOW }]) {
+    const kv = mockKv();
+    seed(kv, { session });
+    const logger = createLogger();
+    const { handler } = makeHandler({ kv, logger });
+    const res = mockRes();
+    await handler(req(proBody()), res);
+    assert.equal(res.statusCode, 401);
+    assertNoStream(res);
+    assertNoLeak(res, logger);
+  }
+});
+
+test('non-paying entitlement states deny pro with 402 even for time-valid sessions', async () => {
+  for (const status of [S.CANCELLED, S.REVOKED, S.EXPIRED, S.PAST_DUE, S.NONE]) {
+    const kv = mockKv();
+    seed(kv, { status });
+    const logger = createLogger();
+    const { handler } = makeHandler({ kv, logger });
+    const res = mockRes();
+    await handler(req(proBody()), res);
+    assert.equal(res.statusCode, 402, status);
+    assertNoStream(res);
+    assertNoLeak(res, logger);
+  }
+});
+
+test('metering day, hour, and minute caps deny with 429', async () => {
+  const cases = [
+    { label: 'day', match: ':d:', allowedBeforeDeny: 100, reason: 'daily cap exceeded' },
+    { label: 'hour', match: ':h:', allowedBeforeDeny: 20, reason: 'hourly cap exceeded' },
+    { label: 'minute', match: ':m:', allowedBeforeDeny: 6, reason: 'rate too high' },
+  ];
+  for (const c of cases) {
+    const kv = mockKv({ incrImpl: async (k, _opts, map) => {
+      const prior = map.get(k) ?? 0;
+      const next = k.includes(c.match) ? c.allowedBeforeDeny + 1 : prior + 1;
+      map.set(k, next);
+      return next;
+    } });
+    seed(kv);
+    const logger = createLogger();
+    const { handler } = makeHandler({ kv, logger });
+    const res = mockRes();
+    await handler(req(proBody()), res);
+    assert.equal(res.statusCode, 429, c.label);
+    assert.equal(res.json().error, c.reason);
+    assertNoStream(res);
+    assertNoLeak(res, logger);
+  }
+});
+
+test('malformed metering counter fails closed with 503, not fail-open', async () => {
+  const kv = mockKv({ incrImpl: async () => 'not-a-counter' });
+  seed(kv);
+  const logger = createLogger();
+  const { handler } = makeHandler({ kv, logger });
+  const res = mockRes();
+  await handler(req(proBody()), res);
+  assert.equal(res.statusCode, 503);
+  assert.equal(res.json().error, 'metering storage unavailable');
+  assertNoStream(res);
+  assertNoLeak(res, logger);
+});
+
+test('pro failures never silently downgrade to free or BYOK and never call shared LLM runner', async () => {
+  let llmCalls = 0;
+  const kv = mockKv();
+  seed(kv, { status: S.REVOKED });
+  const logger = createLogger();
+  const { handler } = makeHandler({
+    kv,
+    logger,
+    runWebRewriteStreamImpl: async () => { llmCalls += 1; },
+  });
+  const res = mockRes();
+  await handler(req(proBody({ apiKey: RAW_KEY, licenseKey: RAW_KEY, email: EMAIL })), res);
+  assert.equal(res.statusCode, 400);
+  assertNoStream(res);
+  assert.equal(llmCalls, 0);
+  assertNoLeak(res, logger);
+});
+
+test('pro errors and logs do not expose raw token, raw key, email, or hmac secret', async () => {
+  const kv = mockKv();
+  seed(kv, { entitlement: { email: EMAIL, rawKey: RAW_KEY } });
+  const logger = createLogger();
+  const enhancedEngine = {
+    kind: 'redteam-engine',
+    isAvailable: () => true,
+    rewrite: async () => { throw new Error(`boom ${TOKEN} ${RAW_KEY} ${EMAIL} ${SECRET}`); },
+  };
+  const { handler } = makeHandler({ kv, logger, enhancedEngine });
+  const res = mockRes();
+  await handler(req(proBody()), res);
+  assert.equal(res.statusCode, 503);
+  assert.equal(res.json().error, 'pro engine error');
+  assertNoStream(res);
+  assertNoLeak(res, logger);
+});
+
+test('pro misconfiguration and engine failures fail closed before streaming', async () => {
+  const cases = [
+    { label: 'missing secret', env: { PATINA_PRO_ENABLED: 'true', PATINA_PRO_PROVIDER: 'openai', PATINA_PRO_MODEL: 'gpt-5.5' }, expected: 'pro service unavailable' },
+    { label: 'unavailable engine', enhancedEngine: { kind: 'down', isAvailable: () => false, rewrite: async () => ({ text: 'bad', scores: {} }) }, expected: 'pro engine unavailable' },
+    { label: 'throwing engine', enhancedEngine: { kind: 'throws', isAvailable: () => true, rewrite: async () => { throw new Error('private failure'); } }, expected: 'pro engine error' },
+  ];
+  for (const c of cases) {
+    const kv = mockKv();
+    seed(kv);
+    const logger = createLogger();
+    const { handler } = makeHandler({ kv, logger, env: c.env ?? PRO_ENV, enhancedEngine: c.enhancedEngine });
+    const res = mockRes();
+    await handler(req(proBody()), res);
+    assert.equal(res.statusCode, 503, c.label);
+    assert.equal(res.json().error, c.expected);
+    assertNoStream(res);
+    assertNoLeak(res, logger);
+  }
+});
+
+test('gate-off free and BYOK paths still call the shared stream runner', async () => {
+  let calls = 0;
+  const runWebRewriteStreamImpl = async ({ emit }) => {
+    calls += 1;
+    emit({ type: STREAM_FRAME_TYPES.START });
+    emit({ type: STREAM_FRAME_TYPES.DONE, scores: { mps: 90, fidelity: 90 } });
+  };
+  const { handler } = makeHandler({
+    env: { PATINA_FREE_API_KEY: 'sk-free-redteam', PATINA_FREE_PROVIDER: 'openai', PATINA_FREE_MODEL: 'gpt-5.5' },
+    runWebRewriteStreamImpl,
+  });
+  const freeRes = mockRes();
+  await handler(req({ mode: 'first', lang: 'ko', tier: 'free', text: '무료 경로' }), freeRes);
+  assert.equal(freeRes.statusCode, 200);
+  assert.ok(freeRes.frames().some((f) => f.type === STREAM_FRAME_TYPES.DONE));
+
+  const byokRes = mockRes();
+  await handler(req({ mode: 'first', lang: 'ko', tier: 'byok', text: '바이오케이 경로', provider: 'openai', model: 'gpt-5.5', apiKey: RAW_KEY }), byokRes);
+  assert.equal(byokRes.statusCode, 200);
+  assert.ok(byokRes.frames().some((f) => f.type === STREAM_FRAME_TYPES.DONE));
+  assert.equal(calls, 2);
+});
+
+test('stub pro output makes no quality claim beyond exact floor scores', async () => {
+  const kv = mockKv();
+  seed(kv);
+  const { handler } = makeHandler({ kv });
+  const res = mockRes();
+  await handler(req(proBody()), res);
+  assert.equal(res.statusCode, 200);
+  const frames = res.frames();
+  const delta = frames.find((f) => f.type === STREAM_FRAME_TYPES.DELTA);
+  const done = frames.find((f) => f.type === STREAM_FRAME_TYPES.DONE);
+  assert.equal(delta.text, proBody().text);
+  assert.deepEqual(done.scores, { mps: MPS_FLOOR, fidelity: FIDELITY_FLOOR });
+});

--- a/tests/unit/rewrite-pro-path.test.js
+++ b/tests/unit/rewrite-pro-path.test.js
@@ -1,0 +1,131 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRewriteApiHandler } from '../../api/rewrite.js';
+import { parseStreamFrame, STREAM_FRAME_TYPES } from '../../src/web-rewrite-contract.js';
+import { hashSessionToken, sessionKey, entitlementKey, PRO_SESSION_TTL_MS, PRO_SESSION_ABSOLUTE_TTL_MS } from '../../src/pro-session.js';
+import { ENTITLEMENT_STATES } from '../../src/pro-entitlements.js';
+
+const S = ENTITLEMENT_STATES;
+const SECRET = 'pro-path-secret';
+const TOKEN = 'opaque-pro-token-abc';
+const NOW = 1_000_000;
+
+const PRO_ENV = Object.freeze({
+  PATINA_PRO_ENABLED: 'true',
+  PATINA_PRO_PROVIDER: 'openai',
+  PATINA_PRO_MODEL: 'gpt-5.5',
+  PATINA_PRO_HMAC_SECRET: SECRET,
+});
+
+function mockKv() {
+  const map = new Map();
+  return { map, async get(k) { return map.has(k) ? map.get(k) : null; }, async set(k, v) { map.set(k, v); }, async incr(k) { const n = (map.get(k) ?? 0) + 1; map.set(k, n); return n; } };
+}
+
+/** Seed an active entitlement + a valid session bound to it. */
+function seed(kv, { entitlementId = 'eid-1', status = S.ACTIVE } = {}) {
+  kv.map.set(entitlementKey(entitlementId), JSON.stringify({ status, effectiveAt: 0, version: 0, subscriptionId: 'sub_1' }));
+  kv.map.set(sessionKey(hashSessionToken(SECRET, TOKEN)), JSON.stringify({
+    entitlementId, issuedAt: NOW, expiresAt: NOW + PRO_SESSION_TTL_MS, absoluteExpiresAt: NOW + PRO_SESSION_ABSOLUTE_TTL_MS,
+  }));
+}
+
+function proReq(overrides = {}) {
+  const body = JSON.stringify({ mode: 'first', lang: 'ko', tier: 'pro', text: '안녕하세요 테스트', proSessionToken: TOKEN, ...overrides });
+  return {
+    method: 'POST',
+    headers: { 'x-real-ip': '1.2.3.4' },
+    async *[Symbol.asyncIterator]() { yield Buffer.from(body, 'utf8'); },
+  };
+}
+function mockRes() {
+  return {
+    statusCode: 0, headers: {}, chunks: [],
+    setHeader(k, v) { this.headers[k.toLowerCase()] = v; },
+    write(c) { this.chunks.push(String(c)); return true; },
+    end(c) { if (c != null) this.chunks.push(String(c)); },
+    frames() { return this.chunks.join('').split('\n').filter(Boolean).map(parseStreamFrame).filter(Boolean); },
+    json() { try { return JSON.parse(this.chunks.join('')); } catch { return null; } },
+  };
+}
+function makeHandler(kv) {
+  return createRewriteApiHandler({ env: PRO_ENV, kv, logger: { info() {}, error() {} }, now: () => NOW });
+}
+
+test('a valid pro request streams start/delta/done from the enhanced (stub) engine', async () => {
+  const kv = mockKv();
+  seed(kv);
+  const res = mockRes();
+  await makeHandler(kv)(proReq(), res);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.headers['cache-control'], 'no-store');
+  const frames = res.frames();
+  assert.equal(frames[0].type, STREAM_FRAME_TYPES.START);
+  assert.ok(frames.some((f) => f.type === STREAM_FRAME_TYPES.DELTA && typeof f.text === 'string'));
+  const done = frames.find((f) => f.type === STREAM_FRAME_TYPES.DONE);
+  assert.ok(done && done.scores && typeof done.scores.mps === 'number');
+});
+
+test('an unknown/invalid pro session token fails closed 401 (no stream)', async () => {
+  const kv = mockKv(); // nothing seeded -> no session record
+  const res = mockRes();
+  await makeHandler(kv)(proReq(), res);
+  assert.equal(res.statusCode, 401);
+  assert.equal(res.json().error, 'pro session not valid');
+});
+
+test('a revoked entitlement fails closed 402 even with a time-valid session', async () => {
+  const kv = mockKv();
+  seed(kv, { status: S.REVOKED });
+  const res = mockRes();
+  await makeHandler(kv)(proReq(), res);
+  assert.equal(res.statusCode, 402);
+});
+
+test('metering caps a burst: the 7th pro request in a minute is 429', async () => {
+  const kv = mockKv();
+  seed(kv);
+  const handler = makeHandler(kv);
+  for (let i = 0; i < 6; i++) {
+    const res = mockRes();
+    await handler(proReq(), res);
+    assert.equal(res.statusCode, 200, `request ${i + 1} should pass`);
+  }
+  const over = mockRes();
+  await handler(proReq(), over);
+  assert.equal(over.statusCode, 429);
+});
+
+test('missing PATINA_PRO_HMAC_SECRET fails closed 503', async () => {
+  const kv = mockKv();
+  seed(kv);
+  const handler = createRewriteApiHandler({
+    env: { PATINA_PRO_ENABLED: 'true', PATINA_PRO_PROVIDER: 'openai', PATINA_PRO_MODEL: 'gpt-5.5' },
+    kv, logger: { info() {}, error() {} }, now: () => NOW,
+  });
+  const res = mockRes();
+  await handler(proReq(), res);
+  assert.equal(res.statusCode, 503);
+});
+
+test('gate-off: a free request through the same handler is unaffected by the pro path', async () => {
+  // With the gate off and a free tier, validation/flow is the existing path.
+  const kv = mockKv();
+  const handler = createRewriteApiHandler({ env: { PATINA_FREE_API_KEY: 'sk-free', KV_REST_API_URL: undefined }, kv, logger: { info() {}, error() {} }, now: () => NOW, runWebRewriteStreamImpl: async ({ emit }) => { emit({ type: STREAM_FRAME_TYPES.START }); emit({ type: STREAM_FRAME_TYPES.DONE, scores: { mps: 90, fidelity: 90 } }); } });
+  const body = JSON.stringify({ mode: 'first', lang: 'ko', tier: 'free', text: '안녕하세요' });
+  const req = { method: 'POST', headers: { 'x-real-ip': '9.9.9.9' }, async *[Symbol.asyncIterator]() { yield Buffer.from(body, 'utf8'); } };
+  const res = mockRes();
+  await handler(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.frames().some((f) => f.type === STREAM_FRAME_TYPES.DONE));
+});
+
+test('a KV outage during the pro lookup fails closed 503 (not a generic 500, not free/BYOK)', async () => {
+  const throwingKv = { async get() { throw new Error('kv down'); }, async set() {}, async incr() { return 1; } };
+  const res = mockRes();
+  await makeHandler(throwingKv)(proReq(), res);
+  assert.equal(res.statusCode, 503);
+  assert.equal(res.json().error, 'pro session storage unavailable');
+  // no success stream frames
+  assert.equal(res.frames().some((f) => f.type === STREAM_FRAME_TYPES.DONE), false);
+});

--- a/tests/unit/web-rewrite-contract.pro-gate.redteam.test.js
+++ b/tests/unit/web-rewrite-contract.pro-gate.redteam.test.js
@@ -1,0 +1,175 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  WEB_TIERS,
+  isProEnabled,
+  redactSecrets,
+  resolveProviderModel,
+  validateRewriteRequest,
+} from '../../src/web-rewrite-contract.js';
+
+const PRO_ENV = Object.freeze({
+  PATINA_PRO_ENABLED: 'true',
+  PATINA_PRO_PROVIDER: 'openai',
+  PATINA_PRO_MODEL: 'gpt-5.5',
+});
+
+const VALID_PRO_BODY = Object.freeze({
+  mode: 'first',
+  lang: 'ko',
+  tier: WEB_TIERS.PRO,
+  text: '적대적 테스트 문장',
+  proSessionToken: 'opaque-session-token',
+});
+
+function assertRejectsCleanly(body, env, expectedStatus, label) {
+  assert.doesNotThrow(() => validateRewriteRequest(body, env), label);
+  const result = validateRewriteRequest(body, env);
+  assert.equal(result.ok, false, label);
+  assert.equal(result.status, expectedStatus, label);
+  assert.equal(typeof result.error, 'string', label);
+  assert.notEqual(result.error.length, 0, label);
+  return result;
+}
+
+function assertNoRawSecrets(serialized, secrets) {
+  for (const secret of secrets) {
+    assert.equal(serialized.includes(secret), false, `raw secret survived serialization: ${secret}`);
+  }
+}
+
+test('redteam pro gate: PATINA_PRO_ENABLED bypass spellings stay disabled', () => {
+  for (const value of ['True', 'TRUE', ' true ', '1', 'yes']) {
+    const env = { ...PRO_ENV, PATINA_PRO_ENABLED: value };
+    assert.equal(isProEnabled(env), false, `gate opened for ${JSON.stringify(value)}`);
+
+    const validation = validateRewriteRequest(VALID_PRO_BODY, env);
+    assert.equal(validation.ok, false, `pro validation opened for ${JSON.stringify(value)}`);
+    assert.equal(validation.status, 403, `pro validation did not fail closed for ${JSON.stringify(value)}`);
+
+    const resolved = resolveProviderModel({ tier: WEB_TIERS.PRO }, env);
+    assert.equal(resolved.ok, false, `pro provider resolved for ${JSON.stringify(value)}`);
+    assert.equal(resolved.error, 'pro tier unavailable');
+  }
+});
+
+test('redteam pro gate: gate-off pro never silently downgrades to free or BYOK', () => {
+  const attempts = [
+    { ...VALID_PRO_BODY },
+    { ...VALID_PRO_BODY, provider: 'openai', model: 'gpt-5.5' },
+    { ...VALID_PRO_BODY, provider: 'openai', model: 'gpt-4.1-mini', apiKey: 'sk-attacker-byok-123456' },
+    { ...VALID_PRO_BODY, apiKey: 'sk-attacker-byok-123456' },
+    { ...VALID_PRO_BODY, text: 'x'.repeat(12000), history: [{ role: 'user', content: 'previous' }] },
+    { ...VALID_PRO_BODY, mode: 'refine', original: '원문', text: '수정' },
+  ];
+
+  for (const body of attempts) {
+    const result = assertRejectsCleanly(body, {}, 403, JSON.stringify(body));
+    assert.equal(result.error, 'pro tier unavailable');
+  }
+});
+
+test('redteam pro gate: tier prototype-pollution and type-confusion values reject without throwing', () => {
+  const tierValues = ['__proto__', { toString: () => 'pro' }, ['pro'], 1];
+  for (const tier of tierValues) {
+    assertRejectsCleanly(
+      { mode: 'first', lang: 'ko', tier, text: '문장', proSessionToken: 'opaque-session-token' },
+      PRO_ENV,
+      400,
+      `tier=${Object.prototype.toString.call(tier)}`,
+    );
+  }
+});
+
+test('redteam pro gate: gate-on pro rejects simultaneous raw license, route override, and apiKey injection', () => {
+  const attempts = [
+    { ...VALID_PRO_BODY, licenseKey: 'LEMON-RAW-KEY' },
+    { ...VALID_PRO_BODY, provider: 'claude', model: 'claude-opus-4-1' },
+    { ...VALID_PRO_BODY, apiKey: 'sk-attacker-byok-123456' },
+    {
+      ...VALID_PRO_BODY,
+      licenseKey: 'LEMON-RAW-KEY',
+      provider: 'claude',
+      model: 'claude-opus-4-1',
+      apiKey: 'sk-attacker-byok-123456',
+    },
+  ];
+
+  for (const body of attempts) {
+    assertRejectsCleanly(body, PRO_ENV, 400, JSON.stringify(body));
+  }
+});
+
+test('redteam pro gate: proSessionToken rejects non-string, blank, and oversized values', () => {
+  const badTokens = [undefined, null, 0, 1, false, {}, [], '', '   ', 'x'.repeat(65536)];
+  for (const proSessionToken of badTokens) {
+    assertRejectsCleanly(
+      { ...VALID_PRO_BODY, proSessionToken },
+      PRO_ENV,
+      400,
+      `proSessionToken=${Object.prototype.toString.call(proSessionToken)}`,
+    );
+  }
+});
+
+test('redteam pro gate: pro redaction covers license/signature/session/entitlement families, casing, nesting, and preserves input', () => {
+  const rawSecrets = [
+    'LEMON-RAW-KEY',
+    'sig-secret-value',
+    'opaque-pro-session',
+    'browser-session-token',
+    'entitlement-token-value',
+    'nested-license-value',
+    'case-signature-value',
+    'case-pro-session-value',
+  ];
+  const input = {
+    licenseKey: rawSecrets[0],
+    lemonSignature: rawSecrets[1],
+    proSessionToken: rawSecrets[2],
+    sessionToken: rawSecrets[3],
+    entitlementToken: rawSecrets[4],
+    nested: [{ license_key: rawSecrets[5] }, { harmless: 'visible' }],
+    LEMON_SIGNATURE: rawSecrets[6],
+    Pro_Session_Token: rawSecrets[7],
+    message: 'visible text without raw key names',
+  };
+  const before = JSON.stringify(input);
+
+  const redacted = redactSecrets(input);
+  const serialized = JSON.stringify(redacted);
+
+  assert.equal(JSON.stringify(input), before, 'redactSecrets must not mutate input');
+  assertNoRawSecrets(serialized, rawSecrets);
+  assert.equal(serialized.includes('[REDACTED]'), true);
+  assert.equal(redacted.message, 'visible text without raw key names');
+  assert.equal(redacted.nested[1].harmless, 'visible');
+
+  for (const rawKey of ['licenseKey', 'lemonSignature', 'proSessionToken', 'sessionToken', 'entitlementToken']) {
+    assert.equal(serialized.includes(`"${rawKey}":"${input[rawKey]}"`), false, `${rawKey} raw value survived`);
+  }
+});
+
+test('redteam pro gate: gate-on pro fails closed when provider is missing or model is not allowlisted', () => {
+  const missingProvider = validateRewriteRequest(VALID_PRO_BODY, { PATINA_PRO_ENABLED: 'true' });
+  assert.equal(missingProvider.ok, false);
+  assert.equal(missingProvider.status, 400);
+  assert.equal(missingProvider.error, 'pro provider not configured');
+
+  const badModel = validateRewriteRequest(VALID_PRO_BODY, {
+    PATINA_PRO_ENABLED: 'true',
+    PATINA_PRO_PROVIDER: 'openai',
+    PATINA_PRO_MODEL: 'attacker-model',
+  });
+  assert.equal(badModel.ok, false);
+  assert.equal(badModel.status, 400);
+  assert.equal(badModel.error, 'pro model not configured');
+
+  assert.equal(resolveProviderModel({ tier: WEB_TIERS.PRO }, { PATINA_PRO_ENABLED: 'true' }).ok, false);
+  assert.equal(resolveProviderModel({ tier: WEB_TIERS.PRO }, {
+    PATINA_PRO_ENABLED: 'true',
+    PATINA_PRO_PROVIDER: 'openai',
+    PATINA_PRO_MODEL: 'attacker-model',
+  }).ok, false);
+});

--- a/tests/unit/web-rewrite-contract.pro-gate.test.js
+++ b/tests/unit/web-rewrite-contract.pro-gate.test.js
@@ -1,0 +1,219 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  WEB_TIERS,
+  TIER_LIMITS,
+  isProEnabled,
+  resolveProviderModel,
+  redactSecrets,
+  validateRewriteRequest,
+  MAX_PRO_SESSION_TOKEN_CHARS,
+} from '../../src/web-rewrite-contract.js';
+
+// G001: the hosted Pro tier is added to the isomorphic contract but is
+// DISABLED BY DEFAULT behind a single `PATINA_PRO_ENABLED` gate. These tests
+// assert (a) the gate is fail-closed off by default, (b) gate-off leaves the
+// free/BYOK request path byte-for-byte unchanged (no regression), and (c) when
+// the gate is on, Pro requests use an opaque session token and a server-pinned
+// enhanced route, never caller-chosen provider/model/apiKey or a raw key.
+
+const PRO_ENV = Object.freeze({
+  PATINA_PRO_ENABLED: 'true',
+  PATINA_PRO_PROVIDER: 'openai',
+  PATINA_PRO_MODEL: 'gpt-5.5',
+});
+
+// --- tier constants ---------------------------------------------------------
+test('WEB_TIERS exposes pro and TIER_LIMITS.pro carries the agreed caps', () => {
+  assert.equal(WEB_TIERS.PRO, 'pro');
+  assert.deepEqual(TIER_LIMITS.pro, {
+    maxChars: 12000,
+    maxConcurrent: 2,
+    reqPerDay: 100,
+    burstPerHour: 20,
+    requestsPerMinute: 6,
+  });
+});
+
+// --- the gate ---------------------------------------------------------------
+test('isProEnabled is disabled by default and only true for explicit "true"', () => {
+  assert.equal(isProEnabled(), false);
+  assert.equal(isProEnabled({}), false);
+  assert.equal(isProEnabled({ PATINA_PRO_ENABLED: undefined }), false);
+  assert.equal(isProEnabled({ PATINA_PRO_ENABLED: '1' }), false);
+  assert.equal(isProEnabled({ PATINA_PRO_ENABLED: 'TRUE' }), false);
+  assert.equal(isProEnabled({ PATINA_PRO_ENABLED: 'yes' }), false);
+  assert.equal(isProEnabled({ PATINA_PRO_ENABLED: 'true' }), true);
+});
+
+// --- gate OFF: Pro is fail-closed ------------------------------------------
+test('validateRewriteRequest rejects a pro request when the gate is off (403)', () => {
+  const res = validateRewriteRequest(
+    { mode: 'first', lang: 'ko', tier: 'pro', text: '안녕하세요', proSessionToken: 'opaque-token' },
+    {}, // gate off
+  );
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 403);
+  assert.equal(res.error, 'pro tier unavailable');
+});
+
+test('resolveProviderModel fails closed for pro when the gate is off', () => {
+  const res = resolveProviderModel({ tier: 'pro' }, {});
+  assert.equal(res.ok, false);
+  assert.equal(res.error, 'pro tier unavailable');
+});
+
+// --- gate OFF: free/BYOK regression (must be byte-for-byte unchanged) -------
+test('gate-off: free first-turn request still validates exactly as before', () => {
+  const res = validateRewriteRequest({ mode: 'first', lang: 'ko', tier: 'free', text: '테스트 문장' }, {});
+  assert.equal(res.ok, true);
+  assert.equal(res.value.tier, 'free');
+  assert.equal(res.value.provider, 'openai');
+  assert.equal(res.value.apiKey, undefined);
+  assert.equal(res.value.proSessionToken, undefined);
+});
+
+test('gate-off: byok request still validates with an allowlisted model + key', () => {
+  const res = validateRewriteRequest(
+    { mode: 'first', lang: 'en', tier: 'byok', text: 'hello there', provider: 'openai', model: 'gpt-4.1', apiKey: 'sk-xxxx' },
+    {},
+  );
+  assert.equal(res.ok, true);
+  assert.equal(res.value.tier, 'byok');
+  assert.equal(res.value.apiKey, 'sk-xxxx');
+});
+
+test('gate-off: free tier with a caller apiKey is still rejected', () => {
+  const res = validateRewriteRequest({ mode: 'first', lang: 'ko', tier: 'free', text: '문장', apiKey: 'sk-x' }, {});
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 400);
+  assert.match(res.error, /must not include an apiKey/);
+});
+
+test('gate-off: resolveProviderModel free/byok branches are unchanged', () => {
+  const free = resolveProviderModel({ tier: 'free' }, {});
+  assert.equal(free.ok, true);
+  assert.equal(free.baseURL, 'https://api.openai.com/v1');
+  const byok = resolveProviderModel({ tier: 'byok', provider: 'claude', model: 'claude-sonnet-4-5' }, {});
+  assert.equal(byok.ok, true);
+  assert.equal(byok.baseURL, 'https://api.anthropic.com/v1');
+});
+
+test('an unknown tier is still rejected (now naming the three valid tiers)', () => {
+  const res = validateRewriteRequest({ mode: 'first', lang: 'ko', tier: 'enterprise', text: 'x' }, {});
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 400);
+  assert.match(res.error, /free.*byok.*pro/);
+});
+
+// --- gate ON: Pro happy path + hardening ------------------------------------
+test('gate-on: a pro request with an opaque session token resolves the server enhanced route', () => {
+  const res = validateRewriteRequest(
+    { mode: 'first', lang: 'ko', tier: 'pro', text: '안녕하세요', proSessionToken: 'opaque-session-token' },
+    PRO_ENV,
+  );
+  assert.equal(res.ok, true);
+  assert.equal(res.value.tier, 'pro');
+  assert.equal(res.value.provider, 'openai');
+  assert.equal(res.value.model, 'gpt-5.5');
+  assert.equal(res.value.proSessionToken, 'opaque-session-token');
+  assert.equal(res.value.apiKey, undefined);
+});
+
+test('gate-on: pro rejects a raw licenseKey on the rewrite contract', () => {
+  const res = validateRewriteRequest(
+    { mode: 'first', lang: 'ko', tier: 'pro', text: '문장', licenseKey: 'LEMON-RAW-KEY', proSessionToken: 't' },
+    PRO_ENV,
+  );
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 400);
+  assert.match(res.error, /proSessionToken, not a raw licenseKey/);
+});
+
+test('gate-on: pro rejects caller provider/model override', () => {
+  const res = validateRewriteRequest(
+    { mode: 'first', lang: 'ko', tier: 'pro', text: '문장', proSessionToken: 't', provider: 'claude', model: 'claude-opus-4-1' },
+    PRO_ENV,
+  );
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 400);
+  assert.match(res.error, /must not include provider\/model/);
+});
+
+test('gate-on: pro rejects a caller apiKey', () => {
+  const res = validateRewriteRequest(
+    { mode: 'first', lang: 'ko', tier: 'pro', text: '문장', proSessionToken: 't', apiKey: 'sk-x' },
+    PRO_ENV,
+  );
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 400);
+  assert.match(res.error, /pro tier must not include an apiKey/);
+});
+
+test('gate-on: pro requires a non-empty proSessionToken', () => {
+  for (const bad of [undefined, '', '   ', 42, null]) {
+    const res = validateRewriteRequest(
+      { mode: 'first', lang: 'ko', tier: 'pro', text: '문장', proSessionToken: bad },
+      PRO_ENV,
+    );
+    assert.equal(res.ok, false);
+    assert.equal(res.status, 400);
+    assert.match(res.error, /requires a proSessionToken/);
+  }
+});
+
+test('gate-on: pro enforces the 12000-char cap with 413', () => {
+  const res = validateRewriteRequest(
+    { mode: 'first', lang: 'ko', tier: 'pro', text: 'a'.repeat(12001), proSessionToken: 't' },
+    PRO_ENV,
+  );
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 413);
+});
+
+test('gate-on: pro fails closed when the server enhanced route is not configured', () => {
+  const res = resolveProviderModel({ tier: 'pro' }, { PATINA_PRO_ENABLED: 'true' });
+  assert.equal(res.ok, false);
+  assert.equal(res.error, 'pro provider not configured');
+});
+
+// --- redaction (new Pro secret-key families) --------------------------------
+test('redactSecrets strips pro license/session/signature key families', () => {
+  const out = redactSecrets({
+    licenseKey: 'LEMON-RAW-KEY',
+    proSessionToken: 'opaque-token',
+    sessionToken: 'sess',
+    entitlementToken: 'ent',
+    lemonSignature: 'sig-abc',
+    keep: 'visible',
+  });
+  assert.equal(out.licenseKey, '[REDACTED]');
+  assert.equal(out.proSessionToken, '[REDACTED]');
+  assert.equal(out.sessionToken, '[REDACTED]');
+  assert.equal(out.entitlementToken, '[REDACTED]');
+  assert.equal(out.lemonSignature, '[REDACTED]');
+  assert.equal(out.keep, 'visible');
+});
+
+// --- gate hardening from G001 review (architect + red-team blockers) --------
+test('gate-on: pro fails closed when the provider is set but the model is missing', () => {
+  // Provider-only misconfiguration must NOT silently route to a preset model.
+  const res = resolveProviderModel({ tier: 'pro' }, { PATINA_PRO_ENABLED: 'true', PATINA_PRO_PROVIDER: 'openai' });
+  assert.equal(res.ok, false);
+  assert.equal(res.error, 'pro model not configured');
+});
+
+test('gate-on: pro rejects an oversized proSessionToken (abuse/DoS bound)', () => {
+  const ok = validateRewriteRequest(
+    { mode: 'first', lang: 'ko', tier: 'pro', text: '문장', proSessionToken: 'x'.repeat(MAX_PRO_SESSION_TOKEN_CHARS) },
+    PRO_ENV,
+  );
+  assert.equal(ok.ok, true);
+  const tooLong = validateRewriteRequest(
+    { mode: 'first', lang: 'ko', tier: 'pro', text: '문장', proSessionToken: 'x'.repeat(MAX_PRO_SESSION_TOKEN_CHARS + 1) },
+    PRO_ENV,
+  );
+  assert.equal(tooLong.ok, false);
+  assert.equal(tooLong.status, 400);
+  assert.match(tooLong.error, /proSessionToken is too long/);
+});

--- a/tests/unit/web-rewrite-contract.test.js
+++ b/tests/unit/web-rewrite-contract.test.js
@@ -299,5 +299,5 @@ test('evaluateFloors fails closed on missing or non-numeric scores', () => {
 
 test('REWRITE_MODES and WEB_TIERS expose the documented values', () => {
   assert.deepEqual(REWRITE_MODES, { FIRST: 'first', REFINE: 'refine' });
-  assert.deepEqual(WEB_TIERS, { FREE: 'free', BYOK: 'byok' });
+  assert.deepEqual(WEB_TIERS, { FREE: 'free', BYOK: 'byok', PRO: 'pro' });
 });


### PR DESCRIPTION
## What

Adds the **disabled-by-default** hosted Pro monetization layer (open-core) on top
of the existing free/BYOK web surface. Pro is gated behind `PATINA_PRO_ENABLED`
(off by default), so this is a no-op for the live free playground until the gate
and secrets are explicitly set.

## Scope (G001–G008)

- **Contract** (`src/web-rewrite-contract.js`): `pro` tier + `isProEnabled` gate, license/session/signature redaction, oversized-token bound.
- **KV store contract** (`api/rewrite.js`): shared memory + REST `get/set/incr/expire`, string-only values, secrets never in URLs.
- **Entitlement state machine** (`src/pro-entitlements.js`): idempotency, out-of-order/stale reject, terminal-resurrection prevention, fail-closed expiry.
- **Opaque Pro session token** (`src/pro-session.js`, `api/pro-session.js`): license key presented once, sliding + absolute TTL, raw key/token never stored.
- **Lemon Squeezy webhook mirror** (`src/lemon-webhook.js`, `api/lemon-webhook.js`): timing-safe signature, idempotency, refund/cancel subscription scoping.
- **EnhancedRewriteEngine contract + public stub** (`src/enhanced-rewrite-engine-contract.js`).
- **Pro metering + Pro rewrite path**: `session -> entitlement -> metering -> engine`, explicit 401/402/429/503, never falls back to free/BYOK.
- **Client + ko legal copy** (`playground/rewrite-client.js`, `src/pro-legal-copy.js`).
- **Leak gate** (`scripts/check-no-private-assets.mjs`): case-insensitive globs, `**/server/**` any depth, monetization fixtures.
- **Docs**: `docs/PRO.md` (open-core boundary + Vercel deploy runbook), `docs/RELEASE-CHECKLIST.md` (payment-open order-inversion gates); `NOTICE` trademark.

## Verification

- `npm test`: **1178 pass / 0 fail / 1 skip**
- `npm run check:no-private-assets`: **0 forbidden** (360 packed + 951 tracked)
- `npm run lint`: clean (syntax/eslint/typecheck/spellcheck)

## Out of scope (do NOT enable on prod from this PR)

- Activating Pro on production (`PATINA_PRO_ENABLED=true` + secrets) — premature: the engine is a deterministic **stub** (no quality gain) and checkout stays hidden.
- The private enhanced ko engine (CROSS-TRACK) and public checkout — gated by `docs/RELEASE-CHECKLIST.md` (gate 12 + KIPO trademark).

Merging this only ships dormant, gated code. Free/BYOK behavior is unchanged.
