### PR TITLE
fix(review): resolve #583 dev-branch review — meaning-proxy + persona (11 findings)

### DIFF
--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -35,7 +35,7 @@ import { resolve } from 'node:path';
 import { loadPersona } from '../personas/loader.js';
 import { evaluatePersonaGate } from '../personas/gates.js';
 import { personaMatchScore } from '../features/persona-match.js';
-import { personaOwnsVoice } from '../personas/compose.js';
+import { personaHasVoiceTraits } from '../personas/compose.js';
 import { evaluateMeaningProxy } from '../features/meaning-proxy.js';
 import { pathToFileURL } from 'node:url';
 import { humanizeXliffDocument, resolveUniqueCap } from './xliff.js';
@@ -109,11 +109,14 @@ export async function runDefault(parsed, logger) {
 
   // v6.2 profile-voice retirement: profiles no longer carry voice — the active
   // persona is the sole voice owner. Warn once when a non-default profile is
-  // used for a rewrite without a voice-owning persona, so users relying on the
-  // old profile voice migrate to a persona (e.g. --persona blog-essay).
-  if (mode === 'rewrite' && parsed.profile && parsed.profile !== 'default' && !personaOwnsVoice(persona)) {
+  // requested for a rewrite but the active persona injects no genre voice
+  // traits, so users relying on the old profile voice migrate to a persona
+  // (e.g. --persona blog-essay). Keyed on the EFFECTIVE profile name so the
+  // warning also fires for `.patina.yaml` profile users (not just --profile),
+  // and stays silent when namuwiki fell back to default for a non-ko run.
+  if (mode === 'rewrite' && profileName !== 'default' && !personaHasVoiceTraits(persona)) {
     logger.warn?.('profile.voice_retired', {
-      message: `[patina] profile "${parsed.profile}" no longer provides voice — profiles are pattern-policy only now. For genre voice use a persona (e.g. patina --lang ${lang} --persona <id> ...); run \`patina persona list --lang ${lang}\`.`,
+      message: `[patina] profile "${profileName}" no longer provides voice — profiles are pattern-policy only now. For genre voice use a persona (e.g. patina --lang ${lang} --persona <id> ...); run \`patina persona list --lang ${lang}\`.`,
     });
   }
 
@@ -339,12 +342,16 @@ export async function runDefault(parsed, logger) {
             });
             process.exitCode = Math.max(Number(process.exitCode) || 0, 4);
           }
-          if (gate.advisory.length > 0) {
-            // ADVISORY: voice-match quality and surface churn — never block or
-            // change the exit code. Surface churn is not a meaning signal.
-            const bits = [];
-            if (!gate.personaMatchPass) bits.push(`voice match ${gate.personaMatch} < ${gate.personaMatchMin}`);
-            if (!gate.churnPass) bits.push(`surface churn ${gate.churn} > ${gate.churnMax}`);
+          // ADVISORY (never blocks or changes the exit code): voice-match
+          // quality and surface churn. meaningProxy is Phase A JSON-only — it
+          // rides gate.advisory + the meaning_proxy report but MUST NOT emit a
+          // CLI warning, so key the warning on the CLI-warnable bits (not on
+          // gate.advisory.length, which would print an empty/leaky message when
+          // meaningProxy is the only advisory item).
+          const bits = [];
+          if (!gate.personaMatchPass) bits.push(`voice match ${gate.personaMatch} < ${gate.personaMatchMin}`);
+          if (!gate.churnPass) bits.push(`surface churn ${gate.churn} > ${gate.churnMax}`);
+          if (bits.length > 0) {
             logger.warn('persona.advisory', {
               message: `[patina] persona advisory: ${bits.join('; ')} (quality signals only; output not blocked).`,
             });

--- a/src/commands/persona.js
+++ b/src/commands/persona.js
@@ -42,6 +42,17 @@ function assertLang(lang) {
   }
 }
 
+// Consume the value after a value-taking flag. A missing value (end of args) or
+// a following flag (`-`/`--`) is an input error, not a silent `undefined` that
+// would build an empty-description persona or crash on readFileSync(undefined).
+function takeValue(args, i, flag) {
+  const v = args[i + 1];
+  if (v === undefined || v.startsWith('-')) {
+    throw inputError(`${flag} requires a value`, `Missing value after ${flag}.`, `Pass ${flag} <value>.`);
+  }
+  return [v, i + 1];
+}
+
 // Extract the first balanced JSON object from an LLM response.
 function parseFirstJson(text) {
   const raw = String(text || '');
@@ -199,10 +210,8 @@ function makeCallLLM({ backends } = {}) {
 
 function writePersonaFile({ repoRoot, lang, id, frontmatter, force }) {
   const dir = resolve(repoRoot, 'custom', 'personas', lang);
-  const path = resolve(dir, `${id}.md`);
-  if (!path.startsWith(dir + '/')) {
-    throw inputError(`persona path escaped its library: ${id}`, `${path} is outside ${dir}.`, 'Use a plain id with no path separators.');
-  }
+  // Cross-platform containment guard (uses path.sep, not a hardcoded '/').
+  const path = safePersonaPath(dir, id);
   if (existsSync(path) && !force) {
     throw inputError(
       `persona already exists: ${id}`,
@@ -222,11 +231,11 @@ function parsePersonaNewArgs(args) {
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === '-h' || arg === '--help') opts.help = true;
-    else if (arg === '--lang' || arg === '--language') opts.lang = args[++i];
+    else if (arg === '--lang' || arg === '--language') { [opts.lang, i] = takeValue(args, i, arg); }
     else if (arg === '--template') opts.mode = 'template';
-    else if (arg === '--from-sample') { opts.mode = 'sample'; opts.sampleFile = args[++i]; }
-    else if (arg === '--describe') { opts.mode = 'describe'; opts.describe = args[++i]; }
-    else if (arg === '--backend') opts.backend = args[++i];
+    else if (arg === '--from-sample') { opts.mode = 'sample'; [opts.sampleFile, i] = takeValue(args, i, arg); }
+    else if (arg === '--describe') { opts.mode = 'describe'; [opts.describe, i] = takeValue(args, i, arg); }
+    else if (arg === '--backend') { [opts.backend, i] = takeValue(args, i, arg); }
     else if (arg === '--force') opts.force = true;
     else if (arg === '--no-interactive') opts.interactive = false;
     else if (!arg.startsWith('-') && opts.id === null) opts.id = arg;
@@ -339,9 +348,15 @@ export function runPersonaList(args, deps = {}) {
     const all = listPersonas(repoRoot, l);
     const customIds = new Set(existsSync(customDir) ? all.filter((id) => existsSync(resolve(customDir, `${id}.md`))) : []);
     const builtinIds = existsSync(builtinDir) ? all.filter((id) => existsSync(resolve(builtinDir, `${id}.md`))) : [];
+    const builtinSet = new Set(builtinIds);
+    // A custom id that also exists as a built-in shadows it: the loader is
+    // custom-first, so the custom file is what actually runs. Surface it
+    // explicitly instead of hiding it under `built-in`.
+    const shadowed = all.filter((id) => customIds.has(id) && builtinSet.has(id));
     result[l] = {
       builtin: builtinIds,
-      custom: all.filter((id) => customIds.has(id) && !builtinIds.includes(id)),
+      custom: all.filter((id) => customIds.has(id) && !builtinSet.has(id)),
+      shadowed,
     };
   }
   if (json) {
@@ -352,7 +367,11 @@ export function runPersonaList(args, deps = {}) {
   for (const [l, groups] of Object.entries(result)) {
     lines.push(`${l}:`);
     lines.push(`  built-in: ${groups.builtin.join(', ') || '(none)'}`);
-    lines.push(`  custom:   ${groups.custom.join(', ') || '(none)'}`);
+    const customLabels = [
+      ...groups.custom,
+      ...groups.shadowed.map((id) => `${id} (shadows built-in)`),
+    ];
+    lines.push(`  custom:   ${customLabels.join(', ') || '(none)'}`);
   }
   console.log(lines.join('\n'));
   return result;
@@ -477,11 +496,11 @@ function parsePersonaEditArgs(args) {
   const opts = { id: null, lang: 'ko', mode: null, sampleFile: null, describe: null, name: null, backend: process.env.PATINA_BACKEND || null };
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
-    if (arg === '--lang' || arg === '--language') opts.lang = args[++i];
-    else if (arg === '--from-sample') { opts.mode = 'sample'; opts.sampleFile = args[++i]; }
-    else if (arg === '--describe') { opts.mode = 'describe'; opts.describe = args[++i]; }
-    else if (arg === '--name') { opts.mode = 'name'; opts.name = args[++i]; }
-    else if (arg === '--backend') opts.backend = args[++i];
+    if (arg === '--lang' || arg === '--language') { [opts.lang, i] = takeValue(args, i, arg); }
+    else if (arg === '--from-sample') { opts.mode = 'sample'; [opts.sampleFile, i] = takeValue(args, i, arg); }
+    else if (arg === '--describe') { opts.mode = 'describe'; [opts.describe, i] = takeValue(args, i, arg); }
+    else if (arg === '--name') { opts.mode = 'name'; [opts.name, i] = takeValue(args, i, arg); }
+    else if (arg === '--backend') { [opts.backend, i] = takeValue(args, i, arg); }
     else if (!arg.startsWith('-') && opts.id === null) opts.id = arg;
     else throw inputError(`unknown persona edit argument: ${arg}`, 'Unrecognized flag or extra positional.', 'See `patina persona --help`.');
   }

--- a/src/features/meaning-proxy.js
+++ b/src/features/meaning-proxy.js
@@ -15,13 +15,18 @@
 import { tokenize } from './index.js';
 
 const NUMBER_RE = /\d[\d.,]*/g;
+// Valid thousands grouping only (1,200 / 1,234,567 / 1,234.56). Non-standard
+// grouping like 1,2 or 3,14 is intentionally NOT stripped so it never collapses
+// onto 12 / 314 and masks a genuinely dropped number.
+const GROUPED_THOUSANDS_RE = /^\d{1,3}(,\d{3})+(\.\d+)?$/;
 
 // Own, Lane-A-pure numeric extraction (mirrors verify.js#numbersIn so this module
 // imports nothing from Lane B). Normalizes grouping commas (1,200 === 1200).
 function numbersIn(text) {
   const out = new Set();
   for (const m of String(text ?? '').matchAll(NUMBER_RE)) {
-    const normalized = m[0].replace(/,/g, '').replace(/\.+$/, '');
+    const raw = m[0].replace(/\.+$/, '');
+    const normalized = GROUPED_THOUSANDS_RE.test(raw) ? raw.replace(/,/g, '') : raw;
     if (normalized) out.add(normalized);
   }
   return out;
@@ -69,7 +74,11 @@ export function rareTokenRecall(original, rewrite, lang = 'ko') {
   const rJoined = String(rewrite ?? '').normalize('NFC').toLowerCase();
   let survived = 0;
   for (const t of rare) {
-    if (rSet.has(t) || rJoined.includes(t)) survived += 1;
+    // Substring fallback only for CJK or long (>=5) Latin tokens. Short Latin
+    // rare tokens (us / art / ai / go) would false-survive inside business /
+    // chair / ongoing, masking a dropped entity/term.
+    const allowSubstring = CJK_RE.test(t) || t.length >= 5;
+    if (rSet.has(t) || (allowSubstring && rJoined.includes(t))) survived += 1;
   }
   return { active: true, recall: survived / rare.length, rareCount: rare.length, survived };
 }
@@ -154,7 +163,10 @@ export function evaluateMeaningProxy({ original, rewrite, lang = 'ko' } = {}) {
   // Signal 4 — length-ratio EXTREME bounds (truncation / hallucinated expansion).
   const oTokens = tokenize(String(original ?? ''), { lang }).length;
   const rTokens = tokenize(String(rewrite ?? ''), { lang }).length;
-  const lengthRatio = oTokens === 0 ? 1 : rTokens / oTokens;
+  // Empty original + non-empty rewrite is closer to hallucinated expansion than a
+  // meaning-preserving rewrite, so it must fail the extreme-bounds check rather
+  // than record a benign ratio of 1.
+  const lengthRatio = oTokens === 0 ? (rTokens === 0 ? 1 : Infinity) : rTokens / oTokens;
   if (lengthRatio < 0.4 || lengthRatio > 2.5) {
     reasons.push(`length ratio ${lengthRatio.toFixed(2)} outside [0.4, 2.5] — truncation or expansion`);
     bump('fail');

--- a/src/personas/compose.js
+++ b/src/personas/compose.js
@@ -149,15 +149,19 @@ export function formatPersonaDirective(persona, { lang, tone, korean } = {}) {
 }
 
 /**
- * Whether a persona actively shapes voice (so a profile's voice guidance should
- * defer to it). True when the persona injects content emphasis (depth "content")
- * or has any active voice block. A style-only persona with no active blocks
- * (e.g. `preserve`) does NOT own voice, so profile voice guidance still applies.
+ * Whether a persona injects ACTIVE voice traits — content-depth emphasis or any
+ * active voice block. This is NOT a statement about voice OWNERSHIP: under the
+ * v6.2 contract any active persona (including the `preserve` default) is the
+ * sole voice owner. This predicate answers only the narrower question the
+ * profile-voice-retirement migration warning needs: does the persona carry
+ * genre voice traits? A trait-less persona like `preserve` returns false, so a
+ * user still relying on the retired profile voice gets nudged toward a
+ * genre-voicing persona.
  *
  * @param {object} persona Normalized persona object.
- * @returns {boolean} True if the persona governs voice.
+ * @returns {boolean} True if the persona injects active voice traits.
  */
-export function personaOwnsVoice(persona) {
+export function personaHasVoiceTraits(persona) {
   if (!persona) return false;
   if (persona.depth === 'content') return true;
   const blocks = persona.blocks ?? {};

--- a/src/prompt-builder.js
+++ b/src/prompt-builder.js
@@ -255,7 +255,7 @@ export function buildPrompt(options) {
   prompt += `Process the following text according to the output mode "${mode}".\n\n`;
 
   if (mode === 'rewrite') {
-    prompt += buildRewriteInstructions(structurePacks, lexicalPacks, { lang, includeSelfAudit, rewriteHeadings });
+    prompt += buildRewriteInstructions(structurePacks, lexicalPacks, { lang, includeSelfAudit, rewriteHeadings, personaActive: Boolean(persona) });
     prompt += buildTransformDirective({ jargon, korean: false });
   } else if (mode === 'diff') {
     prompt += buildDiffInstructions();
@@ -324,7 +324,7 @@ function buildHeadingPreservationRule(lang, rewriteHeadings = false) {
 function buildRewriteInstructions(
   structurePacks,
   lexicalPacks,
-  { includeSelfAudit = true, lang = 'ko', includeKoreanAdvisory = true, rewriteHeadings = false } = {}
+  { includeSelfAudit = true, lang = 'ko', includeKoreanAdvisory = true, rewriteHeadings = false, personaActive = false } = {}
 ) {
   const phaseCount = includeSelfAudit ? 3 : 2;
   let inst = `Follow the ${phaseCount}-Phase pipeline:\n\n`;
@@ -360,8 +360,16 @@ function buildRewriteInstructions(
   inst += `2. Rewrite AI-sounding expressions into natural alternatives\n`;
   inst += `3. Preserve core meaning, claims, polarity, causation, numbers\n`;
   inst += `4. Keep overall length close to the original — the fidelity gate measures character length and full marks require staying within 70-130% of the input. Cut filler and hype freely, but replace it with natural phrasing of similar weight; never compress the text into a summary\n`;
-  inst += `5. Match profile tone\n`;
-  inst += `6. Inject personality per voice guidelines\n`;
+  if (personaActive) {
+    // v6.2: persona is the sole voice owner; the profile contributes pattern
+    // policy only, so the strict instructions must not tell the model to take
+    // tone/personality from the (now voice-retired) profile body.
+    inst += `5. Follow the active persona's voice — the profile contributes pattern policy only\n`;
+    inst += `6. Do not apply profile-body voice guidance while a persona is active\n`;
+  } else {
+    inst += `5. Match profile tone\n`;
+    inst += `6. Inject personality per voice guidelines\n`;
+  }
   inst += `7. Respect blocklist/allowlist and pattern overrides\n\n`;
   const cjkGuard = buildCjkClauseRewriteGuard(lang);
   if (cjkGuard) {

--- a/src/verify.js
+++ b/src/verify.js
@@ -8,13 +8,19 @@ import { createLogger } from './logger.js';
 // Numeric tokens (integers, decimals, grouped numbers). Used by the cheap,
 // LLM-free meaning guard to catch numbers that silently vanish in a rewrite.
 const NUMBER_RE = /\d[\d.,]*/g;
+// Valid thousands grouping only (1,200 / 1,234,567 / 1,234.56). Non-standard
+// grouping like 1,2 or 3,14 is intentionally NOT stripped so it never collapses
+// onto 12 / 314 and masks a genuinely dropped number on the enforcing guard.
+const GROUPED_THOUSANDS_RE = /^\d{1,3}(,\d{3})+(\.\d+)?$/;
 
 function numbersIn(text) {
   const out = new Set();
   for (const m of String(text ?? '').matchAll(NUMBER_RE)) {
-    // Normalize grouping commas (1,200 === 1200) and strip trailing separators
-    // so the same number in a different format is not flagged as dropped.
-    const normalized = m[0].replace(/,/g, '').replace(/\.+$/, '');
+    // Normalize valid grouping commas (1,200 === 1200) and strip trailing
+    // separators so the same number in a different format is not flagged as
+    // dropped; non-standard grouping (1,2) is preserved to avoid false negatives.
+    const raw = m[0].replace(/\.+$/, '');
+    const normalized = GROUPED_THOUSANDS_RE.test(raw) ? raw.replace(/,/g, '') : raw;
     if (normalized) out.add(normalized);
   }
   return out;

--- a/tests/e2e/cli-persona.test.js
+++ b/tests/e2e/cli-persona.test.js
@@ -170,4 +170,25 @@ describe('CLI persona harness', () => {
     assert.equal(exitCode, 0);
     assert.ok(errors.join('\n').includes('no longer provides voice'), 'expected the profile voice-retirement migration warning');
   });
+
+  it('warns for a .patina.yaml profile (config, not --profile) with no voice persona', async () => {
+    // The migration-relevant user has `profile: blog` in config and no --profile
+    // flag; the warning must key on the EFFECTIVE profile name, not parsed.profile.
+    const enPath = resolve(keyDir, 'en-config-profile.txt');
+    writeFileSync(enPath, 'This is a plain test sentence with no numbers.');
+    const configPath = resolve(keyDir, 'profile-blog.yaml');
+    writeFileSync(configPath, 'language: en\nprofile: blog\n');
+    const { errors, exitCode } = await captureConsole(() => main([
+      '--config', configPath,
+      '--format', 'json',
+      '--api-key-file', mockApiKeyPath,
+      '--base-url', `http://127.0.0.1:${mock.port}`,
+      '--model', 'gpt-5',
+      enPath,
+    ]));
+    assert.equal(exitCode, 0);
+    const err = errors.join('\n');
+    assert.ok(err.includes('no longer provides voice'), 'config-file profile must also trigger the migration warning');
+    assert.ok(err.includes('"blog"'), 'warning names the effective profile from config');
+  });
 });

--- a/tests/unit/meaning-proxy.test.js
+++ b/tests/unit/meaning-proxy.test.js
@@ -53,6 +53,50 @@ test('dropped numbers are reported deterministically', () => {
   assert.deepEqual(droppedNumbers('1,200 units', '1200 units'), []);
 });
 
+test('empty original + non-empty rewrite fails as hallucinated expansion (#2)', () => {
+  const r = evaluateMeaningProxy({ original: '', rewrite: 'a fabricated new fact', lang: 'en' });
+  assert.equal(r.severity, 'fail', 'empty→non-empty must not record a benign ratio of 1');
+  assert.equal(r.ok, false);
+  // A true no-op (empty→empty) stays benign.
+  assert.notEqual(evaluateMeaningProxy({ original: '', rewrite: '', lang: 'en' }).severity, 'fail');
+});
+
+test('comma grouping normalizes only valid thousands groups (#3)', () => {
+  // Valid grouping collapses so 1,200 === 1200 (no false dropped-number).
+  assert.deepEqual(droppedNumbers('1,200 units', '1200 units'), []);
+  assert.deepEqual(droppedNumbers('n 1,234,567', 'n 1234567'), []);
+  assert.deepEqual(droppedNumbers('rate 1,234.56', 'rate 1234.56'), []);
+  // Non-standard grouping is preserved so it never collapses onto 12 / 314 and
+  // masks a genuinely dropped number.
+  assert.deepEqual(droppedNumbers('value 1,2', 'value 12'), ['1,2']);
+  assert.deepEqual(droppedNumbers('pi 3,14', 'pi 314'), ['3,14']);
+});
+
+test('rare-token recall does not false-survive short Latin substrings (#4)', () => {
+  // us/art/ai embedded inside business/party/chair must NOT count as survived.
+  const r = rareTokenRecall('AI US art', 'chair business party', 'en');
+  assert.equal(r.active, true);
+  assert.equal(r.survived, 0);
+  assert.equal(r.recall, 0);
+  // CJK substrings and long (>=5) Latin tokens still survive as substrings.
+  assert.ok(rareTokenRecall('삼성전자 반도체 실적', '삼성전자의 반도체 실적이 좋다', 'ko').recall > 0);
+  assert.ok(rareTokenRecall('deterministic humanizer pipeline', 'the deterministic humanizers pipelines run', 'en').recall > 0);
+});
+
+test('negation counting: multilingual advisory matrix and known Phase A gaps (#5)', () => {
+  // Working cases across languages.
+  assert.equal(countNegations('cannot go without it, notable', 'en'), 2);
+  assert.equal(countNegations('ではありません', 'ja'), 1);
+  assert.equal(countNegations('不能 没有', 'zh'), 2);
+  // KNOWN advisory-only gaps, pinned so Phase B calibration has a baseline:
+  //  ko: glued 안됐다/못했다 are missed; 아니메이션 false-positives on 아니 → net 1.
+  assert.equal(countNegations('안됐다 못했다 아니메이션', 'ko'), 1);
+  //  ja: mid-sentence 使わずに missed; 少ない (lexical adj) false-positive on ない → net 1.
+  assert.equal(countNegations('使わずに 少ない', 'ja'), 1);
+  //  zh: 非常/无锡 (compound / proper noun) false-positive on 非/无 → 4 not 2.
+  assert.equal(countNegations('不能 没有 非常 无锡', 'zh'), 4);
+});
+
 test('meaning-proxy imports no backend/LLM module (Lane A purity)', () => {
   const src = readFileSync(resolve(REPO_ROOT, 'src/features/meaning-proxy.js'), 'utf8');
   const imports = [...src.matchAll(/^import\s+.*?from\s+['"]([^'"]+)['"]/gm)].map((m) => m[1]);

--- a/tests/unit/persona-command.test.js
+++ b/tests/unit/persona-command.test.js
@@ -240,3 +240,34 @@ test('persona dispatch unknown subcommand lists all five subcommands', async () 
     (err) => err instanceof PatinaCliError && /new, list, show, rm, edit/.test(err.message),
   );
 });
+
+test('persona list marks a custom persona that shadows a built-in (#7)', async () => {
+  const repoRoot = tempRepo();
+  // Copy-on-edit natural-ko into custom/ → an active runtime shadow of the built-in.
+  await runPersonaEdit(['natural-ko', '--lang', 'ko', '--name', 'My Natural KO'], { repoRoot, logger: silent });
+  const listing = runPersonaList(['--lang', 'ko', '--format', 'json'], { repoRoot });
+  assert.ok(listing.ko.shadowed.includes('natural-ko'), 'shadowed list surfaces the shadowing id');
+  assert.ok(!listing.ko.custom.includes('natural-ko'), 'shadowing id is not double-listed under custom');
+  assert.ok(listing.ko.builtin.includes('natural-ko'), 'the underlying built-in still exists');
+  const { logs } = captureLog(() => runPersonaList(['--lang', 'ko'], { repoRoot }));
+  assert.match(logs.join('\n'), /natural-ko \(shadows built-in\)/);
+});
+
+test('persona new/edit reject a value-taking flag with a missing value (#8)', async () => {
+  const repoRoot = tempRepo();
+  for (const args of [['x', '--describe'], ['x', '--from-sample'], ['x', '--lang'], ['x', '--backend']]) {
+    await assert.rejects(
+      () => runPersonaNew(args, { repoRoot, logger: silent }),
+      (err) => err instanceof PatinaCliError && err.exitCode === 2,
+      `persona new ${args.join(' ')} must fail closed, not build an empty/undefined persona`,
+    );
+  }
+  await runPersonaNew(['seed', '--lang', 'ko', '--template'], { repoRoot, logger: silent });
+  for (const args of [['seed', '--lang', 'ko', '--name'], ['seed', '--lang', 'ko', '--describe'], ['seed', '--lang', 'ko', '--from-sample']]) {
+    await assert.rejects(
+      () => runPersonaEdit(args, { repoRoot, logger: silent }),
+      (err) => err instanceof PatinaCliError && err.exitCode === 2,
+      `persona edit ${args.join(' ')} must fail closed`,
+    );
+  }
+});

--- a/tests/unit/persona-gates.test.js
+++ b/tests/unit/persona-gates.test.js
@@ -143,6 +143,27 @@ test('persona gate with null mps/fidelity and high churn still passes safety (ch
   assert.deepEqual(result.advisory, ['churn']);
 });
 
+test('meaningProxy fail rides advisory only and never sets a CLI-warnable bit (#1)', () => {
+  const result = evaluatePersonaGate({
+    persona: contentPersona,
+    personaMatch: 90, // passes advisory
+    mps: 95,
+    fidelity: 95, // safety passes
+    churn: 0.1, // passes advisory
+    droppedNumbers: [],
+    thresholds: { personaMatchMin: 70, mpsFloor: 70, fidelityFloor: 70, churnMax: 0.45 },
+    meaningProxy: { severity: 'fail', reasons: ['dropped terms/entities'] },
+  });
+  // Phase A: even a meaningProxy 'fail' is advisory — it never blocks the gate.
+  assert.equal(result.pass, true);
+  assert.deepEqual(result.advisory, ['meaningProxy'], 'rides the gate advisory list (JSON report)');
+  // run.js keys the CLI warning on personaMatch/churn only; both pass here, so no
+  // warning fires (the pre-fix path printed an empty "persona advisory: " line).
+  assert.equal(result.personaMatchPass, true);
+  assert.equal(result.churnPass, true);
+  assert.equal(result.meaningProxyPass, false);
+});
+
 test('ablation decision falls back on two consecutive failed rounds', () => {
   const fail = {
     aggregatePass: false,

--- a/tests/unit/verify.test.js
+++ b/tests/unit/verify.test.js
@@ -24,6 +24,15 @@ test('deterministicMeaningGuard treats grouped and plain numbers as equal (1,200
   );
 });
 
+test('deterministicMeaningGuard preserves non-standard grouping so a dropped 1,2 is not masked by 12', () => {
+  // Valid thousands grouping still normalizes (no false positive).
+  assert.deepEqual(deterministicMeaningGuard('n 1,234,567', 'n 1234567'), []);
+  // "1,2" (list/version/coordinate) must NOT collapse onto "12": dropping it
+  // while the rewrite happens to contain 12 must still flag on the enforcing guard.
+  const warnings = deterministicMeaningGuard('rated 1,2 overall', 'rated 12 overall');
+  assert.ok(warnings.some((w) => /numbers/.test(w)), warnings.join(' | '));
+});
+
 // ---------- verifyRewrite (injected scorers + callLLM) ----------
 
 const baseArgs = {


### PR DESCRIPTION
Resolves the GPT-5.5 Pro `main..dev` review tracked in #583. All 11 findings fixed at source, with tests. Nothing added to the deterministic Lane-A layer.

## Majors — user-facing
- **#1** `cli/run.js` — meaningProxy no longer leaks an empty CLI advisory (`persona advisory:  (…)`); the warning is keyed on the CLI-warnable bits (voice-match/churn), not `advisory.length`. meaningProxy still rides the JSON report.
- **#6** `cli/run.js` — profile-voice-retirement warning keys on the **effective** `profileName`, so `.patina.yaml` `profile:` users get it (not just `--profile`); stays silent on the namuwiki→default non-ko fallback.
- **#7** `commands/persona.js` — `persona list` surfaces a custom persona that shadows a built-in (`shadowed` JSON field + `id (shadows built-in)` in human output).
- **#8** `commands/persona.js` — `takeValue()`; `persona new`/`edit` fail closed (exit 2) on a missing value after `--describe`/`--from-sample`/`--name`/`--lang`/`--backend`.

## Majors — meaning-proxy JSON quality (pre Phase B)
- **#2** empty original + non-empty rewrite → `Infinity` ratio → `fail` (was benign `1`).
- **#3** `meaning-proxy.js` + `verify.js` — `numbersIn` normalizes only **valid** thousands grouping (`1,200`→`1200`); `1,2`/`3,14` preserved so they never collapse onto `12`/`314`. `verify.js` is the **enforcing** guard, so that one is the more severe of the two.
- **#4** rare-token substring fallback restricted to CJK or Latin ≥5 (`us`/`art`/`ai` no longer false-survive in `business`/`chair`).
- **#5** kept advisory; pinned a ko/ja/zh negation fixture matrix as a Phase-B baseline.

## Cleanup
- **#9** `compose.js` — `personaOwnsVoice` → `personaHasVoiceTraits` + comment clarified (voice *traits* for the migration warning, not v6.2 ownership).
- **#10** `prompt-builder.js` — strict rewrite instructions persona-aware; no-persona output byte-identical (golden snapshots unchanged).
- **#11** `persona.js` — `writePersonaFile` reuses `safePersonaPath` (cross-platform `path.sep`).

## Verification
- `node --test`: **1164 pass / 0 fail** (1 pre-existing live-quality skip)
- `npm run lint`: syntax / eslint / tsc / cspell all clean

Closes #583.