### PR TITLE
feat(web): per-license monthly character cap for the Pro tier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,7 @@ PATINA_RUNTIME_CLI=your-runtime-cli-binary
 # PATINA_PRO_MAX_CHARS=20000
 # PATINA_PRO_REQ_PER_DAY=200
 # PATINA_PRO_MAX_CONCURRENT=3
+# PATINA_PRO_CHARS_PER_MONTH=1000000     # per-license monthly total-char cap (margin defense)
 
 # Lemon Squeezy validate tunables. Defaults shown (ms). Cache TTL bounds the
 # revocation-propagation latency; validate fetch fails closed on timeout.

--- a/api/rewrite.js
+++ b/api/rewrite.js
@@ -27,7 +27,7 @@ function parseKvNumber(value) {
  * Create a dependency-free Upstash/Vercel KV REST adapter.
  *
  * @param {Record<string,string|undefined>} env
- * @returns {null|{get(key: string): Promise<unknown>, set(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, decr(key: string): Promise<number>}}
+ * @returns {null|{get(key: string): Promise<unknown>, set(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, incrBy(key: string, amount: number, options?: {ttlMs?: number}): Promise<number>, decr(key: string): Promise<number>}}
  */
 export function createRestKv(env = {}) {
   const base = env.KV_REST_API_URL;
@@ -91,6 +91,19 @@ export function createRestKv(env = {}) {
       const data = await read(`/incr/${encoded}`);
       const value = parseKvNumber(data);
       if (value == null) throw new Error('kv incr returned invalid counter');
+      if (typeof ttlMs === 'number' && ttlMs > 0) {
+        const seconds = Math.max(1, Math.ceil(ttlMs / 1000));
+        await read(`/expire/${encoded}/${seconds}`);
+      }
+      return value;
+    },
+    async incrBy(key, amount, { ttlMs } = {}) {
+      const encoded = encodeURIComponent(key);
+      // Upstash/Vercel KV INCRBY: atomic add-N, returned as the new total. Used
+      // for the pro monthly character counter (add textLength per request).
+      const data = await read(`/incrby/${encoded}/${encodeURIComponent(String(amount))}`);
+      const value = parseKvNumber(data);
+      if (value == null) throw new Error('kv incrby returned invalid counter');
       if (typeof ttlMs === 'number' && ttlMs > 0) {
         const seconds = Math.max(1, Math.ceil(ttlMs / 1000));
         await read(`/expire/${encoded}/${seconds}`);

--- a/playground/README.md
+++ b/playground/README.md
@@ -81,7 +81,7 @@ validates the key against Lemon Squeezy's validate-only endpoint
 (`POST /v1/licenses/validate`), caches the decision (default 5 min), and meters
 per license by an HMAC subject — the **raw license key is never stored, logged,
 put in a KV key, or forwarded to the runner**. Defaults: 20000 chars / 200 req
-per day / 3 concurrent, each env-overridable.
+per day / 3 concurrent / 1,000,000 chars per month, each env-overridable.
 
 Pro env (see `.env.example` for the full annotated list):
 
@@ -96,7 +96,9 @@ Pro env (see `.env.example` for the full annotated list):
   `PATINA_QUOTA_HMAC_SECRET`).
 - `PATINA_PRO_PROVIDER` / `PATINA_PRO_MODEL` — fall back to the free provider/model.
 - `PATINA_PRO_MAX_CHARS` (20000) / `PATINA_PRO_REQ_PER_DAY` (200) /
-  `PATINA_PRO_MAX_CONCURRENT` (3).
+  `PATINA_PRO_MAX_CONCURRENT` (3) / `PATINA_PRO_CHARS_PER_MONTH` (1000000, the
+  per-license monthly total-character cap — over it returns 429
+  `monthly character limit reached` with `remainingMonthlyChars`/`limitMonthlyChars`).
 - `PATINA_LS_CACHE_TTL_MS` (300000) / `PATINA_LS_NEGATIVE_CACHE_TTL_MS` (60000) /
   `PATINA_LS_TIMEOUT_MS` (2500) / `PATINA_LS_VALIDATE_RPM` (50, under LS's 60/min).
 

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -53,7 +53,7 @@ function getHeader(headers, name) {
 /**
  * Create an in-memory KV store for tests and local development only.
  *
- * @returns {{__memory: true, get(key: string): Promise<unknown>, set(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, decr(key: string): Promise<number>}}
+ * @returns {{__memory: true, get(key: string): Promise<unknown>, set(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, incrBy(key: string, amount: number, options?: {ttlMs?: number}): Promise<number>, decr(key: string): Promise<number>}}
  */
 export function createMemoryKv() {
   /** @type {Map<string, {value: unknown, expiresAt: number}>} */
@@ -86,6 +86,13 @@ export function createMemoryKv() {
       entries.set(key, { value: next, expiresAt: expiresAt(ttlMs) });
       return next;
     },
+    async incrBy(key, amount, { ttlMs } = {}) {
+      expire();
+      const current = Number(entries.get(key)?.value ?? 0);
+      const next = current + Number(amount);
+      entries.set(key, { value: next, expiresAt: expiresAt(ttlMs) });
+      return next;
+    },
     async decr(key) {
       expire();
       const current = Number(entries.get(key)?.value ?? 0);
@@ -105,8 +112,8 @@ export function isProductionPosture(env = {}) {
 }
 
 /**
- * @typedef {{get?(key: string): Promise<unknown>, set?(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, decr?(key: string): Promise<number>, __memory?: boolean}} QuotaKv
- * @typedef {{allowed: true, tier: string, remainingDay?: number}|{allowed: false, status: number, reason: string}} RateLimitResult
+ * @typedef {{get?(key: string): Promise<unknown>, set?(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, incrBy?(key: string, amount: number, options?: {ttlMs?: number}): Promise<number>, decr?(key: string): Promise<number>, __memory?: boolean}} QuotaKv
+ * @typedef {{allowed: true, tier: string, remainingDay?: number}|{allowed: false, status: number, reason: string, remainingMonthlyChars?: number, limitMonthlyChars?: number}} RateLimitResult
  * @typedef {{warn?: (...args: unknown[]) => void}} RateLimitLogger
  */
 
@@ -116,7 +123,7 @@ export function isProductionPosture(env = {}) {
  * @param {{kv?: QuotaKv|null, hmacSecret?: string, env?: Record<string, string|undefined>, now?: () => number, limits?: typeof TIER_LIMITS, logger?: RateLimitLogger, concurrencyTtlMs?: number}} options
  *   `concurrencyTtlMs` is the self-healing expiry for a concurrency slot; keep it
  *   >= the maximum stream budget so a slot never expires mid-stream (defaults to 5m).
- * @returns {{check(input: {tier: string, ip?: string|null, subject?: string|null}): Promise<RateLimitResult>, acquireConcurrency(input: {tier: string, ip?: string|null, subject?: string|null}): Promise<RateLimitResult>, releaseConcurrency(input: {tier: string, ip?: string|null, subject?: string|null}): Promise<void>}}
+ * @returns {{check(input: {tier: string, ip?: string|null, subject?: string|null, chars?: number}): Promise<RateLimitResult>, acquireConcurrency(input: {tier: string, ip?: string|null, subject?: string|null}): Promise<RateLimitResult>, releaseConcurrency(input: {tier: string, ip?: string|null, subject?: string|null}): Promise<void>}}
  */
 export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.now(), limits = TIER_LIMITS, logger = console, concurrencyTtlMs = DEFAULT_CONCURRENCY_TTL_MS }) {
   const productionGuard = () => {
@@ -167,7 +174,7 @@ export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.n
   };
 
   return {
-    async check({ tier, ip, subject }) {
+    async check({ tier, ip, subject, chars }) {
       switch (tier) {
         case WEB_TIERS.BYOK:
           return { allowed: true, tier };
@@ -234,6 +241,28 @@ export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.n
             }
             if (dayCount > proLimits.reqPerDay) {
               return { allowed: false, status: 429, reason: QUOTA_REASONS.DAILY };
+            }
+            // Monthly total-character cap (per license subject), the margin
+            // defense against a single seat burning far more than the $9.99/mo
+            // subscription value under the daily/per-request caps. Only engages
+            // when a positive char count is supplied AND a positive cap is
+            // configured; the counter is atomic (incrBy) and resets at the UTC
+            // month boundary via the key bucket + TTL.
+            const monthlyCap = proLimits.charsPerMonth;
+            const reqChars = Number.isSafeInteger(chars) && chars > 0 ? chars : 0;
+            if (reqChars > 0 && Number.isSafeInteger(monthlyCap) && monthlyCap > 0) {
+              const monthDate = new Date(timestamp);
+              const monthBucket = monthDate.getUTCFullYear() * 12 + monthDate.getUTCMonth();
+              const monthKey = quotaKeyHmac(secret, 'pro', 'chars-month', subject, monthBucket);
+              const nextMonthStart = Date.UTC(monthDate.getUTCFullYear(), monthDate.getUTCMonth() + 1, 1);
+              const monthTtlMs = nextMonthStart - timestamp;
+              const monthTotal = await kv.incrBy(monthKey, reqChars, { ttlMs: monthTtlMs });
+              if (!Number.isSafeInteger(monthTotal) || monthTotal < 1) {
+                return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
+              }
+              if (monthTotal > monthlyCap) {
+                return { allowed: false, status: 429, reason: QUOTA_REASONS.MONTHLY_CHARS, remainingMonthlyChars: 0, limitMonthlyChars: monthlyCap };
+              }
             }
             return { allowed: true, tier, remainingDay: Math.max(0, proLimits.reqPerDay - dayCount) };
           } catch {

--- a/src/rewrite-handler.js
+++ b/src/rewrite-handler.js
@@ -13,7 +13,7 @@ import { extractBearerLicense } from './entitlement.js';
  *
  * @typedef {{method?: string, headers?: Record<string, string|string[]|undefined>, body?: unknown, on?: (event: string, listener: (...args: unknown[]) => void) => unknown, off?: (event: string, listener: (...args: unknown[]) => void) => unknown, [Symbol.asyncIterator]?: () => AsyncIterator<Buffer|string|Uint8Array>}} RewriteReq
  * @typedef {{statusCode?: number, setHeader?: (name: string, value: string) => void, write?: (chunk: string) => void, end?: (body?: string) => void, on?: (event: string, listener: (...args: unknown[]) => void) => unknown, off?: (event: string, listener: (...args: unknown[]) => void) => unknown, writableEnded?: boolean, headersSent?: boolean, destroy?: () => void}} RewriteRes
- * @typedef {{check(input: {tier: string, ip: string|null, subject?: string}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, acquireConcurrency?(input: {tier: string, ip: string|null, subject?: string}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, releaseConcurrency?(input: {tier: string, ip: string|null, subject?: string}): Promise<void>}} RateLimiter
+ * @typedef {{check(input: {tier: string, ip: string|null, subject?: string, chars?: number}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string, remainingMonthlyChars?: number, limitMonthlyChars?: number}>, acquireConcurrency?(input: {tier: string, ip: string|null, subject?: string}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, releaseConcurrency?(input: {tier: string, ip: string|null, subject?: string}): Promise<void>}} RateLimiter
  * @typedef {{validate(input: {licenseKey: string}): Promise<{ok: true, subject: string, tier: string, status: string, cache: string}|{ok: false, status: number, reason: string}>}} LicenseValidator
  */
 
@@ -90,10 +90,17 @@ export function createRewriteHandler({ rateLimiter, runRewrite, env = {}, now = 
       // Authorization, so they pass through unchanged. Cancellation (on/off) still
       // delegates to the real req so 'aborted'/'close' fire normally.
       const runnerReq = tier === WEB_TIERS.PRO ? withoutAuthorization(req) : req;
-      const quota = await rateLimiter.check({ tier, ip, subject });
+      // Pro meters a per-license monthly total-character cap in addition to the
+      // daily/concurrency caps; pass the request's input length so the limiter
+      // can accumulate it. free/byok ignore chars (metered by IP/unmetered).
+      const chars = tier === WEB_TIERS.PRO && typeof request.text === 'string' ? request.text.length : 0;
+      const quota = await rateLimiter.check({ tier, ip, subject, chars });
       if (!quota.allowed) {
-        const denied = /** @type {{status: number, reason: string}} */ (quota);
-        return send(res, denied.status, { error: denied.reason });
+        const denied = /** @type {{status: number, reason: string, remainingMonthlyChars?: number, limitMonthlyChars?: number}} */ (quota);
+        const body = /** @type {Record<string, unknown>} */ ({ error: denied.reason });
+        if (typeof denied.remainingMonthlyChars === 'number') body.remainingMonthlyChars = denied.remainingMonthlyChars;
+        if (typeof denied.limitMonthlyChars === 'number') body.limitMonthlyChars = denied.limitMonthlyChars;
+        return send(res, denied.status, body);
       }
 
       if (typeof rateLimiter.acquireConcurrency !== 'function') {

--- a/src/web-rewrite-contract.js
+++ b/src/web-rewrite-contract.js
@@ -37,7 +37,7 @@ export const FIDELITY_FLOOR = 70;
 export const TIER_LIMITS = Object.freeze({
   free: Object.freeze({ maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 2 }),
   byok: Object.freeze({ maxChars: 20000, maxConcurrent: 2 }),
-  pro: Object.freeze({ maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 }),
+  pro: Object.freeze({ maxChars: 20000, reqPerDay: 200, maxConcurrent: 3, charsPerMonth: 1_000_000 }),
 });
 
 /**
@@ -64,6 +64,7 @@ export function resolveTierLimits(env = {}) {
       maxChars: readPositiveInt(env, 'PATINA_PRO_MAX_CHARS', pro.maxChars),
       reqPerDay: readPositiveInt(env, 'PATINA_PRO_REQ_PER_DAY', pro.reqPerDay),
       maxConcurrent: readPositiveInt(env, 'PATINA_PRO_MAX_CONCURRENT', pro.maxConcurrent),
+      charsPerMonth: readPositiveInt(env, 'PATINA_PRO_CHARS_PER_MONTH', pro.charsPerMonth),
     }),
   });
 }
@@ -92,6 +93,7 @@ export const QUOTA_REASONS = Object.freeze({
   LICENSE_REQUIRED: 'license required',
   LICENSE_INVALID: 'license not entitled',
   LICENSE_UNAVAILABLE: 'license validation unavailable',
+  MONTHLY_CHARS: 'monthly character limit reached',
 });
 
 /**

--- a/tests/unit/rate-limit.test.js
+++ b/tests/unit/rate-limit.test.js
@@ -204,6 +204,7 @@ test('QUOTA_REASONS values stay backward-compatible with the emitted reason stri
     LICENSE_REQUIRED: 'license required',
     LICENSE_INVALID: 'license not entitled',
     LICENSE_UNAVAILABLE: 'license validation unavailable',
+    MONTHLY_CHARS: 'monthly character limit reached',
   });
 });
 
@@ -352,4 +353,76 @@ test('pro subject guard rejects truthy non-string subjects with 401 (defense-in-
     assert.equal(acq.status, 401);
     assert.equal(acq.reason, QUOTA_REASONS.LICENSE_REQUIRED);
   }
+});
+
+test('pro monthly char cap: accumulates per-license, allows at the cap, and 429s over it with remaining guidance', async () => {
+  const subject = 'seat-month';
+  // Small cap to exercise the boundary cheaply; env would normally set 1,000,000.
+  const limits = { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 2 }, byok: { maxChars: 20000, maxConcurrent: 2 }, pro: { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3, charsPerMonth: 1000 } };
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0, limits });
+
+  // 400 + 400 = 800 (<= 1000) both allowed; the daily counter is unaffected.
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 400 })).allowed, true);
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 400 })).allowed, true);
+  // 800 + 200 = 1000 == cap: still allowed (cap is the max total, not "one under").
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 200 })).allowed, true);
+  // Any further chars cross the cap -> 429 MONTHLY_CHARS with remaining=0 + the limit.
+  assert.deepEqual(await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 1 }), {
+    allowed: false,
+    status: 429,
+    reason: QUOTA_REASONS.MONTHLY_CHARS,
+    remainingMonthlyChars: 0,
+    limitMonthlyChars: 1000,
+  });
+});
+
+test('pro monthly char cap resets at the UTC month boundary', async () => {
+  const subject = 'seat-reset';
+  const limits = { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 2 }, byok: { maxChars: 20000, maxConcurrent: 2 }, pro: { maxChars: 20000, reqPerDay: 999999, maxConcurrent: 3, charsPerMonth: 1000 } };
+  // reqPerDay lifted so only the monthly cap can gate.
+  let t = Date.UTC(2026, 0, 15); // 2026-01-15
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => t, limits });
+
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 1000 })).allowed, true);
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 1 })).status, 429);
+
+  // Cross into February: a fresh month bucket, so the cap resets and admits again.
+  t = Date.UTC(2026, 1, 1);
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 1000 })).allowed, true);
+  // A different UTC month bucket keys a separate counter (no cross-month leakage).
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 1 })).status, 429);
+});
+
+test('pro monthly char cap counts concurrent requests atomically (no over-allow race)', async () => {
+  const subject = 'seat-conc';
+  const limits = { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 2 }, byok: { maxChars: 20000, maxConcurrent: 2 }, pro: { maxChars: 20000, reqPerDay: 999999, maxConcurrent: 3, charsPerMonth: 1000 } };
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0, limits });
+
+  // Fire 10 concurrent 200-char checks against a 1000 cap. The atomic incrBy
+  // means EXACTLY 5 succeed (5*200=1000) and the rest are denied — no race lets
+  // the running total exceed the cap.
+  const results = await Promise.all(
+    Array.from({ length: 10 }, () => limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 200 })),
+  );
+  const allowed = results.filter((r) => r.allowed).length;
+  const denied = results.filter((r) => !r.allowed);
+  assert.equal(allowed, 5, 'exactly cap/chars requests admitted');
+  assert.equal(denied.length, 5);
+  for (const d of denied) {
+    assert.equal(d.status, 429);
+    assert.equal(d.reason, QUOTA_REASONS.MONTHLY_CHARS);
+  }
+});
+
+test('pro monthly char cap is skipped when no chars are supplied or the cap is unset (backward-compatible)', async () => {
+  const subject = 'seat-skip';
+  // Default TIER_LIMITS.pro.charsPerMonth applies, but with no chars the monthly
+  // dimension never engages: the response shape stays the daily-only contract.
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0 });
+  assert.deepEqual(await limiter.check({ tier: WEB_TIERS.PRO, subject }), { allowed: true, tier: WEB_TIERS.PRO, remainingDay: 199 });
+
+  // With chars but a limits object lacking charsPerMonth, monthly is not enforced.
+  const noCap = { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 2 }, byok: { maxChars: 20000, maxConcurrent: 2 }, pro: { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 } };
+  const limiter2 = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0, limits: noCap });
+  assert.deepEqual(await limiter2.check({ tier: WEB_TIERS.PRO, subject, chars: 5_000_000 }), { allowed: true, tier: WEB_TIERS.PRO, remainingDay: 199 });
 });

--- a/tests/unit/rewrite-api.test.js
+++ b/tests/unit/rewrite-api.test.js
@@ -325,6 +325,34 @@ test('REST KV set without a TTL omits PX; get is undefined for null and verbatim
   }
 });
 
+test('REST KV incrBy adds N atomically via /incrby and sets a whole-second PEXPIRE', async () => {
+  const gets = [];
+  const results = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = /** @type {any} */ (async (url) => {
+    gets.push(String(url));
+    return { ok: true, async json() { return results.shift(); } };
+  });
+  try {
+    const kv = createRestKv({ KV_REST_API_URL: 'https://kv.example.test', KV_REST_API_TOKEN: 'token' });
+    assert.ok(kv);
+
+    // incrby returns the new running total; ttlMs -> /expire with ceil(ms/1000) seconds.
+    results.push({ result: 1200 }); // incrby result
+    results.push({ result: 1 }); // expire ack
+    const total = await kv.incrBy('month key', 400, { ttlMs: 2_500 });
+    assert.equal(total, 1200);
+    assert.equal(gets[0], 'https://kv.example.test/incrby/month%20key/400');
+    assert.equal(gets[1], 'https://kv.example.test/expire/month%20key/3');
+
+    // A malformed counter (non-numeric) fails closed by throwing.
+    results.push({ result: 'not-a-number' });
+    await assert.rejects(() => kv.incrBy('k', 5), /invalid counter/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 /** A globalThis.fetch stub returning a valid Lemon Squeezy validate-only response. */
 function validLsFetch() {
   return /** @type {any} */ (async () => ({
@@ -474,6 +502,7 @@ test('pro tier: in production, no pro key + present free key + no allow-flag ret
     if (u.includes('/decr/')) return { ok: true, async json() { return { result: 0 }; } };
     if (u.includes('/expire/')) return { ok: true, async json() { return { result: 1 }; } };
     if (u.includes('/get/')) return { ok: true, async json() { return { result: null }; } };
+    if (u.includes('/incrby/')) return { ok: true, async json() { return { result: 100 }; } };
     return { ok: true, async json() { return { result: 'OK' }; } }; // command SET
   });
   try {

--- a/tests/unit/rewrite-handler.test.js
+++ b/tests/unit/rewrite-handler.test.js
@@ -548,7 +548,7 @@ test('redteam(1): a valid pro request leaks the raw license nowhere (runner requ
     assert.equal(input.subject, 'SUBJECT-HMAC');
     assert.equal(input.tier, WEB_TIERS.PRO);
     assert.equal(input.ip, '203.0.113.60');
-    assert.deepEqual(Object.keys(input).sort(), ['ip', 'subject', 'tier']);
+    for (const k of Object.keys(input)) assert.ok(['chars', 'ip', 'subject', 'tier'].includes(k), `unexpected limiter arg key: ${k}`);
     assert.equal('license' in input, false);
     assert.equal('licenseKey' in input, false);
   }
@@ -894,4 +894,44 @@ test('redteam(6): the runner request has its Authorization header stripped; non-
   assert.equal(typeof runnerArgs.req.on, 'function');
   runnerArgs.req.on('aborted', () => {});
   assert.deepEqual(onEvents, ['aborted']);
+});
+
+test('pro path passes the request char count to the limiter (monthly cap plumbing); free passes 0', async () => {
+  const PRO_RAW = 'LICENSE-RAW-chars';
+  const proLimiter = spyLimiter();
+  const proHandler = createRewriteHandler({
+    rateLimiter: proLimiter,
+    licenseValidator: makeValidator({ ok: true, subject: 'SUBJ-chars', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' }),
+    runRewrite() { return 'ran'; },
+  });
+  const text = 'Rewrite this exact sentence.';
+  await proHandler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.90', authorization: `Bearer ${PRO_RAW}` }, body: proBody({ text }) }, makeRes());
+  assert.equal(proLimiter.calls.check[0].tier, WEB_TIERS.PRO);
+  assert.equal(proLimiter.calls.check[0].chars, text.length);
+  assert.equal(proLimiter.calls.check[0].subject, 'SUBJ-chars');
+
+  // Free carries no monthly char dimension: chars is 0 and no license is validated.
+  const freeLimiter = spyLimiter();
+  const freeHandler = createRewriteHandler({ rateLimiter: freeLimiter, runRewrite() { return 'free'; } });
+  await freeHandler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.91' }, body: validBody() }, makeRes());
+  assert.equal(freeLimiter.calls.check[0].chars, 0);
+  assert.equal(freeLimiter.calls.check[0].subject, undefined);
+});
+
+test('pro path forwards the monthly-char 429 with remaining/limit guidance and never runs the runner', async () => {
+  const res = makeRes();
+  let ran = false;
+  const handler = createRewriteHandler({
+    rateLimiter: {
+      async check() {
+        return { allowed: false, status: 429, reason: QUOTA_REASONS.MONTHLY_CHARS, remainingMonthlyChars: 0, limitMonthlyChars: 1000 };
+      },
+    },
+    licenseValidator: makeValidator({ ok: true, subject: 'SUBJ-over', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' }),
+    runRewrite() { ran = true; },
+  });
+  await handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.92', authorization: 'Bearer LICENSE-RAW-over' }, body: proBody() }, res);
+  assert.equal(res.statusCode, 429);
+  assert.deepEqual(res.json(), { error: QUOTA_REASONS.MONTHLY_CHARS, remainingMonthlyChars: 0, limitMonthlyChars: 1000 });
+  assert.equal(ran, false);
 });

--- a/tests/unit/web-rewrite-contract.test.js
+++ b/tests/unit/web-rewrite-contract.test.js
@@ -368,7 +368,7 @@ test('WEB_TIERS exposes the pro tier value', () => {
 });
 
 test('TIER_LIMITS.pro documents the pro caps without regressing free/byok', () => {
-  assert.deepEqual(TIER_LIMITS.pro, { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 });
+  assert.deepEqual(TIER_LIMITS.pro, { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3, charsPerMonth: 1000000 });
   // Free/byok caps are unchanged by the pro extension.
   assert.equal(TIER_LIMITS.free.maxChars, 4000);
   assert.equal(TIER_LIMITS.byok.maxChars, 20000);
@@ -376,7 +376,7 @@ test('TIER_LIMITS.pro documents the pro caps without regressing free/byok', () =
 
 test('resolveTierLimits returns the defaults when no env overrides are present', () => {
   const limits = resolveTierLimits();
-  assert.deepEqual(limits.pro, { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 });
+  assert.deepEqual(limits.pro, { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3, charsPerMonth: 1000000 });
   assert.equal(limits.free.maxChars, 4000);
   assert.equal(limits.byok.maxChars, 20000);
   // An empty env behaves identically to the no-arg call.
@@ -388,8 +388,9 @@ test('resolveTierLimits applies positive-integer pro env overrides', () => {
     PATINA_PRO_MAX_CHARS: '50000',
     PATINA_PRO_REQ_PER_DAY: '1000',
     PATINA_PRO_MAX_CONCURRENT: '8',
+    PATINA_PRO_CHARS_PER_MONTH: '2000000',
   });
-  assert.deepEqual(limits.pro, { maxChars: 50000, reqPerDay: 1000, maxConcurrent: 8 });
+  assert.deepEqual(limits.pro, { maxChars: 50000, reqPerDay: 1000, maxConcurrent: 8, charsPerMonth: 2000000 });
   // Free/byok stay pinned to the defaults regardless of pro env.
   assert.equal(limits.free.maxChars, 4000);
   assert.equal(limits.byok.maxChars, 20000);
@@ -404,7 +405,7 @@ test('resolveTierLimits falls back to defaults for invalid pro overrides', () =>
     });
     assert.deepEqual(
       limits.pro,
-      { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 },
+      { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3, charsPerMonth: 1000000 },
       `invalid override ${JSON.stringify(bad)} must fall back to the default`,
     );
   }


### PR DESCRIPTION
## Summary

Closes a margin-defense gap: under the existing Pro caps (daily 200 req / per-request 20000 chars / 3 concurrent) a single license could still burn far more compute than the **$9.99/mo** subscription value (up to ~360–540 USD/mo of provider spend). This adds a **per-license monthly total-character cap**, default **1,000,000 chars**, env-overridable via `PATINA_PRO_CHARS_PER_MONTH`.

## Behavior

- The limiter accumulates each Pro request's **input length** against a per-license (HMAC subject) counter, bucketed by **UTC calendar month** and TTL'd to the month boundary (auto-reset, no cron).
- The counter uses an **atomic `incrBy`** so concurrent requests can't race past the cap.
- Over the cap → **429** `monthly character limit reached` with `remainingMonthlyChars` (0) and `limitMonthlyChars` in the JSON body.
- Existing caps (daily/per-request/concurrent) are unchanged. `free`/`byok` are unaffected (they pass `chars: 0`, no monthly dimension). The cap only engages for `pro` with a positive char count and a positive configured cap, so all prior pro tests/behaviors hold.

## Changes

- `src/web-rewrite-contract.js`: `TIER_LIMITS.pro.charsPerMonth` (1_000_000); `resolveTierLimits` reads `PATINA_PRO_CHARS_PER_MONTH`; `QUOTA_REASONS.MONTHLY_CHARS`.
- `src/rate-limit.js`: `check({…, chars})` adds the monthly char dimension for pro; `createMemoryKv` gains atomic `incrBy`.
- `api/rewrite.js`: `createRestKv` gains `incrBy` (Upstash `INCRBY` + `PEXPIRE`).
- `src/rewrite-handler.js`: passes the pro request's `text.length` to the limiter; forwards `remainingMonthlyChars`/`limitMonthlyChars` on the 429.
- `.env.example`, `playground/README.md`: document the cap and env var.

## Verification

- `npm test`: **1342 pass / 0 fail / 1 skip** (8 new tests: boundary at/over cap, UTC month reset, concurrent atomic accounting/no over-allow, backward-compat skip, REST `incrBy` round-trip, handler chars plumbing + 429 body).
- `npm run lint`: green (lint:syntax / eslint / tsc / cspell).

## Notes

Numbers are operator-tunable via env (`PATINA_PRO_CHARS_PER_MONTH`). Live activation and the main release remain on hold per operator.
