### PR TITLE
chore(release): 6.2.0 — version bump across release-sync surfaces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "patina",
       "source": "./",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "description": "Strip the AI packaging, keep the meaning. Detect and rewrite AI writing patterns across KO/EN/ZH/JA with MPS/fidelity checks. Runs the root SKILL.md as the /patina skill.",
       "homepage": "https://github.com/devswha/patina",
       "repository": "https://github.com/devswha/patina",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
   "name": "patina",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese so text reads as if a human wrote it. Meaning-preservation (MPS) verified, audit-friendly. The root SKILL.md is loaded as the /patina skill.",
   "author": {
     "name": "devswha",

--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "6.1.0"
+version: "6.2.0"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,11 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
-## Unreleased
+## 6.2.0 — 2026-07-05
 
-**Persona seeds for en/zh/ja, `persona show|rm|edit`, and profile-voice retirement.**
+**Personas everywhere: en/zh/ja seeds, `persona show|rm|edit`, profile-voice retirement, an advisory meaning-floor proxy, and a hosted playground Voice selector.**
 
-Semver rationale: minor — additive persona seeds and subcommands plus a profile
-behavior change (profiles are now pattern-policy only). The version bump across
-release-sync surfaces and the `dev → main` release land separately.
+Semver rationale: minor — additive persona seeds and subcommands, a deterministic advisory meaning proxy, and the playground Voice selector, plus a profile behavior change (profiles are now pattern-policy only; the active persona owns voice). No stable public CLI/API is removed.
 
 ### Added
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -142,7 +142,7 @@ test -f ~/.claude/skills/patina/SKILL.md && \
   grep '^version:' ~/.claude/skills/patina/SKILL.md
 ```
 
-Expected output: `version: 6.1.0` (or newer).
+Expected output: `version: 6.2.0` (or newer).
 
 For each host you installed into, also verify the symlink target:
 
@@ -182,7 +182,7 @@ Or through Docker after the GHCR release image exists:
 
 ```bash
 printf '%s\n' 'Coffee has emerged as a pivotal cultural phenomenon.' \
-  | docker run --rm -i -e PATINA_API_KEY ghcr.io/devswha/patina:6.1.0 --lang en --provider openai
+  | docker run --rm -i -e PATINA_API_KEY ghcr.io/devswha/patina:6.2.0 --lang en --provider openai
 ```
 
 The Docker image intentionally does not bake in codex/claude/gemini CLI binaries or logins. Use API-backed providers inside the container, or mount your own authenticated tooling explicitly.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 6.1.0" src="https://img.shields.io/badge/version-6.1.0-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 6.2.0" src="https://img.shields.io/badge/version-6.2.0-blue"></a>
 </p>
 
 <p align="center">
@@ -206,7 +206,7 @@ If meaning drifts, the change is retried or rolled back. Deterministic analysis 
 
 ```yaml
 # .patina.default.yaml
-version: "6.1.0"
+version: "6.2.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/README_JA.md
+++ b/README_JA.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#クイックスタート)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-6.1.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-6.2.0-blue)](CHANGELOG.md)
 
 > **AIっぽさだけを落として、意味はそのまま。**
 
@@ -186,7 +186,7 @@ Input
 
 ```yaml
 # .patina.default.yaml
-version: "6.1.0"
+version: "6.2.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/README_KR.md
+++ b/README_KR.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#빠른-시작)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-6.1.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-6.2.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <a href="https://patina.vibetip.help/"><b>브라우저에서 바로 써보기 — 설치 없음</b></a>
@@ -186,7 +186,7 @@ Input
 
 ```yaml
 # .patina.default.yaml
-version: "6.1.0"
+version: "6.2.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Skill](https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet)](#快速开始)
 [![Multi-language](https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green)](https://github.com/devswha/patina)
-[![Version](https://img.shields.io/badge/version-6.1.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-6.2.0-blue)](CHANGELOG.md)
 
 <p align="center">
   <strong>去掉 AI 味，保留原意。</strong>
@@ -188,7 +188,7 @@ Input
 
 ```yaml
 # .patina.default.yaml
-version: "6.1.0"
+version: "6.2.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 6.1.0
+version: 6.2.0
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "6.1.0"
+    "patina-cli": "6.2.0"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What

Version bump to **6.2.0** across every release-sync surface, landing the bump on `dev` ahead of the `dev → main` release merge.

Gated by `release:check` (`scripts/check-release-metadata.mjs`):
- `package.json`, `SKILL.md`, `.patina.default.yaml`, `README.md` config example
- `packages/patina-humanizer/package.json` (version + `patina-cli` dep)
- `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
- `CHANGELOG.md` — `Unreleased` dated as `## 6.2.0 — 2026-07-05`

Also synced (not gated, but version-bearing): README badges (en/kr/ja/zh) + KR/JA/ZH config blocks, `INSTALLATION.md` version line + docker tag.

## What ships in 6.2.0

The persona line accumulated on `dev` since 6.1.0:
- en/zh/ja seed personas; `patina persona show|rm|edit`
- profile voice retirement (persona is the sole voice owner)
- deterministic, LLM-free advisory meaning-floor proxy (Phase A)
- ko hosted-rewrite **voice-parity fix** (#585)
- hosted playground **Voice selector** (#586)

## Verification

- `release:check` → **OK for 6.2.0**
- `node --test` → **1171 pass / 0 fail** (1 pre-existing live-quality skip)
- `npm run lint` (syntax/eslint/tsc/cspell) → clean

Merges into `dev`; the `dev → main` release PR follows.
