### PR TITLE
fix: five verified bugs from the 2026-07-01 triage (#564–#568)

### DIFF
--- a/api/rewrite.js
+++ b/api/rewrite.js
@@ -26,7 +26,7 @@ function parseKvNumber(value) {
  * Create a dependency-free Upstash/Vercel KV REST adapter.
  *
  * @param {Record<string,string|undefined>} env
- * @returns {null|{get(key: string): Promise<unknown>, incr(key: string, options?: {ttlMs?: number}): Promise<number>}}
+ * @returns {null|{get(key: string): Promise<unknown>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, decr(key: string): Promise<number>}}
  */
 export function createRestKv(env = {}) {
   const base = env.KV_REST_API_URL;
@@ -57,6 +57,12 @@ export function createRestKv(env = {}) {
       }
       return value;
     },
+    async decr(key) {
+      const data = await read(`/decr/${encodeURIComponent(key)}`);
+      const value = parseKvNumber(data);
+      if (value == null) throw new Error('kv decr returned invalid counter');
+      return value;
+    },
   };
 }
 
@@ -71,6 +77,7 @@ export function createRewriteApiHandler({ env = /** @type {Record<string,string|
       kv,
       hmacSecret: env.PATINA_QUOTA_HMAC_SECRET,
       env,
+      logger: /** @type {any} */ (logger),
     }),
     runRewrite: async ({ res, request }) => {
       // Resolve the effective LLM key server-side: BYOK uses the caller's key;

--- a/scripts/check-no-private-assets.mjs
+++ b/scripts/check-no-private-assets.mjs
@@ -112,16 +112,24 @@ export function runGate({ packedFiles = [], trackedFiles = [] } = {}) {
  *
  * @param {string} cwd Package directory containing a package.json.
  * @param {string} [prefix=''] Repo-relative prefix to prepend to each file path.
+ * @param {{spawn?: typeof spawnSync}} [options] Test seam for process spawning.
  * @returns {string[]} Repo-relative file paths.
  * @throws {Error} When `npm pack` fails or emits unparseable JSON.
  */
-export function collectPackedFiles(cwd, prefix = '') {
-  const result = spawnSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+export function collectPackedFiles(cwd, prefix = '', { spawn = spawnSync } = {}) {
+  const result = spawn(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
     cwd,
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
   });
-  if (result.error) throw result.error;
+  if (result.error) {
+    const code = result.error.code ? ` (${result.error.code})` : '';
+    const hint =
+      result.error.code === 'ENOENT'
+        ? ' npm executable not found on PATH — mixed WSL/Windows environments must put Linux npm ahead of /mnt/c/... Windows npm.'
+        : '';
+    throw new Error(`npm pack --dry-run could not start in ${cwd}${code}.${hint}`, { cause: result.error });
+  }
   if ((result.status ?? 1) !== 0) {
     throw new Error(`npm pack --dry-run failed in ${cwd}:\n${result.stderr || result.stdout}`);
   }

--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -194,7 +194,16 @@ export async function withBackendConcurrencySlot({
   // the derived default above.
   const remainingTimeout = () =>
     (Number.isFinite(deadline) ? Math.max(0, deadline - Date.now()) : timeout);
+  // Never start backend work on an already-spent budget: an expired shared
+  // deadline used to reach `fn(0)` on both the unbounded path and via the
+  // slot-acquired-after-expiry race below (#567).
+  const assertBudget = () => {
+    if (Number.isFinite(deadline) && Date.now() >= deadline) {
+      throw new TimeoutError(`${backendName || 'backend'}: shared deadline expired before backend start`);
+    }
+  };
   if (!Number.isFinite(maxConcurrency)) {
+    assertBudget();
     return fn(remainingTimeout());
   }
 
@@ -208,6 +217,9 @@ export async function withBackendConcurrencySlot({
   });
 
   try {
+    // The slot can be won in the instant the deadline expires (mkdir succeeds
+    // between the loop's deadline check and now). Re-check before invoking.
+    assertBudget();
     return await fn(remainingTimeout());
   } finally {
     releaseBackendSlot(slot);
@@ -230,6 +242,12 @@ async function acquireBackendSlot({
   mkdirSync(root, { recursive: true });
 
   for (;;) {
+    // Deadline gates the ROUND, not just the sleep: checking only after a
+    // failed acquisition round let a slot freed during the sleep be acquired
+    // after the deadline had already expired (#567).
+    if (Date.now() >= deadline) {
+      throw new TimeoutError(`${backendName || 'backend'}: timed out waiting for concurrency slot (cap ${maxConcurrency})`);
+    }
     for (let index = 0; index < maxConcurrency; index++) {
       const slot = join(root, `slot-${index}`);
       cleanupStaleSlot(slot, staleMs);

--- a/src/features/lexicon-core.js
+++ b/src/features/lexicon-core.js
@@ -112,6 +112,15 @@ export function computeDensity(paragraphText, tokens, lexicon) {
       hits.push(entry);
       continue;
     }
+    // lexicon/ai-en.md documents "A trailing `s` or `ing` form counts as the
+    // same entry" for English strict entries, but only the exact token was
+    // ever matched (#566). Accept the two documented inflections for non-CJK
+    // single-token entries; CJK strict matching is substring-based below and
+    // Korean inflections are absorbed by phrase matching per the same doc.
+    if (!cjkSubstring && (tokenSet.has(`${lowerEntry}s`) || tokenSet.has(`${lowerEntry}ing`))) {
+      hits.push(entry);
+      continue;
+    }
     const isMultiToken = /[^\p{L}\p{N}]/u.test(lowerEntry);
     if (cjkSubstring) {
       if (lowerText.includes(lowerEntry)) hits.push(entry);

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -52,7 +52,7 @@ function getHeader(headers, name) {
 /**
  * Create an in-memory KV store for tests and local development only.
  *
- * @returns {{__memory: true, get(key: string): Promise<unknown>, set(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>}}
+ * @returns {{__memory: true, get(key: string): Promise<unknown>, set(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, decr(key: string): Promise<number>}}
  */
 export function createMemoryKv() {
   /** @type {Map<string, {value: unknown, expiresAt: number}>} */
@@ -85,6 +85,13 @@ export function createMemoryKv() {
       entries.set(key, { value: next, expiresAt: expiresAt(ttlMs) });
       return next;
     },
+    async decr(key) {
+      expire();
+      const current = Number(entries.get(key)?.value ?? 0);
+      const next = current - 1;
+      entries.set(key, { value: next, expiresAt: entries.get(key)?.expiresAt ?? Number.POSITIVE_INFINITY });
+      return next;
+    },
   };
 }
 
@@ -97,17 +104,41 @@ export function isProductionPosture(env = {}) {
 }
 
 /**
- * @typedef {{get?(key: string): Promise<unknown>, set?(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, __memory?: boolean}} QuotaKv
+ * @typedef {{get?(key: string): Promise<unknown>, set?(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, decr?(key: string): Promise<number>, __memory?: boolean}} QuotaKv
  * @typedef {{allowed: true, tier: string, remainingDay?: number}|{allowed: false, status: number, reason: string}} RateLimitResult
+ * @typedef {{warn?: (...args: unknown[]) => void}} RateLimitLogger
  */
 
 /**
  * Create a fail-closed rate limiter for the shared free proxy.
  *
- * @param {{kv?: QuotaKv|null, hmacSecret?: string, env?: Record<string, string|undefined>, now?: () => number, limits?: typeof TIER_LIMITS}} options
- * @returns {{check(input: {tier: string, ip?: string|null}): Promise<RateLimitResult>}}
+ * @param {{kv?: QuotaKv|null, hmacSecret?: string, env?: Record<string, string|undefined>, now?: () => number, limits?: typeof TIER_LIMITS, logger?: RateLimitLogger}} options
+ * @returns {{check(input: {tier: string, ip?: string|null}): Promise<RateLimitResult>, acquireConcurrency(input: {tier: string, ip?: string|null}): Promise<RateLimitResult>, releaseConcurrency(input: {tier: string, ip?: string|null}): Promise<void>}}
  */
-export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.now(), limits = TIER_LIMITS }) {
+export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.now(), limits = TIER_LIMITS, logger = console }) {
+  const getConcurrencyKey = (tier, ip) => {
+    if (tier === WEB_TIERS.BYOK) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: true, tier }) };
+    const production = isProductionPosture(env);
+    if (production && (!kv || kv.__memory)) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: 'quota storage unavailable' }) };
+    if (production && !hmacSecret) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: 'quota secret unavailable' }) };
+    if (!kv) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: 'quota storage unavailable' }) };
+    if (!ip) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 400, reason: 'client ip unavailable' }) };
+    const secret = hmacSecret || 'patina-local-quota-secret';
+    return { ok: true, key: quotaKeyHmac(secret, 'free', 'concurrent', ip) };
+  };
+
+  const releaseKey = async (key) => {
+    if (!kv || typeof kv.decr !== 'function') {
+      logger.warn?.('quota concurrency release skipped: kv decr unavailable');
+      return;
+    }
+    try {
+      await kv.decr(key);
+    } catch {
+      logger.warn?.('quota concurrency release failed');
+    }
+  };
+
   return {
     async check({ tier, ip }) {
       if (tier === WEB_TIERS.BYOK) return { allowed: true, tier };
@@ -151,6 +182,29 @@ export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.n
       } catch {
         return { allowed: false, status: 503, reason: 'quota storage unavailable' };
       }
+    },
+    async acquireConcurrency({ tier, ip }) {
+      const resolved = getConcurrencyKey(tier, ip);
+      if (!resolved.ok) return resolved.result;
+      const freeLimits = limits.free;
+      try {
+        const activeCount = await kv.incr(resolved.key, { ttlMs: 5 * 60 * 1000 });
+        if (!Number.isSafeInteger(activeCount) || activeCount < 1) {
+          return { allowed: false, status: 503, reason: 'quota storage unavailable' };
+        }
+        if (activeCount > freeLimits.maxConcurrent) {
+          await releaseKey(resolved.key);
+          return { allowed: false, status: 429, reason: 'concurrent limit exceeded' };
+        }
+        return { allowed: true, tier };
+      } catch {
+        return { allowed: false, status: 503, reason: 'quota storage unavailable' };
+      }
+    },
+    async releaseConcurrency({ tier, ip }) {
+      const resolved = getConcurrencyKey(tier, ip);
+      if (!resolved.ok || !resolved.key) return;
+      await releaseKey(resolved.key);
     },
   };
 }

--- a/src/rewrite-handler.js
+++ b/src/rewrite-handler.js
@@ -6,7 +6,7 @@ import { extractClientIp } from './rate-limit.js';
 /**
  * @typedef {{method?: string, headers?: Record<string, string|string[]|undefined>, body?: unknown, [Symbol.asyncIterator]?: () => AsyncIterator<Buffer|string|Uint8Array>}} RewriteReq
  * @typedef {{statusCode?: number, setHeader?: (name: string, value: string) => void, end?: (body?: string) => void}} RewriteRes
- * @typedef {{check(input: {tier: string, ip: string|null}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>}} RateLimiter
+ * @typedef {{check(input: {tier: string, ip: string|null}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, acquireConcurrency?(input: {tier: string, ip: string|null}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, releaseConcurrency?(input: {tier: string, ip: string|null}): Promise<void>}} RateLimiter
  */
 
 /**
@@ -49,8 +49,23 @@ export function createRewriteHandler({ rateLimiter, runRewrite, env = {}, now = 
         return send(res, denied.status, { error: denied.reason });
       }
 
-      // await so a runner rejection is caught by the redacted 500 handler below.
-      return await runRewrite({ req, res, request, now });
+      if (typeof rateLimiter.acquireConcurrency !== 'function') {
+        // await so a runner rejection is caught by the redacted 500 handler below.
+        return await runRewrite({ req, res, request, now });
+      }
+
+      const concurrency = await rateLimiter.acquireConcurrency({ tier, ip });
+      if (!concurrency.allowed) {
+        const denied = /** @type {{status: number, reason: string}} */ (concurrency);
+        return send(res, denied.status, { error: denied.reason });
+      }
+
+      try {
+        // await so a runner rejection is caught by the redacted 500 handler below.
+        return await runRewrite({ req, res, request, now });
+      } finally {
+        await rateLimiter.releaseConcurrency?.({ tier, ip });
+      }
     } catch (err) {
       logger.error?.(redactSecrets({ message: String(/** @type {any} */ (err)?.message ?? err) }));
       return send(res, 500, { error: 'internal error' });

--- a/src/web-rewrite-contract.js
+++ b/src/web-rewrite-contract.js
@@ -105,10 +105,21 @@ function isSecretKey(key) {
   const norm = String(key).toLowerCase().replace(/[_-]/g, '');
   return SECRET_KEY_MARKERS.some((marker) => norm.includes(marker));
 }
-/** Inline secret shapes inside free-form strings (Bearer tokens, OpenAI keys). */
+/**
+ * Inline secret shapes inside free-form strings (Bearer tokens, OpenAI keys),
+ * plus labelled secrets (`apiKey=...`, `x-api-key: ...`, `token=...`) that
+ * upstream provider error messages embed regardless of key format (#565).
+ * The value part is bounded (no nested quantifiers) so a hostile error string
+ * cannot trigger catastrophic backtracking; over-redacting is the safe
+ * failure for a log boundary.
+ */
 const SECRET_VALUE_RES = [
   /Bearer\s+[A-Za-z0-9._-]+/gi,
   /\bsk-[A-Za-z0-9._-]{8,}/g,
+  /\b(?:x-)?api[-_]?key\s*[:=]\s*[^\s"'`&,;]{6,}/gi,
+  /\b(?:access|refresh)[-_]?token\s*[:=]\s*[^\s"'`&,;]{6,}/gi,
+  /\bclient[-_]?secret\s*[:=]\s*[^\s"'`&,;]{6,}/gi,
+  /\b(?:token|secret|password|passwd|credential|authorization)\s*[:=]\s*[^\s"'`&,;]{6,}/gi,
 ];
 const REDACTED = '[REDACTED]';
 

--- a/tests/unit/backend-contract.test.js
+++ b/tests/unit/backend-contract.test.js
@@ -166,3 +166,31 @@ test('withBackendConcurrencySlot hands the full timeout to an uncapped backend w
   assert.equal(result, 'ok');
   assert.ok(received > 4000 && received <= 5000, `expected ~full budget, got ${received}`);
 });
+
+test('withBackendConcurrencySlot refuses to start fn after the shared deadline expired (#567)', async () => {
+  let invoked = false;
+  await assert.rejects(
+    withBackendConcurrencySlot({
+      backendName: `test-expired-${process.pid}-${Date.now()}`,
+      maxConcurrency: 1,
+      deadline: Date.now() - 1000,
+      fn: () => { invoked = true; },
+    }),
+    (err) => isTimeoutError(err)
+  );
+  assert.equal(invoked, false, 'fn must not run on a spent budget');
+});
+
+test('uncapped backends also refuse an expired shared deadline (#567)', async () => {
+  let invoked = false;
+  await assert.rejects(
+    withBackendConcurrencySlot({
+      backendName: 'test-expired-uncapped',
+      maxConcurrency: Infinity,
+      deadline: Date.now() - 1000,
+      fn: () => { invoked = true; },
+    }),
+    (err) => isTimeoutError(err)
+  );
+  assert.equal(invoked, false, 'uncapped path must not run fn with remainingTimeout 0');
+});

--- a/tests/unit/check-no-private-assets.test.js
+++ b/tests/unit/check-no-private-assets.test.js
@@ -4,6 +4,7 @@ import {
   FORBIDDEN_GLOBS,
   globToRegExp,
   matchForbidden,
+  collectPackedFiles,
   runGate,
 } from '../../scripts/check-no-private-assets.mjs';
 
@@ -125,5 +126,45 @@ describe('leak gate: runGate over collected file lists', () => {
     });
     assert.strictEqual(result.ok, false);
     assert.deepStrictEqual(result.violations.map((v) => v.source).sort(), ['git', 'package']);
+  });
+});
+
+describe('leak gate: npm pack collection', () => {
+  it('throws an actionable diagnostic when npm cannot be spawned', () => {
+    assert.throws(
+      () =>
+        collectPackedFiles('/repo', '', {
+          spawn: () => ({ error: { code: 'ENOENT' } }),
+        }),
+      /npm executable not found on PATH — mixed WSL\/Windows environments must put Linux npm ahead of \/mnt\/c\/\.\.\. Windows npm/,
+    );
+  });
+
+  it('parses npm pack JSON from an injected spawn without changing paths', () => {
+    const calls = [];
+    const files = collectPackedFiles('/repo/pkg', 'packages/pkg/', {
+      spawn: (command, args, options) => {
+        calls.push({ command, args, options });
+        return {
+          status: 0,
+          stdout: JSON.stringify([
+            {
+              files: [{ path: 'package.json' }, { path: 'src/index.js' }, 'README.md'],
+            },
+          ]),
+          stderr: '',
+        };
+      },
+    });
+
+    assert.deepStrictEqual(files, [
+      'packages/pkg/package.json',
+      'packages/pkg/src/index.js',
+      'packages/pkg/README.md',
+    ]);
+    assert.strictEqual(calls[0].command, process.platform === 'win32' ? 'npm.cmd' : 'npm');
+    assert.deepStrictEqual(calls[0].args, ['pack', '--dry-run', '--json', '--ignore-scripts']);
+    assert.strictEqual(calls[0].options.cwd, '/repo/pkg');
+    assert.strictEqual(calls[0].options.encoding, 'utf8');
   });
 });

--- a/tests/unit/lexicon.test.js
+++ b/tests/unit/lexicon.test.js
@@ -212,3 +212,20 @@ test('cache preserves language-aware strict semantics (EN whole-word vs CJK subs
     assert.deepEqual(computeDensity(text, tokenize(text, { lang }), lex), hot);
   }
 });
+
+test('EN strict entries accept documented trailing s/ing inflections (#566)', () => {
+  const lexicon = { lang: 'en', strict: ['unlock'], phrases: [] };
+  for (const text of [
+    'This update unlocks a smaller workflow.',
+    'This update is unlocking a smaller workflow.',
+    'This update will unlock a smaller workflow.',
+  ]) {
+    assert.deepEqual(computeDensity(text, tokenize(text), lexicon).hits, ['unlock'], text);
+  }
+  // Entry-level dedup still holds when base and inflected forms co-occur.
+  const both = computeDensity('unlock unlocks unlocking', tokenize('unlock unlocks unlocking'), lexicon);
+  assert.equal(both.matches, 1);
+  // Only the two documented suffixes count — other derivations stay cold.
+  const align = { lang: 'en', strict: ['align'], phrases: [] };
+  assert.equal(computeDensity('the alignment shifted', tokenize('the alignment shifted'), align).matches, 0);
+});

--- a/tests/unit/rate-limit.test.js
+++ b/tests/unit/rate-limit.test.js
@@ -28,7 +28,7 @@ test('extractClientIp honors trusted-header precedence and comma splitting', () 
   assert.equal(extractClientIp({}), null);
 });
 
-test('createMemoryKv supports get, set, incr, and TTL expiry', async () => {
+test('createMemoryKv supports get, set, incr, decr, and TTL expiry', async () => {
   const originalNow = Date.now;
   let clock = 1_000;
   Date.now = () => clock;
@@ -38,6 +38,8 @@ test('createMemoryKv supports get, set, incr, and TTL expiry', async () => {
     assert.equal(await kv.get('a'), 'value');
     assert.equal(await kv.incr('n', { ttlMs: 50 }), 1);
     assert.equal(await kv.incr('n', { ttlMs: 50 }), 2);
+    assert.equal(await kv.decr('n'), 1);
+    assert.equal(await kv.get('n'), 1);
     clock += 51;
     assert.equal(await kv.get('a'), undefined);
     assert.equal(await kv.get('n'), undefined);
@@ -139,4 +141,36 @@ test('missing client IP returns 400', async () => {
     status: 400,
     reason: 'client ip unavailable',
   });
+});
+
+test('free concurrency limit rejects a second active slot and releases after completion', async () => {
+  const limiter = createRateLimiter({
+    kv: createMemoryKv(),
+    hmacSecret: 'secret',
+    now: () => 0,
+    limits: { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 99, burstPerHour: 99 }, byok: { maxChars: 20000, maxConcurrent: 2 } },
+  });
+
+  assert.deepEqual(await limiter.acquireConcurrency({ tier: WEB_TIERS.FREE, ip: '203.0.113.30' }), {
+    allowed: true,
+    tier: WEB_TIERS.FREE,
+  });
+  assert.deepEqual(await limiter.acquireConcurrency({ tier: WEB_TIERS.FREE, ip: '203.0.113.30' }), {
+    allowed: false,
+    status: 429,
+    reason: 'concurrent limit exceeded',
+  });
+  await limiter.releaseConcurrency({ tier: WEB_TIERS.FREE, ip: '203.0.113.30' });
+  assert.equal((await limiter.acquireConcurrency({ tier: WEB_TIERS.FREE, ip: '203.0.113.30' })).allowed, true);
+});
+
+test('BYOK concurrency bypasses shared free slot limit', async () => {
+  const limiter = createRateLimiter({
+    kv: createMemoryKv(),
+    hmacSecret: 'secret',
+    limits: { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 99, burstPerHour: 99 }, byok: { maxChars: 20000, maxConcurrent: 2 } },
+  });
+
+  assert.equal((await limiter.acquireConcurrency({ tier: WEB_TIERS.BYOK, ip: null })).allowed, true);
+  assert.equal((await limiter.acquireConcurrency({ tier: WEB_TIERS.BYOK, ip: null })).allowed, true);
 });

--- a/tests/unit/rewrite-api.test.js
+++ b/tests/unit/rewrite-api.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import handler, { createRewriteApiHandler } from '../../api/rewrite.js';
+import handler, { createRestKv, createRewriteApiHandler } from '../../api/rewrite.js';
 
 function makeReq({ body = undefined, method = 'POST' } = {}) {
   return {
@@ -134,4 +134,24 @@ test('byok tier forwards the caller key (not the server free key) to the stream 
   await api(byokReq, res);
   assert.equal(res.statusCode, 200);
   assert.equal(seenKey, 'sk-caller-byok-key', 'byok must use the caller key, not the server free key');
+});
+
+test('REST KV adapter calls Upstash decr and parses the numeric result', async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = /** @type {any} */ (async (url) => {
+    calls.push(String(url));
+    if (String(url).includes('/decr/')) {
+      return { ok: true, async json() { return { result: 4 }; } };
+    }
+    return { ok: true, async json() { return { result: 1 }; } };
+  });
+  try {
+    const kv = createRestKv({ KV_REST_API_URL: 'https://kv.example.test/', KV_REST_API_TOKEN: 'token' });
+    assert.ok(kv);
+    assert.equal(await kv.decr('slot key'), 4);
+    assert.equal(calls[0], 'https://kv.example.test/decr/slot%20key');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/tests/unit/rewrite-handler.test.js
+++ b/tests/unit/rewrite-handler.test.js
@@ -1,7 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { setImmediate } from 'node:timers';
 
 import { createRewriteHandler } from '../../src/rewrite-handler.js';
+import { createMemoryKv, createRateLimiter } from '../../src/rate-limit.js';
 import { WEB_TIERS } from '../../src/web-rewrite-contract.js';
 
 function makeRes() {
@@ -34,6 +36,19 @@ function validBody(overrides = {}) {
 function allowedLimiter() {
   return { async check() { return { allowed: true, tier: WEB_TIERS.FREE }; } };
 }
+
+function deferred() {
+  /** @type {(value?: unknown) => void} */
+  let resolve;
+  /** @type {(reason?: unknown) => void} */
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 
 test('factory throws without runRewrite or rateLimiter.check', () => {
   assert.throws(() => createRewriteHandler({ rateLimiter: allowedLimiter() }), TypeError);
@@ -147,4 +162,111 @@ test('thrown handler error returns generic 500 and logs a redacted message', asy
   assert.equal(res.ended.includes('sk-secret'), false);
   assert.equal(JSON.stringify(logs).includes('sk-secret'), false);
   assert.match(JSON.stringify(logs), /\[REDACTED\]/);
+});
+
+test('free concurrent requests allow one runner and reject the second before runRewrite', async () => {
+  const gate = deferred();
+  let calls = 0;
+  const limiter = createRateLimiter({
+    kv: createMemoryKv(),
+    hmacSecret: 'secret',
+    now: () => 0,
+    limits: { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 99, burstPerHour: 99 }, byok: { maxChars: 20000, maxConcurrent: 2 } },
+  });
+  const handler = createRewriteHandler({
+    rateLimiter: limiter,
+    async runRewrite({ res }) {
+      calls += 1;
+      res.statusCode = 200;
+      await gate.promise;
+      res.end(JSON.stringify({ ok: true }));
+    },
+  });
+
+  const firstRes = makeRes();
+  const first = handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.31' }, body: validBody() }, firstRes);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const secondRes = makeRes();
+  await handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.31' }, body: validBody() }, secondRes);
+
+  assert.equal(calls, 1);
+  assert.equal(secondRes.statusCode, 429);
+  assert.deepEqual(secondRes.json(), { error: 'concurrent limit exceeded' });
+
+  gate.resolve();
+  await first;
+  assert.equal(firstRes.statusCode, 200);
+  assert.deepEqual(firstRes.json(), { ok: true });
+
+  const thirdRes = makeRes();
+  await handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.31' }, body: validBody() }, thirdRes);
+  assert.equal(thirdRes.statusCode, 200);
+  assert.equal(calls, 2);
+});
+
+test('free concurrency slot is released when runRewrite throws', async () => {
+  let calls = 0;
+  const limiter = createRateLimiter({
+    kv: createMemoryKv(),
+    hmacSecret: 'secret',
+    now: () => 0,
+    limits: { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 99, burstPerHour: 99 }, byok: { maxChars: 20000, maxConcurrent: 2 } },
+  });
+  const handler = createRewriteHandler({
+    rateLimiter: limiter,
+    runRewrite() {
+      calls += 1;
+      if (calls === 1) throw new Error('boom');
+      return 'ok';
+    },
+    logger: { error() {} },
+  });
+
+  const firstRes = makeRes();
+  await handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.32' }, body: validBody() }, firstRes);
+  assert.equal(firstRes.statusCode, 500);
+
+  const secondRes = makeRes();
+  const result = await handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.32' }, body: validBody() }, secondRes);
+  assert.equal(result, 'ok');
+  assert.equal(calls, 2);
+});
+
+test('BYOK concurrent requests bypass free concurrency limit', async () => {
+  const gate = deferred();
+  let calls = 0;
+  const limiter = createRateLimiter({
+    kv: createMemoryKv(),
+    hmacSecret: 'secret',
+    now: () => 0,
+    limits: { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 99, burstPerHour: 99 }, byok: { maxChars: 20000, maxConcurrent: 2 } },
+  });
+  const handler = createRewriteHandler({
+    rateLimiter: limiter,
+    async runRewrite({ res }) {
+      calls += 1;
+      res.statusCode = 200;
+      await gate.promise;
+      res.end(JSON.stringify({ ok: true }));
+    },
+  });
+  const body = validBody({
+    tier: WEB_TIERS.BYOK,
+    provider: 'openai',
+    model: 'gpt-5.5',
+    apiKey: 'sk-test-byok-key',
+  });
+
+  const firstRes = makeRes();
+  const secondRes = makeRes();
+  const first = handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.33' }, body }, firstRes);
+  const second = handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.33' }, body }, secondRes);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(calls, 2);
+  gate.resolve();
+  await Promise.all([first, second]);
+  assert.equal(firstRes.statusCode, 200);
+  assert.equal(secondRes.statusCode, 200);
 });

--- a/tests/unit/web-rewrite-contract.test.js
+++ b/tests/unit/web-rewrite-contract.test.js
@@ -301,3 +301,20 @@ test('REWRITE_MODES and WEB_TIERS expose the documented values', () => {
   assert.deepEqual(REWRITE_MODES, { FIRST: 'first', REFINE: 'refine' });
   assert.deepEqual(WEB_TIERS, { FREE: 'free', BYOK: 'byok' });
 });
+
+test('redactSecrets masks labelled provider secrets in free-form strings (#565)', () => {
+  const cases = [
+    'call failed: apiKey=FAKE_PROVIDER_KEY_1234567890',
+    'upstream said x-api-key: FAKE_ANTHROPIC_KEY_abcdef123456 rejected',
+    'token=ghp_FAKEFAKE1234567890 expired',
+    'client_secret: FAKESECRET99 invalid',
+    'authorization: FAKEAUTH999999 denied',
+  ];
+  for (const message of cases) {
+    const out = /** @type {{message: string}} */ (redactSecrets({ message }));
+    assert.ok(!/FAKE|ghp_/.test(out.message), `leaked: ${out.message}`);
+    assert.ok(out.message.includes('[REDACTED]'), `not redacted: ${out.message}`);
+  }
+  // Benign prose without labelled values survives untouched.
+  assert.equal(redactSecrets('no secrets here, just text'), 'no secrets here, just text');
+});


### PR DESCRIPTION
Each of the five triage issues was independently re-verified before fixing (the referenced `.omo/evidence` artifacts are not in this snapshot, so every claim was re-reproduced from scratch). All five confirmed real; each fix ships a focused regression test.

Closes #564, closes #565, closes #566, closes #567, closes #568.

| Issue | Verified by | Fix |
|---|---|---|
| #566 EN strict lexicon misses s/ing | Live: `unlocks`/`unlocking` → 0 hits while `lexicon/ai-en.md` documents the variants | `computeDensity` accepts the two documented inflections for non-CJK single-token entries; dedup preserved; benchmark/dogfood zero drift |
| #567 backend starts after deadline | Live: expired deadline → `fn(remainingTimeout=0)` invoked on both bounded and uncapped paths | Deadline gates each acquisition round; budget re-checked after slot acquisition and on the uncapped path; `TimeoutError` before `fn` |
| #564 free maxConcurrent unenforced | Code: handler flow is validate→day/hour quota→runRewrite, no concurrency tracking anywhere | `acquireConcurrency`/`releaseConcurrency` on the rate limiter (HMAC-keyed KV counter, 5-min TTL, decr compensation); memory KV + Upstash REST adapter gain `decr`; handler wraps `runRewrite` in acquire/finally-release; BYOK bypass unchanged |
| #565 labelled secrets in logs | Live: `apiKey=FAKE…`, `x-api-key: …`, `token=…` all passed `redactSecrets` untouched | Bounded labelled-secret patterns added to `SECRET_VALUE_RES` (api-key/token/secret/password/credential/authorization families) |
| #568 leak gate ENOENT on WSL/Windows | Code: `spawnSync('npm')` ignores `result.error`; win32 needs `npm.cmd` | Portable npm resolution, explicit spawn-error diagnostic with mixed-PATH hint, injectable spawn seam + unit coverage |

## Gates
`npm test` 1082/1082 (+13 new regressions) · lint/typecheck/spellcheck clean · benchmark 100% (49 fixtures, detector table unchanged) · dogfood all docs <30 · `node scripts/check-no-private-assets.mjs` passes (354 packed + 931 tracked).