### PR TITLE
feat(playground): frontend hardening — a11y, error UX, server abort, quota reason contract

### DIFF
--- a/api/rewrite.js
+++ b/api/rewrite.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { createRateLimiter, createMemoryKv, isProductionPosture } from '../src/rate-limit.js';
 import { createRewriteHandler } from '../src/rewrite-handler.js';
-import { encodeStreamFrame, WEB_TIERS } from '../src/web-rewrite-contract.js';
+import { encodeStreamFrame, QUOTA_REASONS, WEB_TIERS } from '../src/web-rewrite-contract.js';
 import { buildRewriteMetric } from '../src/web-observability.js';
 import { runWebRewriteStream } from '../src/web-rewrite-stream.js';
 
@@ -67,6 +67,13 @@ export function createRestKv(env = {}) {
 }
 
 /**
+ * Default server-side budget for one rewrite stream (provider call + scoring).
+ * Bounds upstream work even when the client stays connected; override with
+ * env.PATINA_WEB_REWRITE_TIMEOUT_MS.
+ */
+const WEB_REWRITE_TIMEOUT_MS = 180_000;
+
+/**
  * @param {{env?: Record<string,string|undefined>, runWebRewriteStreamImpl?: typeof runWebRewriteStream, logger?: {info?: Function, warn?: Function, error?: Function, debug?: Function}, now?: () => number}} [options]
  */
 export function createRewriteApiHandler({ env = /** @type {Record<string,string|undefined>} */ (process.env), runWebRewriteStreamImpl = runWebRewriteStream, logger = console, now = () => Date.now() } = {}) {
@@ -79,7 +86,7 @@ export function createRewriteApiHandler({ env = /** @type {Record<string,string|
       env,
       logger: /** @type {any} */ (logger),
     }),
-    runRewrite: async ({ res, request }) => {
+    runRewrite: async ({ req, res, request }) => {
       // Resolve the effective LLM key server-side: BYOK uses the caller's key;
       // free uses the server's own provider key (never the request, which has
       // no key on the free tier). Fail closed if the free service is unconfigured.
@@ -87,16 +94,36 @@ export function createRewriteApiHandler({ env = /** @type {Record<string,string|
       if (!apiKey) {
         res.statusCode = 503;
         res.setHeader?.('Content-Type', 'application/json');
-        res.end?.(JSON.stringify({ error: 'rewrite service unavailable' }));
+        res.end?.(JSON.stringify({ error: QUOTA_REASONS.SERVICE_UNAVAILABLE }));
         return;
       }
       res.statusCode = 200;
       res.setHeader?.('Content-Type', 'application/x-ndjson');
+      // Server-side cancellation: when the client disconnects mid-stream,
+      // abort provider/scoring work so the upstream request and the free-tier
+      // concurrency slot are released promptly (the handler's finally still
+      // runs releaseConcurrency). 'close' with an unfinished response means a
+      // premature disconnect on Node/Vercel; after a clean end the guard is
+      // false and the abort is skipped. Runtimes whose req/res mocks lack
+      // emitter methods degrade gracefully (optional calls) to the timeout.
+      const controller = new AbortController();
+      const onClose = () => { if (!res.writableEnded) controller.abort(); };
+      res.on?.('close', onClose);
+      req.on?.('aborted', onClose);
+      const envTimeout = Number(env.PATINA_WEB_REWRITE_TIMEOUT_MS);
+      const timeout = Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : WEB_REWRITE_TIMEOUT_MS;
       const startedAt = now();
-      await runWebRewriteStreamImpl({
-        request: { ...request, apiKey },
-        emit: (frame) => res.write?.(encodeStreamFrame(frame)),
-      });
+      try {
+        await runWebRewriteStreamImpl({
+          request: { ...request, apiKey },
+          emit: (frame) => res.write?.(encodeStreamFrame(frame)),
+          signal: controller.signal,
+          timeout,
+        });
+      } finally {
+        res.off?.('close', onClose);
+        req.off?.('aborted', onClose);
+      }
       res.end?.();
       // Sanitized observability ONLY: route/tier/provider/model/status/bucketed
       // latency + char count. Never the text, prompt, output, key, or full IP.

--- a/playground/DESIGN.md
+++ b/playground/DESIGN.md
@@ -1,120 +1,148 @@
 ---
-version: alpha
+version: beta
 name: patina-chat-design
 extends: ../DESIGN.md (brand source of truth)
-base: lovable.dev (getdesign.md) + patina brand accents
+base: editorial dark (patina brand accents on a near-black canvas)
 description: >
-  Design tokens for the full-page patina chat, reskinned in Lovable's warm-light
-  language: a faintly-warm near-white canvas, a signature aurora gradient behind
-  the empty-state hero, charcoal text on a charcoal-opacity gray scale, hairline
-  borders (not shadows) for containment, full-pill action buttons with an inset
-  shadow, and humanist display type. patina's brand stays as the functional
-  accent system: teal = humanized output, copper = the AI "before", amber/gold =
-  preserved meaning.
+  Design tokens for the full-page patina playground (landing + chat), in the
+  editorial-dark language actually shipped in chatgpt.css: a neutral near-black
+  canvas, white type on a gray opacity scale, hairline borders for containment,
+  a single restrained teal accent (no rainbow/aurora slop), full-pill action
+  buttons with an inset shadow, and humanist display type. patina's brand stays
+  as the functional accent system: teal = humanized output, copper = the AI
+  "before", gold = preserved meaning.
 
 colors:
-  # Surfaces (Lovable warm-light)
-  bg: "#faf9f6"            # page (near-white, faintly warm)
-  bg-cream: "#f7f4ed"      # warm cream surface
-  bg-side: "#f4f1e9"       # sidebar
-  bg-elev: "#ffffff"       # composer / cards
-  border: "#eceae4"        # passive hairline
-  border-strong: "rgba(28,28,28,0.22)"  # interactive border
+  # Surfaces — neutral near-black
+  bg: "#0a0a0b"            # page canvas
+  bg-cream: "#1b1b1f"      # elevated surface (cards / badges / bar+foot)
+  bg-side: "#0e0e10"       # sidebar
+  bg-elev: "#141417"       # composer / prompt / editor panel
+  bg-hover: "rgba(255,255,255,0.05)"
+  bg-hover-2: "rgba(255,255,255,0.08)"
 
-  # Text (charcoal opacity scale)
-  text: "#1c1c1c"
-  text-dim: "#5f5f5d"
-  text-faint: "rgba(28,28,28,0.42)"
+  # Text — white on near-black
+  text: "#fafafa"
+  text-dim: "#a1a1aa"
+  text-faint: "#7c7c84"
 
-  # Patina accents (deepened for contrast on light)
-  accent: "#0d9488"        # patina teal — avatar, send, focus, links, after
-  accent-press: "#0f766e"
-  on-accent: "#ffffff"
-  copper: "#b45c25"        # AI "packaging" / the "before"
-  gold: "#a16207"          # preserved-meaning (deep amber)
+  # Borders — neutral hairlines
+  border: "#27272a"
+  border-strong: "#3f3f46"
 
-  # Lovable signature primary (used for high-emphasis dark CTAs if needed)
-  dark: "#1c1c1c"
-  on-dark: "#fcfbf8"
+  # Patina semantic accents
+  accent: "#2dd4bf"        # patina teal — the single primary accent
+  accent-soft: "#5eead4"
+  accent-press: "#14b8a6"
+  on-accent: "#04181a"     # dark text on a teal fill
+  copper: "#d9772f"        # AI "packaging" / the "before"
+  gold: "#ffe6a8"          # preserved-meaning core (MPS/fidelity values)
+
+  # High-emphasis pill (nav GitHub button): white on near-black
+  dark: "#fafafa"
+  on-dark: "#0a0a0b"
 
 typography:
-  sans: '"Camera Plain Variable", ui-rounded, Inter, ui-sans-serif, -apple-system, "Segoe UI", "Noto Sans KR", sans-serif'
+  sans: '"Pretendard Variable", Pretendard, Inter, ui-sans-serif, -apple-system, "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Noto Sans SC", "Noto Sans JP", Roboto, Helvetica, Arial, sans-serif'
   mono: 'SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace'
-  weights: "400 body/UI, 600 headings (Lovable caps at 600)"
+  weights: "400 body/UI, 600 headings"
   notes: >
-    Camera Plain Variable is Lovable's font and is NOT bundled — the stack falls
-    back to ui-rounded/Inter/system. Headings run tight (letter-spacing -1.2px at
-    44px). Numeric data (badges/signals) uses mono.
+    Pretendard Variable is loaded from jsDelivr (the only external origin the
+    page touches). Headings run tight (letter-spacing -1.6px at the hero clamp,
+    -1.2px at section titles). Numeric data (badges/signals) uses mono.
 
 depth:
-  philosophy: "Shallow. Hairline #eceae4 borders contain; one soft focus shadow."
-  inset: "rgba(255,255,255,0.2) 0 0.5px 0 0 inset, rgba(0,0,0,0.18) 0 0 0 0.5px inset, rgba(0,0,0,0.05) 0 1px 2px 0"
-  focus: "rgba(0,0,0,0.1) 0 4px 12px"
+  philosophy: "Shallow. Hairline #27272a borders contain; one soft focus shadow; inset on pills."
+  inset: "rgba(255,255,255,0.08) 0 0.5px 0 0 inset, rgba(0,0,0,0.35) 0 0 0 0.5px inset, rgba(0,0,0,0.25) 0 1px 2px 0"
+  focus: "rgba(0,0,0,0.55) 0 4px 16px"
 
 rounded:
   sm: 8px        # controls
-  card: 12px     # chips / cards
+  card: 16px     # editor panel / bench cards
   bubble: 18px   # message bubbles
-  composer: 26px # big Lovable composer card
+  composer: 26px # composer card (prompt card is 28px)
   pill: 9999px   # buttons, badges, send
 
-aurora:
-  use: "Behind the empty-state hero only (the landing moment); reading surfaces stay cream."
+glow:
+  use: "Behind the hero only; reading surfaces stay flat near-black."
   value: >
-    radial-gradient(60% 55% at 50% -8%, rgba(120,160,255,.40), transparent 70%),
-    radial-gradient(48% 42% at 16% 48%, rgba(196,150,255,.34), transparent 70%),
-    radial-gradient(52% 46% at 86% 60%, rgba(255,150,205,.34), transparent 72%),
-    radial-gradient(62% 52% at 50% 116%, rgba(255,180,120,.40), transparent 70%)
+    radial-gradient(60% 48% at 50% -10%, rgba(45,212,191,0.07), transparent 72%),
+    radial-gradient(90% 60% at 50% 122%, rgba(255,255,255,0.02), transparent 70%)
+  notes: "Single-accent teal glow + a fine dot-grid texture masked toward the title. Deliberately not a multi-color aurora."
+
+accessibility:
+  focus-ring: "outline: 2px solid {colors.accent}; outline-offset: 2px on :focus-visible for every interactive control."
+  live-regions: "#thread is role=log aria-live=polite; error notes are role=alert; aria-busy toggles during streaming."
+  mobile-sidebar: "closed off-canvas sidebar gets visibility:hidden so it leaves the tab order and a11y tree."
+  mobile-nav: "≤900px the nav links wrap onto a full-width scrollable row instead of being hidden."
 
 components:
   app-canvas:  { backgroundColor: "{colors.bg}", textColor: "{colors.text}" }
   sidebar:     { backgroundColor: "{colors.bg-side}", borderColor: "{colors.border}" }
   newchat:     { backgroundColor: "{colors.bg-elev}", radius: pill, shadow: inset }
-  empty-hero:  { background: aurora, logo: "{colors.accent}", title: "44px / 600 / -1.2px" }
-  msg-user:    { backgroundColor: "{colors.bg-cream}", borderLeft: "2px {colors.copper}" } # AI "before"
-  msg-patina:  { avatar: "{colors.accent}", textColor: "{colors.text}" }                   # the "after"
-  badge:       { backgroundColor: "{colors.bg-cream}", font: mono, valueColor: "{colors.gold}" } # preserved meaning
-  signal:      { before: "{colors.copper}", after: "{colors.accent}" }                      # copper → teal arc
+  hero:        { background: glow, accentWord: "{colors.accent}", title: "clamp(40px,6.4vw,64px) / 600 / -1.6px" }
+  msg-user:    { backgroundColor: "{colors.bg-cream}", borderColor: "{colors.border}" }
+  msg-patina:  { avatar: "{colors.bg-cream}", textColor: "{colors.text}" }
+  badge:       { backgroundColor: "{colors.bg-cream}", font: mono, valueColor: "{colors.gold}" }
+  signal:      { before: "{colors.copper}", after: "{colors.accent}" }
   composer:    { backgroundColor: "{colors.bg-elev}", radius: composer, borderColor: "{colors.border}", focus: focus-shadow }
-  send-button: { backgroundColor: "{colors.accent}", textColor: "{colors.on-accent}", radius: pill, shadow: inset }
+  send-button: { backgroundColor: "{colors.accent}", textColor: "{colors.on-accent}", radius: pill, shadow: inset, stopState: "is-stop swaps to {colors.bg-cream} with a square stop glyph" }
+  editor:      { backgroundColor: "{colors.bg-elev}", chrome: "{colors.bg-cream}", tabs: "teal is-active tint", diff: "copper removals / teal additions" }
 ---
 
 ## Overview
 
-The chat adopts Lovable's warm-light language — a faintly-warm near-white page
-(`#faf9f6`), charcoal text (`#1c1c1c`) on a charcoal-opacity gray scale, hairline
-`#eceae4` borders instead of drop shadows, full-pill action buttons with the
-signature multi-layer inset shadow, and the signature aurora gradient (blue →
-purple → pink → orange) behind the empty-state hero. Brand strategy lives in the
-root [`DESIGN.md`](../DESIGN.md); this file is the chat implementation token set.
+The playground ships an **editorial dark** theme — a neutral near-black canvas
+(`#0a0a0b`), white type (`#fafafa`) on a gray opacity scale, hairline `#27272a`
+borders instead of drop shadows, full-pill action buttons with a multi-layer
+inset shadow, and a single restrained teal glow behind the hero. Brand strategy
+lives in the root [`DESIGN.md`](../DESIGN.md); this file is the playground
+implementation token set and mirrors `playground/chatgpt.css` exactly.
 
-patina's brand survives as the **functional accent system**, in light-readable
-shades, so each rewrite still replays the icon's copper → teal → gold story:
+patina's brand is the **functional accent system**, so each rewrite replays the
+icon's copper → teal → gold story:
 
-- **teal `#0d9488`** — humanized output. Single dominant accent: avatar/logo,
-  send button, focus, links, the **after** AI-signal count.
-- **copper `#b45c25`** — the AI "packaging". Left edge of the **user** message
-  (the pasted, AI-sounding input) and the **before** AI-signal count.
-- **amber/gold `#a16207`** — preserved meaning. The **MPS / fidelity** numbers, in mono.
+- **teal `#2dd4bf`** — humanized output. The single dominant accent: hero grad
+  word, send button, focus rings, links, tabs, the **after** AI-signal count.
+- **copper `#d9772f`** — the AI "packaging". The **before** diff removals and
+  the **before** AI-signal count.
+- **gold `#ffe6a8`** — preserved meaning. The **MPS / fidelity** numbers, in mono.
 
 **Key characteristics**
 
-- Warm near-white canvas; aurora only behind the empty hero, never behind reading.
-- Hairline borders contain; depth is shallow (one soft focus shadow, inset on buttons).
+- Near-black canvas; a single-accent teal glow + dot grid behind the hero only.
+- Hairline borders contain; depth is shallow (one soft focus shadow, inset pills).
 - Full-pill buttons/badges; big rounded composer card; humanist headings run tight.
-- Two weights (400 / 600); patina teal/copper/gold carry meaning, not decoration.
+- Two weights (400 / 600); teal/copper/gold carry meaning, not decoration.
+- Keyboard-first: every interactive control has a visible `:focus-visible` ring;
+  streamed output and errors are announced via live regions.
 
 ## Applied in
 
-- `playground/chatgpt.css` — tokens in `:root`; aurora on `.empty`; semantic rules
-  on `.msg--user` (copper edge), `.msg--patina`/`.composer__send`/avatars (teal),
-  `.badge b` (gold mono), `.signal-bar .sig-before|.sig-after` (copper→teal).
-- `playground/chatgpt.js` — emits `.sig-before` / `.sig-after` spans.
+- `playground/chatgpt.css` — tokens in `:root`; glow on `.hero__sky`; semantic
+  rules on the editor diff (`.dtok--rm` copper / `.dtok--add` teal), `.badge b`
+  (gold mono), `.signal-bar .sig-before|.sig-after` (copper→teal); the shared
+  `:focus-visible` ring block; mobile rules (nav link row ≤900px, off-canvas
+  sidebar visibility ≤820px).
+- `playground/chatgpt.js` — emits `.sig-before` / `.sig-after` spans and builds
+  all localized copy via DOM nodes (`textContent` + `createElement`; no
+  innerHTML for localized strings).
 - Landing (VDL-inspired editorial layer, from vibedesignlab.net): Pretendard
   Variable as primary `--font`; `.sec__head` left-aligned with a chip-on-hairline
   `.eyebrow` device (`<span>` chip + `::after` rule); larger clamped `.hero__title`
-  / `.sec__title` scale; gallery section padding. Accent stays patina teal —
-  VDL's single-hot-accent principle, not its red.
+  / `.sec__title` scale. Accent stays patina teal — VDL's single-hot-accent
+  principle, not its red.
 
-> Note: a dark patina×voltagent variant is preserved in git history (commit
-> `style(playground): dark patina×voltagent chat theme (checkpoint)`).
+## Analytics
+
+`playground/analytics.js` is an **intentional no-op queue shim** for
+`window.va` (`vercel.json` rewrites `/analytics.js` to it). It is not loaded by
+`index.html` and performs no network calls; it exists so a deployment layer that
+injects Vercel Analytics finds a same-origin queue instead of erroring. Keep it
+no-op — enabling real telemetry needs an explicit product decision, and the CSP
+stays self-only either way.
+
+> History: an earlier Lovable-style **warm-light** token set (near-white
+> `#faf9f6` canvas, multi-color aurora) is preserved in git history for this
+> file; the shipped theme has been the editorial dark set above since the
+> `style(playground)` dark-theme checkpoint.

--- a/playground/analytics.js
+++ b/playground/analytics.js
@@ -1,4 +1,12 @@
 /* global window */
+// Intentional no-op analytics queue shim (kept deliberately unused by default).
+//
+// vercel.json rewrites /analytics.js to this file, and index.html does NOT load
+// it: the playground performs no telemetry calls of its own. The shim exists so
+// a deployment layer that injects Vercel Analytics (window.va) finds a
+// same-origin queue instead of throwing. It must stay dependency-free, make no
+// network requests, and never add external origins (CSP is self-only). Turning
+// real telemetry on is a product decision — see playground/DESIGN.md §Analytics.
 window.va = window.va || function queueVercelAnalytics(...args) {
   (window.vaq = window.vaq || []).push(args);
 };

--- a/playground/chatgpt.css
+++ b/playground/chatgpt.css
@@ -360,9 +360,58 @@ details.foldout[open] > summary::before { content: "▾ "; }
 .composer__send:disabled { background: var(--bg-cream); color: var(--text-faint); cursor: not-allowed; box-shadow: none; }
 .composer__hint { max-width: var(--maxw); margin: 8px auto 0; text-align: center; font-size: 11.5px; color: var(--text-faint); }
 
+/* stop/send icon swap — while streaming the send buttons become Stop controls */
+.prompt__send .ic-stop, .composer__send .ic-stop { display: none; }
+.prompt__send.is-stop .ic-send, .composer__send.is-stop .ic-send { display: none; }
+.prompt__send.is-stop .ic-stop, .composer__send.is-stop .ic-stop { display: block; }
+.prompt__send.is-stop, .composer__send.is-stop { background: var(--bg-cream); color: var(--text); box-shadow: var(--inset); cursor: pointer; }
+.prompt__send.is-stop:hover, .composer__send.is-stop:hover { background: var(--bg-hover-2); }
+
+/* inline preflight errors (cap / BYOK key) — shown before any network request */
+.prompt__error { color: #fca5a5; font-size: 13px; margin: 10px 6px 0; }
+.composer__error { max-width: var(--maxw); margin: 8px auto 0; text-align: center; font-size: 12.5px; color: #fca5a5; }
+.ctl__err { font-size: 11px; color: #fca5a5; }
+.ctl__input.is-invalid { border-color: #ef4444aa; }
+
+/* retry a failed (non-floor) attempt */
+.retrybtn { display: inline-flex; align-items: center; margin-top: 10px; font-family: inherit; font-size: 13px; border-radius: 9999px; padding: 6px 16px; cursor: pointer; background: transparent; border: 1px solid var(--border-strong); color: var(--text); transition: background .15s; }
+.retrybtn:hover { background: var(--bg-hover); }
+
+/* ───────── keyboard focus (a11y) ─────────
+   Hover-only affordances are invisible to keyboard users; every interactive
+   control gets one consistent focus ring. :focus-visible keeps mouse clicks
+   ring-free while preserving the ring for Tab navigation. */
+.nav__brand:focus-visible,
+.nav__links a:focus-visible,
+.btn:focus-visible,
+.suggest__pill:focus-visible,
+.editor__tab:focus-visible,
+.editor__btn:focus-visible,
+.xcard__replay:focus-visible,
+.xcard__try:focus-visible,
+.cta__btn:focus-visible,
+.newchat:focus-visible,
+.histitem:focus-visible,
+.iconbtn:focus-visible,
+.prompt__send:focus-visible,
+.composer__send:focus-visible,
+.bench__link:focus-visible,
+.foot__links a:focus-visible,
+details.foldout > summary:focus-visible,
+.retrybtn:focus-visible,
+.ctl__select:focus-visible,
+.ctl__input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 /* ───────── responsive ───────── */
 @media (max-width: 900px) {
-  .nav__links { display: none; }
+  /* Keep Docs/Examples/Benchmark/Ethics reachable on small screens: instead of
+     hiding the links, wrap them onto their own full-width scrollable row. */
+  .nav__links { order: 4; flex-basis: 100%; margin-left: 0; gap: 14px; overflow-x: auto; scrollbar-width: none; padding-bottom: 2px; }
+  .nav__links::-webkit-scrollbar { display: none; }
+  .nav__links a { font-size: 14px; white-space: nowrap; }
   .ctl__label { display: none; }
   .how__grid { grid-template-columns: 1fr; gap: 28px; }
   .bench__cards { grid-template-columns: repeat(2, 1fr); }
@@ -371,7 +420,11 @@ details.foldout[open] > summary::before { content: "▾ "; }
 }
 @media (max-width: 820px) {
   .sidebar { position: absolute; z-index: 30; height: 100%; box-shadow: 4px 0 24px rgba(0,0,0,.12); }
-  .chat:not(.sidebar-open) .sidebar { margin-left: -260px; }
+  /* visibility:hidden drops the closed off-canvas sidebar out of the tab order
+     and the accessibility tree (inert-equivalent, no JS needed); the delay
+     keeps the slide-out animation visible. */
+  .chat:not(.sidebar-open) .sidebar { margin-left: -260px; visibility: hidden; transition: margin-left .2s ease, visibility 0s .2s; }
+  .chat.sidebar-open .sidebar { visibility: visible; }
   .iconbtn { display: inline-block; }
   .editor__dots { display: none; }
   .editor__state { display: none; }

--- a/playground/chatgpt.js
+++ b/playground/chatgpt.js
@@ -2,9 +2,10 @@
 // patina — Lovable-composition controller: landing (hero prompt + sections) that
 // transitions into a chat view. Reuses the isomorphic streaming client + contract;
 // renders via safe DOM APIs.
-import { createRewriteThread, streamRewrite } from './rewrite-client.js';
+import { createRewriteThread, streamRewrite, classifyRewriteError, REWRITE_ERROR_KINDS } from './rewrite-client.js';
 import {
   PROVIDER_PRESETS,
+  TIER_LIMITS,
   WEB_TIERS,
   MPS_FLOOR,
   FIDELITY_FLOOR,
@@ -50,7 +51,7 @@ const LANG_NAME = { ko: '한국어', en: 'English', zh: '中文', ja: '日本語
 // Localized landing copy — the description follows the selected language.
 const I18N = {
   en: {
-    title: 'Make it sound <span class="grad">human</span>',
+    title: ['Make it sound ', 'human', ''],
     sub: 'Paste AI-sounding text — patina rewrites it naturally. KO·EN·ZH·JA.',
     promptPh: 'Paste the text you want to clean up…',
     howTitle: 'Three steps',
@@ -68,7 +69,7 @@ const I18N = {
     ctaTitle: 'Paste your own and see',
     ctaSub: 'Drop an AI-sounding draft into the box above. No code, no key.',
     ctaBtn: 'Start at the top ↑',
-    note: 'Deterministic humanizer —<br />same claim, numbers, tone.',
+    note: ['Deterministic humanizer —', 'same claim, numbers, tone.'],
     hint: 'patina changes only the wording — never the claim, numbers, or causation. This demo rewrites via a local CLI; MPS/fidelity are preview values.',
     chatPh: 'Keep refining…  (Enter to send · Shift+Enter for newline)',
     newchat: 'New chat',
@@ -77,9 +78,18 @@ const I18N = {
     failNote: 'Rewrite failed. Try again, or check the mode/key.',
     quotaDaily: 'You’ve used today’s free quota. Try again tomorrow, or switch to BYOK mode with your own API key for unlimited use.',
     quotaHourly: 'Free quota is full for now. Try again shortly, or use BYOK mode with your own API key.',
+    quotaConcurrent: 'A rewrite is already running for your connection. Wait for it to finish, then try again.',
+    serviceDown: 'The rewrite service is temporarily unavailable. Please try again later.',
+    tooLong: 'Text is over the {tier} limit of {cap} characters. Shorten it and try again.',
+    keyMissing: 'Enter your API key to use API mode.',
+    stopNote: 'Stopped — the rewrite was cancelled.',
+    timeoutNote: 'Rewrite timed out — no response from the server. Please try again.',
+    netNote: 'Network error: {msg}',
+    retry: 'Retry',
+    stopLabel: 'Stop',
   },
   ko: {
-    title: 'AI 티 없이, <span class="grad">자연스럽게</span>',
+    title: ['AI 티 없이, ', '자연스럽게', ''],
     sub: 'AI 티 나는 문장을 붙여넣으면 patina가 자연스럽게 다듬어요. KO·EN·ZH·JA.',
     promptPh: '다듬고 싶은 문장을 붙여넣어 보세요…',
     howTitle: '세 단계면 끝',
@@ -97,7 +107,7 @@ const I18N = {
     ctaTitle: '직접 붙여넣어 확인해 보세요',
     ctaSub: 'AI 티 나는 초안을 위 입력칸에 붙여넣으면 끝. 코드도 키도 필요 없어요.',
     ctaBtn: '맨 위로 가서 시작하기 ↑',
-    note: '의미·숫자·톤을 바꾸지 않는<br />결정론적 휴머나이저.',
+    note: ['의미·숫자·톤을 바꾸지 않는', '결정론적 휴머나이저.'],
     hint: 'patina는 주장·수치·인과를 바꾸지 않고 표현만 다듬습니다. 데모는 로컬 CLI로 리라이트하며 MPS/fidelity는 프리뷰 값입니다.',
     chatPh: '이어서 다듬기…  (Enter 전송 · Shift+Enter 줄바꿈)',
     newchat: '새 대화',
@@ -106,9 +116,18 @@ const I18N = {
     failNote: '리라이트 실패. 다시 시도하거나 모드·키를 확인해 주세요.',
     quotaDaily: '오늘 무료 사용량을 다 쓰셨어요. 내일 다시 시도하거나, 본인 API 키로 BYOK 모드를 쓰면 제한 없이 이용할 수 있어요.',
     quotaHourly: '무료 사용량이 잠시 가득 찼어요. 잠시 후 다시 시도하거나, 본인 API 키로 BYOK 모드를 쓰면 바로 이용할 수 있어요.',
+    quotaConcurrent: '이미 진행 중인 리라이트가 있어요. 끝난 뒤 다시 시도해 주세요.',
+    serviceDown: '리라이트 서비스를 잠시 사용할 수 없어요. 나중에 다시 시도해 주세요.',
+    tooLong: '{tier} 모드 한도({cap}자)를 넘었어요. 줄여서 다시 시도해 주세요.',
+    keyMissing: 'API 모드를 쓰려면 API 키를 입력해 주세요.',
+    stopNote: '중단했어요 — 리라이트가 취소됐어요.',
+    timeoutNote: '서버 응답이 없어 리라이트가 시간 초과됐어요. 다시 시도해 주세요.',
+    netNote: '네트워크 오류: {msg}',
+    retry: '다시 시도',
+    stopLabel: '중단',
   },
   zh: {
-    title: '让文字更<span class="grad">像人写的</span>',
+    title: ['让文字更', '像人写的', ''],
     sub: '粘贴有 AI 味的文字，patina 会自然地改写。支持 KO·EN·ZH·JA。',
     promptPh: '粘贴你想润色的文字…',
     howTitle: '三步搞定',
@@ -126,7 +145,7 @@ const I18N = {
     ctaTitle: '粘贴你的文字试试',
     ctaSub: '把有 AI 味的草稿粘到上面的输入框，无需代码或密钥。',
     ctaBtn: '回到顶部开始 ↑',
-    note: '不改变主张·数字·语气的<br />确定性人性化工具。',
+    note: ['不改变主张·数字·语气的', '确定性人性化工具。'],
     hint: 'patina 只调整措辞，绝不改变主张、数字或因果。本演示通过本地 CLI 改写，MPS/fidelity 为预览值。',
     chatPh: '继续润色…  (Enter 发送 · Shift+Enter 换行)',
     newchat: '新对话',
@@ -135,9 +154,18 @@ const I18N = {
     failNote: '改写失败。请重试，或检查模式 / 密钥。',
     quotaDaily: '今天的免费额度已用完。请明天再试，或切换到 BYOK 模式使用自己的 API 密钥，即可无限制使用。',
     quotaHourly: '免费额度暂时已满。请稍后再试，或使用 BYOK 模式和自己的 API 密钥。',
+    quotaConcurrent: '已有一个改写正在进行。请等它完成后再试。',
+    serviceDown: '改写服务暂时不可用，请稍后再试。',
+    tooLong: '文字超过 {tier} 模式的 {cap} 字上限。请缩短后重试。',
+    keyMissing: '使用 API 模式请先输入 API 密钥。',
+    stopNote: '已停止 — 改写已取消。',
+    timeoutNote: '服务器无响应，改写超时。请重试。',
+    netNote: '网络错误：{msg}',
+    retry: '重试',
+    stopLabel: '停止',
   },
   ja: {
-    title: 'AIっぽさを消して、<span class="grad">自然に</span>',
+    title: ['AIっぽさを消して、', '自然に', ''],
     sub: 'AIっぽい文章を貼り付けると、patinaが自然に書き換えます。KO·EN·ZH·JA対応。',
     promptPh: '整えたい文章を貼り付けてください…',
     howTitle: '3ステップで完了',
@@ -155,7 +183,7 @@ const I18N = {
     ctaTitle: '自分の文章で試す',
     ctaSub: 'AIっぽい下書きを上の入力欄に貼るだけ。コードも鍵も不要。',
     ctaBtn: '上に戻って始める ↑',
-    note: '主張・数字・トーンを変えない<br />決定論的ヒューマナイザー。',
+    note: ['主張・数字・トーンを変えない', '決定論的ヒューマナイザー。'],
     hint: 'patinaは表現だけを整え、主張・数値・因果は変えません。デモはローカルCLIで書き換え、MPS/fidelityはプレビュー値です。',
     chatPh: 'さらに整える…  (Enter送信 · Shift+Enter改行)',
     newchat: '新しいチャット',
@@ -164,6 +192,15 @@ const I18N = {
     failNote: '書き換えに失敗しました。再試行するか、モード・キーを確認してください。',
     quotaDaily: '本日の無料利用枠を使い切りました。明日また試すか、ご自身のAPIキーでBYOKモードに切り替えると無制限で使えます。',
     quotaHourly: '無料利用枠が一時的にいっぱいです。しばらくして再試行するか、ご自身のAPIキーでBYOKモードをお使いください。',
+    quotaConcurrent: 'すでに実行中の書き換えがあります。完了後にもう一度お試しください。',
+    serviceDown: '書き換えサービスは一時的に利用できません。しばらくしてからお試しください。',
+    tooLong: '{tier}モードの上限（{cap}文字）を超えています。短くしてからお試しください。',
+    keyMissing: 'APIモードを使うにはAPIキーを入力してください。',
+    stopNote: '停止しました — 書き換えはキャンセルされました。',
+    timeoutNote: 'サーバーから応答がなくタイムアウトしました。もう一度お試しください。',
+    netNote: 'ネットワークエラー：{msg}',
+    retry: '再試行',
+    stopLabel: '停止',
   },
 };
 
@@ -565,10 +602,53 @@ function detectLang(text) {
 }
 
 // ---------- unified submit ----------
-async function submit(text) {
+/** In-flight rewrite attempt: { controller, cancelled }. One at a time (busy gate). */
+let active = null;
+
+function i18n() { return I18N[els.lang.value] || I18N.en; }
+function tfmt(template, vars) { return String(template).replace(/\{(\w+)\}/g, (_, k) => String(vars[k] ?? '')); }
+function tierLabel(tier) { return tier === WEB_TIERS.BYOK ? 'API' : 'Free'; }
+// Error notes are live alerts so assistive tech announces failures.
+function errorNote(text) { const n = el('div', 'error-note', text); n.setAttribute('role', 'alert'); return n; }
+
+function stopActive() {
+  if (active) { active.cancelled = true; active.controller.abort(); }
+}
+
+function inlineErrorNode(source) { return source === 'chat' ? $('#composer-error') : $('#hero-error'); }
+function clearInlineErrors() {
+  document.querySelectorAll('#hero-error, #composer-error, #key-error').forEach((n) => { /** @type {HTMLElement} */ (n).hidden = true; n.textContent = ''; });
+  els.apiKey.classList.remove('is-invalid');
+}
+function showInlineError(node, msg) { if (!node) return; node.textContent = msg; node.hidden = false; }
+
+// Client preflight mirrors the server contract caps (TIER_LIMITS — the server
+// stays the enforcer) so over-cap or key-less requests never hit the network.
+function preflight(clean, source) {
+  const t = i18n();
+  const tier = els.tier.value;
+  const cap = TIER_LIMITS[tier]?.maxChars;
+  if (cap && clean.length > cap) {
+    showInlineError(inlineErrorNode(source), tfmt(t.tooLong, { cap, tier: tierLabel(tier) }));
+    return false;
+  }
+  if (tier === WEB_TIERS.BYOK && els.apiKey.value.trim().length === 0) {
+    els.apiKey.classList.add('is-invalid');
+    showInlineError($('#key-error'), t.keyMissing);
+    showInlineError(inlineErrorNode(source), t.keyMissing);
+    els.apiKey.focus();
+    return false;
+  }
+  return true;
+}
+
+async function submit(text, source = 'hero') {
   if (state.busy) return;
   const clean = String(text || '').trim();
   if (!clean) return;
+
+  clearInlineErrors();
+  if (!preflight(clean, source)) return;
 
   let convo = activeConvo();
   if (!convo) { newConvo(); convo = activeConvo(); }
@@ -586,8 +666,6 @@ async function submit(text) {
   }
 
   showChat();
-  state.busy = true;
-  updateHeroSend(); updateChatSend();
 
   convo.messages.push({ role: 'user', text: clean });
   if (convo.title === 'New chat') { convo.title = clean.slice(0, 40); renderSidebar(); }
@@ -597,13 +675,9 @@ async function submit(text) {
   inner.appendChild(buildUserMsg(clean));
 
   const { node, body, textEl } = buildPatinaMsg();
-  textEl.style.display = 'none';
-  const typing = buildTyping();
-  body.appendChild(typing);
   inner.appendChild(node);
-  scrollDown();
 
-  els.heroInput.value = ''; autoGrow(els.heroInput); updateHeroSend();
+  els.heroInput.value = ''; autoGrow(els.heroInput);
   els.input.value = ''; autoGrow(els.input);
 
   const reqBody = convo.thread.buildRequest({
@@ -611,12 +685,31 @@ async function submit(text) {
     provider: els.provider.value, model: els.model.value, apiKey: els.apiKey.value,
   });
 
+  await runAttempt({ convo, clean, reqBody, body, textEl });
+}
+
+// One streaming attempt against /api/rewrite. Retry re-invokes this with the
+// same request context; the thread only commits on a done frame, so a failed
+// or cancelled attempt never poisons the conversation state.
+async function runAttempt(attempt) {
+  const { convo, clean, reqBody, body, textEl } = attempt;
+  state.busy = true;
+  updateHeroSend(); updateChatSend();
+  els.thread.setAttribute('aria-busy', 'true');
+
+  textEl.style.display = 'none';
+  textEl.classList.remove('msg__text--flagged');
+  const typing = buildTyping();
+  body.appendChild(typing);
+  scrollDown();
+
   let started = false;
   const start = () => { if (started) return; started = true; if (typing.parentElement) typing.remove(); textEl.style.display = ''; textEl.classList.add('streaming'); };
 
   // Fail-safe: if no stream frame arrives for IDLE_MS, abort so the UI never
   // hangs on a stalled backend (issue #541). The timer re-arms on every frame.
   const controller = new AbortController();
+  active = { controller, cancelled: false };
   const IDLE_MS = 60000;
   let timedOut = false;
   let idleTimer;
@@ -647,57 +740,110 @@ async function submit(text) {
     if (!ok) {
       if (typing.parentElement) typing.remove();
       textEl.classList.remove('streaming');
-      const t = I18N[els.lang.value] || I18N.en;
+      const t = i18n();
       const ff = finalFrame || {};
-      const attempt = typeof ff.rewrite === 'string' ? ff.rewrite.trim() : '';
+      const attemptText = typeof ff.rewrite === 'string' ? ff.rewrite.trim() : '';
       const hasScores = ff.mps != null || ff.fidelity != null;
-      if (attempt || hasScores) {
+      if (attemptText || hasScores) {
         // meaning floor not met: show the flagged attempt + scores + a clear warning (auditable, not silently shipped)
         textEl.style.display = '';
-        textEl.textContent = attempt || cleanStream(textEl.textContent);
+        textEl.textContent = attemptText || cleanStream(textEl.textContent);
         textEl.classList.add('msg__text--flagged');
         body.appendChild(buildMeta({ mps: ff.mps, fidelity: ff.fidelity, signals: ff.signals, diff: ff.diff, floorFailed: true }));
-        body.appendChild(el('div', 'error-note', t.floorWarn));
+        body.appendChild(errorNote(t.floorWarn));
       } else {
         textEl.style.display = 'none';
-        if (ff.status === 429) {
-          const hourly = typeof ff.error === 'string' && /hour/i.test(ff.error);
-          body.appendChild(el('div', 'error-note', hourly ? t.quotaHourly : t.quotaDaily));
-        } else {
-          const status = ff.status ? ` (HTTP ${ff.status})` : '';
-          body.appendChild(el('div', 'error-note', t.failNote + status));
-        }
+        body.appendChild(errorNote(failureMessage(classifyRewriteError(ff), ff, t)));
+        addRetry(body, attempt);
       }
     }
   } catch (e) {
     if (typing.parentElement) typing.remove();
     textEl.style.display = ''; textEl.classList.remove('streaming');
-    const msg = timedOut
-      ? 'Rewrite timed out — no response from the server. Please try again.'
-      : `Network error: ${String(e?.message || e)}`;
-    body.appendChild(el('div', 'error-note', msg));
+    const t = i18n();
+    const cancelled = active ? active.cancelled === true : false;
+    const msg = cancelled ? t.stopNote : timedOut ? t.timeoutNote : tfmt(t.netNote, { msg: String(e?.message || e) });
+    body.appendChild(errorNote(msg));
+    if (!cancelled) addRetry(body, attempt);
   } finally {
     clearTimeout(idleTimer);
+    active = null;
     state.busy = false;
+    els.thread.setAttribute('aria-busy', 'false');
     updateHeroSend(); updateChatSend();
     els.input.focus();
   }
 }
 
+// Stable error-kind → localized copy. Classification is centralized in
+// rewrite-client.js#classifyRewriteError (no ad-hoc string matching here).
+function failureMessage(kind, ff, t) {
+  const K = REWRITE_ERROR_KINDS;
+  switch (kind) {
+    case K.QUOTA_DAILY: return t.quotaDaily;
+    case K.QUOTA_HOURLY: return t.quotaHourly;
+    case K.QUOTA_CONCURRENT: return t.quotaConcurrent;
+    case K.IP_UNAVAILABLE:
+    case K.QUOTA_STORAGE:
+    case K.QUOTA_SECRET:
+    case K.SERVICE_UNAVAILABLE: return t.serviceDown;
+    case K.TEXT_TOO_LONG: {
+      const tier = els.tier.value;
+      return tfmt(t.tooLong, { cap: TIER_LIMITS[tier]?.maxChars ?? '', tier: tierLabel(tier) });
+    }
+    default: return t.failNote + (ff.status ? ` (HTTP ${ff.status})` : '');
+  }
+}
+
+// Retry a failed (non-floor) attempt: one resubmission per user activation.
+// Prior error UI is cleared; the thread still only commits on a done frame.
+function addRetry(body, attempt) {
+  const btn = el('button', 'retrybtn', i18n().retry);
+  btn.type = 'button';
+  btn.addEventListener('click', () => {
+    if (state.busy) return; // another attempt is streaming; keep the button for later
+    body.querySelectorAll('.error-note, .retrybtn').forEach((n) => n.remove());
+    runAttempt(attempt);
+  });
+  body.appendChild(btn);
+  scrollDown();
+}
+
 // ---------- composer UX ----------
 function autoGrow(node) { node.style.height = 'auto'; node.style.height = Math.min(node.scrollHeight, 200) + 'px'; }
-function updateHeroSend() { els.heroSend.disabled = state.busy || els.heroInput.value.trim().length === 0; }
-function updateChatSend() { els.send.disabled = state.busy || els.input.value.trim().length === 0; }
+function byokBlocked() { return els.tier.value === WEB_TIERS.BYOK && els.apiKey.value.trim().length === 0; }
+// While streaming, the send buttons become enabled Stop controls (is-stop).
+function syncSendButton(btn, input) {
+  btn.classList.toggle('is-stop', state.busy);
+  btn.setAttribute('aria-label', state.busy ? i18n().stopLabel : 'Send');
+  btn.disabled = state.busy ? false : (input.value.trim().length === 0 || byokBlocked());
+}
+function updateHeroSend() { syncSendButton(els.heroSend, els.heroInput); }
+function updateChatSend() { syncSendButton(els.send, els.input); }
 function scrollDown() { els.thread.scrollTop = els.thread.scrollHeight; }
-function closeMobileSidebar() { els.chat.classList.remove('sidebar-open'); }
+function closeMobileSidebar() { els.chat.classList.remove('sidebar-open'); els.toggleSidebar.setAttribute('aria-expanded', 'false'); }
 
 function applyI18n(lang) {
   const t = I18N[lang] || I18N.en;
   const set = (sel, text) => { const n = document.querySelector(sel); if (n) n.textContent = text; };
-  const setHtml = (sel, html) => { const n = document.querySelector(sel); if (n) n.innerHTML = html; };
-  setHtml('.hero__title', t.title);
+  // Structured copy is rendered via DOM nodes (textContent + createElement), so
+  // localized strings are never parsed as HTML (no innerHTML injection surface).
+  const setTitle = (sel, parts) => {
+    const n = document.querySelector(sel); if (!n) return;
+    n.textContent = parts[0];
+    n.appendChild(el('span', 'grad', parts[1]));
+    if (parts[2]) n.appendChild(document.createTextNode(parts[2]));
+  };
+  const setLines = (sel, lines) => {
+    const n = document.querySelector(sel); if (!n) return;
+    n.textContent = '';
+    lines.forEach((line, i) => { if (i) n.appendChild(document.createElement('br')); n.appendChild(document.createTextNode(line)); });
+  };
+  document.documentElement.lang = lang;
+  setTitle('.hero__title', t.title);
   set('.hero__sub', t.sub);
   els.heroInput.setAttribute('placeholder', t.promptPh);
+  els.heroInput.setAttribute('aria-label', t.promptPh);
   set('.how .sec__title', t.howTitle);
   const stepEls = document.querySelectorAll('.how__steps li');
   t.steps.forEach((s, i) => { const li = stepEls[i]; if (!li) return; const h = li.querySelector('h3'); const p = li.querySelector('p'); if (h) h.textContent = s[0]; if (p) p.textContent = s[1]; });
@@ -716,9 +862,10 @@ function applyI18n(lang) {
   set('.cta__title', t.ctaTitle);
   set('.cta__sub', t.ctaSub);
   set('#cta-start', t.ctaBtn);
-  setHtml('.sidebar__note', t.note);
+  setLines('.sidebar__note', t.note);
   set('.composer__hint', t.hint);
   els.input.setAttribute('placeholder', t.chatPh);
+  els.input.setAttribute('aria-label', t.chatPh);
   const nc = document.querySelector('#new-chat span:last-child'); if (nc) nc.textContent = t.newchat;
   const ex = EXAMPLES.find((e) => e.lang === lang) || EXAMPLES[0];
   const setPreview = (sel, tag, text) => { const n = document.querySelector(sel); if (!n) return; n.textContent = ''; n.appendChild(el('span', 'hp-tag', tag)); n.appendChild(document.createTextNode(text)); };
@@ -729,26 +876,36 @@ function applyI18n(lang) {
 function onLangChange() {
   applyI18n(els.lang.value);
   renderSuggest();
+  // Re-localize stateful button labels (e.g. an active Stop control's aria-label).
+  updateHeroSend(); updateChatSend();
   const convo = activeConvo();
   if (convo && convo.messages.length === 0) convo.thread = createRewriteThread({ lang: els.lang.value });
 }
 
 // ---------- events ----------
-els.heroForm.addEventListener('submit', (e) => { e.preventDefault(); submit(els.heroInput.value); });
+els.heroForm.addEventListener('submit', (e) => { e.preventDefault(); if (state.busy) { stopActive(); return; } submit(els.heroInput.value, 'hero'); });
 els.heroInput.addEventListener('input', () => { autoGrow(els.heroInput); updateHeroSend(); });
-els.heroInput.addEventListener('keydown', (e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submit(els.heroInput.value); } });
+els.heroInput.addEventListener('keydown', (e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); if (!state.busy) submit(els.heroInput.value, 'hero'); } });
 
-els.composer.addEventListener('submit', (e) => { e.preventDefault(); submit(els.input.value); });
+els.composer.addEventListener('submit', (e) => { e.preventDefault(); if (state.busy) { stopActive(); return; } submit(els.input.value, 'chat'); });
 els.input.addEventListener('input', () => { autoGrow(els.input); updateChatSend(); });
-els.input.addEventListener('keydown', (e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submit(els.input.value); } });
+els.input.addEventListener('keydown', (e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); if (!state.busy) submit(els.input.value, 'chat'); } });
 
-els.newChat.addEventListener('click', () => { newConvo(); showChat(); els.input.value = ''; autoGrow(els.input); updateChatSend(); closeMobileSidebar(); els.input.focus(); });
-els.toggleSidebar.addEventListener('click', () => { els.chat.classList.toggle('sidebar-open'); });
+els.newChat.addEventListener('click', () => { if (state.busy) stopActive(); newConvo(); showChat(); els.input.value = ''; autoGrow(els.input); updateChatSend(); closeMobileSidebar(); els.input.focus(); });
+els.toggleSidebar.addEventListener('click', () => {
+  const open = els.chat.classList.toggle('sidebar-open');
+  els.toggleSidebar.setAttribute('aria-expanded', String(open));
+});
 els.homeLink.addEventListener('click', (e) => { e.preventDefault(); showLanding(); globalThis.scrollTo({ top: 0, behavior: 'smooth' }); });
 els.ctaStart && els.ctaStart.addEventListener('click', () => { globalThis.scrollTo({ top: 0, behavior: 'smooth' }); els.heroInput.focus(); });
 
 els.lang.addEventListener('change', onLangChange);
-els.tier.addEventListener('change', syncTier);
+els.tier.addEventListener('change', () => { syncTier(); clearInlineErrors(); updateHeroSend(); updateChatSend(); });
+els.apiKey.addEventListener('input', () => {
+  els.apiKey.classList.remove('is-invalid');
+  const ke = $('#key-error'); if (ke) { ke.hidden = true; ke.textContent = ''; }
+  updateHeroSend(); updateChatSend();
+});
 els.provider.addEventListener('change', populateModels);
 
 // ---------- init ----------

--- a/playground/index.html
+++ b/playground/index.html
@@ -58,7 +58,8 @@
         </label>
         <label class="ctl ctl--byok ctl--key" id="key-ctl">
           <span class="ctl__label">API key</span>
-          <input id="api-key" class="ctl__input" type="password" autocomplete="off" placeholder="sk-… (kept in your browser)" />
+          <input id="api-key" class="ctl__input" type="password" autocomplete="off" placeholder="sk-… (kept in your browser)" aria-label="API key (kept in your browser)" />
+          <span class="ctl__err" id="key-error" role="alert" hidden></span>
         </label>
       </div>
     </header>
@@ -72,12 +73,14 @@
           <p class="hero__sub">Paste AI-sounding text — patina rewrites it naturally. KO·EN·ZH·JA.</p>
 
           <form class="prompt" id="hero-form">
-            <textarea class="prompt__input" id="hero-input" rows="1" placeholder="Paste the text you want to clean up…" autofocus></textarea>
+            <textarea class="prompt__input" id="hero-input" rows="1" placeholder="Paste the text you want to clean up…" aria-label="Paste the text you want to clean up…" autofocus></textarea>
             <div class="prompt__bar">
               <button class="prompt__send" id="hero-send" type="submit" disabled aria-label="Send">
-                <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M12 4l-7 7h4v7h6v-7h4z"/></svg>
+                <svg class="ic-send" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M12 4l-7 7h4v7h6v-7h4z"/></svg>
+                <svg class="ic-stop" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><rect x="6" y="6" width="12" height="12" rx="2" fill="currentColor"/></svg>
               </button>
             </div>
+            <p class="prompt__error" id="hero-error" role="alert" hidden></p>
           </form>
 
           <div class="suggest" id="suggest"></div>
@@ -185,17 +188,19 @@
 
       <main class="chatmain">
         <header class="chatbar">
-          <button class="iconbtn" id="toggle-sidebar" type="button" aria-label="Toggle sidebar">☰</button>
+          <button class="iconbtn" id="toggle-sidebar" type="button" aria-label="Toggle sidebar" aria-controls="sidebar" aria-expanded="false">☰</button>
           <span class="chatbar__title">patina</span>
         </header>
-        <div class="thread" id="thread"></div>
+        <div class="thread" id="thread" role="log" aria-live="polite" aria-relevant="additions text" aria-busy="false"></div>
         <div class="composer-wrap">
           <form class="composer" id="composer">
-            <textarea id="input" class="composer__input" rows="1" placeholder="Keep refining…  (Enter to send · Shift+Enter for newline)"></textarea>
+            <textarea id="input" class="composer__input" rows="1" placeholder="Keep refining…  (Enter to send · Shift+Enter for newline)" aria-label="Keep refining…  (Enter to send · Shift+Enter for newline)"></textarea>
             <button class="composer__send" id="send" type="submit" aria-label="Send" disabled>
-              <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M12 4l-7 7h4v7h6v-7h4z"/></svg>
+              <svg class="ic-send" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M12 4l-7 7h4v7h6v-7h4z"/></svg>
+              <svg class="ic-stop" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><rect x="6" y="6" width="12" height="12" rx="2" fill="currentColor"/></svg>
             </button>
           </form>
+          <p class="composer__error" id="composer-error" role="alert" hidden></p>
           <p class="composer__hint">patina changes only the wording — never the claim, numbers, or causation. This demo rewrites via a local CLI; MPS/fidelity are preview values.</p>
         </div>
       </main>

--- a/playground/rewrite-client.js
+++ b/playground/rewrite-client.js
@@ -3,6 +3,7 @@
 
 import {
   CONTEXT_LIMITS,
+  QUOTA_REASONS,
   REWRITE_MODES,
   STREAM_FRAME_TYPES,
   WEB_TIERS,
@@ -203,4 +204,54 @@ export async function streamRewrite({
   const frame = { type: STREAM_FRAME_TYPES.ERROR, error: 'stream ended before done' };
   onError?.(frame);
   return { ok: false, finalFrame: frame };
+}
+
+/**
+ * Stable error kinds for terminal rewrite failures. The UI maps these to
+ * localized copy; server reason strings are recognized in exactly one place
+ * (here) instead of ad-hoc substring checks scattered through the controller.
+ */
+export const REWRITE_ERROR_KINDS = Object.freeze({
+  QUOTA_DAILY: 'quota_daily',
+  QUOTA_HOURLY: 'quota_hourly',
+  QUOTA_CONCURRENT: 'quota_concurrent',
+  IP_UNAVAILABLE: 'ip_unavailable',
+  QUOTA_STORAGE: 'quota_storage',
+  QUOTA_SECRET: 'quota_secret',
+  SERVICE_UNAVAILABLE: 'service_unavailable',
+  TEXT_TOO_LONG: 'text_too_long',
+  FLOOR_FAILED: 'floor_failed',
+  UNKNOWN: 'unknown',
+});
+
+/**
+ * Classify a terminal error frame ({status?, code?, error?}) into a stable
+ * REWRITE_ERROR_KINDS value. Reason strings come from the shared contract's
+ * QUOTA_REASONS (single source of truth for src/rate-limit.js, api/rewrite.js,
+ * and this classifier) plus validateRewriteRequest's 413
+ * 'text exceeds N characters for tier T'. Unrecognized 429s fall back to
+ * QUOTA_HOURLY (retry-shortly copy is the least misleading), unrecognized
+ * 5xx to SERVICE_UNAVAILABLE.
+ *
+ * @param {Record<string, unknown>|null|undefined} frame
+ * @returns {string} one of REWRITE_ERROR_KINDS
+ */
+export function classifyRewriteError(frame) {
+  const K = REWRITE_ERROR_KINDS;
+  const R = QUOTA_REASONS;
+  const status = Number(frame?.status);
+  const code = typeof frame?.code === 'string' ? frame.code : '';
+  const reason = typeof frame?.error === 'string' ? frame.error.toLowerCase() : '';
+  if (code === 'floor_failed') return K.FLOOR_FAILED;
+  if (reason.includes(R.DAILY)) return K.QUOTA_DAILY;
+  if (reason.includes(R.HOURLY)) return K.QUOTA_HOURLY;
+  if (reason.includes(R.CONCURRENT)) return K.QUOTA_CONCURRENT;
+  if (reason.includes(R.IP_UNAVAILABLE)) return K.IP_UNAVAILABLE;
+  if (reason.includes(R.STORAGE_UNAVAILABLE)) return K.QUOTA_STORAGE;
+  if (reason.includes(R.SECRET_UNAVAILABLE)) return K.QUOTA_SECRET;
+  if (reason.includes(R.SERVICE_UNAVAILABLE)) return K.SERVICE_UNAVAILABLE;
+  if (status === 413 || (reason.includes('exceeds') && reason.includes('characters'))) return K.TEXT_TOO_LONG;
+  if (status === 429) return K.QUOTA_HOURLY;
+  if (status === 502 || status === 503 || status === 504) return K.SERVICE_UNAVAILABLE;
+  return K.UNKNOWN;
 }

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -1,0 +1,394 @@
+#!/usr/bin/env node
+// @ts-check
+// Local, rewrite-aware preview/test server for the patina playground.
+//
+// Why this exists: `vercel dev` needs project linking AND an OpenAI key for the
+// free tier (PATINA_FREE_API_KEY) — neither is required to test the *frontend*.
+// This server mirrors the vercel.json static rewrites and mounts the REAL
+// /api/rewrite handler + REAL runWebRewriteStream contract path, stubbing ONLY
+// the three LLM network calls (rewrite + MPS + fidelity). The deterministic
+// signal layer (scoreDeterministicSignals) still runs for real, so the
+// before -> after AI-signal arrow is genuine. MPS/fidelity are fixed preview
+// values — the composer hint already calls them out as preview.
+//
+// Usage: node scripts/dev-server.mjs [--port 4178] [--host 0.0.0.0]
+// This is a dev/test harness only. Do NOT deploy it.
+
+import http from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createRewriteHandler } from '../src/rewrite-handler.js';
+import { encodeStreamFrame } from '../src/web-rewrite-contract.js';
+import { runWebRewriteStream } from '../src/web-rewrite-stream.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+// Optional real-LLM mode for experimentation: when PATINA_DEV_LLM_* are set, the
+// dev server runs the REAL patina rewrite via that OpenAI-compatible endpoint
+// (e.g. OpenCode Zen -> DeepSeek). Scoring stays stubbed unless _SCORE=real, since
+// the extra judge calls are slow on free models and add no signal to a rewrite test.
+const DEV_LLM = {
+  baseURL: process.env.PATINA_DEV_LLM_BASE_URL,
+  apiKey: process.env.PATINA_DEV_LLM_KEY,
+  model: process.env.PATINA_DEV_LLM_MODEL,
+  realScore: process.env.PATINA_DEV_LLM_SCORE === 'real',
+};
+const DEV_LLM_ON = Boolean(DEV_LLM.baseURL && DEV_LLM.apiKey && DEV_LLM.model);
+
+// ---------- args ----------
+function parseArgs(argv) {
+  const out = { port: 4178, host: '0.0.0.0' };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--port' || a === '-p') out.port = Number(argv[++i]);
+    else if (a === '--host' || a === '-h') out.host = String(argv[++i]);
+  }
+  if (!Number.isInteger(out.port) || out.port <= 0) out.port = 4178;
+  return out;
+}
+
+// ---------- static: vercel.json rewrites + repo-tree fallback ----------
+const REWRITES = new Map([
+  ['/', '/playground/index.html'],
+  ['/chatgpt.js', '/playground/chatgpt.js'],
+  ['/chatgpt.css', '/playground/chatgpt.css'],
+  ['/rewrite-client.js', '/playground/rewrite-client.js'],
+  ['/analytics.js', '/playground/analytics.js'],
+]);
+
+const CONTENT_TYPES = new Map([
+  ['.html', 'text/html; charset=utf-8'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.mjs', 'text/javascript; charset=utf-8'],
+  ['.css', 'text/css; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.svg', 'image/svg+xml'],
+  ['.png', 'image/png'],
+  ['.jpg', 'image/jpeg'],
+  ['.jpeg', 'image/jpeg'],
+  ['.webp', 'image/webp'],
+  ['.ico', 'image/x-icon'],
+  ['.woff2', 'font/woff2'],
+  ['.map', 'application/json; charset=utf-8'],
+]);
+
+function contentTypeFor(filePath) {
+  return CONTENT_TYPES.get(path.extname(filePath).toLowerCase()) || 'application/octet-stream';
+}
+
+async function serveStatic(req, res, urlPath) {
+  // Reject malformed percent-encoding (or an encoded NUL) on the RAW request
+  // path FIRST — before the rewrite/SPA fallback below can mask a garbage
+  // extension-less path (e.g. /%ff, /%E0%A4%A, /%00) with a 200 index page.
+  // Malformed encoding is a client error (400), never an internal 500.
+  try {
+    if (decodeURIComponent(urlPath).includes('\u0000')) {
+      res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' }).end('400 Bad Request: malformed path encoding');
+      return;
+    }
+  } catch {
+    res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' }).end('400 Bad Request: malformed path encoding');
+    return;
+  }
+
+  // Apply vercel.json rewrites; default unknown extension-less paths to "/".
+  let rel = REWRITES.get(urlPath) || urlPath;
+  if (rel === urlPath && !path.extname(urlPath)) rel = REWRITES.get('/'); // SPA-ish fallback
+
+  const decoded = decodeURIComponent(rel);
+  const abs = path.resolve(REPO_ROOT, '.' + decoded);
+  // Path-traversal guard: never serve outside the repo root.
+  if (abs !== REPO_ROOT && !abs.startsWith(REPO_ROOT + path.sep)) {
+    res.writeHead(403).end('forbidden');
+    return;
+  }
+  try {
+    const info = await stat(abs);
+    if (info.isDirectory()) { res.writeHead(403).end('forbidden'); return; }
+    const buf = await readFile(abs);
+    res.writeHead(200, {
+      'Content-Type': contentTypeFor(abs),
+      'Cache-Control': 'no-store',
+      'Content-Length': buf.length,
+    });
+    // HEAD must return headers only — never a body (RFC 9110 §9.3.2).
+    res.end(req.method === 'HEAD' ? undefined : buf);
+  } catch {
+    res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' }).end('404 Not Found: ' + urlPath);
+  }
+}
+
+// ---------- mock LLM (only the network calls are faked) ----------
+const HUMANIZE = {
+  en: [
+    [/\bWe are (?:thrilled|excited|delighted|pleased|proud) to announce that\b/gi, 'We are announcing'],
+    [/\bI am (?:thrilled|excited|delighted|pleased|proud) to (?:announce|share) that\b/gi, 'I want to share that'],
+    [/\bin today(?:'|’)s (?:fast-paced|rapidly evolving|ever-evolving|digital|modern) (?:world|landscape|age|era)\b,?\s*/gi, 'Today, '],
+    [/\bin the (?:ever-evolving|rapidly changing|dynamic) (?:world|landscape) of\b/gi, 'in'],
+    [/\bit(?:'|’)s (?:important|worth|crucial|essential) to (?:note|mention|remember|understand) that\b,?\s*/gi, ''],
+    [/\bit is (?:important|worth|crucial|essential) to (?:note|mention|remember|understand) that\b,?\s*/gi, ''],
+    [/\bplays? a (?:crucial|key|pivotal|significant|vital|critical) role in\b/gi, 'is key to'],
+    [/\bplays? a (?:crucial|key|pivotal|significant|vital|critical) role\b/gi, 'matters'],
+    [/\ba testament to\b/gi, 'proof of'],
+    [/\b(?:delve|dive|delves|dives) (?:deep(?:er|ly)? )?into\b/gi, 'look at'],
+    [/\b(?:delving|diving) (?:deep(?:er|ly)? )?into\b/gi, 'looking at'],
+    [/\bnavigat(?:e|es|ing) the (?:complexities|landscape|challenges) of\b/gi, 'handle'],
+    [/\bunlock(?:ing)? the (?:full )?potential of\b/gi, 'get the most from'],
+    [/\bcutting-edge,?\s*/gi, ''],
+    [/\bbest-in-class,?\s*/gi, ''],
+    [/\bstate-of-the-art,?\s*/gi, ''],
+    [/\bworld-class\s*/gi, 'solid '],
+    [/\bgroundbreaking\b/gi, 'new'],
+    [/\bgame[- ]?changer\b/gi, 'big deal'],
+    [/\btransformative\b/gi, 'big'],
+    [/\brevolutioniz(?:e|es|ed|ing)\b/gi, 'change'],
+    [/\bleverag(?:e|es|ed|ing)\b/gi, 'use'],
+    [/\butiliz(?:e|es|ed|ing)\b/gi, 'use'],
+    [/\bharness(?:ing|es|ed)?\b/gi, 'use'],
+    [/\bsynerg(?:y|ies)\b/gi, 'teamwork'],
+    [/\bseamless(?:ly)?\s*/gi, ''],
+    [/\bstreamlin(?:e|es|ed|ing)\b/gi, 'simplify'],
+    [/\brobust\b/gi, 'solid'],
+    [/\bcomprehensive\b/gi, 'complete'],
+    [/\bnuanced\b/gi, 'subtle'],
+    [/\b(?:complexities|intricacies)\b/gi, 'details'],
+    [/\bcrucial\b/gi, 'key'],
+    [/\bpivotal\b/gi, 'key'],
+    [/\bmultifaceted\b/gi, 'broad'],
+    [/\bmeaningful\b/gi, 'real'],
+    [/\btangible\b/gi, 'real'],
+    [/\bfoster(?:ing|s|ed)?\b/gi, 'build'],
+    [/\bempower(?:ing|s|ed)?\b/gi, 'help'],
+    [/\belevat(?:e|es|ed|ing)\b/gi, 'raise'],
+    [/\bunderscore(?:s|d)?\b/gi, 'show'],
+    [/\bhighlights? the importance of\b/gi, 'shows the value of'],
+    [/\bfurther enhance\b/gi, 'improve'],
+    [/\b(?:furthermore|moreover|additionally)\b,?\s*/gi, 'Also, '],
+    [/\bensur(?:e|es|ed|ing)\b/gi, 'make sure'],
+    [/\bembark(?:ing)? on a journey\b/gi, 'start'],
+    [/\bat scale\b/gi, ''],
+    [/\bIn (?:conclusion|summary),?\s*/gi, 'So '],
+    [/\bOverall,\s*/gi, ''],
+    [/\s—\s/g, ', '],
+  ],
+  ko: [
+    [/본 (솔루션|제품|서비스|보고서|글)은/g, '이 $1은'],
+    [/혁신적인\s*/g, ''],
+    [/혁명적인\s*/g, ''],
+    [/획기적인\s*/g, '새로운 '],
+    [/혁명을 이끌고\s*/g, '크게 바꾸고 '],
+    [/패러다임/g, '방식'],
+    [/근본적으로\s*/g, '크게 '],
+    [/궁극적으로,?\s*/g, '결국 '],
+    [/전례 없는/g, '큰'],
+    [/시너지를 활용하여/g, '협업으로'],
+    [/시너지/g, '협업'],
+    [/극대화하는/g, '크게 높이는'],
+    [/극대화하고/g, '크게 높이고'],
+    [/극대화/g, '크게 높임'],
+    [/원활하게\s*/g, ''],
+    [/제고하는/g, '높이는'],
+    [/제고/g, '향상'],
+    [/사료됩니다/g, '생각합니다'],
+    [/사료된다/g, '생각한다'],
+    [/진심으로 기쁘게 생각합니다/g, '기쁩니다'],
+    [/기쁘게 생각합니다/g, '기쁩니다'],
+    [/결론적으로,?\s*/g, '정리하면 '],
+    [/다각적인/g, '다양한'],
+    [/다각화된/g, '다양한'],
+    [/선보이게 되어/g, '내놓게 되어'],
+    [/에 기여할 것으로/g, '에 도움이 될 것으로'],
+  ],
+  zh: [
+    [/总而言之[，,]?/g, '总之，'],
+    [/综上所述[，,]?/g, '总的来说，'],
+    [/在(?:当今)?数字时代[，,]?/g, '现在，'],
+    [/值得注意的是[，,]?/g, '注意，'],
+    [/充分利用/g, '用'],
+    [/前沿协同效应/g, '协作'],
+    [/协同效应/g, '协作'],
+    [/无缝\s*/g, ''],
+    [/赋能/g, '帮助'],
+    [/前所未有的/g, '很大的'],
+    [/综合性的?/g, '完整的'],
+    [/极大地提升/g, '提升'],
+    [/全面提升/g, '提升'],
+    [/多元化的方法/g, '多种方法'],
+    [/打造/g, '做'],
+    [/助力/g, '帮助'],
+    [/从长远来看[，,]?/g, '长远看，'],
+    [/良性循环/g, '正向循环'],
+    [/奠定(?:了)?(?:坚实的)?基础/g, '打基础'],
+    [/释放/g, '带来'],
+  ],
+  ja: [
+    [/結論として[、,]?\s*/g, 'まとめると、'],
+    [/(?:近年では|昨今)[、,]?\s*/g, '最近は、'],
+    [/(?:デジタル時代|現代社会)において[、,]?\s*/g, '今は、'],
+    [/革新的な\s*/g, ''],
+    [/画期的な\s*/g, '新しい'],
+    [/シナジーを活用し[、,]?/g, '連携して'],
+    [/シナジー/g, '連携'],
+    [/シームレスに?\s*/g, ''],
+    [/かつてない/g, '大きな'],
+    [/一層向上させる/g, '高める'],
+    [/多角的なアプローチ/g, 'いろいろな取り組み'],
+    [/重要なのは/g, '大事なのは'],
+    [/が求められます/g, 'が必要です'],
+    [/切り開く/g, '広げる'],
+  ],
+};
+
+function humanize(text, lang) {
+  let out = String(text ?? '');
+  for (const [re, rep] of (HUMANIZE[lang] || HUMANIZE.en)) out = out.replace(re, rep);
+  // Tidy whitespace left behind by removals, then re-capitalize a latin opener
+  // (dropping a leading phrase like "It's important to note that " can expose a
+  // lowercase first word).
+  out = out.replace(/[ \t]{2,}/g, ' ').replace(/\s+([,.!?;:。、！？])/g, '$1').trim();
+  out = out.replace(/^([a-z])/, (m) => m.toUpperCase());
+  return out || String(text ?? '');
+}
+
+function* chunkText(text) {
+  // Stream in small grapheme-ish chunks so the UI shows the typing animation
+  // across both space-delimited (latin) and CJK scripts.
+  const size = 4;
+  for (let i = 0; i < text.length; i += size) yield text.slice(i, i + size);
+}
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Dev /api/rewrite runner.
+ * - PATINA_DEV_LLM_* set -> REAL patina rewrite via that endpoint (e.g. DeepSeek
+ *   through OpenCode Zen); scoring stubbed unless PATINA_DEV_LLM_SCORE=real.
+ * - BYOK + a real key     -> the REAL patina pipeline on the contract's provider.
+ * - free / no key          -> deterministic offline humanizer; ONLY the LLM network
+ *   calls are stubbed (asset/prompt loading, frame protocol, floors, diff, and
+ *   the deterministic signal layer are the real production code path).
+ * @param {{request: any, emit: (frame: any) => void}} args
+ */
+async function mockRunWebRewriteStream({ request, emit }) {
+  // Experimental real LLM (any OpenAI-compatible endpoint), applied to all tiers.
+  if (DEV_LLM_ON) {
+    const realReq = { ...request, baseURL: DEV_LLM.baseURL, apiKey: DEV_LLM.apiKey, model: DEV_LLM.model };
+    const scoreFns = DEV_LLM.realScore ? undefined : {
+      scoreMPS: async () => ({ mps: 90, verdict: 'preview' }),
+      scoreFidelity: async () => ({ fidelity: 88, verdict: 'preview' }),
+    };
+    return runWebRewriteStream({ request: realReq, repoRoot: REPO_ROOT, ...(scoreFns ? { scoreFns } : {}), emit });
+  }
+
+  // Real end-to-end when the caller supplied their own provider key (BYOK).
+  if (request.tier === 'byok' && request.apiKey && request.apiKey !== apiEnv.PATINA_FREE_API_KEY) {
+    return runWebRewriteStream({ request, repoRoot: REPO_ROOT, emit });
+  }
+
+  const humanized = humanize(request.text, request.lang);
+
+  /** Stub the streaming rewrite call: stream `humanized`, return it. */
+  const callLLMStream = async ({ onDelta }) => {
+    for (const chunk of chunkText(humanized)) {
+      onDelta?.(chunk);
+      await delay(22);
+    }
+    return { text: humanized };
+  };
+
+  /** Stub the two LLM judge calls with fixed passing preview scores. */
+  const scoreFns = {
+    scoreMPS: async () => ({ mps: 92, verdict: 'preview' }),
+    scoreFidelity: async () => ({ fidelity: 88, verdict: 'preview' }),
+    // scoreDeterministicSignals intentionally omitted -> real deterministic layer runs.
+  };
+
+  return runWebRewriteStream({
+    request,
+    repoRoot: REPO_ROOT,
+    callLLMStream,
+    scoreFns,
+    emit,
+  });
+}
+
+// ---------- /api/rewrite handler (real handler, mocked runner) ----------
+const apiEnv = {
+  // Resolved server-side for parity with api/rewrite.js; the mock runner ignores
+  // it. Never a real provider key.
+  PATINA_FREE_API_KEY: 'local-mock-key',
+  // Non-production posture (in-memory quota path); the limiter below is allow-all.
+  NODE_ENV: 'development',
+};
+
+// Real handler shell + REAL contract validation, but with an allow-all rate
+// limiter so frontend iteration is not throttled by the production free-tier
+// quota (5/hour). Production (api/rewrite.js) keeps the fail-closed KV+HMAC
+// quota — this relaxation is local-test-only.
+const rewriteApi = createRewriteHandler({
+  env: apiEnv,
+  rateLimiter: { check: async ({ tier }) => ({ allowed: true, tier }) },
+  logger: { error: console.error },
+  runRewrite: async ({ res, request }) => {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.setHeader('Cache-Control', 'no-store');
+    await mockRunWebRewriteStream({
+      request: { ...request, apiKey: request.apiKey ?? apiEnv.PATINA_FREE_API_KEY },
+      emit: (frame) => res.write(encodeStreamFrame(frame)),
+    });
+    res.end();
+  },
+});
+
+// ---------- server ----------
+const { port, host } = parseArgs(process.argv.slice(2));
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url || '/', 'http://localhost');
+  const urlPath = url.pathname;
+
+  if (urlPath === '/api/rewrite') {
+    // The fail-closed rate limiter needs a client IP from a trusted header; a
+    // local browser request has none, so inject one for the in-memory quota.
+    req.headers['x-real-ip'] = req.socket.remoteAddress || '127.0.0.1';
+    res.setHeader('X-Patina-Mock', DEV_LLM_ON ? '0' : '1');
+    rewriteApi(req, res).catch((err) => {
+      console.error('rewrite handler error:', err);
+      if (!res.headersSent) res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'internal error' }));
+    });
+    return;
+  }
+
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.writeHead(405).end('method not allowed');
+    return;
+  }
+  serveStatic(req, res, urlPath).catch((err) => {
+    console.error('static error:', err);
+    if (!res.headersSent) res.writeHead(500).end('internal error');
+  });
+});
+
+server.on('error', (err) => {
+  if (/** @type {any} */ (err)?.code === 'EADDRINUSE') {
+    console.error(`Port ${port} is in use. Re-run with --port <free-port>.`);
+    process.exit(1);
+  }
+  throw err;
+});
+
+server.listen(port, host, () => {
+  const shown = host === '0.0.0.0' ? 'localhost' : host;
+  console.log('');
+  const mode = DEV_LLM_ON
+    ? `REAL LLM via ${DEV_LLM.model} @ ${DEV_LLM.baseURL} (scoring ${DEV_LLM.realScore ? 'real' : 'stubbed'})`
+    : 'offline humanizer mock (free) / real BYOK';
+  console.log('  patina playground dev server');
+  console.log(`  → http://${shown}:${port}/`);
+  console.log(`  → /api/rewrite: ${mode}`);
+  console.log('');
+});

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { createHmac } from 'node:crypto';
-import { TIER_LIMITS, WEB_TIERS } from './web-rewrite-contract.js';
+import { QUOTA_REASONS, TIER_LIMITS, WEB_TIERS } from './web-rewrite-contract.js';
 
 const DAY_MS = 86_400_000;
 const HOUR_MS = 3_600_000;
@@ -119,10 +119,10 @@ export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.n
   const getConcurrencyKey = (tier, ip) => {
     if (tier === WEB_TIERS.BYOK) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: true, tier }) };
     const production = isProductionPosture(env);
-    if (production && (!kv || kv.__memory)) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: 'quota storage unavailable' }) };
-    if (production && !hmacSecret) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: 'quota secret unavailable' }) };
-    if (!kv) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: 'quota storage unavailable' }) };
-    if (!ip) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 400, reason: 'client ip unavailable' }) };
+    if (production && (!kv || kv.__memory)) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE }) };
+    if (production && !hmacSecret) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: QUOTA_REASONS.SECRET_UNAVAILABLE }) };
+    if (!kv) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE }) };
+    if (!ip) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 400, reason: QUOTA_REASONS.IP_UNAVAILABLE }) };
     const secret = hmacSecret || 'patina-local-quota-secret';
     return { ok: true, key: quotaKeyHmac(secret, 'free', 'concurrent', ip) };
   };
@@ -144,10 +144,10 @@ export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.n
       if (tier === WEB_TIERS.BYOK) return { allowed: true, tier };
 
       const production = isProductionPosture(env);
-      if (production && (!kv || kv.__memory)) return { allowed: false, status: 503, reason: 'quota storage unavailable' };
-      if (production && !hmacSecret) return { allowed: false, status: 503, reason: 'quota secret unavailable' };
-      if (!kv) return { allowed: false, status: 503, reason: 'quota storage unavailable' };
-      if (!ip) return { allowed: false, status: 400, reason: 'client ip unavailable' };
+      if (production && (!kv || kv.__memory)) return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
+      if (production && !hmacSecret) return { allowed: false, status: 503, reason: QUOTA_REASONS.SECRET_UNAVAILABLE };
+      if (!kv) return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
+      if (!ip) return { allowed: false, status: 400, reason: QUOTA_REASONS.IP_UNAVAILABLE };
 
       const secret = hmacSecret || 'patina-local-quota-secret';
       const timestamp = now();
@@ -166,21 +166,21 @@ export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.n
         // would otherwise fail OPEN on a public abuse boundary.
         const dayCount = await kv.incr(dayKey, { ttlMs: dayTtlMs });
         if (!Number.isSafeInteger(dayCount) || dayCount < 1) {
-          return { allowed: false, status: 503, reason: 'quota storage unavailable' };
+          return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
         }
         if (dayCount > freeLimits.reqPerDay) {
-          return { allowed: false, status: 429, reason: 'daily quota exceeded' };
+          return { allowed: false, status: 429, reason: QUOTA_REASONS.DAILY };
         }
         const hourCount = await kv.incr(hourKey, { ttlMs: hourTtlMs });
         if (!Number.isSafeInteger(hourCount) || hourCount < 1) {
-          return { allowed: false, status: 503, reason: 'quota storage unavailable' };
+          return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
         }
         if (hourCount > freeLimits.burstPerHour) {
-          return { allowed: false, status: 429, reason: 'hourly burst exceeded' };
+          return { allowed: false, status: 429, reason: QUOTA_REASONS.HOURLY };
         }
         return { allowed: true, tier, remainingDay: Math.max(0, freeLimits.reqPerDay - dayCount) };
       } catch {
-        return { allowed: false, status: 503, reason: 'quota storage unavailable' };
+        return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
       }
     },
     async acquireConcurrency({ tier, ip }) {
@@ -190,15 +190,15 @@ export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.n
       try {
         const activeCount = await kv.incr(resolved.key, { ttlMs: 5 * 60 * 1000 });
         if (!Number.isSafeInteger(activeCount) || activeCount < 1) {
-          return { allowed: false, status: 503, reason: 'quota storage unavailable' };
+          return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
         }
         if (activeCount > freeLimits.maxConcurrent) {
           await releaseKey(resolved.key);
-          return { allowed: false, status: 429, reason: 'concurrent limit exceeded' };
+          return { allowed: false, status: 429, reason: QUOTA_REASONS.CONCURRENT };
         }
         return { allowed: true, tier };
       } catch {
-        return { allowed: false, status: 503, reason: 'quota storage unavailable' };
+        return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
       }
     },
     async releaseConcurrency({ tier, ip }) {

--- a/src/rewrite-handler.js
+++ b/src/rewrite-handler.js
@@ -4,8 +4,14 @@ import { byteLength, redactSecrets, validateRewriteRequest } from './web-rewrite
 import { extractClientIp } from './rate-limit.js';
 
 /**
- * @typedef {{method?: string, headers?: Record<string, string|string[]|undefined>, body?: unknown, [Symbol.asyncIterator]?: () => AsyncIterator<Buffer|string|Uint8Array>}} RewriteReq
- * @typedef {{statusCode?: number, setHeader?: (name: string, value: string) => void, end?: (body?: string) => void}} RewriteRes
+ * Cancellation contract: `runRewrite` receives the raw `req`/`res`. Runtimes
+ * that expose emitter methods let the runner observe client disconnects —
+ * `res` emits 'close' (with `writableEnded === false` on a premature
+ * disconnect) and legacy `req` emits 'aborted'. All emitter members are
+ * optional so bare serverless/test mocks keep working.
+ *
+ * @typedef {{method?: string, headers?: Record<string, string|string[]|undefined>, body?: unknown, on?: (event: string, listener: (...args: unknown[]) => void) => unknown, off?: (event: string, listener: (...args: unknown[]) => void) => unknown, [Symbol.asyncIterator]?: () => AsyncIterator<Buffer|string|Uint8Array>}} RewriteReq
+ * @typedef {{statusCode?: number, setHeader?: (name: string, value: string) => void, write?: (chunk: string) => void, end?: (body?: string) => void, on?: (event: string, listener: (...args: unknown[]) => void) => unknown, off?: (event: string, listener: (...args: unknown[]) => void) => unknown, writableEnded?: boolean}} RewriteRes
  * @typedef {{check(input: {tier: string, ip: string|null}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, acquireConcurrency?(input: {tier: string, ip: string|null}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, releaseConcurrency?(input: {tier: string, ip: string|null}): Promise<void>}} RateLimiter
  */
 

--- a/src/web-rewrite-contract.js
+++ b/src/web-rewrite-contract.js
@@ -46,6 +46,23 @@ export const TIER_LIMITS = Object.freeze({
 export const CONTEXT_LIMITS = Object.freeze({ maxTurns: 6, maxBytes: 12 * 1024 });
 
 /**
+ * Stable quota/service denial reason strings, emitted by the rate limiter
+ * (src/rate-limit.js) and the API entry (api/rewrite.js) and recognized by the
+ * browser error classifier (playground/rewrite-client.js). These exact strings
+ * are part of the public error contract: keep values backward-compatible and
+ * change them only with a coordinated classifier/UI migration.
+ */
+export const QUOTA_REASONS = Object.freeze({
+  DAILY: 'daily quota exceeded',
+  HOURLY: 'hourly burst exceeded',
+  CONCURRENT: 'concurrent limit exceeded',
+  IP_UNAVAILABLE: 'client ip unavailable',
+  STORAGE_UNAVAILABLE: 'quota storage unavailable',
+  SECRET_UNAVAILABLE: 'quota secret unavailable',
+  SERVICE_UNAVAILABLE: 'rewrite service unavailable',
+});
+
+/**
  * Stream frame protocol. The handler streams newline-delimited JSON ("NDJSON")
  * frames over a POST fetch ReadableStream. Every line is exactly one JSON frame
  * with a `type` field. A successful stream is `start` → `delta`* → `done`; any

--- a/src/web-rewrite-stream.js
+++ b/src/web-rewrite-stream.js
@@ -104,22 +104,34 @@ export async function runWebRewriteStream({
   const fidelityScore = scoreFns.scoreFidelity || scoreFidelity;
   const deterministicScore = scoreFns.scoreDeterministicSignals || scoreDeterministicSignals;
 
-  const [mps, fidelity] = await Promise.all([
-    mpsScore({ original, rewritten: rewrite, apiKey: request.apiKey, baseURL: request.baseURL, model: request.model, signal, timeout }),
-    fidelityScore({ original, rewritten: rewrite, apiKey: request.apiKey, baseURL: request.baseURL, model: request.model, signal, timeout }),
-  ]);
-  const signals = {
-    before: deterministicScore({ text: original, config: effectiveConfig, repoRoot }),
-    after: deterministicScore({ text: rewrite, config: effectiveConfig, repoRoot }),
-  };
-  const diff = summarizeDiff(original, rewrite);
+  let mps, fidelity, signals, diff;
+  try {
+    [mps, fidelity] = await Promise.all([
+      mpsScore({ original, rewritten: rewrite, apiKey: request.apiKey, baseURL: request.baseURL, model: request.model, signal, timeout }),
+      fidelityScore({ original, rewritten: rewrite, apiKey: request.apiKey, baseURL: request.baseURL, model: request.model, signal, timeout }),
+    ]);
+    signals = {
+      before: deterministicScore({ text: original, config: effectiveConfig, repoRoot }),
+      after: deterministicScore({ text: rewrite, config: effectiveConfig, repoRoot }),
+    };
+    diff = summarizeDiff(original, rewrite);
+  } catch (err) {
+    // A scoring failure (including an abort during scoring) must terminate as
+    // a clean NDJSON error frame — never bubble to the handler's JSON 500,
+    // which would append a non-frame tail to an already-started stream.
+    const error = safeError(err);
+    emit({ type: STREAM_FRAME_TYPES.ERROR, code: 'scoring_failed', error });
+    return { ok: false, code: 'scoring_failed', error };
+  }
 
   // Pass the raw score values to evaluateFloors, which strictly requires a
   // finite number >= floor (a non-number fails closed). No Number() coercion.
   const floors = evaluateFloors({ mps: rawScore(mps, 'mps'), fidelity: rawScore(fidelity, 'fidelity') });
   if (!floors.ok) {
-    emit({ type: STREAM_FRAME_TYPES.ERROR, code: 'floor_failed', failed: floors.failed, rewrite, mps, fidelity });
-    return { ok: false, code: 'floor_failed', failed: floors.failed, mps, fidelity };
+    // Keep the already-computed audit metadata (deterministic signals + length
+    // diff) on floor failures so a flagged attempt stays auditable in the UI.
+    emit({ type: STREAM_FRAME_TYPES.ERROR, code: 'floor_failed', failed: floors.failed, rewrite, mps, fidelity, signals, diff });
+    return { ok: false, code: 'floor_failed', failed: floors.failed, mps, fidelity, signals, diff };
   }
 
   emit({ type: STREAM_FRAME_TYPES.DONE, rewrite, mps, fidelity, signals, diff });

--- a/tests/unit/playground-a11y.test.js
+++ b/tests/unit/playground-a11y.test.js
@@ -1,0 +1,102 @@
+// Static a11y invariants for the playground web surface (no DOM library, no
+// new dependencies): these assert that the markup/CSS/controller keep the
+// accessibility contract added in the frontend audit — labeled primary inputs,
+// a live-region chat thread, alert-role error notes, keyboard-visible focus,
+// and a closed mobile sidebar that leaves the tab order.
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const html = readFileSync(join(root, 'playground', 'index.html'), 'utf8');
+const css = readFileSync(join(root, 'playground', 'chatgpt.css'), 'utf8');
+const js = readFileSync(join(root, 'playground', 'chatgpt.js'), 'utf8');
+
+/** Extract the full opening tag that carries the given id. */
+function openingTag(source, id) {
+  const m = source.match(new RegExp(`<[a-z]+[^>]*\\bid="${id}"[^>]*>`));
+  assert.ok(m, `expected an element with id="${id}"`);
+  return m[0];
+}
+
+test('primary textareas carry aria-labels (hero + composer)', () => {
+  assert.match(openingTag(html, 'hero-input'), /aria-label="/);
+  assert.match(openingTag(html, 'input'), /aria-label="/);
+});
+
+test('chat thread is an announced live region', () => {
+  const thread = openingTag(html, 'thread');
+  assert.match(thread, /role="log"/);
+  assert.match(thread, /aria-live="polite"/);
+  assert.match(thread, /aria-relevant="additions text"/);
+  assert.match(thread, /aria-busy="false"/);
+});
+
+test('sidebar toggle exposes expanded state and its target', () => {
+  const toggle = openingTag(html, 'toggle-sidebar');
+  assert.match(toggle, /aria-controls="sidebar"/);
+  assert.match(toggle, /aria-expanded="false"/);
+});
+
+test('inline preflight error containers are alert-roled', () => {
+  for (const id of ['hero-error', 'composer-error', 'key-error']) {
+    assert.match(openingTag(html, id), /role="alert"/, `${id} must have role="alert"`);
+  }
+});
+
+test('every keyboard-interactive control has a :focus-visible style', () => {
+  const selectors = [
+    '.nav__links a:focus-visible',
+    '.btn:focus-visible',
+    '.suggest__pill:focus-visible',
+    '.editor__tab:focus-visible',
+    '.editor__btn:focus-visible',
+    '.xcard__replay:focus-visible',
+    '.xcard__try:focus-visible',
+    '.cta__btn:focus-visible',
+    '.newchat:focus-visible',
+    '.histitem:focus-visible',
+    '.iconbtn:focus-visible',
+    '.prompt__send:focus-visible',
+    '.composer__send:focus-visible',
+  ];
+  for (const sel of selectors) {
+    assert.ok(css.includes(sel), `chatgpt.css must style ${sel}`);
+  }
+  // The shared ring must actually draw something.
+  const block = css.slice(css.indexOf('.nav__links a:focus-visible'));
+  assert.match(block, /outline:\s*2px solid/);
+});
+
+test('closed mobile sidebar leaves the tab order (visibility: hidden)', () => {
+  const rule = css.match(/\.chat:not\(\.sidebar-open\) \.sidebar \{[^}]*\}/);
+  assert.ok(rule, 'expected a closed-sidebar rule in the mobile media query');
+  assert.match(rule[0], /visibility:\s*hidden/);
+});
+
+test('controller syncs the document language on locale change', () => {
+  assert.match(js, /document\.documentElement\.lang = lang/);
+});
+
+test('controller toggles thread aria-busy around streaming', () => {
+  assert.match(js, /setAttribute\('aria-busy', 'true'\)/);
+  assert.match(js, /setAttribute\('aria-busy', 'false'\)/);
+});
+
+test('error notes are announced via role=alert', () => {
+  assert.match(js, /setAttribute\('role', 'alert'\)/);
+});
+
+test('sidebar toggle keeps aria-expanded in sync', () => {
+  assert.match(js, /setAttribute\('aria-expanded', String\(open\)\)/);
+  assert.match(js, /setAttribute\('aria-expanded', 'false'\)/);
+});
+
+test('localized copy never flows through innerHTML (clear-only usage allowed)', () => {
+  const assignments = js.match(/\.innerHTML\s*=\s*[^;]+/g) || [];
+  for (const a of assignments) {
+    assert.match(a, /\.innerHTML\s*=\s*''/, `unexpected non-empty innerHTML assignment: ${a}`);
+  }
+});

--- a/tests/unit/rate-limit.test.js
+++ b/tests/unit/rate-limit.test.js
@@ -7,7 +7,7 @@ import {
   extractClientIp,
   quotaKeyHmac,
 } from '../../src/rate-limit.js';
-import { WEB_TIERS } from '../../src/web-rewrite-contract.js';
+import { QUOTA_REASONS, WEB_TIERS } from '../../src/web-rewrite-contract.js';
 
 test('quotaKeyHmac is deterministic, part-sensitive, and never exposes the raw IP', () => {
   const ip = '203.0.113.7';
@@ -173,4 +173,57 @@ test('BYOK concurrency bypasses shared free slot limit', async () => {
 
   assert.equal((await limiter.acquireConcurrency({ tier: WEB_TIERS.BYOK, ip: null })).allowed, true);
   assert.equal((await limiter.acquireConcurrency({ tier: WEB_TIERS.BYOK, ip: null })).allowed, true);
+});
+
+test('QUOTA_REASONS values stay backward-compatible with the emitted reason strings', () => {
+  // The browser classifier and any deployed clients key off these exact
+  // strings; this pins the contract so a constant rename cannot silently
+  // change the wire format.
+  assert.deepEqual(QUOTA_REASONS, {
+    DAILY: 'daily quota exceeded',
+    HOURLY: 'hourly burst exceeded',
+    CONCURRENT: 'concurrent limit exceeded',
+    IP_UNAVAILABLE: 'client ip unavailable',
+    STORAGE_UNAVAILABLE: 'quota storage unavailable',
+    SECRET_UNAVAILABLE: 'quota secret unavailable',
+    SERVICE_UNAVAILABLE: 'rewrite service unavailable',
+  });
+});
+
+test('abuse accounting is pinned: an hourly-denied attempt still consumes daily quota', async () => {
+  // Deliberate product/architecture decision (ralplan G003, architect review):
+  // the daily counter increments BEFORE the hourly burst check and is not
+  // rolled back on an hourly denial. Burst hammering therefore burns daily
+  // quota — an abuse deterrent. Changing this order without an atomic limiter
+  // would open an unlimited-hammering vector; this test locks the behavior.
+  const HOUR_MS = 3_600_000;
+  let t = 0;
+  const limiter = createRateLimiter({
+    kv: createMemoryKv(),
+    hmacSecret: 'secret',
+    now: () => t,
+    limits: { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 3, burstPerHour: 1 }, byok: { maxChars: 20000, maxConcurrent: 2 } },
+  });
+  const ip = '203.0.113.42';
+
+  // Hour 1: one allowed (day=1), one hourly-denied (day=2 — consumed anyway).
+  assert.equal((await limiter.check({ tier: WEB_TIERS.FREE, ip })).allowed, true);
+  assert.deepEqual(await limiter.check({ tier: WEB_TIERS.FREE, ip }), {
+    allowed: false,
+    status: 429,
+    reason: QUOTA_REASONS.HOURLY,
+  });
+
+  // Hour 2: burst window reset; one allowed (day=3).
+  t = HOUR_MS;
+  assert.equal((await limiter.check({ tier: WEB_TIERS.FREE, ip })).allowed, true);
+
+  // Next attempt hits the DAILY cap (day=4 > 3), not the hourly one — proving
+  // the hour-1 denial consumed a daily slot. Under quota-fairness accounting
+  // this would still be an hourly denial (day would only be 3 here).
+  assert.deepEqual(await limiter.check({ tier: WEB_TIERS.FREE, ip }), {
+    allowed: false,
+    status: 429,
+    reason: QUOTA_REASONS.DAILY,
+  });
 });

--- a/tests/unit/rewrite-api.test.js
+++ b/tests/unit/rewrite-api.test.js
@@ -19,8 +19,11 @@ function makeReq({ body = undefined, method = 'POST' } = {}) {
 function makeRes() {
   const headers = new Map();
   const chunks = [];
+  /** @type {Map<string, Set<Function>>} */
+  const listeners = new Map();
   return {
     statusCode: 200,
+    writableEnded: false,
     setHeader(name, value) {
       headers.set(String(name).toLowerCase(), String(value));
     },
@@ -33,6 +36,20 @@ function makeRes() {
     end(body = '') {
       if (body) chunks.push(String(body));
       this.ended = true;
+      this.writableEnded = true;
+    },
+    on(event, listener) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)?.add(listener);
+      return this;
+    },
+    off(event, listener) {
+      listeners.get(event)?.delete(listener);
+      return this;
+    },
+    /** Simulate the runtime 'close' event (premature when writableEnded is false). */
+    emitClose() {
+      for (const listener of listeners.get('close') ?? []) listener();
     },
     chunks,
     ended: false,
@@ -154,4 +171,70 @@ test('REST KV adapter calls Upstash decr and parses the numeric result', async (
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+test('the api wires an abort signal and a bounded timeout into the stream runner', async () => {
+  const env = { NODE_ENV: 'test', PATINA_FREE_API_KEY: 'sk-server-free-key' };
+  /** @type {any} */
+  let seen;
+  const injected = /** @type {any} */ (async ({ signal, timeout, emit }) => {
+    seen = { signal, timeout };
+    emit({ type: 'done', rewrite: 'ok' });
+  });
+  const api = createRewriteApiHandler({ env, runWebRewriteStreamImpl: injected });
+  const res = makeRes();
+  await api(makeReq(), res);
+  assert.ok(seen, 'runner must be invoked');
+  assert.ok(seen.signal instanceof globalThis.AbortSignal, 'runner must receive an AbortSignal');
+  assert.equal(seen.signal.aborted, false, 'signal must not be pre-aborted');
+  assert.equal(typeof seen.timeout, 'number');
+  assert.ok(seen.timeout > 0, 'timeout must be a positive bound');
+});
+
+test('PATINA_WEB_REWRITE_TIMEOUT_MS overrides the default stream budget', async () => {
+  const env = { NODE_ENV: 'test', PATINA_FREE_API_KEY: 'sk-server-free-key', PATINA_WEB_REWRITE_TIMEOUT_MS: '5000' };
+  let seenTimeout;
+  const injected = /** @type {any} */ (async ({ timeout, emit }) => {
+    seenTimeout = timeout;
+    emit({ type: 'done', rewrite: 'ok' });
+  });
+  const api = createRewriteApiHandler({ env, runWebRewriteStreamImpl: injected });
+  await api(makeReq(), makeRes());
+  assert.equal(seenTimeout, 5000);
+});
+
+test('client disconnect aborts the runner signal and never yields a false done frame', async () => {
+  const env = { NODE_ENV: 'test', PATINA_FREE_API_KEY: 'sk-server-free-key' };
+  const res = makeRes();
+  let abortedInsideRunner = false;
+  const injected = /** @type {any} */ (async ({ signal, emit }) => {
+    emit({ type: 'start', provider: 'openai', model: 'gpt-5.5' });
+    // Simulate the client dropping the connection while the runner is mid-flight.
+    res.emitClose();
+    abortedInsideRunner = signal.aborted;
+    // A signal-honoring runner terminates with an error frame, never done.
+    emit({ type: 'error', code: 'stream_failed', error: 'request aborted' });
+  });
+  const api = createRewriteApiHandler({ env, runWebRewriteStreamImpl: injected });
+  await api(makeReq(), res);
+  assert.equal(abortedInsideRunner, true, 'premature close must abort the runner signal');
+  const lines = res.chunks.join('').trim().split('\n').map((line) => JSON.parse(line));
+  assert.equal(lines.some((f) => f.type === 'done'), false, 'no false success done frame');
+  assert.equal(lines.at(-1)?.type, 'error');
+});
+
+test('a clean close after end does not abort the runner signal', async () => {
+  const env = { NODE_ENV: 'test', PATINA_FREE_API_KEY: 'sk-server-free-key' };
+  const res = makeRes();
+  /** @type {any} */
+  let seenSignal;
+  const injected = /** @type {any} */ (async ({ signal, emit }) => {
+    seenSignal = signal;
+    emit({ type: 'done', rewrite: 'ok' });
+  });
+  const api = createRewriteApiHandler({ env, runWebRewriteStreamImpl: injected });
+  await api(makeReq(), res);
+  // Node also emits 'close' after a normal end; writableEnded guards the abort.
+  res.emitClose();
+  assert.equal(seenSignal.aborted, false, 'clean completion must not abort');
 });

--- a/tests/unit/rewrite-client.test.js
+++ b/tests/unit/rewrite-client.test.js
@@ -2,7 +2,12 @@ import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 
 import { CONTEXT_LIMITS, WEB_TIERS } from '../../src/web-rewrite-contract.js';
-import { createRewriteThread, streamRewrite } from '../../playground/rewrite-client.js';
+import {
+  classifyRewriteError,
+  createRewriteThread,
+  REWRITE_ERROR_KINDS,
+  streamRewrite,
+} from '../../playground/rewrite-client.js';
 
 function streamResponse(lines, { status = 200 } = {}) {
   const encoder = new globalThis.TextEncoder();
@@ -132,4 +137,64 @@ test('createRewriteThread builds first/refine requests (commit-on-done) and caps
   assert.equal(thread.original, undefined);
   assert.equal(thread.currentDraft, '');
   assert.deepEqual(thread.turns, []);
+});
+
+test('classifyRewriteError maps every server reason string to a stable kind', () => {
+  const K = REWRITE_ERROR_KINDS;
+  // Exact reason strings emitted by src/rate-limit.js, api/rewrite.js, and
+  // validateRewriteRequest — the classifier is the single recognition point.
+  assert.equal(classifyRewriteError({ status: 429, error: 'daily quota exceeded' }), K.QUOTA_DAILY);
+  assert.equal(classifyRewriteError({ status: 429, error: 'hourly burst exceeded' }), K.QUOTA_HOURLY);
+  assert.equal(classifyRewriteError({ status: 429, error: 'concurrent limit exceeded' }), K.QUOTA_CONCURRENT);
+  assert.equal(classifyRewriteError({ status: 400, error: 'client ip unavailable' }), K.IP_UNAVAILABLE);
+  assert.equal(classifyRewriteError({ status: 503, error: 'quota storage unavailable' }), K.QUOTA_STORAGE);
+  assert.equal(classifyRewriteError({ status: 503, error: 'quota secret unavailable' }), K.QUOTA_SECRET);
+  assert.equal(classifyRewriteError({ status: 503, error: 'rewrite service unavailable' }), K.SERVICE_UNAVAILABLE);
+  assert.equal(classifyRewriteError({ status: 413, error: 'text exceeds 4000 characters for tier free' }), K.TEXT_TOO_LONG);
+  assert.equal(classifyRewriteError({ status: 413, error: 'original exceeds 20000 characters for tier byok' }), K.TEXT_TOO_LONG);
+  assert.equal(classifyRewriteError({ code: 'floor_failed', error: 'floors failed' }), K.FLOOR_FAILED);
+});
+
+test('classifyRewriteError falls back conservatively for unrecognized failures', () => {
+  const K = REWRITE_ERROR_KINDS;
+  // Unknown quota reason → retry-shortly copy beats a wrong "come back tomorrow".
+  assert.equal(classifyRewriteError({ status: 429, error: 'rate limited' }), K.QUOTA_HOURLY);
+  assert.equal(classifyRewriteError({ status: 503, error: 'upstream exploded' }), K.SERVICE_UNAVAILABLE);
+  assert.equal(classifyRewriteError({ status: 502 }), K.SERVICE_UNAVAILABLE);
+  assert.equal(classifyRewriteError({ status: 500, error: 'internal error' }), K.UNKNOWN);
+  assert.equal(classifyRewriteError({ status: 400, error: 'invalid JSON' }), K.UNKNOWN);
+  assert.equal(classifyRewriteError({}), K.UNKNOWN);
+  assert.equal(classifyRewriteError(null), K.UNKNOWN);
+  assert.equal(classifyRewriteError(undefined), K.UNKNOWN);
+});
+
+test('streamRewrite abort rejects with AbortError so the caller can classify user cancel', async () => {
+  const encoder = new globalThis.TextEncoder();
+  const fetchImpl = async (_url, init) => ({
+    ok: true,
+    status: 200,
+    body: new globalThis.ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"type":"start"}\n'));
+        // Simulate fetch abort semantics: the pending read rejects on abort.
+        init.signal.addEventListener('abort', () => {
+          controller.error(new globalThis.DOMException('The operation was aborted.', 'AbortError'));
+        });
+      },
+    }),
+  });
+
+  const controller = new globalThis.AbortController();
+  const done = [];
+  await assert.rejects(
+    streamRewrite({
+      body: { mode: 'first', lang: 'en', tier: 'free', text: 'Hello' },
+      fetchImpl,
+      signal: controller.signal,
+      onStart: () => controller.abort(),
+      onDone: () => done.push('done'),
+    }),
+    (err) => err.name === 'AbortError',
+  );
+  assert.deepEqual(done, []);
 });

--- a/tests/unit/web-rewrite-stream.test.js
+++ b/tests/unit/web-rewrite-stream.test.js
@@ -75,6 +75,51 @@ test('runWebRewriteStream fail-closes floor failures with error and no done', as
   assert.equal(terminal.type, 'error');
   assert.equal(terminal.code, 'floor_failed');
   assert.deepEqual(terminal.failed, ['mps']);
+  // Floor failures keep the flagged attempt auditable: the already-computed
+  // deterministic signals and length diff must ride on the error frame.
+  assert.equal(terminal.rewrite, 'bad rewrite');
+  assert.deepEqual(terminal.mps, { mps: 50 });
+  assert.deepEqual(terminal.fidelity, { fidelity: 95 });
+  assert.equal(terminal.signals.before.text, 'original anchor');
+  assert.equal(terminal.signals.after.text, 'bad rewrite');
+  assert.equal(terminal.diff.beforeChars, 'original anchor'.length);
+  assert.equal(terminal.diff.afterChars, 'bad rewrite'.length);
+  assert.equal(result.signals.after.text, 'bad rewrite');
+  assert.equal(result.diff.afterChars, 'bad rewrite'.length);
+});
+
+test('runWebRewriteStream forwards the abort signal and timeout to the LLM stream and scorers', async () => {
+  const frames = [];
+  const controller = new AbortController();
+  const seen = { stream: null, scorers: [] };
+  const callLLMStream = async ({ signal, timeout, onDelta }) => {
+    seen.stream = { signal, timeout };
+    onDelta('ok');
+    return { text: 'ok text' };
+  };
+  const scoreFns = {
+    scoreMPS: async ({ signal, timeout }) => { seen.scorers.push({ signal, timeout }); return { mps: 95 }; },
+    scoreFidelity: async ({ signal, timeout }) => { seen.scorers.push({ signal, timeout }); return { fidelity: 92 }; },
+    scoreDeterministicSignals: ({ text }) => ({ text }),
+  };
+
+  const result = await runWebRewriteStream({
+    request,
+    callLLMStream,
+    scoreFns,
+    emit: (frame) => frames.push(frame),
+    signal: controller.signal,
+    timeout: 4321,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(seen.stream.signal, controller.signal);
+  assert.equal(seen.stream.timeout, 4321);
+  assert.equal(seen.scorers.length, 2);
+  for (const scorer of seen.scorers) {
+    assert.equal(scorer.signal, controller.signal);
+    assert.equal(scorer.timeout, 4321);
+  }
 });
 
 test('runWebRewriteStream emits stream_failed and no done when transport throws', async () => {
@@ -110,4 +155,29 @@ test('runWebRewriteStream scores refine against request.original, not latest dra
   assert.equal(calls[1][1], 'original anchor');
   assert.notEqual(calls[0][1], request.text);
   assert.equal(frames.at(-1).type, 'done');
+});
+
+test('runWebRewriteStream turns a scoring failure into a terminal redacted error frame (no done, no throw)', async () => {
+  const frames = [];
+  const callLLMStream = async ({ onDelta }) => {
+    onDelta('ok');
+    return { text: 'ok text' };
+  };
+  const scoreFns = {
+    scoreMPS: async () => { throw new Error('scorer aborted sk-secret1234567890'); },
+    scoreFidelity: async () => ({ fidelity: 92 }),
+    scoreDeterministicSignals: ({ text }) => ({ text }),
+  };
+
+  // Must resolve (not reject): a throw here would bubble to the API handler's
+  // JSON 500 and append a non-frame tail to an already-started NDJSON stream.
+  const result = await runWebRewriteStream({ request, callLLMStream, scoreFns, emit: (frame) => frames.push(frame) });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'scoring_failed');
+  assert.equal(frames.some((f) => f.type === 'done'), false);
+  const terminal = frames.at(-1);
+  assert.equal(terminal.type, 'error');
+  assert.equal(terminal.code, 'scoring_failed');
+  assert.doesNotMatch(terminal.error, /sk-secret/);
 });


### PR DESCRIPTION
## Summary

Ralplan-approved frontend audit implementation (consensus plan: Planner → Architect → Critic, executed as ultragoal G001–G003). Rewrites nothing about the product pipeline — this hardens the playground web surface and its server path.

### Stage 1 — UI/A11y + client validation (`playground/`)
- **a11y**: aria-labels on both primary textareas; `#thread` is a `role=log` `aria-live=polite` region with `aria-busy` toggling; error notes are `role=alert`; `document.documentElement.lang` syncs on locale change; sidebar toggle exposes `aria-controls`/`aria-expanded`; every interactive control has a `:focus-visible` ring; the closed mobile sidebar leaves the tab order.
- **XSS surface**: `applyI18n` no longer uses `innerHTML` — all localized copy is built with DOM nodes (`textContent` + `createElement`). Locked by a static test.
- **client validation**: tier-cap preflight (free 4000 / BYOK 20000 chars) and BYOK key check with inline field errors — invalid requests never hit the network.
- **error UX**: stable `classifyRewriteError` replaces ad-hoc 429 string matching; distinct daily/hourly/concurrent quota copy in KO/EN/ZH/JA; **Stop** control mid-stream (abort + cancel-specific message); **Retry** after non-floor failures (once per activation, busy-guarded; the thread still commits only on a `done` frame).

### Stage 2 — server-side cancellation + audit metadata
- `api/rewrite.js` wires an `AbortController` to `res` `'close'` (`writableEnded` guard) + legacy `req` `'aborted'` and passes `signal` + a bounded timeout (`PATINA_WEB_REWRITE_TIMEOUT_MS`, default 180s) into `runWebRewriteStream` — client disconnects now cancel provider/scoring work and free the concurrency slot promptly.
- `floor_failed` frames keep the already-computed `signals` + `diff` so flagged attempts stay auditable in the UI.
- Scoring failures (incl. abort during scoring) terminate as a redacted `scoring_failed` NDJSON frame instead of bubbling into a mixed JSON 500 tail on an already-started stream.

### Stage 3 — quota reason contract + hygiene
- `QUOTA_REASONS` constants in the isomorphic contract (values identical to prior wire strings — backward compatible), consumed by the rate limiter, API entry, and browser classifier. Compat + **abuse-accounting order pinned by tests** (hourly denial still consumes daily quota — deliberate, per architect review; fairness reordering without an atomic limiter would open a hammering vector).
- dev-server: HEAD returns headers only (with `Content-Length`); malformed/NUL percent-encoded paths return 400 before the SPA fallback can mask them.
- Mobile (≤900px) nav links wrap onto a scrollable row instead of disappearing.
- `playground/DESIGN.md` synced to the shipped editorial-dark theme; `analytics.js` documented as an intentional no-op queue shim.

## Verification
- `npm test`: **1109 pass / 0 fail** (incl. 20+ new tests: static a11y invariants, classifier matrix, abort propagation, accounting pin)
- `npm run lint`: syntax + eslint + tsc + cspell clean
- Per-story architect reviews: CLEAR×3 / APPROVE (incl. delta re-reviews after fixes)
- Red-team QA per story with headless-Chromium automation at 1440px/375px: XSS payloads render as text, cap boundaries exact (4000 pass / 4001 blocked), Stop/Retry state purity, live mid-stream abort + recovery, mobile keyboard traversal. 4 defects found by the gates were fixed and re-proven in this branch.
- **No README-family file is touched** (concurrent README work stays conflict-free); `src/features/*` unchanged; no new dependencies.

## Follow-ups (out of scope, tracked in the plan ADR)
- Atomic (Lua/KV-transaction) rate limiter, then revisit quota-fairness accounting
- Real telemetry decision for the analytics shim
- `playground/README.md` stale `npx vercel dev` note (README currently locked by another session)