### PR TITLE
chore(release): 6.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "patina",
       "source": "./",
-      "version": "6.2.0",
+      "version": "6.3.0",
       "description": "Strip the AI packaging, keep the meaning. Detect and rewrite AI writing patterns across KO/EN/ZH/JA with MPS/fidelity checks. Runs the root SKILL.md as the /patina skill.",
       "homepage": "https://github.com/devswha/patina",
       "repository": "https://github.com/devswha/patina",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
   "name": "patina",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese so text reads as if a human wrote it. Meaning-preservation (MPS) verified, audit-friendly. The root SKILL.md is loaded as the /patina skill.",
   "author": {
     "name": "devswha",

--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "6.2.0"
+version: "6.3.0"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
+## 6.3.0 — 2026-07-07
+
+**Hosted Pro tier: a Lemon Squeezy license-gated paid tier ($9.99/mo USD) on `/api/rewrite`, on Claude Sonnet 5, with a per-license monthly character cap.**
+
+Semver rationale: minor — additive hosted-service tier and env; the existing `free` (IP quota) and `byok` (caller key) contracts are unchanged and pinned by tests. No stable public CLI/API is removed. `src/features/*` (the deterministic layer) is untouched.
+
+### Added
+
+- **Pro tier (validate-only Lemon Squeezy license gate)**: `/api/rewrite` gains a `pro` tier alongside `free`/`byok`. The caller sends `Authorization: Bearer <license_key>`; the server validates it against Lemon Squeezy's validate-only endpoint (`POST /v1/licenses/validate`), caches the decision (5 min positive / 1 min negative), and meters per license by an **HMAC subject**. Fail-closed everywhere; the raw license key is never stored, logged, put in a KV key, forwarded to the runner, or returned. New `src/entitlement.js` (`extractBearerLicense`, `createLemonSqueezyLicenseValidator`) fronts LS with a single-flight admission guard that keeps patina under LS's 60 req/min ceiling. Contract additions in `src/web-rewrite-contract.js`: `WEB_TIERS.PRO`, `TIER_LIMITS.pro` (20000 chars / 200 req-day / 3 concurrent), `resolveTierLimits`, a dominant 401 `LICENSE_REQUIRED` auth gate, and `QUOTA_REASONS.LICENSE_*`.
+- **Claude Sonnet 5 on the Pro tier**: `PROVIDER_PRESETS.claude` adds `claude-sonnet-5` (the flagship default); Pro pins `PATINA_PRO_PROVIDER=claude` / `PATINA_PRO_MODEL=claude-sonnet-5` via env.
+- **Per-license monthly character cap (margin defense)**: a new `PATINA_PRO_CHARS_PER_MONTH` cap (default 1,000,000) accumulates each Pro request's input length per license subject in a UTC-month-bucketed, atomic KV counter that resets at the month boundary. Over the cap returns 429 `monthly character limit reached` with `remainingMonthlyChars`/`limitMonthlyChars`. The KV adapters gain an atomic `incrBy` (Upstash `INCRBY` + `PEXPIRE`).
+- **Pro env + docs**: `.env.example` and `playground/README.md` document every new env var (`LS_STORE_ID`, `LS_PRO_VARIANT_ID`, `LS_PRO_PRODUCT_ID`, `PATINA_PRO_API_KEY`, `PATINA_LICENSE_HMAC_SECRET`, `PATINA_PRO_PROVIDER`, `PATINA_PRO_MODEL`, `PATINA_PRO_MAX_CHARS`, `PATINA_PRO_REQ_PER_DAY`, `PATINA_PRO_MAX_CONCURRENT`, `PATINA_PRO_CHARS_PER_MONTH`, `PATINA_LS_CACHE_TTL_MS`, `PATINA_LS_NEGATIVE_CACHE_TTL_MS`, `PATINA_LS_TIMEOUT_MS`, `PATINA_LS_VALIDATE_RPM`, `PATINA_PRO_ALLOW_FREE_KEY`) and the $9.99/mo price.
+
 ## 6.2.0 — 2026-07-05
 
 **Personas everywhere: en/zh/ja seeds, `persona show|rm|edit`, profile-voice retirement, an advisory meaning-floor proxy, and a hosted playground Voice selector.**

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 6.2.0" src="https://img.shields.io/badge/version-6.2.0-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 6.3.0" src="https://img.shields.io/badge/version-6.3.0-blue"></a>
 </p>
 
 <p align="center">
@@ -206,7 +206,7 @@ If meaning drifts, the change is retried or rolled back. Deterministic analysis 
 
 ```yaml
 # .patina.default.yaml
-version: "6.2.0"
+version: "6.3.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 6.2.0
+version: 6.3.0
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "6.2.0"
+    "patina-cli": "6.3.0"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version-sync bump to 6.3.0 across all gated surfaces (package.json + humanizer + plugin/marketplace manifests + SKILL.md + .patina.default.yaml + README badge/config + CHANGELOG). Ships the hosted Pro tier (Lemon Squeezy validate-only, $9.99/mo) on Claude Sonnet 5 with a per-license monthly char cap. Local: release:check OK, npm test 1342 pass/0 fail/1 skip, npm run lint green.