### PR TITLE
fix(web): harden rewrite service per security audit (L-1..L-4)

### DIFF
--- a/api/rewrite.js
+++ b/api/rewrite.js
@@ -79,11 +79,19 @@ const WEB_REWRITE_TIMEOUT_MS = 180_000;
 export function createRewriteApiHandler({ env = /** @type {Record<string,string|undefined>} */ (process.env), runWebRewriteStreamImpl = runWebRewriteStream, logger = console, now = () => Date.now() } = {}) {
   const restKv = createRestKv(env);
   const kv = isProductionPosture(env) ? restKv : (restKv ?? createMemoryKv());
+  // One stream budget, computed once: bounds upstream work (provider + scoring)
+  // and, via concurrencyTtlMs, keeps a free-tier slot alive for at least a full
+  // stream so an operator-extended timeout can't expire the slot mid-stream and
+  // desync the counter (a later decr would drive it negative). Floor at 5m.
+  const envTimeout = Number(env.PATINA_WEB_REWRITE_TIMEOUT_MS);
+  const streamTimeoutMs = Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : WEB_REWRITE_TIMEOUT_MS;
+  const concurrencyTtlMs = Math.max(5 * 60 * 1000, streamTimeoutMs + 30_000);
   return createRewriteHandler({
     rateLimiter: createRateLimiter({
       kv,
       hmacSecret: env.PATINA_QUOTA_HMAC_SECRET,
       env,
+      concurrencyTtlMs,
       logger: /** @type {any} */ (logger),
     }),
     runRewrite: async ({ req, res, request }) => {
@@ -110,23 +118,25 @@ export function createRewriteApiHandler({ env = /** @type {Record<string,string|
       const onClose = () => { if (!res.writableEnded) controller.abort(); };
       res.on?.('close', onClose);
       req.on?.('aborted', onClose);
-      const envTimeout = Number(env.PATINA_WEB_REWRITE_TIMEOUT_MS);
-      const timeout = Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : WEB_REWRITE_TIMEOUT_MS;
       const startedAt = now();
+      let result;
       try {
-        await runWebRewriteStreamImpl({
+        result = await runWebRewriteStreamImpl({
           request: { ...request, apiKey },
           emit: (frame) => res.write?.(encodeStreamFrame(frame)),
           signal: controller.signal,
-          timeout,
+          timeout: streamTimeoutMs,
         });
       } finally {
         res.off?.('close', onClose);
         req.off?.('aborted', onClose);
       }
       res.end?.();
-      // Sanitized observability ONLY: route/tier/provider/model/status/bucketed
-      // latency + char count. Never the text, prompt, output, key, or full IP.
+      // Sanitized observability ONLY: route/tier/provider/model/status/outcome/
+      // bucketed latency + char count. Never the text, prompt, output, key, or
+      // full IP. The HTTP status is a genuine 200 (frames already committed), so
+      // `outcome` — not `status` — carries whether the stream itself failed, so
+      // abuse/provider-failure/floor-failure spikes stay observable.
       logger.info?.('rewrite.metric', buildRewriteMetric({
         tier: request.tier,
         provider: request.provider,
@@ -134,6 +144,7 @@ export function createRewriteApiHandler({ env = /** @type {Record<string,string|
         status: 200,
         latencyMs: now() - startedAt,
         quotaDecision: 'allowed',
+        outcome: result && result.ok === false ? String(result.code || 'failed') : 'ok',
         charCount: typeof request.text === 'string' ? request.text.length : 0,
       }));
     },

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -5,6 +5,7 @@ import { QUOTA_REASONS, TIER_LIMITS, WEB_TIERS } from './web-rewrite-contract.js
 
 const DAY_MS = 86_400_000;
 const HOUR_MS = 3_600_000;
+const DEFAULT_CONCURRENCY_TTL_MS = 5 * 60 * 1000;
 
 /**
  * Return a hex sha256 HMAC quota key for NUL-separated parts.
@@ -112,10 +113,12 @@ export function isProductionPosture(env = {}) {
 /**
  * Create a fail-closed rate limiter for the shared free proxy.
  *
- * @param {{kv?: QuotaKv|null, hmacSecret?: string, env?: Record<string, string|undefined>, now?: () => number, limits?: typeof TIER_LIMITS, logger?: RateLimitLogger}} options
+ * @param {{kv?: QuotaKv|null, hmacSecret?: string, env?: Record<string, string|undefined>, now?: () => number, limits?: typeof TIER_LIMITS, logger?: RateLimitLogger, concurrencyTtlMs?: number}} options
+ *   `concurrencyTtlMs` is the self-healing expiry for a concurrency slot; keep it
+ *   >= the maximum stream budget so a slot never expires mid-stream (defaults to 5m).
  * @returns {{check(input: {tier: string, ip?: string|null}): Promise<RateLimitResult>, acquireConcurrency(input: {tier: string, ip?: string|null}): Promise<RateLimitResult>, releaseConcurrency(input: {tier: string, ip?: string|null}): Promise<void>}}
  */
-export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.now(), limits = TIER_LIMITS, logger = console }) {
+export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.now(), limits = TIER_LIMITS, logger = console, concurrencyTtlMs = DEFAULT_CONCURRENCY_TTL_MS }) {
   const getConcurrencyKey = (tier, ip) => {
     if (tier === WEB_TIERS.BYOK) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: true, tier }) };
     const production = isProductionPosture(env);
@@ -188,7 +191,7 @@ export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.n
       if (!resolved.ok) return resolved.result;
       const freeLimits = limits.free;
       try {
-        const activeCount = await kv.incr(resolved.key, { ttlMs: 5 * 60 * 1000 });
+        const activeCount = await kv.incr(resolved.key, { ttlMs: concurrencyTtlMs });
         if (!Number.isSafeInteger(activeCount) || activeCount < 1) {
           return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
         }

--- a/src/rewrite-handler.js
+++ b/src/rewrite-handler.js
@@ -11,7 +11,7 @@ import { extractClientIp } from './rate-limit.js';
  * optional so bare serverless/test mocks keep working.
  *
  * @typedef {{method?: string, headers?: Record<string, string|string[]|undefined>, body?: unknown, on?: (event: string, listener: (...args: unknown[]) => void) => unknown, off?: (event: string, listener: (...args: unknown[]) => void) => unknown, [Symbol.asyncIterator]?: () => AsyncIterator<Buffer|string|Uint8Array>}} RewriteReq
- * @typedef {{statusCode?: number, setHeader?: (name: string, value: string) => void, write?: (chunk: string) => void, end?: (body?: string) => void, on?: (event: string, listener: (...args: unknown[]) => void) => unknown, off?: (event: string, listener: (...args: unknown[]) => void) => unknown, writableEnded?: boolean}} RewriteRes
+ * @typedef {{statusCode?: number, setHeader?: (name: string, value: string) => void, write?: (chunk: string) => void, end?: (body?: string) => void, on?: (event: string, listener: (...args: unknown[]) => void) => unknown, off?: (event: string, listener: (...args: unknown[]) => void) => unknown, writableEnded?: boolean, headersSent?: boolean, destroy?: () => void}} RewriteRes
  * @typedef {{check(input: {tier: string, ip: string|null}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, acquireConcurrency?(input: {tier: string, ip: string|null}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, releaseConcurrency?(input: {tier: string, ip: string|null}): Promise<void>}} RateLimiter
  */
 
@@ -93,6 +93,15 @@ function setSecurityHeaders(res) {
  * @returns {undefined}
  */
 export function send(res, status, obj) {
+  // If the response is already committed (an exception escaped after a stream
+  // started writing frames), re-setting status/headers would throw
+  // ERR_HTTP_HEADERS_SENT inside the caller's catch and reject the handler
+  // promise. Fail closed by tearing down the socket: the client's stream
+  // contract already reads a truncated (no `done`) response as an error.
+  if (res.headersSent || res.writableEnded) {
+    res.destroy?.();
+    return undefined;
+  }
   res.statusCode = status;
   res.setHeader?.('Cache-Control', 'no-store');
   res.setHeader?.('X-Content-Type-Options', 'nosniff');

--- a/src/web-observability.js
+++ b/src/web-observability.js
@@ -10,8 +10,11 @@
 
 /** The complete set of fields a rewrite metric may contain. */
 export const METRIC_FIELDS = Object.freeze([
-  'route', 'tier', 'provider', 'model', 'status', 'latencyBucket', 'quotaDecision', 'charBucket',
+  'route', 'tier', 'provider', 'model', 'status', 'latencyBucket', 'quotaDecision', 'charBucket', 'outcome',
 ]);
+
+/** Closed set of stream outcomes; anything else normalizes to 'n/a' so the field can never carry free-form text. */
+const OUTCOME_VALUES = Object.freeze(new Set(['ok', 'stream_failed', 'scoring_failed', 'floor_failed']));
 
 /** Bucket a latency (ms) into a coarse band so timings are not individually identifying. */
 export function latencyBucket(ms) {
@@ -40,10 +43,10 @@ export function charBucket(count) {
  * are read; any extra keys passed in are ignored, so text/prompt/key/IP can
  * never flow through.
  *
- * @param {{route?:string, tier?:string, provider?:string, model?:string, status?:number, latencyMs?:number, quotaDecision?:string, charCount?:number}} [input]
- * @returns {{route:string, tier:string, provider:string, model:string, status:number, latencyBucket:string, quotaDecision:string, charBucket:string}}
+ * @param {{route?:string, tier?:string, provider?:string, model?:string, status?:number, latencyMs?:number, quotaDecision?:string, charCount?:number, outcome?:string}} [input]
+ * @returns {{route:string, tier:string, provider:string, model:string, status:number, latencyBucket:string, quotaDecision:string, charBucket:string, outcome:string}}
  */
-export function buildRewriteMetric({ route = '/api/rewrite', tier, provider, model, status, latencyMs, quotaDecision, charCount } = {}) {
+export function buildRewriteMetric({ route = '/api/rewrite', tier, provider, model, status, latencyMs, quotaDecision, charCount, outcome } = {}) {
   return {
     route: String(route),
     tier: tier === 'free' || tier === 'byok' ? tier : 'unknown',
@@ -53,6 +56,7 @@ export function buildRewriteMetric({ route = '/api/rewrite', tier, provider, mod
     latencyBucket: latencyBucket(latencyMs),
     quotaDecision: quotaDecision ? String(quotaDecision) : 'n/a',
     charBucket: charBucket(charCount),
+    outcome: OUTCOME_VALUES.has(String(outcome)) ? String(outcome) : 'n/a',
   };
 }
 

--- a/src/web-rewrite-stream.js
+++ b/src/web-rewrite-stream.js
@@ -17,9 +17,19 @@ function rawScore(score, field) {
   return /** @type {any} */ (score)?.[field];
 }
 
-/** @param {unknown} err */
-function safeError(err) {
-  return String(redactSecrets(/** @type {any} */ (err)?.message ?? err ?? 'unknown error'));
+/**
+ * @param {unknown} err
+ * @param {string} [secret] Request-scoped API key to scrub verbatim, on top of
+ *   pattern-based redaction. Covers provider key formats (e.g. GLM `id.secret`)
+ *   that carry no `sk-`/`Bearer`/label marker for the regex to catch, so a key
+ *   echoed in a provider error body never reaches an error frame or a log line.
+ */
+function safeError(err, secret) {
+  let out = String(redactSecrets(/** @type {any} */ (err)?.message ?? err ?? 'unknown error'));
+  if (typeof secret === 'string' && secret.length >= 8 && out.includes(secret)) {
+    out = out.split(secret).join('[REDACTED]');
+  }
+  return out;
 }
 
 /** @param {unknown} value */
@@ -94,7 +104,7 @@ export async function runWebRewriteStream({
     });
     rewrite = formatRewriteBodyForBrowser(streamResult.text);
   } catch (err) {
-    const error = safeError(err);
+    const error = safeError(err, request.apiKey);
     emit({ type: STREAM_FRAME_TYPES.ERROR, code: 'stream_failed', error });
     return { ok: false, code: 'stream_failed', error };
   }
@@ -119,7 +129,7 @@ export async function runWebRewriteStream({
     // A scoring failure (including an abort during scoring) must terminate as
     // a clean NDJSON error frame — never bubble to the handler's JSON 500,
     // which would append a non-frame tail to an already-started stream.
-    const error = safeError(err);
+    const error = safeError(err, request.apiKey);
     emit({ type: STREAM_FRAME_TYPES.ERROR, code: 'scoring_failed', error });
     return { ok: false, code: 'scoring_failed', error };
   }

--- a/tests/unit/rate-limit.test.js
+++ b/tests/unit/rate-limit.test.js
@@ -164,6 +164,20 @@ test('free concurrency limit rejects a second active slot and releases after com
   assert.equal((await limiter.acquireConcurrency({ tier: WEB_TIERS.FREE, ip: '203.0.113.30' })).allowed, true);
 });
 
+test('concurrency slot TTL defaults to 5m and honors an override so an extended stream never expires the slot', async () => {
+  const defaultCalls = [];
+  const defaultKv = { async incr(_key, opts) { defaultCalls.push(opts); return 1; }, async decr() { return 0; } };
+  const defaultLimiter = createRateLimiter({ kv: defaultKv, hmacSecret: 'secret', now: () => 0 });
+  await defaultLimiter.acquireConcurrency({ tier: WEB_TIERS.FREE, ip: '203.0.113.40' });
+  assert.equal(defaultCalls[0].ttlMs, 5 * 60 * 1000);
+
+  const overrideCalls = [];
+  const overrideKv = { async incr(_key, opts) { overrideCalls.push(opts); return 1; }, async decr() { return 0; } };
+  const overrideLimiter = createRateLimiter({ kv: overrideKv, hmacSecret: 'secret', now: () => 0, concurrencyTtlMs: 12 * 60 * 1000 });
+  await overrideLimiter.acquireConcurrency({ tier: WEB_TIERS.FREE, ip: '203.0.113.40' });
+  assert.equal(overrideCalls[0].ttlMs, 12 * 60 * 1000);
+});
+
 test('BYOK concurrency bypasses shared free slot limit', async () => {
   const limiter = createRateLimiter({
     kv: createMemoryKv(),

--- a/tests/unit/rewrite-api.test.js
+++ b/tests/unit/rewrite-api.test.js
@@ -119,6 +119,25 @@ test('the entrypoint emits a sanitized rewrite metric (no text/key/IP) on succes
   assert.equal('apiKey' in metric.fields, false);
 });
 
+test('the rewrite metric records the stream outcome so a failed stream is not logged as success', async () => {
+  const env = { NODE_ENV: 'test', PATINA_FREE_PROVIDER: 'openai', PATINA_FREE_MODEL: 'gpt-5.5', PATINA_FREE_API_KEY: 'sk-server-free-key' };
+  const metrics = [];
+  const logger = { info: (evt, fields) => metrics.push({ evt, fields }), error() {}, warn() {}, debug() {} };
+  const injected = async ({ emit }) => {
+    emit({ type: 'start', provider: 'openai', model: 'gpt-5.5' });
+    emit({ type: 'error', code: 'stream_failed', error: 'provider down' });
+    return { ok: false, code: 'stream_failed', error: 'provider down' };
+  };
+  const api = createRewriteApiHandler({ env, runWebRewriteStreamImpl: injected, logger });
+  const res = makeRes();
+  await api(makeReq(), res);
+
+  const metric = metrics.find((m) => m.evt === 'rewrite.metric');
+  assert.ok(metric, 'a rewrite.metric must be emitted even when the stream fails');
+  assert.equal(metric.fields.status, 200, 'the HTTP response genuinely committed 200');
+  assert.equal(metric.fields.outcome, 'stream_failed', 'but the stream failure must stay observable');
+});
+
 test('free tier fails closed with 503 when the server free API key is unconfigured', async () => {
   const env = { NODE_ENV: 'test', PATINA_FREE_PROVIDER: 'openai', PATINA_FREE_MODEL: 'gpt-5.5' }; // no PATINA_FREE_API_KEY
   let runnerCalled = false;

--- a/tests/unit/rewrite-handler.test.js
+++ b/tests/unit/rewrite-handler.test.js
@@ -270,3 +270,37 @@ test('BYOK concurrent requests bypass free concurrency limit', async () => {
   assert.equal(firstRes.statusCode, 200);
   assert.equal(secondRes.statusCode, 200);
 });
+test('send() tears down an already-committed response instead of throwing ERR_HTTP_HEADERS_SENT', async () => {
+  let destroyed = false;
+  const res = {
+    statusCode: 0,
+    headersSent: false,
+    writableEnded: false,
+    setHeader() {
+      // Mirror Node: mutating headers after they are flushed throws.
+      if (this.headersSent) throw new Error('ERR_HTTP_HEADERS_SENT');
+    },
+    write() {
+      // Writing the first frame commits the response (headers flushed).
+      this.headersSent = true;
+    },
+    end() {
+      if (this.headersSent) throw new Error('ERR_HTTP_HEADERS_SENT');
+    },
+    destroy() { destroyed = true; },
+  };
+  const handler = createRewriteHandler({
+    rateLimiter: allowedLimiter(),
+    runRewrite({ res: r }) {
+      r.write('{"type":"start"}\n'); // stream started -> response committed
+      throw new Error('boom after the first frame');
+    },
+    logger: { error() {} },
+  });
+
+  await assert.doesNotReject(
+    handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.24' }, body: validBody() }, res),
+    'a committed-response 500 path must not re-throw ERR_HTTP_HEADERS_SENT',
+  );
+  assert.equal(destroyed, true, 'a committed response must be torn down, not re-headered');
+});

--- a/tests/unit/web-rewrite-stream.redteam.test.js
+++ b/tests/unit/web-rewrite-stream.redteam.test.js
@@ -5,6 +5,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { callLLMStream } from '../../src/streaming-api.js';
 import { runWebRewriteStream } from '../../src/web-rewrite-stream.js';
+import { redactSecrets } from '../../src/web-rewrite-contract.js';
 import { createRestKv, createRewriteApiHandler } from '../../api/rewrite.js';
 
 const baseRequest = {
@@ -204,6 +205,28 @@ test('redteam key leak scrubs stream_failed errors and emitted frames never expo
   assertNoDone(frames);
   const serialized = JSON.stringify({ frames, result });
   assert.doesNotMatch(serialized, /sk-LEAK/);
+  for (const frame of frames) assertNoSecretFields(frame);
+});
+
+test('redteam key leak scrubs an unlabelled provider key (GLM id.secret) that no redaction pattern matches', async () => {
+  // GLM keys are `id.secret` with no sk-/Bearer/label marker, so the pattern
+  // redactor (SECRET_VALUE_RES) cannot catch them echoed in an error body — only
+  // the request-scoped exact-substring scrub in safeError can.
+  const glmKey = '6a1b2c3d4e5f60718293.aZ9xY8wV7uT6sR5q';
+  // Sanity: pattern-based redaction alone leaves this key intact (proves the gap).
+  assert.equal(String(redactSecrets(`echoed ${glmKey}`)).includes(glmKey), true);
+
+  const { frames, result } = await runStream({
+    request: { ...baseRequest, apiKey: glmKey },
+    callLLMStream: async () => { throw new Error(`401 invalid api key: ${glmKey}`); },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'stream_failed');
+  assertNoDone(frames);
+  const serialized = JSON.stringify({ frames, result });
+  assert.doesNotMatch(serialized, /aZ9xY8wV7uT6sR5q/);
+  assert.equal(serialized.includes(glmKey), false);
   for (const frame of frames) assertNoSecretFields(frame);
 });
 


### PR DESCRIPTION
## 요약
읽기 전용 보안 감사(`fable-audit-patina.md`)에서 나온 6개 발견 중, **의도된 설계가 아닌 저위험 하드닝 4건(L-1~L-4)** 을 수정. M-1/M-2는 테스트로 못박힌 설계·배포 결정이라 **의도적으로 손대지 않음**.

## 변경 (L-1 ~ L-4)
- **L-1** — `safeError`에서 요청 스코프 BYOK 키를 exact-substring으로 스크럽. 라벨/접두사 없는 프로바이더 키 형식(예: GLM `id.secret`)이 정규식 redaction을 통과해 에러 프레임/로그로 새는 경로 차단. (`src/web-rewrite-stream.js`)
- **L-2** — rewrite 메트릭에 스트림 결과를 반영하는 sanitized 닫힌집합 `outcome` 필드 추가. 실패 스트림이 성공으로 집계되던 문제 해결. HTTP status는 실제값 200 유지. (`src/web-observability.js`, `api/rewrite.js`)
- **L-3** — 이미 커밋된 응답에서 `send()`가 2차 `ERR_HTTP_HEADERS_SENT`를 던지지 않도록 `headersSent/writableEnded` 가드 + `res.destroy()` fail-closed. (`src/rewrite-handler.js`)
- **L-4** — 동시성 슬롯 TTL을 스트림 예산에서 파생(`max(5분, timeout+30s)`). 운영자가 타임아웃을 연장해도 슬롯이 스트림 중간에 만료돼 카운터가 어긋나는 문제 방지. (`src/rate-limit.js`, `api/rewrite.js`)

## 의도적으로 두는 것
- **M-1 (BYOK 무제한)** — `rate-limit.redteam.test.js` category 4 및 `rate-limit.test.js`가 "BYOK는 공유 쿼터를 우회한다"를 명시적으로 assert. 한도를 걸면 계약 위반 + 프로덕션 가용성 회귀.
- **M-2 (IP 헤더 신뢰)** — category 2가 비신뢰 헤더 무시(Vercel 전제)를 assert. env 구성/비-Vercel fail-closed는 배포 결정 사항.

## 검증
- `npm test`: 1175 pass / 1 skip
- `npm run lint`: syntax · eslint · tsc · cspell 전부 통과
