### PR TITLE
fix(web): restore ko voice parity in the hosted rewrite (persona was never wired)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ release-sync surfaces and the `dev → main` release land separately.
 
 - **Profiles are now pattern-policy only; the persona is the sole voice owner.** Whenever a persona is active (including the `preserve` default), the profile's voice body is no longer sent to the model — all voice comes from the active persona. The 17 `profiles/*.md` dropped their `voice-overrides` frontmatter and voice-guidance bodies (versions bumped to 2.0.0), keeping scope + `pattern-overrides` + pattern-handling. Register precedence is unchanged (`--tone` > persona > profile). **Deprecation/migration:** a runtime warning fires when a non-default profile is used for a rewrite without a voice-owning persona — for genre voice, use a persona (e.g. `--persona blog-essay`); run `patina persona list`. The persona schema still forbids pattern control.
 
+### Fixed
+
+- **Hosted playground rewrite lost its voice under the profile-voice retirement (regression).** The web/serverless rewrite path (`src/web-rewrite.js`) never resolved a persona, so once profiles stopped carrying voice a hosted Korean rewrite received neither the (now-retired) profile voice body nor a persona directive — only the shared `core/voice.md`, silently degrading quality versus the CLI. The web path now resolves the active persona through the same logic the CLI uses, extracted to `src/personas/resolve.js` (`resolvePersonaForRun`) as the single source of truth: `ko` defaults to the `preserve` persona (voice parity with the CLI), while en/zh/ja stay persona-free unless opted in. `personas/**` is now bundled into the Vercel `api/rewrite.js` function so the hosted lookup resolves at runtime (pinned by `tests/unit/web-deploy-invariants.test.js`).
+
 ## 6.1.0 — 2026-07-03
 
 **Personas grow up: enforcing safety gate, multilingual voices, register/profile precedence, and custom voice authoring.**

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -28,11 +28,11 @@ import { detectKoreanRegister } from '../features/stylometry.js';
 import { logBatchSafetyPlan, createBatchCircuitBreaker, shouldHandleBatchFailure, writeBatchOutput, writeAtomicUtf8, resolveBatchOutputPath } from './batch.js';
 import { applyScoreGate, extractScoreOverall } from './score-gate.js';
 import { loadInputs } from './input.js';
-import { PatinaCliError, runtimeError, inputError } from '../errors.js';
+import { PatinaCliError, runtimeError } from '../errors.js';
 import { providerHttpKeyEnvVars, resolveHttpApiKey } from '../auth.js';
 import { DEFAULT_BACKEND_TIMEOUT_MS, getBackendSafety, resolveBackendMaxRetries } from '../backends/contract.js';
 import { resolve } from 'node:path';
-import { loadPersona } from '../personas/loader.js';
+import { resolvePersonaForRun } from '../personas/resolve.js';
 import { evaluatePersonaGate } from '../personas/gates.js';
 import { personaMatchScore } from '../features/persona-match.js';
 import { personaHasVoiceTraits } from '../personas/compose.js';
@@ -612,31 +612,6 @@ function cancellationError() {
  * const cancellation = createCancellationController();
  * cancellation.install();
  */
-
-// Languages with a persona library (personas/{lang}/). Multilingual as of the
-// persona multilang line; each ships at least a `preserve` default.
-const PERSONA_LANGS = new Set(['ko', 'en', 'zh', 'ja']);
-
-export function resolvePersonaForRun({ parsed = {}, config = {}, mode = 'rewrite', lang = 'ko', repoRoot = process.cwd() } = {}) {
-  const defaultPreserve = parsed.persona === undefined && config.persona === 'preserve';
-  const explicitPersona = parsed.persona !== undefined || (config.persona !== undefined && !defaultPreserve);
-  const personaId = parsed.persona ?? config.persona ?? null;
-  const effective = mode === 'rewrite' && !parsed.preview && PERSONA_LANGS.has(lang);
-  if (explicitPersona && !effective) {
-    throw inputError(
-      'persona is only supported for rewrite mode',
-      'A persona runs only when the effective mode is rewrite, preview is off, and the language is one of ko, en, zh, ja.',
-      'Use `patina --persona <name> <file>` on a rewrite (drop --score/--audit/--diff/--preview), or remove the persona setting.'
-    );
-  }
-  if (!effective) return null;
-  // Back-compat: ko keeps its implicit-preserve default (a plain `patina` run
-  // resolves preserve). For en/zh/ja the persona axis is opt-in — a plain rewrite
-  // stays persona-free unless the user explicitly asks (--persona / config), so
-  // existing non-ko rewrites are unchanged.
-  if (lang !== 'ko' && !explicitPersona) return null;
-  return loadPersona(repoRoot, lang, personaId ?? 'preserve');
-}
 
 export function createCancellationController({
   processObj = process,

--- a/src/personas/resolve.js
+++ b/src/personas/resolve.js
@@ -1,0 +1,54 @@
+// @ts-check
+// Single source of truth for "which persona (if any) is active for a rewrite".
+// Shared by the CLI run path (src/cli/run.js) and the web/hosted rewrite path
+// (src/web-rewrite.js) so both surfaces resolve voice ownership identically —
+// the two must not drift (a web-only copy is exactly how the ko voice-parity
+// regression happened after the v6.2 profile-voice retirement).
+import { loadPersona } from './loader.js';
+import { inputError } from '../errors.js';
+
+// Languages with a persona library (personas/{lang}/). Multilingual as of the
+// persona multilang line; each ships at least a `preserve` default.
+export const PERSONA_LANGS = new Set(['ko', 'en', 'zh', 'ja']);
+
+/**
+ * Resolve the active persona for a rewrite invocation, or null when none applies.
+ *
+ * Policy (identical for CLI and web):
+ * - persona only applies when the effective mode is `rewrite`, preview is off,
+ *   and the language has a persona library;
+ * - `ko` keeps its implicit-preserve default (a plain rewrite resolves preserve);
+ * - `en`/`zh`/`ja` are opt-in: a plain rewrite stays persona-free unless a
+ *   persona is explicitly requested via `parsed.persona` or a non-default
+ *   `config.persona`.
+ *
+ * @param {object} [options]
+ * @param {object} [options.parsed] Parsed CLI args (web passes `{}`).
+ * @param {object} [options.config] Effective config (may carry `persona`).
+ * @param {string} [options.mode] Effective output mode.
+ * @param {string} [options.lang] Rewrite language.
+ * @param {string} [options.repoRoot] Bundle/repo root for persona lookup.
+ * @returns {object|null} Normalized persona object, or null when none applies.
+ * @throws {import('../errors.js').PatinaCliError} When a persona is explicitly
+ *   requested for a surface that does not support it.
+ */
+export function resolvePersonaForRun({ parsed = {}, config = {}, mode = 'rewrite', lang = 'ko', repoRoot = process.cwd() } = {}) {
+  const defaultPreserve = parsed.persona === undefined && config.persona === 'preserve';
+  const explicitPersona = parsed.persona !== undefined || (config.persona !== undefined && !defaultPreserve);
+  const personaId = parsed.persona ?? config.persona ?? null;
+  const effective = mode === 'rewrite' && !parsed.preview && PERSONA_LANGS.has(lang);
+  if (explicitPersona && !effective) {
+    throw inputError(
+      'persona is only supported for rewrite mode',
+      'A persona runs only when the effective mode is rewrite, preview is off, and the language is one of ko, en, zh, ja.',
+      'Use `patina --persona <name> <file>` on a rewrite (drop --score/--audit/--diff/--preview), or remove the persona setting.'
+    );
+  }
+  if (!effective) return null;
+  // Back-compat: ko keeps its implicit-preserve default (a plain `patina` run
+  // resolves preserve). For en/zh/ja the persona axis is opt-in — a plain rewrite
+  // stays persona-free unless the user explicitly asks (--persona / config), so
+  // existing non-ko rewrites are unchanged.
+  if (lang !== 'ko' && !explicitPersona) return null;
+  return loadPersona(repoRoot, lang, personaId ?? 'preserve');
+}

--- a/src/web-rewrite.js
+++ b/src/web-rewrite.js
@@ -6,9 +6,10 @@ import { inputError } from './errors.js';
 import { loadCoreFile, loadPatterns, loadProfile } from './loader.js';
 import { formatRewriteBodyForBrowser } from './output.js';
 import { buildPrompt, fenceReferenceText } from './prompt-builder.js';
+import { resolvePersonaForRun } from './personas/resolve.js';
 import { loadWebConfig, resolveBundleRoot } from './web-config.js';
 
-/** @type {Map<string, { config: object, patterns: object[], profile: object, core: object|null }>} */
+/** @type {Map<string, { config: object, patterns: object[], profile: object, core: object|null, persona: object|null }>} */
 const ASSET_CACHE = new Map();
 
 /** @param {unknown} value */
@@ -24,7 +25,7 @@ function cloneConfig(value) {
  * @param {string} options.lang Language code.
  * @param {string} options.profile Profile name.
  * @param {object} options.config Web-safe baseline config.
- * @returns {{ config: object, patterns: object[], profile: object, core: object|null }} Loaded assets.
+ * @returns {{ config: object, patterns: object[], profile: object, core: object|null, persona: object|null }} Loaded assets.
  * @throws {import('./errors.js').PatinaCliError} When required bundled assets are missing or empty.
  */
 export function loadWebAssets({ repoRoot = resolveBundleRoot(), lang, profile, config }) {
@@ -52,7 +53,13 @@ export function loadWebAssets({ repoRoot = resolveBundleRoot(), lang, profile, c
     }
 
     const core = loadCoreFile(repoRoot, 'voice.md');
-    const assets = { config, patterns, profile: loadedProfile, core: core.body ? core : null };
+    // v6.2 profile-voice retirement: persona is the sole voice owner. Resolve
+    // the active persona exactly like the CLI (resolvePersonaForRun) so the
+    // hosted rewrite keeps voice parity — ko defaults to preserve, en/zh/ja stay
+    // persona-free unless config opts in. Without this the ko web prompt loses
+    // ALL voice guidance (retired profile voice body + no persona directive).
+    const persona = resolvePersonaForRun({ config, lang, mode: 'rewrite', repoRoot });
+    const assets = { config, patterns, profile: loadedProfile, core: core.body ? core : null, persona };
     ASSET_CACHE.set(cacheKey, assets);
     return assets;
   } catch (err) {
@@ -84,7 +91,7 @@ function renderHistory(history = []) {
  * @param {object} options
  * @param {object} options.request Validated web rewrite request.
  * @param {object} options.config Web-safe config.
- * @param {{ patterns: object[], profile: object, core: object|null }} options.assets Loaded web assets.
+ * @param {{ patterns: object[], profile: object, core: object|null, persona: object|null }} options.assets Loaded web assets.
  * @returns {string} Prompt text.
  */
 export function buildWebRewritePrompt({ request, config, assets }) {
@@ -93,6 +100,7 @@ export function buildWebRewritePrompt({ request, config, assets }) {
     patterns: assets.patterns,
     profile: assets.profile,
     voice: assets.core,
+    persona: assets.persona,
     scoring: null,
     mode: 'rewrite',
     text: request.text,

--- a/tests/unit/persona-resolver.test.js
+++ b/tests/unit/persona-resolver.test.js
@@ -3,7 +3,7 @@ import { strict as assert } from 'node:assert';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
-import { resolvePersonaForRun } from '../../src/cli/run.js';
+import { resolvePersonaForRun } from '../../src/personas/resolve.js';
 import { PatinaCliError } from '../../src/errors.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/tests/unit/web-deploy-invariants.test.js
+++ b/tests/unit/web-deploy-invariants.test.js
@@ -24,7 +24,7 @@ test('vercel.json bundles patina assets into the rewrite function', () => {
   assert.ok(fn, 'api/rewrite.js must have a functions entry');
   const include = fn.includeFiles;
   assert.equal(typeof include, 'string', 'includeFiles must be a glob string');
-  for (const asset of ['patterns', 'profiles', 'core', 'lexicon', '.patina.default.yaml']) {
+  for (const asset of ['patterns', 'profiles', 'personas', 'core', 'lexicon', '.patina.default.yaml']) {
     assert.ok(
       include.includes(asset),
       `includeFiles must bundle ${asset} (got: ${include})`,

--- a/tests/unit/web-rewrite.test.js
+++ b/tests/unit/web-rewrite.test.js
@@ -54,8 +54,36 @@ test('runWebRewrite first-turn uses real patina assets for every supported langu
     assert.equal(result.rewrite, 'Canned rewrite');
     assert.match(calls[0].prompt, /## Pattern Packs/);
     assert.match(calls[0].prompt, /## Profile/);
-    assert.ok(calls[0].prompt.includes(profileToken), `${lang} prompt missing profile token ${profileToken}`);
+    if (assets.persona) {
+      // ko: persona is the sole voice owner — the profile body is replaced by a
+      // one-line defer and the persona directive is present (voice parity with CLI).
+      assert.match(calls[0].prompt, /voice guidance defers to the active persona/, `${lang} should defer profile voice to the persona`);
+    } else {
+      assert.ok(calls[0].prompt.includes(profileToken), `${lang} prompt missing profile token ${profileToken}`);
+    }
     assert.ok(calls[0].prompt.includes(patternToken), `${lang} prompt missing pattern token ${patternToken}`);
+  }
+});
+
+test('ko web rewrite gives the preserve persona voice ownership (regression: v6.2 profile-voice retirement)', () => {
+  const config = configFor('ko');
+  const assets = loadWebAssets({ repoRoot, lang: 'ko', profile: 'default', config });
+  // Before the fix the web path passed no persona, so a ko rewrite lost ALL voice:
+  // the retired profile body carried none, and no persona directive was emitted.
+  assert.ok(assets.persona, 'ko web assets must resolve a persona');
+  assert.equal(assets.persona.id, 'preserve');
+  const prompt = buildWebRewritePrompt({ request: baseRequest('ko'), config, assets });
+  assert.match(prompt, /voice guidance defers to the active persona/);
+  assert.match(prompt, /페르소나:/); // localized persona directive is present
+});
+
+test('en/zh/ja web rewrite stays persona-free (matches CLI opt-in policy)', () => {
+  for (const lang of ['en', 'zh', 'ja']) {
+    const config = configFor(lang);
+    const assets = loadWebAssets({ repoRoot, lang, profile: 'default', config });
+    assert.equal(assets.persona, null, `${lang} web assets must be persona-free`);
+    const prompt = buildWebRewritePrompt({ request: baseRequest(lang), config, assets });
+    assert.doesNotMatch(prompt, /voice guidance defers to the active persona/);
   }
 });
 

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
   },
   "functions": {
     "api/rewrite.js": {
-      "includeFiles": "{patterns/**,profiles/**,core/**,lexicon/**,.patina.default.yaml}"
+      "includeFiles": "{patterns/**,profiles/**,personas/**,core/**,lexicon/**,.patina.default.yaml}"
     }
   },
   "rewrites": [


### PR DESCRIPTION
## Problem

The web/serverless rewrite path (`src/web-rewrite.js`) **never resolved a persona**. After the v6.2 profile-voice retirement stripped voice guidance out of `profiles/*.md`, a hosted **Korean** rewrite ended up with:

- no profile voice body (retired), and
- no persona directive (never wired),

leaving only the shared `core/voice.md` — a silent quality regression versus the CLI, which defaults `ko` rewrites to the `preserve` persona.

## Root cause

`resolvePersonaForRun` lived inside the heavy CLI module (`src/cli/run.js`), so the lean web path couldn't reuse it and voice ownership had **no single source of truth**. The web path had quietly drifted from the CLI's persona policy.

## Fix

- Extract `resolvePersonaForRun` + `PERSONA_LANGS` into **`src/personas/resolve.js`** as the single source of truth; both `run.js` and the web path import it.
- `loadWebAssets` now resolves the active persona (`ko` → `preserve`; `en/zh/ja` stay persona-free unless config opts in — **identical to the CLI**) and `buildWebRewritePrompt` passes it into `buildPrompt`, so the ko web prompt regains persona voice ownership.
- Bundle `personas/**` into the Vercel `api/rewrite.js` function so the hosted lookup resolves at runtime (pinned by `tests/unit/web-deploy-invariants.test.js`).

No behavior added to the deterministic Lane-A layer.

## Verification

- `node --test` → **1166 pass / 0 fail** (1 pre-existing live-quality skip)
- `npm run lint` (syntax/eslint/tsc/cspell) → clean
- New regression tests: ko web prompts defer voice to the `preserve` persona; en/zh/ja stay persona-free.

## Files

- `src/personas/resolve.js` (new), `src/web-rewrite.js`, `src/cli/run.js`, `vercel.json`
- tests: `web-rewrite.test.js`, `persona-resolver.test.js`, `web-deploy-invariants.test.js`
- `CHANGELOG.md` (Unreleased → Fixed)