### PR TITLE
feat(cli): add XLIFF localization humanize mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
+## Unreleased
+
+### Added
+
+- **XLIFF localization humanize mode** (`patina --xliff <file.xliff>`): humanizes translated `<target>` segments in XLIFF 1.2 files through the existing rewrite pipeline with mandatory per-segment MPS/fidelity floors (≥70), without changing meaning, numbers, or placeholders. Dependency-free quote-aware scanner (no XML library); byte-preserving write-back (only the humanizable target core changes — whitespace, entities, attributes, and all other bytes preserved); atomic writes; default writes a new `*.humanized.xliff` and never clobbers the original; fail-closed (a verify floor miss keeps the original bytes). `--dry-run` reports selection/dedup/cap/cost with **0 LLM calls and 0 writes**; `--max-segments` overrides the default 50 unique-segment cap; `--batch` handles multiple files. Target-state allowlist plus inline-markup/CDATA/ambiguous targets are skipped fail-closed, and identical targets are deduplicated (rewritten once, applied to every duplicate). No `src/features/*` changes and no new runtime dependencies (#569).
+
 ## 6.0.1 — 2026-06-28
 
 **Playground overhaul: editorial restyle, interactive before/after examples, a real benchmark section, and more BYOK providers.**

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -277,3 +277,27 @@ and keep project-specific guards for frontmatter quoting, trailing model footers
 and JSX hazards such as malformed `<digit` fragments.
 
 See [EXIT-CODES.md](EXIT-CODES.md) for the full process contract.
+
+## XLIFF localization humanize: `--xliff`
+
+`--xliff <file.xliff>` humanizes the translated `<target>` segments of an XLIFF 1.2 file (Crowdin/CAT exports) through the normal rewrite pipeline, then writes the file back **byte-for-byte identical except for the humanizable target text**. It is a humanizer, not a translator: it never changes the claim, numbers, polarity, or placeholders (`%s`, `%1$d`, …), and every segment must clear the same MPS/fidelity floors as `--verify` (default 70) or the original target bytes are kept.
+
+```bash
+patina --xliff app.xliff                 # -> app.humanized.xliff (never clobbers the original)
+patina --xliff app.xliff --dry-run        # plan only: 0 LLM calls, 0 writes
+patina --xliff app.xliff --outdir out/    # write into a directory
+patina --xliff app.xliff --in-place       # overwrite the original (explicit + atomic)
+patina --batch --xliff locales/*.xliff    # multiple files
+```
+
+What it does, in order: detect and normalize the file's `target-language` (`ko-KR`→`ko`, `en-US`→`en`, `zh-CN`/`zh-TW`→`zh`, `ja-JP`→`ja`; unsupported languages are rejected) → select humanizable prose targets → deduplicate identical targets → rewrite each unique target once and reuse it for every duplicate → verify each candidate and apply only the ones that pass → write atomically.
+
+**Safety and scope:**
+
+- **Selection is conservative.** A target is processed only when its state is allowlisted (`translated` / `final` / `signed-off` / `needs-review-translation`, or absent) and it reads as prose (≥5 space-delimited words, or ≥12 CJK characters). Locked (`translate="no"`), untranslated, short-UI, inline-markup (`<g>`/`<x>`/`<bpt>`/…), CDATA, and structurally ambiguous targets are **skipped untouched**.
+- **Byte-preserving.** Only the inner target text changes; leading/trailing whitespace, XML entities, attributes, and every other byte are preserved. A no-op rewrite yields a byte-identical file.
+- **Fail-closed.** Malformed input errors out before any write; a verify floor miss keeps the exact original bytes and is reported; the output is written atomically (temp + rename) so a crash never leaves a partial file, and the default output path never overwrites the input.
+- **`--dry-run`** makes **0 LLM calls and 0 writes** and prints total units, selected/unique counts, dedup savings, cap status, skip reasons, the worst-case call/token estimate, and the output path.
+- **`--max-segments <n>`** overrides the default cap of 50 unique segments per file (the cap is enforced after dedup, before any LLM call; over the cap fails closed in execution mode and is flagged in `--dry-run`).
+
+`--xliff` accepts backend/model/provider/base-url/auth/timeout/concurrency/retry/failure-budget flags and `--suffix`/`--outdir`/`--in-place`/`--batch`/`--format`. It rejects rewrite-shaping and other-mode flags (`--audit`/`--score`/`--diff`/`--preview`/`--ocr`/`--serve`/`--exit-on`/`--persona`/`--jargon`/`--tone`/`--profile`/`--rewrite-headings`/`--verify`) with a clear input error. `--dry-run` and `--max-segments` are valid only with `--xliff`.

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
 import { getRepoRoot } from './config.js';
 import { runDoctor } from './commands/doctor.js';
 import { handleAuth, printBackendStatus } from './commands/auth.js';
-import { parseArgs, validateModeExclusivity, validateServeRequest, validatePreviewRequest, validateOutputRouting, validateTransformRequest, validatePersonaRequest, validateVerifyRequest, printHelp } from './cli/args.js';
+import { parseArgs, validateModeExclusivity, validateServeRequest, validatePreviewRequest, validateOutputRouting, validateTransformRequest, validatePersonaRequest, validateVerifyRequest, validateXliffRequest, printHelp } from './cli/args.js';
 import { runDefault } from './cli/run.js';
 import { inputError, renderCliError, getProcessExitCode } from './errors.js';
 import { createLogger } from './logger.js';
@@ -58,6 +58,11 @@ export async function main(args) {
     return;
   }
 
+
+  // XLIFF-specific validation runs before the generic mode guards so combos
+  // like `--xliff --exit-on` get the XLIFF-specific rejection, not a misleading
+  // score-mode error.
+  validateXliffRequest(parsed);
 
   if (parsed.gate !== undefined && !parsed.score) {
     throw inputError(

--- a/src/cli/args.js
+++ b/src/cli/args.js
@@ -8,7 +8,7 @@ const VALUE_OPTIONS = new Set([
   '--lang', '--profile', '--tone', '--persona', '--format', '--exit-on',
   '--suffix', '--outdir', '--model', '--api-key-file', '--base-url',
   '--backend', '--timeout-ms', '--max-concurrency', '--max-retries',
-  '--max-failures', '--max-failure-rate', '--provider', '--config',
+  '--max-failures', '--max-failure-rate', '--provider', '--config', '--max-segments',
 ]);
 
 // Boolean switches. Used to reject `--quiet=1`-style values explicitly and to
@@ -19,7 +19,7 @@ const FLAG_OPTIONS = new Set([
   '--batch', '--in-place', '--allow-private-base-url',
   '--stop-on-retryable-storm', '--no-stop-on-retryable-storm',
   '--list-backends', '--allow-insecure-base-url', '--no-interactive',
-  '--rewrite-headings', '--verify',
+  '--rewrite-headings', '--verify', '--xliff', '--dry-run',
 ]);
 
 // Expand `--name=value` into two tokens for known value-taking options and
@@ -285,6 +285,18 @@ export function parseArgs(rawArgs) {
       case '--no-interactive':
         parsed.noInteractive = true;
         break;
+      case '--xliff':
+        parsed.xliff = true;
+        break;
+      case '--dry-run':
+        parsed.dryRun = true;
+        break;
+      case '--max-segments': {
+        const value = readOptionValue(args, i, arg, { allowFlagLike: true });
+        i++;
+        parsed.maxSegments = parsePositiveIntegerOption(value, arg);
+        break;
+      }
       default:
         if (!arg.startsWith('-')) {
           parsed.files.push(arg);
@@ -549,7 +561,7 @@ export function validateOutputRouting(parsed) {
     parsed.outdir !== undefined ? '--outdir' : null,
   ].filter(Boolean);
   if (destinations.length === 0) return;
-  if (!parsed.batch) {
+  if (!parsed.batch && !parsed.xliff) {
     throw inputError(
       `${destinations[0]} requires --batch`,
       'Output routing flags only apply to batch mode; without --batch the result goes to stdout.',
@@ -595,6 +607,58 @@ export function validateOutputRouting(parsed) {
       }
       seen.set(base, file);
     }
+  }
+}
+
+// XLIFF mode is an explicit, file-to-file localization pass: it humanizes
+// already-translated <target> segments through the normal rewrite+verify path,
+// so it rejects non-rewrite modes, meaning/register-changing flags, and stdin —
+// anything that would make byte-preserving localization unsafe. Run this BEFORE
+// the generic validators so the errors are XLIFF-specific.
+export function validateXliffRequest(parsed) {
+  if (!parsed.xliff) {
+    // --dry-run and --max-segments are XLIFF-only in this MVP.
+    if (parsed.dryRun) {
+      throw inputError('--dry-run requires --xliff',
+        '--dry-run only reports an XLIFF humanize plan; it has no meaning for the normal rewrite modes.',
+        'Run `patina --xliff --dry-run <file.xliff>`.');
+    }
+    if (parsed.maxSegments !== undefined) {
+      throw inputError('--max-segments requires --xliff',
+        '--max-segments only caps the XLIFF humanize segment count.',
+        'Run `patina --xliff --max-segments <n> <file.xliff>`.');
+    }
+    return;
+  }
+
+  /** @type {[string, string][]} incompatible mode/flag pairs (parsed key, flag). */
+  const incompatible = [
+    ['audit', '--audit'], ['score', '--score'], ['diff', '--diff'],
+    ['preview', '--preview'], ['ocr', '--ocr'], ['serve', '--serve'],
+    ['gate', '--exit-on'], ['persona', '--persona'], ['jargon', '--jargon'],
+    ['tone', '--tone'], ['profile', '--profile'], ['rewriteHeadings', '--rewrite-headings'],
+  ];
+  for (const [key, flag] of incompatible) {
+    if (parsed[key] !== undefined && parsed[key] !== false) {
+      throw inputError(`${flag} cannot be combined with --xliff`,
+        `--xliff is a meaning-preserving localization pass over translated <target> segments; ${flag} is not part of that surface in this MVP.`,
+        `Drop ${flag}, or run it separately without --xliff.`);
+    }
+  }
+  if (parsed.verify) {
+    throw inputError('--verify cannot be combined with --xliff',
+      'XLIFF mode always verifies each rewritten segment against the MPS/fidelity floors; verification cannot be disabled or toggled.',
+      'Drop --verify — it is implied by --xliff.');
+  }
+  if (!parsed.files || parsed.files.length === 0) {
+    throw inputError('--xliff requires file paths, not stdin',
+      'XLIFF humanize reads and rewrites structured files in place, so it needs at least one .xliff file argument.',
+      'Run `patina --xliff <file.xliff>`.');
+  }
+  if (parsed.files.length > 1 && !parsed.batch) {
+    throw inputError('--xliff with multiple files requires --batch',
+      'Each XLIFF run writes one output file; processing several inputs at once is batch mode.',
+      'Run `patina --batch --xliff <file1.xliff> <file2.xliff>`.');
   }
 }
 
@@ -711,6 +775,12 @@ OUTPUT & BATCH
                           Keep going through repeated 429/timeout/temporary-exit
                           storms (storm stopping is on by default in batch mode)
   --no-interactive        Do not wait for TTY stdin; exit 2 when no input is given
+
+LOCALIZATION (XLIFF)
+  --xliff                 Humanize translated <target> segments in an XLIFF 1.2 file
+                          (writes {name}.humanized.xliff by default; never clobbers the original)
+  --dry-run               With --xliff: report the plan + cost estimate; make no LLM calls or writes
+  --max-segments <n>      With --xliff: cap unique segments processed per run (default 50)
 
 LANGUAGE & PROFILE
   --lang <code>           Language: ko, en, zh, ja (default: ko)

--- a/src/cli/batch.js
+++ b/src/cli/batch.js
@@ -6,8 +6,8 @@ import {
   resolveBackendMaxRetries,
 } from '../backends/contract.js';
 import { runtimeError } from '../errors.js';
-import { writeFileSync, mkdirSync } from 'node:fs';
-import { resolve, basename, extname } from 'node:path';
+import { writeFileSync, mkdirSync, renameSync, unlinkSync } from 'node:fs';
+import { resolve, basename, extname, dirname, join } from 'node:path';
 
 export function logBatchSafetyPlan({ jobs, backends, parsed, promptMode, timeoutMs, logger }) {
   if (!parsed.batch || jobs.length <= 1) return;
@@ -170,4 +170,57 @@ export async function writeBatchOutput(parsed, inputPath, output) {
 
   writeFileSync(outPath, output, 'utf8');
   console.log(`Written: ${outPath}`);
+}
+
+/**
+ * Atomically write UTF-8 text: write a unique temp file in the destination
+ * directory, then rename onto the final path (rename is atomic on the same
+ * filesystem). On any failure the temp file is removed and the original/final
+ * path is left untouched — a mid-run failure never yields a partial output.
+ * @param {string} destPath
+ * @param {string} contents
+ * @returns {string} the destination path
+ */
+export function writeAtomicUtf8(destPath, contents) {
+  const dir = dirname(destPath);
+  let lastErr;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const tmp = join(dir, `.patina-xliff-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`);
+    try {
+      // Exclusive create ('wx'): never clobber a preexisting temp path or symlink.
+      writeFileSync(tmp, contents, { encoding: 'utf8', flag: 'wx' });
+    } catch (err) {
+      if (err && err.code === 'EEXIST') { lastErr = err; continue; } // name collision → retry
+      throw err; // e.g. missing directory → propagate; no temp was created
+    }
+    try {
+      renameSync(tmp, destPath);
+    } catch (err) {
+      try { unlinkSync(tmp); } catch { /* best-effort cleanup; original/dest untouched */ }
+      throw err;
+    }
+    return destPath;
+  }
+  throw lastErr || new Error('xliff: could not create a unique temp file');
+}
+
+/**
+ * Resolve a batch/XLIFF output path from the routing flags. Precedence:
+ * --in-place (overwrite original) > --outdir (basename into dir) > --suffix
+ * (inserted before the extension) > defaultSuffix. With none set and no
+ * default, returns the input path unchanged (caller decides).
+ * @param {{inPlace?:boolean, outdir?:string, suffix?:string}} parsed
+ * @param {string} inputPath
+ * @param {{defaultSuffix?:string}} [options]
+ * @returns {string}
+ */
+export function resolveBatchOutputPath(parsed, inputPath, { defaultSuffix = '' } = {}) {
+  if (parsed.inPlace) return inputPath;
+  if (parsed.outdir) return join(parsed.outdir, basename(inputPath));
+  const suffix = parsed.suffix ?? defaultSuffix;
+  if (suffix) {
+    const ext = extname(inputPath);
+    return `${inputPath.slice(0, inputPath.length - ext.length)}${suffix}${ext}`;
+  }
+  return inputPath;
 }

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -10,7 +10,7 @@ import { buildTransformVariants } from './args.js';
 import { invokeBackendChain, selectBackendChain, selectOcrBackends, listBackends } from '../backends/index.js';
 import { selectProvider, resolveProviderConfig } from '../providers.js';
 import { validateBaseURL, applyInsecureBaseURLOptIn, applyPrivateBaseURLOptIn } from '../security.js';
-import { formatOutput, formatRewriteBodyForBrowser, validateScoreWeights, buildDeterministicAuditBackstop, stripSelfAudit } from '../output.js';
+import { formatOutput, formatRewriteBodyForBrowser, validateScoreWeights, buildDeterministicAuditBackstop, stripSelfAudit, cleanRewriteOutput } from '../output.js';
 import {
   buildBrowserDiffPromptInput,
   renderExplanationHtml,
@@ -410,7 +410,7 @@ export async function runXliffMode(parsed, ctx, logger, overrides = {}) {
       signal: cancellation.signal, timeout: timeoutMs,
       maxConcurrency: parsed.maxConcurrency, maxRetries: parsed.maxRetries, logger,
     });
-    return stripSelfAudit(raw, { logger: { warn() {} } });
+    return cleanRewriteOutput(raw, { logger: { warn() {} } });
   });
   const verifySegment = overrides.verifySegment || (async ({ core, candidate, lang }) => {
     const { patterns, profile } = getAssets(lang);

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -20,22 +20,23 @@ import {
 } from '../browser-diff.js';
 import { fetchPreviewPage, prepareSnapshotHtml, freezeSnapshotAssets, extractProseBlocks, alignRewrites, buildPreviewHtml, buildContextCardHtml } from '../preview.js';
 import { collectImageCandidates, stageOcrImages, ocrStagedImages, describeImage, hasOcrRunnerOverride } from '../ocr.js';
-import { rmSync } from 'node:fs';
+import { rmSync, readFileSync, mkdirSync } from 'node:fs';
 
 import { verifyRewrite, deterministicMeaningGuard } from '../verify.js';
 import { interpretScore, reconcileScoreOverall, scoreDeterministicSignals } from '../scoring.js';
 import { detectKoreanRegister } from '../features/stylometry.js';
-import { logBatchSafetyPlan, createBatchCircuitBreaker, shouldHandleBatchFailure, writeBatchOutput } from './batch.js';
+import { logBatchSafetyPlan, createBatchCircuitBreaker, shouldHandleBatchFailure, writeBatchOutput, writeAtomicUtf8, resolveBatchOutputPath } from './batch.js';
 import { applyScoreGate, extractScoreOverall } from './score-gate.js';
 import { loadInputs } from './input.js';
 import { PatinaCliError, runtimeError, inputError } from '../errors.js';
 import { providerHttpKeyEnvVars, resolveHttpApiKey } from '../auth.js';
-import { DEFAULT_BACKEND_TIMEOUT_MS, getBackendSafety } from '../backends/contract.js';
+import { DEFAULT_BACKEND_TIMEOUT_MS, getBackendSafety, resolveBackendMaxRetries } from '../backends/contract.js';
 import { resolve } from 'node:path';
 import { loadPersona } from '../personas/loader.js';
 import { evaluatePersonaGate } from '../personas/gates.js';
 import { personaMatchScore } from '../features/persona-match.js';
 import { pathToFileURL } from 'node:url';
+import { humanizeXliffDocument, resolveUniqueCap } from './xliff.js';
 
 /**
  * Run the default patina pipeline for an already-parsed CLI invocation:
@@ -125,7 +126,7 @@ export async function runDefault(parsed, logger) {
         message: `[patina] Backend fallback chain: ${backends.map((b) => b.name).join(' → ')}`,
       });
     }
-    if (backend.name === 'openai-http' && !resolved.apiKey) {
+    if (backend.name === 'openai-http' && !resolved.apiKey && !(parsed.xliff && parsed.dryRun)) {
       const msg = ['No API key found. Set PATINA_API_KEY, PATINA_API_KEY_FILE, OPENAI_API_KEY, or use --api-key-file.'];
       if (provider) {
         msg.push(`(--provider ${provider.name} expects ${provider.apiKeyEnv} or PATINA_API_KEY.)`);
@@ -166,6 +167,11 @@ export async function runDefault(parsed, logger) {
       timeoutMs,
       logger,
     });
+    return;
+  }
+
+  if (parsed.xliff) {
+    await runXliffMode(parsed, { config, repoRoot, voice, scoring, backends, resolved, promptMode, timeoutMs, providerName: provider?.name }, logger);
     return;
   }
 
@@ -365,6 +371,121 @@ export async function runDefault(parsed, logger) {
     logger.closeProgress();
   }
 
+}
+
+/**
+ * XLIFF localization humanize mode. Reads each XLIFF file, humanizes its safe
+ * translated <target> segments through the normal rewrite+verify pipeline, and
+ * writes a byte-preserving output atomically. --dry-run reports the plan with
+ * zero LLM calls and no writes. Language/patterns are resolved per file from the
+ * XLIFF target-language (cached), not the global config language.
+ */
+export async function runXliffMode(parsed, ctx, logger, overrides = {}) {
+  const { config, repoRoot, voice, scoring, backends, resolved, promptMode, timeoutMs, providerName } = ctx;
+  const cancellation = createCancellationController({ logger });
+  const assetCache = new Map();
+  const getAssets = (lang) => {
+    if (assetCache.has(lang)) return assetCache.get(lang);
+    const profileName = resolveProfileForLanguage(config.profile || 'default', lang, logger);
+    const profile = loadProfile(repoRoot, profileName);
+    const patterns = applyProfilePatternOverrides(loadPatterns(repoRoot, lang, config['skip-patterns'] || []), profile, lang);
+    const assets = { patterns, profile };
+    assetCache.set(lang, assets);
+    return assets;
+  };
+  const rewriteSegment = overrides.rewriteSegment || (async ({ core, lang }) => {
+    const { patterns, profile } = getAssets(lang);
+    const prompt = buildPrompt({
+      config: { ...config, language: lang }, patterns,
+      profile: profile.body ? profile : null,
+      voice: voice.body ? voice : null,
+      scoring: scoring.body ? scoring : null,
+      text: core, mode: 'rewrite',
+      tone: { tone: null, source: 'profile_only' },
+      promptMode, documentSignals: null,
+    });
+    const raw = await invokeBackendChain({
+      backends, prompt, apiKey: resolved.apiKey, baseURL: resolved.baseURL,
+      model: resolved.model, modelSource: resolved.modelSource,
+      signal: cancellation.signal, timeout: timeoutMs,
+      maxConcurrency: parsed.maxConcurrency, maxRetries: parsed.maxRetries, logger,
+    });
+    return stripSelfAudit(raw, { logger: { warn() {} } });
+  });
+  const verifySegment = overrides.verifySegment || (async ({ core, candidate, lang }) => {
+    const { patterns, profile } = getAssets(lang);
+    const callLLM = ({ prompt, signal, timeout }) => invokeBackendChain({
+      backends, prompt, apiKey: resolved.apiKey, baseURL: resolved.baseURL,
+      model: resolved.model, modelSource: resolved.modelSource,
+      signal: signal ?? cancellation.signal, timeout: timeout ?? timeoutMs,
+      maxConcurrency: 1, maxRetries: 0, logger,
+    });
+    const v = await verifyRewrite({
+      original: core, rewrite: candidate, config: { ...config, language: lang }, patterns,
+      profile: profile.body ? profile : null,
+      voice: voice.body ? voice : null,
+      scoring: scoring.body ? scoring : null,
+      apiKey: resolved.apiKey, baseURL: resolved.baseURL, model: resolved.model,
+      callLLM, signal: cancellation.signal, timeout: timeoutMs, logger,
+    });
+    return { verified: v.verified, text: v.text, mps: v.mps, fidelity: v.fidelity };
+  });
+  // Worst-case backend attempts per LLM call = sum over the fallback chain of
+  // (that backend's max retries + 1). Used only for the dry-run estimate.
+  const backendAttemptsPerCall = backends.reduce((sum, b) => sum + resolveBackendMaxRetries(b.name, parsed.maxRetries) + 1, 0) || 1;
+
+  cancellation.install();
+  try {
+    for (const file of parsed.files) {
+      cancellation.throwIfCanceled();
+      const xml = readFileSync(file, 'utf8');
+      const outputPath = resolveBatchOutputPath(parsed, file, { defaultSuffix: '.humanized' });
+      const breaker = createBatchCircuitBreaker({ parsed: { ...parsed, batch: true }, total: Math.max(2, resolveUniqueCap(parsed)) });
+      const result = await humanizeXliffDocument({
+        xml,
+        cap: resolveUniqueCap(parsed),
+        dryRun: !!parsed.dryRun,
+        rewriteSegment,
+        verifySegment,
+        backendAttemptsPerCall,
+        provider: providerName,
+        model: resolved.model,
+        outputPath,
+        breaker,
+        signal: cancellation.signal,
+      });
+      if (result.dryRun) {
+        const r = result.report;
+        if ((parsed.format ?? 'markdown') === 'json') {
+          console.log(JSON.stringify({ file, targetLang: result.targetLang, ...r }, null, 2));
+        } else {
+          console.log(
+            `[dry-run] ${file} (target=${result.targetLang})\n`
+            + `  units=${r.totalUnits} selected=${r.selectedCount} unique=${r.uniqueCount} (dedup saves ${r.duplicateSavings})\n`
+            + `  cap=${r.cap} (${r.capStatus}) | worst-case LLM calls=${r.worstCaseLlmCalls} (~${r.callsPerUnique}/segment), backend attempts<=${r.worstCaseBackendAttempts}\n`
+            + `  est input tokens ~${r.inputTokensEstimate.toLocaleString()} | cost: ${r.cost ?? r.costNote}\n`
+            + `  output would be: ${outputPath}\n`
+            + `  skipped: ${Object.entries(r.skippedByReason).map(([k, v]) => `${k}=${v}`).join(', ') || 'none'}\n`
+            + `  (dry-run: 0 LLM calls, 0 writes)`
+          );
+        }
+        continue;
+      }
+      if (parsed.outdir) mkdirSync(parsed.outdir, { recursive: true });
+      if (!parsed.inPlace && resolve(outputPath) === resolve(file)) {
+        throw runtimeError(
+          'xliff: refusing to overwrite the original file',
+          `The computed output path equals the input (${file}).`,
+          'Use --in-place to overwrite intentionally, or --suffix/--outdir for a separate output.'
+        );
+      }
+      writeAtomicUtf8(outputPath, result.outputXml);
+      console.log(`Written: ${outputPath} — ${result.report.changedSegments} segment(s) humanized, ${result.report.uniqueCount - result.report.changedUniqueKeys} kept`);
+    }
+  } finally {
+    cancellation.cleanup();
+    logger.closeProgress();
+  }
 }
 
 

--- a/src/cli/xliff.js
+++ b/src/cli/xliff.js
@@ -1,0 +1,672 @@
+// @ts-check
+// XLIFF localization humanize mode — dependency-free core (parse / scan / select).
+//
+// This module is PURE and LLM-free: it scans XLIFF 1.2 text with a small
+// quote/comment/PI/CDATA-aware forward scanner, isolates each trans-unit's
+// direct <target> inner span unambiguously (rejecting anything it cannot
+// isolate safely), and classifies which targets are safe prose to humanize.
+// It never mutates src/features/* and adds no runtime dependencies.
+//
+// Write-back, dry-run/cost estimation, caps, atomic writes, and the CLI wiring
+// live in later stories (applyXliffReplacements/estimateXliffRun in this file's
+// G002 additions, and runXliffMode/CLI in G003). This story ships the analysis
+// core + tests only.
+
+import { SUPPORTED_LANGS } from '../web-rewrite-contract.js';
+
+/** Named XML entities patina decodes/encodes. Unknown names are treated as unsafe. */
+const NAMED_ENTITIES = Object.freeze({ amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" });
+
+/** target `state` values considered "already translated" and safe to polish. */
+export const TARGET_STATE_ALLOWLIST = Object.freeze(['translated', 'final', 'signed-off', 'needs-review-translation']);
+
+/** Language-tag normalization onto patina's supported set. */
+const LANG_ALIASES = Object.freeze({
+  ko: 'ko', 'ko-kr': 'ko',
+  en: 'en', 'en-us': 'en', 'en-gb': 'en',
+  zh: 'zh', 'zh-cn': 'zh', 'zh-tw': 'zh', 'zh-hans': 'zh', 'zh-hant': 'zh',
+  ja: 'ja', 'ja-jp': 'ja',
+});
+
+/** Prose thresholds (below these, patina abstains anyway → skip as non-prose). */
+const MIN_WORDS = 5;
+const MIN_CJK_CHARS = 12;
+
+/**
+ * Normalize an XLIFF language tag onto patina's supported languages, or null.
+ * @param {unknown} tag
+ * @returns {string|null}
+ */
+export function normalizeLang(tag) {
+  if (typeof tag !== 'string') return null;
+  const key = tag.trim().toLowerCase();
+  if (!key) return null;
+  if (LANG_ALIASES[key]) return LANG_ALIASES[key];
+  const base = key.split(/[-_]/)[0];
+  const mapped = LANG_ALIASES[base];
+  return mapped && SUPPORTED_LANGS.includes(mapped) ? mapped : null;
+}
+
+/**
+ * Scan XLIFF/XML text into a flat token stream in a single forward pass.
+ * Recognizes comments, processing instructions, CDATA, declarations, tags
+ * (open/close/self-close) with quote-aware attribute scanning, and text.
+ * Unterminated constructs produce a terminal `malformed` token.
+ *
+ * @param {string} xml
+ * @returns {Array<{kind:string,start:number,end:number,raw:string,name?:string}>}
+ */
+export function scanXmlTokens(xml) {
+  const s = String(xml);
+  const n = s.length;
+  const tokens = [];
+  let i = 0;
+  while (i < n) {
+    const lt = s.indexOf('<', i);
+    if (lt === -1) {
+      tokens.push({ kind: 'text', start: i, end: n, raw: s.slice(i) });
+      break;
+    }
+    if (lt > i) tokens.push({ kind: 'text', start: i, end: lt, raw: s.slice(i, lt) });
+
+    if (s.startsWith('<!--', lt)) {
+      const c = s.indexOf('-->', lt + 4);
+      if (c === -1) { tokens.push({ kind: 'malformed', start: lt, end: n, raw: s.slice(lt) }); break; }
+      const end = c + 3; tokens.push({ kind: 'comment', start: lt, end, raw: s.slice(lt, end) }); i = end; continue;
+    }
+    if (s.startsWith('<![CDATA[', lt)) {
+      const c = s.indexOf(']]>', lt + 9);
+      if (c === -1) { tokens.push({ kind: 'malformed', start: lt, end: n, raw: s.slice(lt) }); break; }
+      const end = c + 3; tokens.push({ kind: 'cdata', start: lt, end, raw: s.slice(lt, end) }); i = end; continue;
+    }
+    if (s.startsWith('<?', lt)) {
+      const c = s.indexOf('?>', lt + 2);
+      if (c === -1) { tokens.push({ kind: 'malformed', start: lt, end: n, raw: s.slice(lt) }); break; }
+      const end = c + 2; tokens.push({ kind: 'pi', start: lt, end, raw: s.slice(lt, end) }); i = end; continue;
+    }
+    const isDecl = s.startsWith('<!', lt);
+    const isClose = !isDecl && s[lt + 1] === '/';
+    const scanFrom = lt + (isDecl ? 2 : (isClose ? 2 : 1));
+    const end = scanToTagEnd(s, scanFrom, n);
+    if (end === -1) { tokens.push({ kind: 'malformed', start: lt, end: n, raw: s.slice(lt) }); break; }
+    const raw = s.slice(lt, end);
+    if (isDecl) tokens.push({ kind: 'decl', start: lt, end, raw });
+    else if (isClose) tokens.push({ kind: 'close', start: lt, end, raw, name: tagName(raw) });
+    else if (raw.endsWith('/>')) tokens.push({ kind: 'selfclose', start: lt, end, raw, name: tagName(raw) });
+    else tokens.push({ kind: 'open', start: lt, end, raw, name: tagName(raw) });
+    i = end;
+  }
+  return tokens;
+}
+
+/** Scan to the index just past the tag-closing `>`, honoring quoted attribute values. */
+function scanToTagEnd(s, from, n) {
+  let q = 0; // 0 none, 1 single, 2 double
+  for (let j = from; j < n; j++) {
+    const c = s[j];
+    if (q === 1) { if (c === "'") q = 0; }
+    else if (q === 2) { if (c === '"') q = 0; }
+    else if (c === "'") q = 1;
+    else if (c === '"') q = 2;
+    else if (c === '>') return j + 1;
+  }
+  return -1;
+}
+
+/** Extract the element name from a raw tag string (`<name ...>`, `</name>`, `<name/>`). */
+function tagName(raw) {
+  let k = 1;
+  if (raw[k] === '/') k++;
+  while (k < raw.length && /\s/.test(raw[k])) k++;
+  let start = k;
+  while (k < raw.length && !/[\s/>]/.test(raw[k])) k++;
+  return raw.slice(start, k);
+}
+
+/**
+ * Parse attributes from an already quote-scanned opening/self-closing tag.
+ * Returns lower-cased names mapped to decoded values. Never mutates output.
+ * @param {string} raw
+ * @returns {{name:string, attrs:Record<string,string>}}
+ */
+export function parseAttributesFromTag(raw) {
+  const name = tagName(raw);
+  /** @type {Record<string,string>} */
+  const attrs = {};
+  const re = /([A-Za-z_:][\w:.-]*)\s*=\s*("([^"]*)"|'([^']*)')/g;
+  let m;
+  while ((m = re.exec(raw))) {
+    const key = m[1].toLowerCase();
+    const val = m[3] !== undefined ? m[3] : m[4];
+    attrs[key] = decodeXmlText(val);
+  }
+  return { name, attrs };
+}
+
+/**
+ * Decode the 5 predefined XML entities + decimal/hex numeric references.
+ * Unknown named entities are left intact (and flagged separately by
+ * hasUnsupportedEntity so the segment can be skipped fail-closed).
+ * @param {string} s
+ * @returns {string}
+ */
+export function decodeXmlText(s) {
+  return String(s).replace(/&(#x[0-9a-fA-F]+|#[0-9]+|[a-zA-Z][a-zA-Z0-9]*);/g, (whole, body) => {
+    if (body[0] === '#') {
+      const code = (body[1] === 'x' || body[1] === 'X') ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
+      return isLegalXmlChar(code) ? safeFromCodePoint(code, whole) : whole;
+    }
+    return Object.prototype.hasOwnProperty.call(NAMED_ENTITIES, body) ? NAMED_ENTITIES[body] : whole;
+  });
+}
+
+function safeFromCodePoint(code, whole) {
+  try { return String.fromCodePoint(code); } catch { return whole; }
+}
+
+/** XML 1.0 legal character range. Illegal numeric char refs (e.g. &#0;) are unsafe. */
+function isLegalXmlChar(code) {
+  if (!Number.isFinite(code)) return false;
+  return code === 0x9 || code === 0xa || code === 0xd
+    || (code >= 0x20 && code <= 0xd7ff)
+    || (code >= 0xe000 && code <= 0xfffd)
+    || (code >= 0x10000 && code <= 0x10ffff);
+}
+
+/**
+ * True if the string contains a bare `&` or an unknown named entity — either is
+ * unsafe to round-trip, so the segment must be skipped.
+ * @param {string} s
+ * @returns {boolean}
+ */
+export function hasUnsupportedEntity(s) {
+  const str = String(s);
+  const re = /&(#x[0-9a-fA-F]+;|#[0-9]+;|[a-zA-Z][a-zA-Z0-9]*;)?/g;
+  let m;
+  while ((m = re.exec(str))) {
+    const body = m[1];
+    if (!body) return true; // bare '&' not starting a valid entity
+    if (body[0] === '#') {
+      const num = body.slice(1, -1);
+      const code = (num[0] === 'x' || num[0] === 'X') ? parseInt(num.slice(1), 16) : parseInt(num, 10);
+      if (!isLegalXmlChar(code)) return true; // invalid XML numeric char ref
+      continue;
+    }
+    const name = body.slice(0, -1);
+    if (!Object.prototype.hasOwnProperty.call(NAMED_ENTITIES, name)) return true;
+  }
+  return false;
+}
+
+/**
+ * Encode replacement text for an XML text node.
+ * @param {string} s
+ * @returns {string}
+ */
+export function encodeXmlText(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Split a target inner XML span into leading whitespace, core, trailing
+ * whitespace, without overlap. Only `core` is humanized.
+ * @param {string} innerXml
+ * @returns {{leading:string, core:string, trailing:string}}
+ */
+export function splitTargetInnerWhitespace(innerXml) {
+  const s = String(innerXml);
+  const leading = (s.match(/^\s*/) || [''])[0];
+  const rest = s.slice(leading.length);
+  const trailing = (rest.match(/\s*$/) || [''])[0];
+  const core = rest.slice(0, rest.length - trailing.length);
+  return { leading, core, trailing };
+}
+
+/** True if a target inner span contains any inline markup tag (g/x/bpt/…, or any element). */
+export function hasInlineMarkup(innerXml) {
+  return scanXmlTokens(innerXml).some((t) => t.kind === 'open' || t.kind === 'close' || t.kind === 'selfclose');
+}
+
+/** True if a target inner span contains CDATA or a malformed construct. */
+function hasCdataOrMalformed(innerXml) {
+  return scanXmlTokens(innerXml).some((t) => t.kind === 'cdata' || t.kind === 'malformed');
+}
+
+/**
+ * Walk the token stream for one trans-unit (opened at tokens[openIdx]) using a
+ * name-matched nesting stack. Returns the matched close index and the direct
+ * child source/target entries, or null when nesting is malformed/unmatched.
+ */
+function collectUnit(tokens, openIdx) {
+  const stack = [{ name: 'trans-unit', openIdx }];
+  const directTargets = [];
+  const directSources = [];
+  for (let j = openIdx + 1; j < tokens.length; j++) {
+    const t = tokens[j];
+    if (t.kind === 'malformed') return null;
+    if (t.kind === 'open') {
+      const entry = { name: t.name, openIdx: j };
+      if (stack.length === 1 && t.name === 'target') directTargets.push(entry);
+      if (stack.length === 1 && t.name === 'source') directSources.push(entry);
+      stack.push(entry);
+    } else if (t.kind === 'selfclose') {
+      if (stack.length === 1 && t.name === 'target') directTargets.push({ name: 'target', openIdx: j, selfClose: true });
+    } else if (t.kind === 'close') {
+      const top = stack.pop();
+      if (!top || top.name !== t.name) return null;
+      top.closeIdx = j;
+      if (stack.length === 0) {
+        return t.name === 'trans-unit' ? { openIdx, closeIdx: j, directTargets, directSources } : null;
+      }
+    }
+  }
+  return null;
+}
+
+/** Build a per-unit record, or a skip record with a reason. */
+function buildUnitRecord(tokens, unit, xml, index) {
+  const openTok = tokens[unit.openIdx];
+  const { attrs: unitAttrs } = parseAttributesFromTag(openTok.raw);
+  const base = {
+    index,
+    id: unitAttrs.id,
+    resname: unitAttrs.resname,
+    unitAttrs,
+  };
+  // Exactly one, well-formed, non-self-closing direct <target>.
+  if (unit.directTargets.length !== 1) return { ...base, skip: true, reason: 'ambiguous_unit' };
+  const tgt = unit.directTargets[0];
+  if (tgt.selfClose || tgt.closeIdx === undefined) return { ...base, skip: true, reason: 'ambiguous_unit' };
+  if (unit.directSources.length > 1) return { ...base, skip: true, reason: 'ambiguous_unit' };
+
+  const targetOpen = tokens[tgt.openIdx];
+  const targetClose = tokens[tgt.closeIdx];
+  const innerStart = targetOpen.end;
+  const innerEnd = targetClose.start;
+  if (innerEnd < innerStart) return { ...base, skip: true, reason: 'ambiguous_unit' };
+  const targetInnerXml = xml.slice(innerStart, innerEnd);
+  const { attrs: targetAttrs } = parseAttributesFromTag(targetOpen.raw);
+
+  let sourceText;
+  if (unit.directSources.length === 1 && unit.directSources[0].closeIdx !== undefined && !unit.directSources[0].selfClose) {
+    const so = tokens[unit.directSources[0].openIdx];
+    const sc = tokens[unit.directSources[0].closeIdx];
+    if (sc.start >= so.end) sourceText = decodeXmlText(xml.slice(so.end, sc.start));
+  }
+
+  return {
+    ...base,
+    skip: false,
+    state: targetAttrs.state,
+    targetAttrs,
+    targetInnerXml,
+    targetInnerStart: innerStart,
+    targetInnerEnd: innerEnd,
+    sourceText,
+  };
+}
+
+/**
+ * Parse an XLIFF 1.2 document into a target language + trans-unit records.
+ * Throws (fail-closed) when the target language is missing/unsupported or when
+ * no unit can be isolated at all. Individual ambiguous units are recorded as
+ * skips, not fatal.
+ *
+ * @param {string} xml
+ * @param {{langOverride?:string}} [options]
+ * @returns {{targetLang:string, targetLangRaw:string|null, units:Array<object>, ambiguousCount:number, parseableCount:number}}
+ */
+export function parseXliffDocument(xml, { langOverride } = {}) {
+  const tokens = scanXmlTokens(xml);
+  let targetLangRaw = null;
+  for (const t of tokens) {
+    if (t.kind === 'open' && t.name === 'file') {
+      targetLangRaw = parseAttributesFromTag(t.raw).attrs['target-language'] ?? null;
+      break;
+    }
+  }
+  const targetLang = langOverride ? normalizeLang(langOverride) : normalizeLang(targetLangRaw);
+  if (!targetLang) {
+    const err = new Error(`xliff: unsupported or missing target-language: ${targetLangRaw ?? '(none)'}`);
+    /** @type {any} */ (err).code = 'xliff_unsupported_language';
+    throw err;
+  }
+
+  const units = [];
+  let ambiguousCount = 0;
+  let index = 0;
+  for (let a = 0; a < tokens.length; a++) {
+    const t = tokens[a];
+    if (!(t.kind === 'open' && t.name === 'trans-unit')) continue;
+    const unit = collectUnit(tokens, a);
+    if (!unit) { units.push({ index, skip: true, reason: 'ambiguous_unit' }); ambiguousCount++; index++; continue; }
+    const rec = buildUnitRecord(tokens, unit, xml, index);
+    if (rec.skip) ambiguousCount++;
+    units.push(rec);
+    index++;
+  }
+  const parseableCount = units.length - ambiguousCount;
+  if (units.length === 0) {
+    const err = new Error('xliff: no <trans-unit> elements found');
+    /** @type {any} */ (err).code = 'xliff_no_units';
+    throw err;
+  }
+  if (parseableCount === 0) {
+    const err = new Error('xliff: no unambiguously parseable trans-units');
+    /** @type {any} */ (err).code = 'xliff_no_parseable_units';
+    throw err;
+  }
+  return { targetLang, targetLangRaw, units, ambiguousCount, parseableCount };
+}
+
+/** Whether a unit's translate/lock attributes forbid editing. */
+function isLocked(attrs = {}) {
+  return attrs.translate === 'no' || attrs.locked === 'true' || attrs.approved === 'no';
+}
+
+/** Whether the decoded core text is prose worth humanizing. */
+export function isProseLike(text) {
+  const t = String(text).trim();
+  if (!t) return false;
+  if (!/[A-Za-z\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]/.test(t)) return false; // no letters at all
+  // Reject obvious non-prose: URLs, emails, format codes / placeholders only.
+  if (/^(https?:\/\/|mailto:)/i.test(t)) return false;
+  if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(t)) return false;
+  const stripped = t.replace(/%[0-9]*\$?[a-zA-Z]|%\{[^}]*\}|\{\d+\}|\{[a-zA-Z_][\w]*\}|<[^>]+>/g, ' ').trim();
+  if (!stripped) return false;
+  const words = stripped.split(/\s+/).filter(Boolean).length;
+  const cjk = (stripped.match(/[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]/g) || []).length;
+  return words >= MIN_WORDS || cjk >= MIN_CJK_CHARS;
+}
+
+/**
+ * Classify one parsed unit record into a selected segment or a skip+reason.
+ * @param {object} unit A non-skip record from parseXliffDocument.
+ * @returns {{select:boolean, reason?:string, index:number, id?:string, resname?:string, dedupKey?:string, sourceText?:string, targetCore?:string, leading?:string, trailing?:string, targetInnerStart?:number, targetInnerEnd?:number}}
+ */
+export function classifyXliffSegment(unit) {
+  const base = { index: unit.index, id: unit.id, resname: unit.resname };
+  if (unit.skip) return { select: false, reason: unit.reason || 'ambiguous_unit', ...base };
+  if (isLocked(unit.unitAttrs)) return { select: false, reason: 'locked', ...base };
+
+  const state = unit.state;
+  const stateOk = state === undefined || TARGET_STATE_ALLOWLIST.includes(state);
+  if (!stateOk) return { select: false, reason: 'state_not_allowlisted', ...base };
+
+  const inner = unit.targetInnerXml;
+  if (hasCdataOrMalformed(inner)) return { select: false, reason: 'cdata_or_malformed', ...base };
+  if (hasInlineMarkup(inner)) return { select: false, reason: 'inline_markup', ...base };
+  if (hasUnsupportedEntity(inner)) return { select: false, reason: 'unsupported_entity', ...base };
+
+  const { leading, core, trailing } = splitTargetInnerWhitespace(inner);
+  const decodedCore = decodeXmlText(core);
+  if (!decodedCore.trim()) return { select: false, reason: 'empty_target', ...base };
+
+  // Untranslated: target core equals source core after decode+trim. (needs-translation
+  // is already excluded by the state allowlist above.)
+  if (typeof unit.sourceText === 'string' && decodedCore.trim() === unit.sourceText.trim()) {
+    return { select: false, reason: 'untranslated', ...base };
+  }
+  if (!isProseLike(decodedCore)) return { select: false, reason: 'not_prose', ...base };
+
+  return {
+    select: true,
+    ...base,
+    sourceText: unit.sourceText,
+    targetCore: decodedCore,
+    leading,
+    trailing,
+    targetInnerStart: unit.targetInnerStart,
+    targetInnerEnd: unit.targetInnerEnd,
+    dedupKey: decodedCore.replace(/\r\n/g, '\n'),
+  };
+}
+
+/**
+ * Classify every unit in a parsed document and produce selection + skip stats,
+ * with exact-text dedup (key = decoded core after CRLF→LF; no trim/casefold).
+ *
+ * @param {{units:Array<object>}} doc
+ * @returns {{selected:Array<object>, skipped:Array<object>, skippedByReason:Record<string,number>, uniqueKeys:string[], selectedCount:number, uniqueCount:number}}
+ */
+export function selectXliffSegments(doc) {
+  const selected = [];
+  const skipped = [];
+  /** @type {Record<string,number>} */
+  const skippedByReason = {};
+  const seen = new Set();
+  for (const unit of doc.units) {
+    const c = classifyXliffSegment(unit);
+    if (c.select) {
+      selected.push(c);
+      seen.add(c.dedupKey);
+    } else {
+      skipped.push(c);
+      skippedByReason[c.reason] = (skippedByReason[c.reason] || 0) + 1;
+    }
+  }
+  return {
+    selected,
+    skipped,
+    skippedByReason,
+    uniqueKeys: [...seen],
+    selectedCount: selected.length,
+    uniqueCount: seen.size,
+  };
+}
+
+/** Default cap on the number of UNIQUE segments processed per command. */
+export const DEFAULT_UNIQUE_CAP = 50;
+
+/** Resolve the effective unique-segment cap from parsed args (positive int override). */
+export function resolveUniqueCap(parsed = {}) {
+  const n = Number(parsed.maxSegments);
+  return Number.isInteger(n) && n > 0 ? n : DEFAULT_UNIQUE_CAP;
+}
+
+/**
+ * Apply target-inner replacements to XLIFF text. Each replacement is a
+ * `{start, end, replacement}` span over the ORIGINAL string; spans are applied
+ * right-to-left so earlier offsets stay valid, and overlapping spans are
+ * rejected. An empty replacement list returns the input byte-identically, and
+ * every byte outside a replaced span is preserved exactly.
+ * Spans are JS string indices into the original decoded XML string (from the
+ * same string the offsets were derived from), NOT UTF-8 byte offsets.
+ *
+ * @param {string} xmlText
+ * @param {Array<{start:number,end:number,replacement:string}>} replacements
+ * @returns {string}
+ */
+export function applyXliffReplacements(xmlText, replacements) {
+  const s = String(xmlText);
+  if (!Array.isArray(replacements) || replacements.length === 0) return s;
+  const sorted = [...replacements].sort((a, b) => b.start - a.start);
+  let out = s;
+  let prevStart = s.length + 1;
+  for (const r of sorted) {
+    if (!(Number.isInteger(r.start) && Number.isInteger(r.end) && r.start >= 0 && r.end >= r.start && r.end <= s.length)) {
+      throw new Error(`xliff: invalid replacement span [${r.start}, ${r.end}]`);
+    }
+    if (r.end > prevStart) throw new Error('xliff: overlapping replacement spans');
+    out = out.slice(0, r.start) + String(r.replacement) + out.slice(r.end);
+    prevStart = r.start;
+  }
+  return out;
+}
+
+/**
+ * Compute a dry-run report for an XLIFF humanize run. Makes ZERO LLM calls and
+ * writes nothing. Worst-case per unique segment is 6 LLM calls (1 rewrite + 2
+ * verification scoring calls + 1 conservative retry rewrite + 2 retry scoring).
+ *
+ * @param {{totalUnits?:number, selectedCount?:number, uniqueCount?:number, skippedByReason?:Record<string,number>, cap?:number, backendAttemptsPerCall?:number, outputPath?:string|null, provider?:string, model?:string}} [input]
+ * @returns {object}
+ */
+export function estimateXliffRun({
+  totalUnits = 0,
+  selectedCount = 0,
+  uniqueCount = 0,
+  skippedByReason = {},
+  cap = DEFAULT_UNIQUE_CAP,
+  backendAttemptsPerCall = 1,
+  outputPath = null,
+  provider,
+  model,
+} = {}) {
+  const CALLS_PER_UNIQUE = 6; // rewrite + 2 verify + retry rewrite + 2 retry verify
+  const REWRITE_CALLS_PER_UNIQUE = 2; // initial + conservative retry
+  const REWRITE_PROMPT_INPUT_TOKENS = 12000; // measured patina rewrite prompt base
+  const worstCaseLlmCalls = uniqueCount * CALLS_PER_UNIQUE;
+  const attemptsPerCall = Math.max(1, Number(backendAttemptsPerCall) || 1);
+  return {
+    totalUnits,
+    outputPath,
+    selectedCount,
+    uniqueCount,
+    duplicateSavings: Math.max(0, selectedCount - uniqueCount),
+    skippedByReason,
+    cap,
+    capStatus: uniqueCount > cap ? 'cap_exceeded' : 'ok',
+    callsPerUnique: CALLS_PER_UNIQUE,
+    worstCaseLlmCalls,
+    worstCaseBackendAttempts: worstCaseLlmCalls * attemptsPerCall,
+    inputTokensEstimate: uniqueCount * REWRITE_CALLS_PER_UNIQUE * REWRITE_PROMPT_INPUT_TOKENS,
+    tokenEstimateBasis: 'estimated: ~12000 input tokens per rewrite-style call; verifier scoring prompts add more',
+    cost: null,
+    costNote: provider || model ? `pricing unavailable for ${provider ?? '?'}/${model ?? '?'}` : 'pricing unavailable',
+    llmCalls: 0,
+    writes: 0,
+  };
+}
+
+/**
+ * Orchestrate an XLIFF humanize run over a parsed+selected document. PURE except
+ * for the injected `rewriteSegment`/`verifySegment` async callbacks, so tests
+ * can drive it with fakes. Rewrites each UNIQUE selected target core once and
+ * reuses the verified result for all duplicates. A segment is written only when
+ * verification passes AND the core actually changed — so a no-op rewrite yields
+ * a byte-identical file. Verify-floor misses and rewrite errors keep the
+ * original bytes (fail-closed). Dry-run makes zero calls and no changes.
+ *
+ * @param {{
+ *   xml: string,
+ *   langOverride?: string,
+ *   cap?: number,
+ *   dryRun?: boolean,
+ *   rewriteSegment?: (input: {core: string, lang: string, source?: string}) => Promise<string>,
+ *   verifySegment?: (input: {core: string, candidate: string, lang?: string}) => Promise<{verified: boolean, text?: string, mps?: number, fidelity?: number}>,
+ *   backendAttemptsPerCall?: number,
+ *   provider?: string,
+ *   model?: string,
+ *   outputPath?: string|null,
+ *   breaker?: {recordSuccess?: Function, recordFailure?: Function, shouldStop?: Function, toError?: Function}|null,
+ *   signal?: {aborted?: boolean}|null,
+ * }} input
+ * @returns {Promise<{dryRun:boolean, outputXml:string, report:object, targetLang:string}>}
+ */
+export async function humanizeXliffDocument({
+  xml,
+  langOverride,
+  cap = DEFAULT_UNIQUE_CAP,
+  dryRun = false,
+  rewriteSegment,
+  verifySegment,
+  backendAttemptsPerCall = 1,
+  provider,
+  model,
+  outputPath = null,
+  breaker = null,
+  signal = null,
+}) {
+  const doc = parseXliffDocument(xml, { langOverride });
+  const sel = selectXliffSegments(doc);
+  const report = estimateXliffRun({
+    totalUnits: doc.units.length,
+    selectedCount: sel.selectedCount,
+    uniqueCount: sel.uniqueCount,
+    skippedByReason: sel.skippedByReason,
+    cap,
+    backendAttemptsPerCall,
+    outputPath,
+    provider,
+    model,
+  });
+
+  if (dryRun) return { dryRun: true, outputXml: xml, report, targetLang: doc.targetLang };
+
+  if (sel.uniqueCount > cap) {
+    const err = new Error(`xliff: ${sel.uniqueCount} unique segments exceeds the cap of ${cap}; pass --max-segments to raise it or use --dry-run`);
+    /** @type {any} */ (err).code = 'xliff_cap_exceeded';
+    /** @type {any} */ (err).report = report;
+    throw err;
+  }
+
+  if (typeof rewriteSegment !== 'function' || typeof verifySegment !== 'function') {
+    throw new TypeError('humanizeXliffDocument requires rewriteSegment and verifySegment callbacks');
+  }
+
+  // One rewrite+verify per unique dedup key; reuse for every duplicate.
+  const firstByKey = new Map();
+  for (const s of sel.selected) if (!firstByKey.has(s.dedupKey)) firstByKey.set(s.dedupKey, s);
+
+  /** @type {Map<string,string>} verified NEW core keyed by dedup key */
+  const changedByKey = new Map();
+  /** @type {Record<string,{status:string}>} */
+  const perKey = {};
+
+  for (const [key, seg] of firstByKey) {
+    if (signal && signal.aborted) {
+      const e = new Error('xliff: canceled');
+      /** @type {any} */ (e).code = 'canceled';
+      throw e;
+    }
+    let candidate;
+    let verification;
+    try {
+      candidate = await rewriteSegment({ core: seg.targetCore, lang: doc.targetLang, source: seg.sourceText });
+      verification = await verifySegment({ core: seg.targetCore, candidate, lang: doc.targetLang });
+      breaker?.recordSuccess?.();
+    } catch (err) {
+      perKey[key] = { status: 'error' };
+      breaker?.recordFailure?.({ path: seg.id ?? key, err });
+      if (breaker?.shouldStop?.()) throw (breaker.toError ? breaker.toError() : err);
+      continue; // fail-closed: keep original bytes
+    }
+    if (verification && verification.verified && typeof verification.text === 'string') {
+      const newCore = verification.text.trim();
+      if (newCore && newCore !== seg.targetCore.trim()) {
+        changedByKey.set(key, newCore);
+        perKey[key] = { status: 'rewritten' };
+      } else {
+        perKey[key] = { status: 'unchanged' };
+      }
+    } else {
+      perKey[key] = { status: 'floor_failed' };
+    }
+  }
+
+  // Build replacements for EVERY selected segment whose key was verified-changed.
+  const replacements = [];
+  for (const s of sel.selected) {
+    const newCore = changedByKey.get(s.dedupKey);
+    if (newCore === undefined) continue;
+    replacements.push({
+      start: s.targetInnerStart,
+      end: s.targetInnerEnd,
+      replacement: s.leading + encodeXmlText(newCore) + s.trailing,
+    });
+  }
+  const outputXml = applyXliffReplacements(xml, replacements);
+
+  return {
+    dryRun: false,
+    outputXml,
+    report: { ...report, changedSegments: replacements.length, changedUniqueKeys: changedByKey.size, perKey },
+    targetLang: doc.targetLang,
+  };
+}

--- a/src/output.js
+++ b/src/output.js
@@ -245,9 +245,14 @@ export function stripSelfAudit(body, { logger = createLogger() } = {}) {
   const tail = removeSelfAuditBlocks(body.slice(bodyClose + '[/BODY]'.length)).trim();
   return tail ? `${inner}\n\n${tail}` : inner;
 }
+export function cleanRewriteOutput(result, { logger = createLogger() } = {}) {
+  // Strip model scaffolding ([BODY]/[SELF_AUDIT]) and any leaked YAML tone
+  // footer so downstream consumers (browser rewrite pane, XLIFF <target>
+  // write-back) never persist patina's own output chrome as segment content.
+  return removeToneFooter(stripSelfAudit(renderBody(result), { logger }).trim());
+}
 export function formatRewriteBodyForBrowser(result, { logger = createLogger() } = {}) {
-  const body = stripSelfAudit(renderBody(result), { logger }).trim();
-  return removeToneFooter(body);
+  return cleanRewriteOutput(result, { logger });
 }
 
 

--- a/tests/fixtures/xliff/sample.xliff
+++ b/tests/fixtures/xliff/sample.xliff
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file id="1" original="app.json" source-language="zh-CN" target-language="ko" datatype="plaintext">
+    <body>
+      <trans-unit id="u1" resname="notice.delete">
+        <source>由于账户未登录，我们将在一段时间后永久删除文件。</source>
+        <target state="final">계정이 로그인되어 있지 않아, 일정 기간 후 파일을 영구적으로 삭제할 예정입니다.</target>
+      </trans-unit>
+      <trans-unit id="u2" resname="locked.msg" translate="no">
+        <source>此项目已锁定，请勿编辑当前字符串内容。</source>
+        <target state="final">이 항목은 잠겨 있으니 현재 문자열을 편집하지 마세요.</target>
+      </trans-unit>
+      <trans-unit id="u3" resname="untranslated.msg">
+        <source>Please back up your data before initializing the device.</source>
+        <target state="needs-translation">Please back up your data before initializing the device.</target>
+      </trans-unit>
+      <trans-unit id="u4" resname="inline.markup">
+        <source>点击 <g id="1">这里</g> 查看更多详情信息内容。</source>
+        <target state="final">자세한 내용을 보려면 <g id="1">여기</g>를 눌러 주세요.</target>
+      </trans-unit>
+      <trans-unit id="u5" resname="short.label">
+        <source>确定</source>
+        <target state="final">확인</target>
+      </trans-unit>
+      <trans-unit id="u6" resname="notice.delete.dup">
+        <source>另一处相同文案的重复条目内容示例。</source>
+        <target state="final">계정이 로그인되어 있지 않아, 일정 기간 후 파일을 영구적으로 삭제할 예정입니다.</target>
+      </trans-unit>
+      <!-- tricky: a comment containing a fake </target> and <target> should not confuse the scanner -->
+      <trans-unit id="u7" resname="after.comment">
+        <source>服务器迁移完成后请重新登录您的账户以继续使用。</source>
+        <target state="translated">서버 이전이 완료된 후 계정에 다시 로그인하여 계속 이용해 주세요.</target>
+      </trans-unit>
+      <trans-unit id="u8" resname="cdata.target">
+        <source>CDATA content should be skipped by the humanizer entirely.</source>
+        <target state="final"><![CDATA[원시 데이터 <b>굵게</b> 유지되어야 하는 긴 안내 문장입니다.]]></target>
+      </trans-unit>
+      <trans-unit id="u9" resname="ambiguous.multi">
+        <source>Ambiguous unit with two target children in one unit here.</source>
+        <target state="final">첫 번째 대상 문장으로 충분히 긴 안내 문구입니다.</target>
+        <target state="final">두 번째 대상 문장이라 모호하므로 건너뜁니다.</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/tests/unit/xliff-cli.redteam.test.js
+++ b/tests/unit/xliff-cli.redteam.test.js
@@ -1,0 +1,122 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { parseArgs, validateXliffRequest } from '../../src/cli/args.js';
+import { humanizeXliffDocument } from '../../src/cli/xliff.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = readFileSync(resolve(HERE, '../fixtures/xliff/sample.xliff'), 'utf8');
+
+const KO_A = '첫 번째 문장은 사람이 읽기 좋게 다듬을 수 있는 충분히 긴 번역문입니다.';
+const KO_B = '두 번째 문장도 검증 경계값을 확인하기에 충분한 한국어 번역문입니다.';
+const KO_C = '세 번째 문장은 변경하지 않는 경로를 확인하기 위해 준비한 문장입니다.';
+const xml = (units) => `<xliff version="1.2"><file target-language="ko"><body>${units}</body></file></xliff>`;
+const unit = (id, target) => `<trans-unit id="${id}"><source>Source text ${id}</source><target state="translated">${target}</target></trans-unit>`;
+
+test('parseArgs/validateXliffRequest: fail closed for XLIFF-only flags and does not interfere with normal score', () => {
+  for (const argv of [
+    ['--xliff', '--audit', 'f.xliff'],
+    ['--xliff', '--verify', 'f.xliff'],
+    ['--xliff', '--tone', 'casual', 'f.xliff'],
+    ['--xliff', '--persona', 'x', 'f.xliff'],
+    ['--xliff', '--jargon', 'remove', 'f.xliff'],
+    ['--xliff', '--score', 'f.xliff'],
+    ['--xliff', '--preview', 'f.xliff'],
+  ]) {
+    assert.throws(() => validateXliffRequest(parseArgs(argv)), /cannot be combined with --xliff/);
+  }
+
+  assert.throws(() => validateXliffRequest(parseArgs(['--xliff'])), /requires file paths, not stdin/);
+  assert.throws(() => validateXliffRequest(parseArgs(['--xliff', 'a.xliff', 'b.xliff'])), /requires --batch/);
+  assert.throws(() => validateXliffRequest(parseArgs(['--dry-run', 'a.md'])), /--dry-run requires --xliff/);
+  assert.throws(() => validateXliffRequest(parseArgs(['--max-segments', '5', 'a.md'])), /--max-segments requires --xliff/);
+
+  for (const argv of [
+    ['--xliff', '--max-segments', '0', 'f.xliff'],
+    ['--xliff', '--max-segments', '-1', 'f.xliff'],
+    ['--xliff', '--max-segments', 'NaN', 'f.xliff'],
+  ]) {
+    assert.throws(() => parseArgs(argv), /positive integer/);
+  }
+
+  const normal = parseArgs(['--score']);
+  assert.equal(normal.score, true);
+  assert.doesNotThrow(() => validateXliffRequest(normal));
+});
+
+test('humanize orchestration: mixed rewritten, floor-failed, and unchanged keys preserve byte integrity', async () => {
+  const doc = xml(unit('rewrite', KO_A) + unit('floor', KO_B) + unit('unchanged', KO_C));
+  const originalFloor = `<target state="translated">${KO_B}</target>`;
+  const originalUnchanged = `<target state="translated">${KO_C}</target>`;
+
+  const result = await humanizeXliffDocument({
+    xml: doc,
+    rewriteSegment: async ({ core }) => {
+      if (core === KO_A) return `${core} 자연스럽게`;
+      if (core === KO_B) return `${core} 망가짐`;
+      return core;
+    },
+    verifySegment: async ({ core, candidate }) => {
+      if (core === KO_B) return { verified: false, text: candidate, mps: 20, fidelity: 30 };
+      return { verified: true, text: candidate };
+    },
+  });
+
+  assert.equal(result.report.changedUniqueKeys, 1);
+  assert.equal(result.report.changedSegments, 1);
+  assert.equal(result.outputXml.includes('자연스럽게'), true);
+  assert.equal(result.outputXml.includes(originalFloor), true);
+  assert.equal(result.outputXml.includes(originalUnchanged), true);
+  assert.equal(result.outputXml.includes('망가짐'), false);
+  assert.equal(result.report.perKey[KO_B].status, 'floor_failed');
+  assert.equal(result.report.perKey[KO_C].status, 'unchanged');
+});
+
+test('humanize orchestration: breaker stop throws typed breaker error and leaves caller without partial output', async () => {
+  const failures = [];
+  const breakerError = new Error('breaker open');
+  breakerError.code = 'breaker_open';
+  const breaker = {
+    recordSuccess() {},
+    recordFailure(failure) { failures.push(failure); },
+    shouldStop() { return true; },
+    toError() { return breakerError; },
+  };
+
+  await assert.rejects(
+    () => humanizeXliffDocument({
+      xml: FIXTURE,
+      breaker,
+      rewriteSegment: async () => { throw new Error('backend down'); },
+      verifySegment: async ({ candidate }) => ({ verified: true, text: candidate }),
+    }),
+    (err) => err.code === 'breaker_open'
+  );
+  assert.equal(failures.length, 1);
+});
+
+test('humanize orchestration: cap boundary allows exactly capped unique count and rejects one below before calls', async () => {
+  let calls = 0;
+  const ok = await humanizeXliffDocument({
+    xml: FIXTURE,
+    cap: 2,
+    rewriteSegment: async ({ core }) => { calls++; return `${core} 통과`; },
+    verifySegment: async ({ candidate }) => ({ verified: true, text: candidate }),
+  });
+  assert.equal(ok.report.changedUniqueKeys, 2);
+  assert.equal(calls, 2);
+
+  calls = 0;
+  await assert.rejects(
+    () => humanizeXliffDocument({
+      xml: FIXTURE,
+      cap: 1,
+      rewriteSegment: async ({ core }) => { calls++; return `${core} 안됨`; },
+      verifySegment: async ({ candidate }) => ({ verified: true, text: candidate }),
+    }),
+    (err) => err.code === 'xliff_cap_exceeded'
+  );
+  assert.equal(calls, 0);
+});

--- a/tests/unit/xliff-cli.test.js
+++ b/tests/unit/xliff-cli.test.js
@@ -1,0 +1,233 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+import { validateXliffRequest, parseArgs } from '../../src/cli/args.js';
+import { humanizeXliffDocument, parseXliffDocument, selectXliffSegments } from '../../src/cli/xliff.js';
+import { tmpdir } from 'node:os';
+import { runXliffMode } from '../../src/cli/run.js';
+import { execFileSync } from 'node:child_process';
+
+const EN_FIXTURE = '<?xml version="1.0"?>\n<xliff version="1.2"><file target-language="en-US"><body>'
+  + '<trans-unit id="e1"><source>源文本内容示例。</source>'
+  + '<target state="final">This translated sentence is long enough to count as prose for the humanizer.</target>'
+  + '</trans-unit></body></file></xliff>';
+
+const stubLogger = () => ({ info() {}, warn() {}, error() {}, closeProgress() {} });
+const makeCtx = () => ({ config: { language: 'ko', profile: 'default' }, repoRoot: process.cwd(), voice: {}, scoring: {}, backends: [], resolved: { model: 'm' }, promptMode: 'strict', timeoutMs: 1000, providerName: 'deepseek' });
+const fakeRewrite = async ({ core }) => core + ' [H]';
+const fakeVerify = async ({ candidate }) => ({ verified: true, text: candidate });
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = readFileSync(resolve(HERE, '../fixtures/xliff/sample.xliff'), 'utf8');
+
+// ---------- validateXliffRequest ----------
+const base = (over = {}) => ({ files: ['a.xliff'], xliff: true, ...over });
+
+test('validateXliffRequest: rejects incompatible modes/flags', () => {
+  for (const [key, val] of [
+    ['audit', true], ['score', true], ['diff', true], ['preview', true],
+    ['ocr', true], ['serve', true], ['gate', 30], ['persona', 'x'],
+    ['jargon', 'remove'], ['tone', 'casual'], ['profile', 'x'], ['rewriteHeadings', true],
+    ['verify', true],
+  ]) {
+    assert.throws(() => validateXliffRequest(base({ [key]: val })), /cannot be combined with --xliff/, `${key} should be rejected`);
+  }
+});
+
+test('validateXliffRequest: rejects stdin (no files) and multi-file without --batch', () => {
+  assert.throws(() => validateXliffRequest({ xliff: true, files: [] }), /requires file paths, not stdin/);
+  assert.throws(() => validateXliffRequest({ xliff: true, files: ['a.xliff', 'b.xliff'] }), /requires --batch/);
+});
+
+test('validateXliffRequest: accepts single file + allowed flags, and batch multi-file', () => {
+  assert.doesNotThrow(() => validateXliffRequest(base({ backend: 'codex-cli', model: 'x', dryRun: true, maxSegments: 10, format: 'json', suffix: '.h' })));
+  assert.doesNotThrow(() => validateXliffRequest({ xliff: true, batch: true, files: ['a.xliff', 'b.xliff'] }));
+});
+
+test('validateXliffRequest: --dry-run and --max-segments require --xliff', () => {
+  assert.throws(() => validateXliffRequest({ dryRun: true, files: ['a.md'] }), /--dry-run requires --xliff/);
+  assert.throws(() => validateXliffRequest({ maxSegments: 5, files: ['a.md'] }), /--max-segments requires --xliff/);
+  assert.doesNotThrow(() => validateXliffRequest({ files: ['a.md'] })); // non-xliff normal run is unaffected
+});
+
+test('parseArgs: --xliff/--dry-run/--max-segments parse into parsed flags', () => {
+  const p = parseArgs(['--xliff', '--dry-run', '--max-segments', '25', 'f.xliff']);
+  assert.equal(p.xliff, true);
+  assert.equal(p.dryRun, true);
+  assert.equal(p.maxSegments, 25);
+  assert.deepEqual(p.files, ['f.xliff']);
+});
+
+// ---------- humanizeXliffDocument (injected fakes) ----------
+test('humanize: dry-run makes zero calls and returns byte-identical xml', async () => {
+  let calls = 0;
+  const r = await humanizeXliffDocument({
+    xml: FIXTURE, dryRun: true,
+    rewriteSegment: async () => { calls++; return 'x'; },
+    verifySegment: async () => { calls++; return { verified: true }; },
+  });
+  assert.equal(r.dryRun, true);
+  assert.equal(calls, 0);
+  assert.equal(r.outputXml, FIXTURE);
+  assert.equal(r.report.llmCalls, 0);
+});
+
+test('humanize: dedup rewrites each unique key once and applies to ALL duplicates (AC6)', async () => {
+  let rewriteCalls = 0;
+  const r = await humanizeXliffDocument({
+    xml: FIXTURE,
+    rewriteSegment: async ({ core }) => { rewriteCalls++; return core + ' [H]'; },
+    verifySegment: async ({ candidate }) => ({ verified: true, text: candidate }),
+  });
+  // fixture: u1, u6 (same core), u7 selected -> 2 unique keys -> 2 rewrite calls
+  assert.equal(rewriteCalls, 2);
+  assert.equal(r.report.changedUniqueKeys, 2);
+  assert.equal(r.report.changedSegments, 3); // u1 + u6 + u7
+  // both duplicates got the humanized text
+  const occurrences = r.outputXml.split('[H]').length - 1;
+  assert.equal(occurrences, 3);
+});
+
+test('humanize: verify floor miss keeps the original bytes (AC5, fail-closed)', async () => {
+  const r = await humanizeXliffDocument({
+    xml: FIXTURE,
+    rewriteSegment: async ({ core }) => core + ' CHANGED',
+    verifySegment: async () => ({ verified: false, text: 'CHANGED', mps: 40, fidelity: 55 }),
+  });
+  assert.equal(r.report.changedSegments, 0);
+  assert.equal(r.outputXml, FIXTURE); // byte-identical
+  for (const s of Object.values(r.report.perKey)) assert.equal(s.status, 'floor_failed');
+});
+
+test('humanize: verified-but-identical rewrite is a no-op (byte-identical, AC7)', async () => {
+  const r = await humanizeXliffDocument({
+    xml: FIXTURE,
+    rewriteSegment: async ({ core }) => core, // returns the same core
+    verifySegment: async ({ core }) => ({ verified: true, text: core }),
+  });
+  assert.equal(r.report.changedSegments, 0);
+  assert.equal(r.outputXml, FIXTURE);
+});
+
+test('humanize: unique cap is enforced fail-closed in execution mode', async () => {
+  await assert.rejects(
+    () => humanizeXliffDocument({
+      xml: FIXTURE, cap: 1,
+      rewriteSegment: async ({ core }) => core + '!',
+      verifySegment: async ({ candidate }) => ({ verified: true, text: candidate }),
+    }),
+    (err) => err.code === 'xliff_cap_exceeded',
+  );
+});
+
+test('humanize: a rewrite error keeps that segment original and records error (breaker)', async () => {
+  const failures = [];
+  const breaker = { recordSuccess() {}, recordFailure(f) { failures.push(f); }, shouldStop() { return false; } };
+  const r = await humanizeXliffDocument({
+    xml: FIXTURE, breaker,
+    rewriteSegment: async () => { throw new Error('backend boom'); },
+    verifySegment: async ({ candidate }) => ({ verified: true, text: candidate }),
+  });
+  assert.equal(r.report.changedSegments, 0);
+  assert.equal(r.outputXml, FIXTURE);
+  assert.ok(failures.length >= 1);
+  for (const s of Object.values(r.report.perKey)) assert.equal(s.status, 'error');
+});
+
+// sanity: the fixture still selects the expected 2 unique / 3 selected
+test('fixture selection sanity (2 unique, 3 selected)', () => {
+  const sel = selectXliffSegments(parseXliffDocument(FIXTURE));
+  assert.equal(sel.selectedCount, 3);
+  assert.equal(sel.uniqueCount, 2);
+});
+
+// ---------- --exit-on ordering ----------
+test('validateXliffRequest rejects --exit-on (gate) with --xliff, ahead of generic validators', () => {
+  const p = parseArgs(['--xliff', '--exit-on', '30', 'f.xliff']);
+  assert.equal(p.gate, 30);
+  assert.throws(() => validateXliffRequest(p), /cannot be combined with --xliff/);
+});
+
+// ---------- runXliffMode integration (injected rewrite/verify, no LLM) ----------
+test('runXliffMode: resolves each file target-language and passes it to rewrite/verify (cross-language)', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'patina-xliff-run-'));
+  try {
+    const koFile = join(dir, 'ko.xliff'); writeFileSync(koFile, FIXTURE);
+    const enFile = join(dir, 'en.xliff'); writeFileSync(enFile, EN_FIXTURE);
+    const rewriteLangs = [];
+    const verifyLangs = [];
+    await runXliffMode(
+      { xliff: true, batch: true, files: [koFile, enFile] },
+      makeCtx(), stubLogger(),
+      {
+        rewriteSegment: async ({ core, lang }) => { rewriteLangs.push(lang); return core + ' [H]'; },
+        verifySegment: async ({ candidate, lang }) => { verifyLangs.push(lang); return { verified: true, text: candidate }; },
+      },
+    );
+    assert.ok(rewriteLangs.includes('ko'), 'ko target humanized as ko');
+    assert.ok(rewriteLangs.includes('en'), 'en target humanized as en');
+    assert.ok(verifyLangs.includes('ko') && verifyLangs.includes('en'), 'verify gets per-file lang');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('runXliffMode: --outdir creates the directory, writes output, leaves the original untouched', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'patina-xliff-run-'));
+  try {
+    const input = join(dir, 'in.xliff'); writeFileSync(input, FIXTURE);
+    const outdir = join(dir, 'nested', 'out'); // does not exist yet
+    await runXliffMode({ xliff: true, outdir, files: [input] }, makeCtx(), stubLogger(),
+      { rewriteSegment: fakeRewrite, verifySegment: fakeVerify });
+    assert.ok(existsSync(join(outdir, 'in.xliff')), 'output written into created outdir');
+    assert.equal(readFileSync(input, 'utf8'), FIXTURE, 'original untouched');
+    assert.ok(readFileSync(join(outdir, 'in.xliff'), 'utf8').includes('[H]'), 'output humanized');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('runXliffMode: default output is {name}.humanized.xliff and never clobbers the original', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'patina-xliff-run-'));
+  try {
+    const input = join(dir, 'in.xliff'); writeFileSync(input, FIXTURE);
+    await runXliffMode({ xliff: true, files: [input] }, makeCtx(), stubLogger(),
+      { rewriteSegment: fakeRewrite, verifySegment: fakeVerify });
+    assert.ok(existsSync(join(dir, 'in.humanized.xliff')), 'default .humanized output written');
+    assert.equal(readFileSync(input, 'utf8'), FIXTURE, 'original untouched');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('runXliffMode: --dry-run makes no calls and writes no file', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'patina-xliff-run-'));
+  try {
+    const input = join(dir, 'in.xliff'); writeFileSync(input, FIXTURE);
+    let calls = 0;
+    await runXliffMode({ xliff: true, dryRun: true, files: [input] }, makeCtx(), stubLogger(),
+      { rewriteSegment: async () => { calls++; return 'x'; }, verifySegment: async () => { calls++; return { verified: true }; } });
+    assert.equal(calls, 0);
+    assert.equal(existsSync(join(dir, 'in.humanized.xliff')), false, 'dry-run writes nothing');
+    assert.equal(readFileSync(input, 'utf8'), FIXTURE);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// ---------- CLI dispatcher ordering (real subprocess) ----------
+test('CLI: --xliff --exit-on rejects with the XLIFF-specific error before the generic score-gate guard', () => {
+  let err;
+  try {
+    execFileSync('node', ['bin/patina.js', '--xliff', '--exit-on', '30', 'tests/fixtures/xliff/sample.xliff'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (e) { err = e; }
+  assert.ok(err, 'should exit non-zero');
+  assert.equal(err.status, 2);
+  const out = (err.stdout || '') + (err.stderr || '');
+  assert.match(out, /cannot be combined with --xliff/);
+  assert.doesNotMatch(out, /can only be used with --score/);
+});
+
+test('CLI: --xliff --dry-run on the fixture succeeds with zero calls/writes (real subprocess)', () => {
+  const out = execFileSync('node', ['bin/patina.js', '--xliff', '--dry-run', '--format', 'json', 'tests/fixtures/xliff/sample.xliff'], { encoding: 'utf8' });
+  const json = JSON.parse(out);
+  assert.equal(json.llmCalls, 0);
+  assert.equal(json.writes, 0);
+  assert.equal(json.targetLang, 'ko');
+  assert.equal(json.selectedCount, 3);
+  assert.equal(json.uniqueCount, 2);
+});

--- a/tests/unit/xliff-cli.test.js
+++ b/tests/unit/xliff-cli.test.js
@@ -7,6 +7,7 @@ import { validateXliffRequest, parseArgs } from '../../src/cli/args.js';
 import { humanizeXliffDocument, parseXliffDocument, selectXliffSegments } from '../../src/cli/xliff.js';
 import { tmpdir } from 'node:os';
 import { runXliffMode } from '../../src/cli/run.js';
+import { cleanRewriteOutput } from '../../src/output.js';
 import { execFileSync } from 'node:child_process';
 
 const EN_FIXTURE = '<?xml version="1.0"?>\n<xliff version="1.2"><file target-language="en-US"><body>'
@@ -21,6 +22,31 @@ const fakeVerify = async ({ candidate }) => ({ verified: true, text: candidate }
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIXTURE = readFileSync(resolve(HERE, '../fixtures/xliff/sample.xliff'), 'utf8');
+// Regression: the production rewriteSegment cleaner must strip leaked model
+// scaffolding so XLIFF <target> write-back never persists patina's own output
+// chrome (a leaked YAML tone footer / [SELF_AUDIT]) as translated content.
+// Observed live with deepseek-chat on sample/Supernote_en.xliff.
+test('cleanRewriteOutput strips leaked tone footer and self-audit from a segment rewrite', () => {
+  const leaked = [
+    'File name cannot be a system reserved name: %s',
+    '',
+    '---',
+    'tone: instructional',
+    'tone_source: inferred from input type (system error message)',
+    'tone_evidence: ["imperative/declarative structure"]',
+    'tone_confidence: 1.0',
+    '---',
+  ].join('\n');
+  assert.strictEqual(cleanRewriteOutput(leaked), 'File name cannot be a system reserved name: %s');
+
+  const audited = '[BODY]\nHumanized sentence here.\n[/BODY]\n[SELF_AUDIT]\nnotes\n[/SELF_AUDIT]';
+  assert.strictEqual(cleanRewriteOutput(audited), 'Humanized sentence here.');
+
+  // Real translated prose containing an em-dash / triple-dash-like text but no
+  // full tone-footer schema must pass through untouched (no over-stripping).
+  const clean = 'Please read and understand the full content of this document before using the product.';
+  assert.strictEqual(cleanRewriteOutput(clean), clean);
+});
 
 // ---------- validateXliffRequest ----------
 const base = (over = {}) => ({ files: ['a.xliff'], xliff: true, ...over });

--- a/tests/unit/xliff-writeback.redteam.test.js
+++ b/tests/unit/xliff-writeback.redteam.test.js
@@ -1,0 +1,190 @@
+import { after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  applyXliffReplacements,
+  encodeXmlText,
+  estimateXliffRun,
+  parseXliffDocument,
+  selectXliffSegments,
+} from '../../src/cli/xliff.js';
+import { resolveBatchOutputPath, writeAtomicUtf8 } from '../../src/cli/batch.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = readFileSync(resolve(HERE, '../fixtures/xliff/sample.xliff'), 'utf8');
+const REPORT_DIR = '/tmp/patina-qa/g002';
+const REPORT_PATH = join(REPORT_DIR, 'adversarial-report.txt');
+const rows = [];
+const tempDirs = [];
+
+function record(name, expected, actual) {
+  rows.push(`${name}\n  expected: ${expected}\n  actual:   ${actual}`);
+}
+
+function makeTempDir(prefix) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function tempNames(dir) {
+  return readdirSync(dir).filter((name) => name.startsWith('.patina-xliff-') && name.endsWith('.tmp'));
+}
+
+function identityReplacementsForSelected(xml) {
+  const parsed = parseXliffDocument(xml);
+  const { selected } = selectXliffSegments(parsed);
+  return selected.map((seg) => ({
+    start: seg.targetInnerStart,
+    end: seg.targetInnerEnd,
+    replacement: `${seg.leading}${encodeXmlText(seg.targetCore)}${seg.trailing}`,
+  }));
+}
+
+after(() => {
+  writeFileSync(REPORT_PATH, `${rows.join('\n\n')}\n`, 'utf8');
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+test('applyXliffReplacements: adversarial span boundaries and delimiter payloads', () => {
+  const s = 'abcdef';
+  assert.equal(
+    applyXliffReplacements(s, [
+      { start: 6, end: 6, replacement: '<EOF&>' },
+      { start: 0, end: 0, replacement: '<BOF&>' },
+      { start: 2, end: 4, replacement: 'X<&>Y' },
+      { start: 4, end: 6, replacement: 'Z' },
+    ]),
+    '<BOF&>abX<&>YZ<EOF&>'
+  );
+  record('apply spans at BOF/EOF, zero-length insertions, adjacent spans, delimiter chars', '<BOF&>abX<&>YZ<EOF&>', 'matched');
+});
+
+test('applyXliffReplacements: many random-order spans sort and apply against original offsets', () => {
+  const base = Array.from({ length: 240 }, (_, i) => String.fromCharCode(65 + (i % 26))).join('');
+  const spans = [];
+  for (let start = 0; start < base.length; start += 3) {
+    spans.push({ start, end: start + 2, replacement: `[${start}]` });
+  }
+  const shuffled = spans
+    .map((span, i) => ({ span, key: (i * 37) % spans.length }))
+    .sort((a, b) => a.key - b.key)
+    .map(({ span }) => span);
+  let expected = base;
+  for (const r of [...spans].sort((a, b) => b.start - a.start)) {
+    expected = expected.slice(0, r.start) + r.replacement + expected.slice(r.end);
+  }
+  assert.equal(applyXliffReplacements(base, shuffled), expected);
+  record('apply many random-order spans', `length ${expected.length}`, `length ${applyXliffReplacements(base, shuffled).length}`);
+});
+
+test('applyXliffReplacements: exact-boundary overlap is allowed but one-char overlap throws', () => {
+  assert.equal(
+    applyXliffReplacements('012345', [
+      { start: 2, end: 4, replacement: 'AA' },
+      { start: 4, end: 6, replacement: 'BB' },
+    ]),
+    '01AABB'
+  );
+  assert.throws(() => applyXliffReplacements('012345', [
+    { start: 2, end: 5, replacement: 'AA' },
+    { start: 4, end: 6, replacement: 'BB' },
+  ]), /overlapping replacement spans/);
+  record('apply overlap boundary', 'end === next.start ok; end > next.start throws', 'matched');
+});
+
+test('applyXliffReplacements: invalid spans throw before corrupting output', () => {
+  const bad = [
+    { start: -1, end: 1, replacement: 'x' },
+    { start: 2, end: 1, replacement: 'x' },
+    { start: 0, end: 7, replacement: 'x' },
+    { start: 0.5, end: 1, replacement: 'x' },
+    { start: 0, end: 1.5, replacement: 'x' },
+  ];
+  for (const span of bad) {
+    assert.throws(() => applyXliffReplacements('abcdef', [span]), /invalid replacement span/);
+  }
+  record('apply invalid spans', `${bad.length} invalid spans throw`, `${bad.length} invalid spans threw`);
+});
+
+test('applyXliffReplacements: fixture selected-segment identity write-back is byte-for-byte identical', () => {
+  const replacements = identityReplacementsForSelected(FIXTURE);
+  assert.ok(replacements.length > 0, 'fixture must have selected segments');
+  const out = applyXliffReplacements(FIXTURE, replacements);
+  assert.equal(out, FIXTURE);
+  record('fixture identity round-trip AC7', 'byte-identical fixture output', `byte-identical with ${replacements.length} replacements`);
+});
+
+test('applyXliffReplacements: parser offsets round-trip emoji surrogate pairs and CJK without mojibake', () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<xliff version="1.2"><file source-language="en" target-language="ko"><body><trans-unit id="emoji"><source>This sentence should be humanized because it has enough words.</source><target state="final">  이 문장은 이모지 😀😇와 한자 漢字 및 한국어를 함께 포함합니다  </target></trans-unit></body></file></xliff>`;
+  const parsed = parseXliffDocument(xml);
+  const { selected } = selectXliffSegments(parsed);
+  assert.equal(selected.length, 1);
+  const seg = selected[0];
+  assert.equal(seg.targetCore, '이 문장은 이모지 😀😇와 한자 漢字 및 한국어를 함께 포함합니다');
+  const replacement = `${seg.leading}${encodeXmlText(seg.targetCore)}${seg.trailing}`;
+  const out = applyXliffReplacements(xml, [{ start: seg.targetInnerStart, end: seg.targetInnerEnd, replacement }]);
+  assert.equal(out, xml);
+  assert.match(out, /😀😇/u);
+  record('multi-byte/surrogate parser offsets', 'emoji+CJK identity no mojibake', 'byte-identical and emoji preserved');
+});
+
+test('writeAtomicUtf8: write then overwrite preserves exact unicode/newline/CRLF content and no temp remains', () => {
+  const dir = makeTempDir('patina-xliff-atomic-ok-');
+  const dest = join(dir, 'out.xliff');
+  const first = 'line1\r\n한글 😀\n';
+  const second = 'replacement\r\n中文 😇\nlast';
+  assert.equal(writeAtomicUtf8(dest, first), dest);
+  assert.equal(readFileSync(dest, 'utf8'), first);
+  assert.deepEqual(tempNames(dir), []);
+  assert.equal(writeAtomicUtf8(dest, second), dest);
+  assert.equal(readFileSync(dest, 'utf8'), second);
+  assert.deepEqual(tempNames(dir), []);
+  record('writeAtomicUtf8 success/overwrite', 'exact content after atomic replace and no temp', 'matched');
+});
+
+test('writeAtomicUtf8: missing parent throws without destination or temp leftovers in existing dir', () => {
+  const dir = makeTempDir('patina-xliff-atomic-fail-');
+  const missingParent = join(dir, 'missing');
+  const dest = join(missingParent, 'out.xliff');
+  assert.throws(() => writeAtomicUtf8(dest, 'partial?'), /ENOENT/);
+  assert.equal(existsSync(dest), false);
+  assert.deepEqual(tempNames(dir), []);
+  assert.equal(existsSync(missingParent), false);
+  record('writeAtomicUtf8 missing parent failure', 'throws, no dest, no .patina-xliff tmp in existing dir', 'matched');
+});
+
+test('estimateXliffRun: dry-run cap boundaries, clamped attempts, no calls or writes', () => {
+  const zero = estimateXliffRun({ uniqueCount: 0, selectedCount: 0, cap: 2 });
+  assert.equal(zero.capStatus, 'ok');
+  assert.equal(zero.worstCaseLlmCalls, 0);
+  const atCap = estimateXliffRun({ uniqueCount: 2, selectedCount: 2, cap: 2, backendAttemptsPerCall: 0 });
+  assert.equal(atCap.capStatus, 'ok');
+  assert.equal(atCap.worstCaseBackendAttempts, 12);
+  const overCap = estimateXliffRun({ uniqueCount: 3, selectedCount: 3, cap: 2, backendAttemptsPerCall: Number.NaN });
+  assert.equal(overCap.capStatus, 'cap_exceeded');
+  assert.equal(overCap.worstCaseBackendAttempts, 18);
+  for (const report of [zero, atCap, overCap]) {
+    assert.equal(report.llmCalls, 0);
+    assert.equal(report.writes, 0);
+  }
+  record('estimateXliffRun dry-run boundaries', '0 ok, cap ok, cap+1 exceeded, attempts clamp to 1, llm/writes 0', 'matched');
+});
+
+test('resolveBatchOutputPath: suffix and outdir edge cases', () => {
+  assert.equal(resolveBatchOutputPath({ suffix: '' }, '/tmp/input.xlf', { defaultSuffix: '' }), '/tmp/input.xlf');
+  assert.equal(resolveBatchOutputPath({ suffix: 'human' }, '/tmp/input.xlf'), '/tmp/inputhuman.xlf');
+  assert.equal(resolveBatchOutputPath({ suffix: '.human' }, '/tmp/README'), '/tmp/README.human');
+  assert.equal(resolveBatchOutputPath({ outdir: '/tmp/nested/out' }, '/tmp/a/b/input.xlf', { defaultSuffix: '.ignored' }), '/tmp/nested/out/input.xlf');
+  record('resolveBatchOutputPath routing', 'empty suffix unchanged; raw suffix accepted; no extension; nested outdir basename', 'matched');
+});

--- a/tests/unit/xliff-writeback.redteam.test.js
+++ b/tests/unit/xliff-writeback.redteam.test.js
@@ -2,6 +2,7 @@ import { after, test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -22,7 +23,7 @@ import { resolveBatchOutputPath, writeAtomicUtf8 } from '../../src/cli/batch.js'
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIXTURE = readFileSync(resolve(HERE, '../fixtures/xliff/sample.xliff'), 'utf8');
-const REPORT_DIR = '/tmp/patina-qa/g002';
+const REPORT_DIR = join(tmpdir(), 'patina-qa', 'xliff-writeback');
 const REPORT_PATH = join(REPORT_DIR, 'adversarial-report.txt');
 const rows = [];
 const tempDirs = [];
@@ -52,7 +53,12 @@ function identityReplacementsForSelected(xml) {
 }
 
 after(() => {
-  writeFileSync(REPORT_PATH, `${rows.join('\n\n')}\n`, 'utf8');
+  // Best-effort debug artifact; never fail the suite on a report-write issue
+  // (e.g. a CI runner without the local artifact dir).
+  try {
+    mkdirSync(REPORT_DIR, { recursive: true });
+    writeFileSync(REPORT_PATH, `${rows.join('\n\n')}\n`, 'utf8');
+  } catch { /* ignore */ }
   for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
 });
 

--- a/tests/unit/xliff-writeback.test.js
+++ b/tests/unit/xliff-writeback.test.js
@@ -1,0 +1,176 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, readdirSync, mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  applyXliffReplacements,
+  estimateXliffRun,
+  resolveUniqueCap,
+  encodeXmlText,
+  parseXliffDocument,
+  selectXliffSegments,
+  DEFAULT_UNIQUE_CAP,
+} from '../../src/cli/xliff.js';
+import { writeAtomicUtf8, resolveBatchOutputPath } from '../../src/cli/batch.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = readFileSync(resolve(HERE, '../fixtures/xliff/sample.xliff'), 'utf8');
+
+// ---------- applyXliffReplacements ----------
+test('applyXliffReplacements: empty list returns byte-identical input', () => {
+  assert.equal(applyXliffReplacements(FIXTURE, []), FIXTURE);
+});
+
+test('applyXliffReplacements: single + multiple (descending) spans', () => {
+  const s = '0123456789';
+  assert.equal(applyXliffReplacements(s, [{ start: 2, end: 4, replacement: 'XX' }]), '01XX456789');
+  // two non-overlapping spans applied right-to-left
+  assert.equal(applyXliffReplacements(s, [
+    { start: 2, end: 4, replacement: 'A' },
+    { start: 6, end: 8, replacement: 'BBB' },
+  ]), '01A45BBB89');
+});
+
+test('applyXliffReplacements: overlapping or invalid spans throw', () => {
+  const s = '0123456789';
+  assert.throws(() => applyXliffReplacements(s, [
+    { start: 2, end: 6, replacement: 'x' },
+    { start: 4, end: 8, replacement: 'y' },
+  ]), /overlapping/);
+  assert.throws(() => applyXliffReplacements(s, [{ start: 5, end: 3, replacement: 'x' }]), /invalid replacement span/);
+  assert.throws(() => applyXliffReplacements(s, [{ start: 0, end: 999, replacement: 'x' }]), /invalid replacement span/);
+});
+
+// ---------- round-trip + preservation on the real fixture ----------
+function replacementFor(seg, newCore) {
+  return {
+    start: seg.targetInnerStart,
+    end: seg.targetInnerEnd,
+    replacement: seg.leading + encodeXmlText(newCore ?? seg.targetCore) + seg.trailing,
+  };
+}
+
+test('round-trip: rewriting a segment to its own core is byte-identical', () => {
+  const sel = selectXliffSegments(parseXliffDocument(FIXTURE));
+  const u1 = sel.selected.find((s) => s.id === 'u1');
+  const out = applyXliffReplacements(FIXTURE, [replacementFor(u1)]);
+  assert.equal(out, FIXTURE);
+});
+
+test('preservation: a changed segment only mutates its inner span; all other bytes identical', () => {
+  const sel = selectXliffSegments(parseXliffDocument(FIXTURE));
+  const u1 = sel.selected.find((s) => s.id === 'u1');
+  const repl = replacementFor(u1, '계정 로그인이 안 되어 있어 파일이 곧 삭제됩니다.');
+  const out = applyXliffReplacements(FIXTURE, [repl]);
+  assert.notEqual(out, FIXTURE);
+  // bytes before the inner span and after it are untouched
+  assert.equal(out.slice(0, u1.targetInnerStart), FIXTURE.slice(0, u1.targetInnerStart));
+  assert.equal(out.slice(out.length - (FIXTURE.length - u1.targetInnerEnd)), FIXTURE.slice(u1.targetInnerEnd));
+  // the target's own attributes and other units are still present verbatim
+  assert.ok(out.includes('<target state="final">'));
+  assert.ok(out.includes('translate="no"')); // u2 locked attr preserved
+  assert.ok(out.includes('<![CDATA[')); // u8 cdata preserved
+});
+
+test('preservation: leading/trailing whitespace around a target core is kept', () => {
+  const xml = '<xliff version="1.2"><file target-language="ko"><body><trans-unit id="w"><source>src</source><target state="final">\n   이 문장은 충분히 길어서 산문으로 인정되는 안내 문구입니다.   \n  </target></trans-unit></body></file></xliff>';
+  const sel = selectXliffSegments(parseXliffDocument(xml));
+  const seg = sel.selected[0];
+  assert.equal(seg.leading, '\n   ');
+  assert.equal(seg.trailing, '   \n  ');
+  const out = applyXliffReplacements(xml, [replacementFor(seg, '짧게 바꾼 문장입니다.')]);
+  assert.ok(out.includes('<target state="final">\n   짧게 바꾼 문장입니다.   \n  </target>'));
+});
+
+// ---------- estimateXliffRun (dry-run, zero calls) ----------
+test('estimateXliffRun: 6-call/unique multiplier, dedup savings, cap status, no calls/writes', () => {
+  const r = estimateXliffRun({ totalUnits: 9, selectedCount: 3, uniqueCount: 2, cap: 50, backendAttemptsPerCall: 2, provider: 'deepseek', model: 'deepseek-chat' });
+  assert.equal(r.callsPerUnique, 6);
+  assert.equal(r.worstCaseLlmCalls, 12);
+  assert.equal(r.worstCaseBackendAttempts, 24);
+  assert.equal(r.duplicateSavings, 1);
+  assert.equal(r.capStatus, 'ok');
+  assert.equal(r.inputTokensEstimate, 2 * 2 * 12000);
+  assert.equal(r.cost, null);
+  assert.equal(r.llmCalls, 0);
+  assert.equal(r.writes, 0);
+});
+
+test('estimateXliffRun: over-cap reports cap_exceeded', () => {
+  const r = estimateXliffRun({ totalUnits: 200, selectedCount: 80, uniqueCount: 60, cap: 50 });
+  assert.equal(r.capStatus, 'cap_exceeded');
+});
+
+test('resolveUniqueCap: default 50, positive override, invalid falls back', () => {
+  assert.equal(resolveUniqueCap({}), DEFAULT_UNIQUE_CAP);
+  assert.equal(resolveUniqueCap({ maxSegments: 10 }), 10);
+  assert.equal(resolveUniqueCap({ maxSegments: 0 }), 50);
+  assert.equal(resolveUniqueCap({ maxSegments: -3 }), 50);
+  assert.equal(resolveUniqueCap({ maxSegments: 'x' }), 50);
+});
+
+// ---------- writeAtomicUtf8 ----------
+test('writeAtomicUtf8: writes content and leaves no temp file behind', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'patina-xliff-'));
+  try {
+    const dest = join(dir, 'out.xliff');
+    writeAtomicUtf8(dest, 'hello <ko> & 안녕');
+    assert.equal(readFileSync(dest, 'utf8'), 'hello <ko> & 안녕');
+    const leftover = readdirSync(dir).filter((f) => f.includes('.patina-xliff-') && f.endsWith('.tmp'));
+    assert.deepEqual(leftover, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('writeAtomicUtf8: failure (bad dir) throws and leaves no output at destination', () => {
+  const dest = join(tmpdir(), 'no-such-dir-patina', 'nested', 'out.xliff');
+  assert.throws(() => writeAtomicUtf8(dest, 'x'));
+  assert.equal(existsSync(dest), false);
+});
+
+// ---------- resolveBatchOutputPath ----------
+test('resolveBatchOutputPath: in-place / outdir / suffix / default suffix', () => {
+  assert.equal(resolveBatchOutputPath({ inPlace: true }, '/a/b/f.xliff'), '/a/b/f.xliff');
+  assert.equal(resolveBatchOutputPath({ outdir: '/out' }, '/a/b/f.xliff'), '/out/f.xliff');
+  assert.equal(resolveBatchOutputPath({ suffix: '.humanized' }, '/a/b/f.xliff'), '/a/b/f.humanized.xliff');
+  assert.equal(resolveBatchOutputPath({}, '/a/b/f.xliff', { defaultSuffix: '.humanized' }), '/a/b/f.humanized.xliff');
+});
+
+// ---------- hardening: atomic rename-failure cleanup + string-index edges ----------
+test('writeAtomicUtf8: rename onto an existing directory fails, cleans temp, leaves dest intact', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'patina-xliff-'));
+  try {
+    const destDir = join(dir, 'occupied'); // an existing directory at the dest path
+    mkdirSync(destDir);
+    assert.throws(() => writeAtomicUtf8(destDir, 'x')); // rename(file -> dir) fails
+    assert.equal(existsSync(destDir), true); // existing dest untouched
+    const leftover = readdirSync(dir).filter((f) => f.includes('.patina-xliff-') && f.endsWith('.tmp'));
+    assert.deepEqual(leftover, [], 'temp file must be cleaned up after rename failure');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('applyXliffReplacements: adjacent spans, span at 0 and at EOF, astral unicode', () => {
+  const s = '0123456789';
+  // adjacent (touching, non-overlapping) spans are allowed
+  assert.equal(applyXliffReplacements(s, [
+    { start: 2, end: 4, replacement: 'AA' },
+    { start: 4, end: 6, replacement: 'BB' },
+  ]), '01AABB6789');
+  // span at index 0 and at EOF
+  assert.equal(applyXliffReplacements(s, [
+    { start: 0, end: 1, replacement: 'X' },
+    { start: 9, end: 10, replacement: 'Y' },
+  ]), 'X12345678Y');
+  // zero-length insertion span
+  assert.equal(applyXliffReplacements(s, [{ start: 5, end: 5, replacement: '_' }]), '01234_56789');
+  // astral (surrogate-pair) content: offsets from the same JS string round-trip
+  const astral = 'pre 😀 [CORE] 😺 post';
+  const start = astral.indexOf('[CORE]');
+  const out = applyXliffReplacements(astral, [{ start, end: start + '[CORE]'.length, replacement: '바뀜' }]);
+  assert.equal(out, 'pre 😀 바뀜 😺 post');
+});

--- a/tests/unit/xliff.redteam.test.js
+++ b/tests/unit/xliff.redteam.test.js
@@ -1,0 +1,167 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  scanXmlTokens,
+  decodeXmlText,
+  hasUnsupportedEntity,
+  parseXliffDocument,
+  selectXliffSegments,
+} from '../../src/cli/xliff.js';
+
+const KO_PROSE = '이 문장은 충분히 길어서 산문으로 인정되는 안내 문구입니다.';
+const KO_PROSE_2 = '다른 문장도 충분히 길어서 사람이 고칠 수 있는 안내 문구입니다.';
+const wrapUnits = (units, attrs = 'target-language="ko"') => `<xliff version="1.2"><file ${attrs}><body>${units}</body></file></xliff>`;
+const unit = (id, body, attrs = '') => `<trans-unit id="${id}"${attrs}>${body}</trans-unit>`;
+const src = (text = 'source text with enough words') => `<source>${text}</source>`;
+const target = (inner, attrs = ' state="translated"') => `<target${attrs}>${inner}</target>`;
+const byId = (rows) => Object.fromEntries(rows.map((row) => [row.id, row]));
+
+function parseAndSelect(units) {
+  const doc = parseXliffDocument(wrapUnits(units));
+  return { doc, sel: selectXliffSegments(doc) };
+}
+
+function assertNoSelectedId(sel, id, reason) {
+  assert.equal(byId(sel.selected)[id], undefined, `${id} must not be selected`);
+  assert.equal(byId(sel.skipped)[id]?.reason, reason, `${id} skip reason`);
+}
+
+test('scanner: truncated tag/comment/CDATA/PI always yields terminal malformed token', () => {
+  for (const xml of ['<target', '<target attr="unterminated', '<!-- dangling', '<![CDATA[ dangling', '<?pi dangling']) {
+    const tokens = scanXmlTokens(xml);
+    assert.equal(tokens.at(-1)?.kind, 'malformed', xml);
+  }
+});
+
+test('scanner: literal </target> in attributes, comments, and CDATA is not parsed as target close', () => {
+  const attrTokens = scanXmlTokens('<target note="literal </target> in attr">body</target>');
+  assert.equal(attrTokens.filter((t) => t.kind === 'close' && t.name === 'target').length, 1);
+
+  const commentTokens = scanXmlTokens('<target><!-- literal </target> --></target>');
+  assert.equal(commentTokens.filter((t) => t.kind === 'comment').length, 1);
+  assert.equal(commentTokens.filter((t) => t.kind === 'close' && t.name === 'target').length, 1);
+
+  const cdataTokens = scanXmlTokens('<target><![CDATA[literal </target>]]></target>');
+  assert.equal(cdataTokens.filter((t) => t.kind === 'cdata').length, 1);
+  assert.equal(cdataTokens.filter((t) => t.kind === 'close' && t.name === 'target').length, 1);
+});
+
+test('fail-closed structure: nested/mismatched tags, unclosed target, and mixed CDATA are never selected', () => {
+  const good = unit('good', `${src()}${target(KO_PROSE)}`);
+  const nested = unit('nested', `${src()}${target(`${KO_PROSE}<g id="1">inline</g>`)}`);
+  const mismatched = unit('mismatch', `${src()}<target state="translated">${KO_PROSE}<b></target></trans-unit>`);
+  const unclosed = unit('unclosed', `${src()}<target state="translated">${KO_PROSE}`);
+  const mixedCdata = unit('mixed-cdata', `${src()}${target(`앞쪽 텍스트 <![CDATA[${KO_PROSE}]]> 뒤쪽 텍스트`)}`);
+
+  const { doc, sel } = parseAndSelect(good + nested + mismatched + unclosed + mixedCdata);
+  assert.equal(byId(sel.selected).good.targetCore, KO_PROSE);
+  assertNoSelectedId(sel, 'nested', 'inline_markup');
+  assertNoSelectedId(sel, 'mixed-cdata', 'cdata_or_malformed');
+  assert.ok(doc.ambiguousCount >= 2, 'mismatched and unclosed units are ambiguous');
+  assert.equal(sel.selected.some((row) => ['mismatch', 'unclosed'].includes(row.id)), false);
+});
+
+test('entity edge cases: invalid, unknown, malformed, and bare ampersands fail closed; decode never throws', () => {
+  const cases = [
+    ['nul', `prefix &#0; ${KO_PROSE}`, true],
+    ['huge', `prefix &#9999999999; ${KO_PROSE}`, true],
+    ['malformed', `prefix &#; ${KO_PROSE}`, true],
+    ['unknown', `prefix &unknown; ${KO_PROSE}`, true],
+    ['bare', `prefix & ${KO_PROSE}`, true],
+  ];
+
+  for (const [id, inner, unsupported] of cases) {
+    assert.doesNotThrow(() => decodeXmlText(inner), `${id} decode`);
+    assert.equal(hasUnsupportedEntity(inner), unsupported, `${id} unsupported entity classification`);
+  }
+
+  const { sel } = parseAndSelect(cases.map(([id, inner]) => unit(id, `${src()}${target(inner)}`)).join(''));
+  for (const [id] of cases) assertNoSelectedId(sel, id, 'unsupported_entity');
+});
+
+test('target child ambiguity: multiple children, self-closing, empty, whitespace-only, and source order fail closed', () => {
+  const units = [
+    unit('multi-target', `${src()}${target(KO_PROSE)}${target(KO_PROSE_2)}`),
+    unit('multi-source', `${src('one')}${src('two')}${target(KO_PROSE)}`),
+    unit('source-after-target', `${target(KO_PROSE)}${src(KO_PROSE)}`),
+    unit('self-close', `${src()}<target state="translated"/>`),
+    unit('empty', `${src()}${target('')}`),
+    unit('ws', `${src()}${target(' \r\n\t ')}`),
+  ].join('');
+  const { sel } = parseAndSelect(units);
+  assertNoSelectedId(sel, 'multi-target', 'ambiguous_unit');
+  assert.equal(byId(sel.selected)['multi-source'], undefined, 'multi-source must not be selected with ambiguous source');
+  assertNoSelectedId(sel, 'source-after-target', 'untranslated');
+  assertNoSelectedId(sel, 'self-close', 'ambiguous_unit');
+  assertNoSelectedId(sel, 'empty', 'empty_target');
+  assertNoSelectedId(sel, 'ws', 'empty_target');
+});
+
+test('CRLF dedup normalizes core only, while extracted raw span preserves exact leading/trailing bytes', () => {
+  const rawA = '\t  첫 번째 줄입니다.\r\n두 번째 줄도 충분히 길어서 산문입니다.  \n';
+  const rawB = '\t  첫 번째 줄입니다.\n두 번째 줄도 충분히 길어서 산문입니다.  \n';
+  const fixture = wrapUnits(
+    unit('crlf', `${src()}${target(rawA)}`) +
+    unit('lf', `${src()}${target(rawB)}`)
+  );
+  const sel = selectXliffSegments(parseXliffDocument(fixture));
+  const selected = byId(sel.selected);
+  assert.equal(fixture.slice(selected.crlf.targetInnerStart, selected.crlf.targetInnerEnd), rawA);
+  assert.equal(fixture.slice(selected.lf.targetInnerStart, selected.lf.targetInnerEnd), rawB);
+  assert.equal(selected.crlf.leading, '\t  ');
+  assert.equal(selected.crlf.trailing, '  \n');
+  assert.equal(selected.crlf.dedupKey, selected.lf.dedupKey);
+  assert.equal(sel.uniqueCount, 1);
+});
+
+test('nested trans-unit and missing target fail closed without corrupting good unit spans', () => {
+  const fixture = wrapUnits(
+    unit('outer', `${src()}<trans-unit id="inner">${src()}${target(KO_PROSE_2)}</trans-unit>${target(KO_PROSE)}`) +
+    unit('missing-target', `${src()}`) +
+    unit('good', `${src()}${target(KO_PROSE_2)}`)
+  );
+  const doc = parseXliffDocument(fixture);
+  const sel = selectXliffSegments(doc);
+  assertNoSelectedId(sel, 'missing-target', 'ambiguous_unit');
+  assert.equal(byId(sel.selected).good.targetCore, KO_PROSE_2);
+  for (const row of sel.selected) {
+    assert.equal(fixture.slice(row.targetInnerStart, row.targetInnerEnd).trim(), row.targetCore.trim());
+  }
+});
+
+test('document-level fail-closed errors are typed; mixed good and broken units return good plus ambiguity counts', () => {
+  assert.throws(
+    () => parseXliffDocument(wrapUnits(unit('x', `${src()}${target(KO_PROSE)}`), 'target-language="fr"')),
+    (err) => err?.code === 'xliff_unsupported_language'
+  );
+  assert.throws(
+    () => parseXliffDocument(wrapUnits(unit('x', `${src()}<target>${KO_PROSE}`))),
+    (err) => err?.code === 'xliff_no_parseable_units'
+  );
+
+  const doc = parseXliffDocument(wrapUnits(
+    unit('bad', `${src()}<target state="translated">${KO_PROSE}`) +
+    unit('good', `${src()}${target(KO_PROSE_2)}`)
+  ));
+  const sel = selectXliffSegments(doc);
+  assert.equal(doc.ambiguousCount, 1);
+  assert.equal(doc.parseableCount, 1);
+  assert.equal(byId(sel.selected).good.targetCore, KO_PROSE_2);
+});
+
+test('property-ish span accuracy: every selected segment slices to its raw target inner bytes', () => {
+  const raw = '  정확한 시작과 끝 위치를 보존해야 하는 충분히 긴 안내 문장입니다.\r\n';
+  const fixture = wrapUnits(
+    unit('a', `${src()}${target(raw)}`) +
+    unit('skip-inline', `${src()}${target(`${KO_PROSE}<x/>`)}`) +
+    unit('b', `${src()}${target(KO_PROSE_2)}`)
+  );
+  const doc = parseXliffDocument(fixture);
+  const sel = selectXliffSegments(doc);
+  const expected = { a: raw, b: KO_PROSE_2 };
+  for (const row of sel.selected) {
+    assert.equal(fixture.slice(row.targetInnerStart, row.targetInnerEnd), expected[row.id]);
+    assert.ok(row.targetInnerStart < row.targetInnerEnd);
+  }
+}
+);

--- a/tests/unit/xliff.test.js
+++ b/tests/unit/xliff.test.js
@@ -1,0 +1,178 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  scanXmlTokens,
+  parseAttributesFromTag,
+  decodeXmlText,
+  encodeXmlText,
+  hasUnsupportedEntity,
+  normalizeLang,
+  splitTargetInnerWhitespace,
+  hasInlineMarkup,
+  isProseLike,
+  parseXliffDocument,
+  selectXliffSegments,
+} from '../../src/cli/xliff.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = readFileSync(resolve(HERE, '../fixtures/xliff/sample.xliff'), 'utf8');
+
+// ---------- scanner (regex-breakers) ----------
+test('scanXmlTokens: > inside a quoted attribute does not end the tag', () => {
+  const toks = scanXmlTokens('<a b="x>y" c=\'p>q\'>text</a>');
+  const open = toks.find((t) => t.kind === 'open');
+  assert.equal(open.name, 'a');
+  assert.ok(open.raw.includes('b="x>y"'));
+  assert.ok(toks.some((t) => t.kind === 'text' && t.raw === 'text'));
+  assert.ok(toks.some((t) => t.kind === 'close' && t.name === 'a'));
+});
+
+test('scanXmlTokens: comment containing fake </target> is a single comment token', () => {
+  const toks = scanXmlTokens('a<!-- </target><target> -->b');
+  assert.equal(toks.filter((t) => t.kind === 'comment').length, 1);
+  assert.ok(!toks.some((t) => t.kind === 'close' || t.kind === 'open'));
+});
+
+test('scanXmlTokens: PI and CDATA are isolated, not parsed as tags/text', () => {
+  const pi = scanXmlTokens('<?xml version="1.0"?><r/>');
+  assert.equal(pi[0].kind, 'pi');
+  assert.equal(pi[1].kind, 'selfclose');
+  const cd = scanXmlTokens('<t><![CDATA[ <b>x</b> & > ]]></t>');
+  assert.ok(cd.some((t) => t.kind === 'cdata'));
+  // the tags inside CDATA are NOT separate tokens
+  assert.ok(!cd.some((t) => t.kind === 'open' && t.name === 'b'));
+});
+
+test('scanXmlTokens: unterminated constructs become a terminal malformed token', () => {
+  assert.equal(scanXmlTokens('<a ').at(-1).kind, 'malformed');
+  assert.equal(scanXmlTokens('<!-- open').at(-1).kind, 'malformed');
+  assert.equal(scanXmlTokens('<![CDATA[ x').at(-1).kind, 'malformed');
+  assert.equal(scanXmlTokens('<?pi').at(-1).kind, 'malformed');
+});
+
+// ---------- attributes + entities ----------
+test('parseAttributesFromTag: single/double quotes, lower-cased names, decoded values', () => {
+  const { name, attrs } = parseAttributesFromTag('<target A=\'1\' State="final" note="a &amp; b">');
+  assert.equal(name, 'target');
+  assert.equal(attrs.a, '1');
+  assert.equal(attrs.state, 'final');
+  assert.equal(attrs.note, 'a & b');
+});
+
+test('decodeXmlText: named + numeric entities; unknown left intact', () => {
+  assert.equal(decodeXmlText('&amp;&lt;&gt;&quot;&apos;&#65;&#x42;'), '&<>"\'AB');
+  assert.equal(decodeXmlText('a&nbsp;b'), 'a&nbsp;b');
+});
+
+test('hasUnsupportedEntity: bare & and unknown names are unsafe; known/numeric are safe', () => {
+  assert.equal(hasUnsupportedEntity('a &amp; b &#39; &#x41;'), false);
+  assert.equal(hasUnsupportedEntity('a &nbsp; b'), true);
+  assert.equal(hasUnsupportedEntity('a & b'), true);
+});
+
+test('encodeXmlText: text context encoding round-trips through decode', () => {
+  const raw = 'Tom & Jerry <3 "quote" it\'s';
+  assert.equal(encodeXmlText(raw), 'Tom &amp; Jerry &lt;3 &quot;quote&quot; it&#39;s');
+  assert.equal(decodeXmlText(encodeXmlText(raw)), raw);
+});
+
+// ---------- lang / whitespace / inline markup ----------
+test('normalizeLang: maps regional tags to supported base; rejects unsupported', () => {
+  assert.equal(normalizeLang('ko-KR'), 'ko');
+  assert.equal(normalizeLang('zh-CN'), 'zh');
+  assert.equal(normalizeLang('zh-TW'), 'zh');
+  assert.equal(normalizeLang('en-US'), 'en');
+  assert.equal(normalizeLang('ja-JP'), 'ja');
+  assert.equal(normalizeLang('fr'), null);
+  assert.equal(normalizeLang('de-DE'), null);
+  assert.equal(normalizeLang(''), null);
+});
+
+test('splitTargetInnerWhitespace: preserves leading/trailing without overlap', () => {
+  assert.deepEqual(splitTargetInnerWhitespace('  hi there  '), { leading: '  ', core: 'hi there', trailing: '  ' });
+  assert.deepEqual(splitTargetInnerWhitespace('\n\t x \t'), { leading: '\n\t ', core: 'x', trailing: ' \t' });
+  const allWs = splitTargetInnerWhitespace('   ');
+  assert.equal(allWs.core, '');
+  assert.equal(allWs.leading + allWs.trailing, '   ');
+});
+
+test('hasInlineMarkup: true when any element tag is present', () => {
+  assert.equal(hasInlineMarkup('click <g id="1">here</g> now'), true);
+  assert.equal(hasInlineMarkup('plain human text with no markup at all'), false);
+});
+
+test('isProseLike: prose selected, labels/urls/placeholders skipped', () => {
+  assert.equal(isProseLike('This is a full sentence with enough words.'), true);
+  assert.equal(isProseLike('자세한 내용을 확인하려면 여기를 눌러 주세요'), true); // >=12 CJK
+  assert.equal(isProseLike('OK'), false);
+  assert.equal(isProseLike('확인'), false);
+  assert.equal(isProseLike('https://example.com/path'), false);
+  assert.equal(isProseLike('%1$s / {0} / %s'), false);
+  assert.equal(isProseLike('12345 67'), false);
+});
+
+// ---------- parseXliffDocument ----------
+test('parseXliffDocument: detects + normalizes target-language', () => {
+  const doc = parseXliffDocument(FIXTURE);
+  assert.equal(doc.targetLang, 'ko');
+  assert.equal(doc.targetLangRaw, 'ko');
+});
+
+test('parseXliffDocument: throws on unsupported target-language', () => {
+  const bad = '<xliff version="1.2"><file target-language="fr"><body><trans-unit id="a"><source>x</source><target>y</target></trans-unit></body></file></xliff>';
+  assert.throws(() => parseXliffDocument(bad), /unsupported or missing target-language/);
+});
+
+test('parseXliffDocument: no units throws fail-closed', () => {
+  const empty = '<xliff version="1.2"><file target-language="ko"><body></body></file></xliff>';
+  assert.throws(() => parseXliffDocument(empty), /no <trans-unit>/);
+});
+
+// ---------- selection + dedup (fixture integration) ----------
+test('selectXliffSegments: selects safe prose, skips per rule, dedups identical cores', () => {
+  const doc = parseXliffDocument(FIXTURE);
+  const sel = selectXliffSegments(doc);
+  const byId = (arr) => Object.fromEntries(arr.map((s) => [s.id, s]));
+  const selById = byId(sel.selected);
+  const skById = byId(sel.skipped);
+
+  // Selected: u1 (final prose), u6 (dup of u1), u7 (translated prose)
+  assert.ok(selById.u1, 'u1 should be selected');
+  assert.ok(selById.u6, 'u6 (duplicate) should be selected');
+  assert.ok(selById.u7, 'u7 (after comment) should be selected');
+  assert.equal(sel.selectedCount, 3);
+  assert.equal(sel.uniqueCount, 2, 'u1 and u6 share one dedup key');
+
+  // Skips with exact reasons
+  assert.equal(skById.u2.reason, 'locked');
+  assert.equal(skById.u3.reason, 'state_not_allowlisted');
+  assert.equal(skById.u4.reason, 'inline_markup');
+  assert.equal(skById.u5.reason, 'not_prose');
+  assert.equal(skById.u8.reason, 'cdata_or_malformed');
+  assert.equal(skById.u9.reason, 'ambiguous_unit');
+});
+
+test('selection: extracted target inner span slices back to the original bytes', () => {
+  const doc = parseXliffDocument(FIXTURE);
+  const sel = selectXliffSegments(doc);
+  const u1 = sel.selected.find((s) => s.id === 'u1');
+  const rawInner = FIXTURE.slice(u1.targetInnerStart, u1.targetInnerEnd);
+  assert.equal(rawInner.trim(), '계정이 로그인되어 있지 않아, 일정 기간 후 파일을 영구적으로 삭제할 예정입니다.');
+  // dedup key is the decoded core after CRLF->LF
+  assert.equal(u1.dedupKey, '계정이 로그인되어 있지 않아, 일정 기간 후 파일을 영구적으로 삭제할 예정입니다.');
+});
+
+test('state allowlist: processes allowlisted/absent states, skips needs-*/unknown', () => {
+  const mk = (state, body) => `<xliff version="1.2"><file target-language="ko"><body><trans-unit id="x"><source>src</source><target${state === null ? '' : ` state="${state}"`}>${body}</target></trans-unit></body></file></xliff>`;
+  const prose = '이 문장은 충분히 길어서 산문으로 인정되는 안내 문구입니다.';
+  const runOne = (state) => selectXliffSegments(parseXliffDocument(mk(state, prose)));
+  for (const ok of [null, 'translated', 'final', 'signed-off', 'needs-review-translation']) {
+    assert.equal(runOne(ok).selectedCount, 1, `state ${ok} should be processed`);
+  }
+  for (const bad of ['', 'needs-translation', 'new', 'needs-adaptation', 'rejected', 'weird-unknown']) {
+    assert.equal(runOne(bad).selectedCount, 0, `state ${bad} should be skipped`);
+  }
+});


### PR DESCRIPTION
## Summary

Adds an **XLIFF localization humanize mode** to the patina CLI: `patina --xliff <file>` humanizes translated `<target>` segments in XLIFF 1.2 files through the existing rewrite → `verifyRewrite` → backend-chain pipeline, without changing meaning, numbers, polarity, or causation.

New flags: `--xliff`, `--dry-run`, `--max-segments`, and `--batch` for multiple files.

## Design constraints (all honored)

- **Dep-free.** XML is handled by a purpose-built quote-aware mini-scanner — no XML library, no new runtime deps beyond `js-yaml`.
- **Determinism preserved.** No changes under `src/features/*`; reuses `buildPrompt`, `invokeBackendChain`, `verifyRewrite`, and the batch circuit-breaker.
- **Byte-preserving write-back.** Only humanizable target *core* text is replaced (offset-based); leading/trailing whitespace, entities, attributes, and every other byte are preserved.
- **Atomic + fail-closed.** `writeAtomicUtf8` (exclusive temp + rename, cleanup on error); default writes a new `*.humanized.xliff` and **never clobbers** the original; a verify floor miss keeps the original bytes.

## Guardrails

- Target-state allowlist (`translated`/`final`/`signed-off`/`needs-review-translation`/absent); everything else skipped untouched.
- Inline-markup / CDATA / ambiguous / multi-target segments skipped fail-closed.
- Default 50 unique-segment cap (`--max-segments` override); segment failure budget via `createBatchCircuitBreaker`.
- Mandatory per-segment MPS/fidelity verify (floors 70/70).
- `--dry-run`: **0 LLM calls, 0 writes** — reports units/selected/skipped-by-reason/dedup/cap/cost estimate.

## Verification

- `tests/unit/xliff{,-writeback,-cli}.test.js` + red-team suites — 74 focused cases (scanner regex-breakers, byte-identity round-trip, entity/attr/whitespace preservation, cap, atomic-write failure, dedup AC6, floor-miss keep-original AC5, CLI accept/reject matrix, real-subprocess `node bin/patina.js` cases).
- Full `npm test`: **1061 pass / 0 fail / 1 skip**.
- `npm run lint` clean (syntax/eslint/tsc/spellcheck); `npm run check:no-private-assets` 0 forbidden.
- Live dry-run on a real 4,995-unit Crowdin sample: 34 selected, 0 LLM calls, 0 writes.

## Scope notes

- No version bump; no changes to the skill pipeline, patterns, or `src/features/*`.
- CLI-only feature (no playground/GUI surface).
