### PR TITLE
feat(web): add claude-sonnet-5 to the Pro provider allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,8 +70,9 @@ PATINA_RUNTIME_CLI=your-runtime-cli-binary
 # PATINA_LICENSE_HMAC_SECRET=your-long-random-secret
 
 # Pro provider/model (fall back to PATINA_FREE_PROVIDER/MODEL, then preset).
-# PATINA_PRO_PROVIDER=openai
-# PATINA_PRO_MODEL=gpt-5.5
+# Both must be on the PROVIDER_PRESETS allowlist. Pro ships on Claude Sonnet 5.
+# PATINA_PRO_PROVIDER=claude
+# PATINA_PRO_MODEL=claude-sonnet-5
 
 # Pro limits (per-license). Defaults shown.
 # PATINA_PRO_MAX_CHARS=20000

--- a/src/web-rewrite-contract.js
+++ b/src/web-rewrite-contract.js
@@ -124,7 +124,7 @@ export const PROVIDER_PRESETS = Object.freeze({
   }),
   claude: Object.freeze({
     baseURL: 'https://api.anthropic.com/v1',
-    models: Object.freeze(['claude-sonnet-4-5', 'claude-opus-4-1', 'claude-haiku-4-5']),
+    models: Object.freeze(['claude-sonnet-5', 'claude-sonnet-4-5', 'claude-opus-4-1', 'claude-haiku-4-5']),
   }),
   deepseek: Object.freeze({
     baseURL: 'https://api.deepseek.com/v1',

--- a/tests/unit/web-rewrite-contract.test.js
+++ b/tests/unit/web-rewrite-contract.test.js
@@ -431,6 +431,37 @@ test('resolveProviderModel resolves the pro tier from PATINA_PRO_* env', () => {
   assert.notEqual(r.model, 'evil-model');
 });
 
+test('PROVIDER_PRESETS.claude includes claude-sonnet-5 as the flagship default', () => {
+  assert.ok(PROVIDER_PRESETS.claude.models.includes('claude-sonnet-5'));
+  // Flagship is first, so it is the claude preset default (models[0]).
+  assert.equal(PROVIDER_PRESETS.claude.models[0], 'claude-sonnet-5');
+  // The prior sonnet/opus/haiku ids remain allowlisted (no regression).
+  for (const m of ['claude-sonnet-4-5', 'claude-opus-4-1', 'claude-haiku-4-5']) {
+    assert.ok(PROVIDER_PRESETS.claude.models.includes(m));
+  }
+});
+
+test('resolveProviderModel pins the Pro tier to claude-sonnet-5 from PATINA_PRO_* env', () => {
+  const r = resolveProviderModel(
+    { tier: WEB_TIERS.PRO, provider: 'evil', model: 'evil-model' },
+    { PATINA_PRO_PROVIDER: 'claude', PATINA_PRO_MODEL: 'claude-sonnet-5' },
+  );
+  assert.equal(r.ok, true);
+  assert.equal(r.tier, 'pro');
+  assert.equal(r.provider, 'claude');
+  assert.equal(r.model, 'claude-sonnet-5');
+  assert.equal(r.baseURL, PROVIDER_PRESETS.claude.baseURL);
+  assert.notEqual(r.model, 'evil-model');
+});
+
+test('resolveProviderModel accepts a byok claude-sonnet-5 request', () => {
+  const r = resolveProviderModel({ tier: WEB_TIERS.BYOK, provider: 'claude', model: 'claude-sonnet-5' });
+  assert.equal(r.ok, true);
+  assert.equal(r.provider, 'claude');
+  assert.equal(r.model, 'claude-sonnet-5');
+  assert.equal(r.baseURL, PROVIDER_PRESETS.claude.baseURL);
+});
+
 test('resolveProviderModel falls back to PATINA_FREE_* then defaults for pro', () => {
   // PRO env absent -> FREE env is the fallback source.
   const viaFree = resolveProviderModel(


### PR DESCRIPTION
## Summary

Adds **Claude Sonnet 5** (Anthropic, released 2026-06-30) to `PROVIDER_PRESETS.claude` so the Pro tier can run on it. Control tower will inject `PATINA_PRO_PROVIDER=claude` / `PATINA_PRO_MODEL=claude-sonnet-5` into Vercel Production; this allowlist entry must land in the main release for that config to pass `resolveProviderModel` (unlisted models are rejected).

## Changes

- `src/web-rewrite-contract.js`: `claude` preset models now `['claude-sonnet-5', 'claude-sonnet-4-5', 'claude-opus-4-1', 'claude-haiku-4-5']`. Placed first, so `claude-sonnet-5` is the claude preset default. Prior ids remain allowlisted (no regression).
- `.env.example`: Pro provider/model example updated to the real chosen config (`claude` / `claude-sonnet-5`).
- `tests/unit/web-rewrite-contract.test.js`: 3 new tests — allowlist membership + flagship-default position; pro resolution from `PATINA_PRO_*` env; byok resolution of `claude-sonnet-5`.

## Verification

- `npm test`: **1335 pass / 0 fail / 1 skip** (contract suite 65/65 incl. the 3 new tests).
- `npm run lint`: green (lint:syntax / eslint / tsc / cspell).

## Notes

Pricing (informational, not code): intro $2 in / $10 out per 1M through 2026-08-31, then $3 / $15. Live activation and the main release remain on hold per operator.
