### PR TITLE
Release 6.3.0: hosted Pro tier (Lemon Squeezy) on Claude Sonnet 5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "patina",
       "source": "./",
-      "version": "6.2.0",
+      "version": "6.3.0",
       "description": "Strip the AI packaging, keep the meaning. Detect and rewrite AI writing patterns across KO/EN/ZH/JA with MPS/fidelity checks. Runs the root SKILL.md as the /patina skill.",
       "homepage": "https://github.com/devswha/patina",
       "repository": "https://github.com/devswha/patina",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
   "name": "patina",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese so text reads as if a human wrote it. Meaning-preservation (MPS) verified, audit-friendly. The root SKILL.md is loaded as the /patina skill.",
   "author": {
     "name": "devswha",

--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,7 @@ PATINA_RUNTIME_CLI=your-runtime-cli-binary
 # PATINA_PRO_MAX_CHARS=20000
 # PATINA_PRO_REQ_PER_DAY=200
 # PATINA_PRO_MAX_CONCURRENT=3
+# PATINA_PRO_CHARS_PER_MONTH=1000000     # per-license monthly total-char cap (margin defense)
 
 # Lemon Squeezy validate tunables. Defaults shown (ms). Cache TTL bounds the
 # revocation-propagation latency; validate fetch fails closed on timeout.

--- a/.env.example
+++ b/.env.example
@@ -70,8 +70,9 @@ PATINA_RUNTIME_CLI=your-runtime-cli-binary
 # PATINA_LICENSE_HMAC_SECRET=your-long-random-secret
 
 # Pro provider/model (fall back to PATINA_FREE_PROVIDER/MODEL, then preset).
-# PATINA_PRO_PROVIDER=openai
-# PATINA_PRO_MODEL=gpt-5.5
+# Both must be on the PROVIDER_PRESETS allowlist. Pro ships on Claude Sonnet 5.
+# PATINA_PRO_PROVIDER=claude
+# PATINA_PRO_MODEL=claude-sonnet-5
 
 # Pro limits (per-license). Defaults shown.
 # PATINA_PRO_MAX_CHARS=20000

--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,60 @@ PATINA_RUNTIME_CLI=your-runtime-cli-binary
 # MARKETING_WORKSPACE=/home/you/.openclaw-marketing/workspace
 # MARKETING_ENFORCE_ALLOWLIST=true   # default; bootstrap refuses without MARKETING_DISCORD_ALLOWED_USERS
 # MARKETING_RESTART_GATEWAY=false
+# ---------------------------------------------------------------------------
+# Hosted playground / API service (Vercel `/api/rewrite`)
+# Server-side only. The browser never sees these. All tiers fail closed:
+# missing config / KV / HMAC secret is denied before any provider is called.
+# ---------------------------------------------------------------------------
+
+# Upstash-compatible REST KV — required in production for the quota + admission
+# guard. Without it (production posture) every metered request is rejected 503.
+# KV_REST_API_URL=https://your-kv.upstash.io
+# KV_REST_API_TOKEN=your-kv-rest-token
+
+# Free tier: the service's own provider key (rate-limited by IP) + HMAC secret
+# that signs quota/subject KV keys (raw keys/licenses are never stored).
+# PATINA_FREE_API_KEY=your-provider-key
+# PATINA_FREE_PROVIDER=openai
+# PATINA_FREE_MODEL=gpt-4.1-mini
+# PATINA_QUOTA_HMAC_SECRET=your-long-random-secret
+
+# --- Pro tier ($9.99/mo USD, Lemon Squeezy license-gated) -------------------
+# Caller sends `Authorization: Bearer <license_key>`; the server validates it
+# against Lemon Squeezy's validate-only endpoint (POST /v1/licenses/validate),
+# never stores the raw key, and meters per-license by an HMAC subject.
+
+# Lemon Squeezy identity — the validate response meta MUST match these.
+# LS_STORE_ID=425473                 # required
+# LS_PRO_VARIANT_ID=1875389          # required (Pro subscription variant)
+# LS_PRO_PRODUCT_ID=1199625          # optional extra pin (meta.product_id)
+
+# Pro provider key. REQUIRED in production — if absent the Pro path fails closed
+# (503) and NEVER spends the free key on paid traffic.
+# PATINA_PRO_API_KEY=your-pro-provider-key
+
+# HMAC secret for license subjects/KV keys. Required in production; falls back
+# to PATINA_QUOTA_HMAC_SECRET when unset.
+# PATINA_LICENSE_HMAC_SECRET=your-long-random-secret
+
+# Pro provider/model (fall back to PATINA_FREE_PROVIDER/MODEL, then preset).
+# PATINA_PRO_PROVIDER=openai
+# PATINA_PRO_MODEL=gpt-5.5
+
+# Pro limits (per-license). Defaults shown.
+# PATINA_PRO_MAX_CHARS=20000
+# PATINA_PRO_REQ_PER_DAY=200
+# PATINA_PRO_MAX_CONCURRENT=3
+
+# Lemon Squeezy validate tunables. Defaults shown (ms). Cache TTL bounds the
+# revocation-propagation latency; validate fetch fails closed on timeout.
+# PATINA_LS_CACHE_TTL_MS=300000          # positive (valid) result cache
+# PATINA_LS_NEGATIVE_CACHE_TTL_MS=60000  # negative (denied) result cache
+# PATINA_LS_TIMEOUT_MS=2500              # LS validate fetch abort deadline
+# PATINA_LS_VALIDATE_RPM=50              # outbound cap (LS hard limit is 60/min)
+
+# Escape hatch: let Pro fall back to PATINA_FREE_API_KEY when PATINA_PRO_API_KEY
+# is unset. Honored in ALL postures when 'true' (including production) — so leave
+# it unset in production to keep the fail-closed 503. Outside production the
+# free-key fallback is already on without this flag.
+# PATINA_PRO_ALLOW_FREE_KEY=true

--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "6.2.0"
+version: "6.3.0"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
+## 6.3.0 — 2026-07-07
+
+**Hosted Pro tier: a Lemon Squeezy license-gated paid tier ($9.99/mo USD) on `/api/rewrite`, on Claude Sonnet 5, with a per-license monthly character cap.**
+
+Semver rationale: minor — additive hosted-service tier and env; the existing `free` (IP quota) and `byok` (caller key) contracts are unchanged and pinned by tests. No stable public CLI/API is removed. `src/features/*` (the deterministic layer) is untouched.
+
+### Added
+
+- **Pro tier (validate-only Lemon Squeezy license gate)**: `/api/rewrite` gains a `pro` tier alongside `free`/`byok`. The caller sends `Authorization: Bearer <license_key>`; the server validates it against Lemon Squeezy's validate-only endpoint (`POST /v1/licenses/validate`), caches the decision (5 min positive / 1 min negative), and meters per license by an **HMAC subject**. Fail-closed everywhere; the raw license key is never stored, logged, put in a KV key, forwarded to the runner, or returned. New `src/entitlement.js` (`extractBearerLicense`, `createLemonSqueezyLicenseValidator`) fronts LS with a single-flight admission guard that keeps patina under LS's 60 req/min ceiling. Contract additions in `src/web-rewrite-contract.js`: `WEB_TIERS.PRO`, `TIER_LIMITS.pro` (20000 chars / 200 req-day / 3 concurrent), `resolveTierLimits`, a dominant 401 `LICENSE_REQUIRED` auth gate, and `QUOTA_REASONS.LICENSE_*`.
+- **Claude Sonnet 5 on the Pro tier**: `PROVIDER_PRESETS.claude` adds `claude-sonnet-5` (the flagship default); Pro pins `PATINA_PRO_PROVIDER=claude` / `PATINA_PRO_MODEL=claude-sonnet-5` via env.
+- **Per-license monthly character cap (margin defense)**: a new `PATINA_PRO_CHARS_PER_MONTH` cap (default 1,000,000) accumulates each Pro request's input length per license subject in a UTC-month-bucketed, atomic KV counter that resets at the month boundary. Over the cap returns 429 `monthly character limit reached` with `remainingMonthlyChars`/`limitMonthlyChars`. The KV adapters gain an atomic `incrBy` (Upstash `INCRBY` + `PEXPIRE`).
+- **Pro env + docs**: `.env.example` and `playground/README.md` document every new env var (`LS_STORE_ID`, `LS_PRO_VARIANT_ID`, `LS_PRO_PRODUCT_ID`, `PATINA_PRO_API_KEY`, `PATINA_LICENSE_HMAC_SECRET`, `PATINA_PRO_PROVIDER`, `PATINA_PRO_MODEL`, `PATINA_PRO_MAX_CHARS`, `PATINA_PRO_REQ_PER_DAY`, `PATINA_PRO_MAX_CONCURRENT`, `PATINA_PRO_CHARS_PER_MONTH`, `PATINA_LS_CACHE_TTL_MS`, `PATINA_LS_NEGATIVE_CACHE_TTL_MS`, `PATINA_LS_TIMEOUT_MS`, `PATINA_LS_VALIDATE_RPM`, `PATINA_PRO_ALLOW_FREE_KEY`) and the $9.99/mo price.
+
 ## 6.2.0 — 2026-07-05
 
 **Personas everywhere: en/zh/ja seeds, `persona show|rm|edit`, profile-voice retirement, an advisory meaning-floor proxy, and a hosted playground Voice selector.**

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 6.2.0" src="https://img.shields.io/badge/version-6.2.0-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 6.3.0" src="https://img.shields.io/badge/version-6.3.0-blue"></a>
 </p>
 
 <p align="center">
@@ -206,7 +206,7 @@ If meaning drifts, the change is retried or rolled back. Deterministic analysis 
 
 ```yaml
 # .patina.default.yaml
-version: "6.2.0"
+version: "6.3.0"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ More examples: [Before/After Gallery](docs/EXAMPLES.md) ([한국어](docs/EXAMPL
 
 ### Browser playground
 
-Open **[patina.vibetip.help](https://patina.vibetip.help/)** — paste KO / EN / ZH / JA text for a real rewrite gated by the MPS/fidelity floors, with the deterministic AI signal measured before → after. Rewrites and scoring run server-side; the free tier uses the service's own model key (rate-limited). **API mode** forwards your own key per request through the patina server to the provider you pick — never stored or logged (metrics are sanitized: no text, prompt, output, key, or IP).
+Open **[patina.vibetip.help](https://patina.vibetip.help/)** — paste KO / EN / ZH / JA text for a real rewrite gated by the MPS/fidelity floors, with the deterministic AI signal measured before → after. Rewrites and scoring run server-side; the free tier uses the service's own model key (rate-limited). **API mode** forwards your own key per request through the patina server to the provider you pick — never stored or logged (metrics are sanitized: no text, prompt, output, key, or IP). **Pro** ($9.99/mo USD) unlocks higher limits (20000 chars, 200 rewrites/day) with a Lemon Squeezy license key sent as a bearer token — the raw key is validated server-side and never stored or logged.
 
 ### Agent skill
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 6.2.0
+version: 6.3.0
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read

--- a/api/rewrite.js
+++ b/api/rewrite.js
@@ -27,7 +27,7 @@ function parseKvNumber(value) {
  * Create a dependency-free Upstash/Vercel KV REST adapter.
  *
  * @param {Record<string,string|undefined>} env
- * @returns {null|{get(key: string): Promise<unknown>, set(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, decr(key: string): Promise<number>}}
+ * @returns {null|{get(key: string): Promise<unknown>, set(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, incrBy(key: string, amount: number, options?: {ttlMs?: number}): Promise<number>, decr(key: string): Promise<number>}}
  */
 export function createRestKv(env = {}) {
   const base = env.KV_REST_API_URL;
@@ -91,6 +91,19 @@ export function createRestKv(env = {}) {
       const data = await read(`/incr/${encoded}`);
       const value = parseKvNumber(data);
       if (value == null) throw new Error('kv incr returned invalid counter');
+      if (typeof ttlMs === 'number' && ttlMs > 0) {
+        const seconds = Math.max(1, Math.ceil(ttlMs / 1000));
+        await read(`/expire/${encoded}/${seconds}`);
+      }
+      return value;
+    },
+    async incrBy(key, amount, { ttlMs } = {}) {
+      const encoded = encodeURIComponent(key);
+      // Upstash/Vercel KV INCRBY: atomic add-N, returned as the new total. Used
+      // for the pro monthly character counter (add textLength per request).
+      const data = await read(`/incrby/${encoded}/${encodeURIComponent(String(amount))}`);
+      const value = parseKvNumber(data);
+      if (value == null) throw new Error('kv incrby returned invalid counter');
       if (typeof ttlMs === 'number' && ttlMs > 0) {
         const seconds = Math.max(1, Math.ceil(ttlMs / 1000));
         await read(`/expire/${encoded}/${seconds}`);

--- a/api/rewrite.js
+++ b/api/rewrite.js
@@ -79,11 +79,19 @@ const WEB_REWRITE_TIMEOUT_MS = 180_000;
 export function createRewriteApiHandler({ env = /** @type {Record<string,string|undefined>} */ (process.env), runWebRewriteStreamImpl = runWebRewriteStream, logger = console, now = () => Date.now() } = {}) {
   const restKv = createRestKv(env);
   const kv = isProductionPosture(env) ? restKv : (restKv ?? createMemoryKv());
+  // One stream budget, computed once: bounds upstream work (provider + scoring)
+  // and, via concurrencyTtlMs, keeps a free-tier slot alive for at least a full
+  // stream so an operator-extended timeout can't expire the slot mid-stream and
+  // desync the counter (a later decr would drive it negative). Floor at 5m.
+  const envTimeout = Number(env.PATINA_WEB_REWRITE_TIMEOUT_MS);
+  const streamTimeoutMs = Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : WEB_REWRITE_TIMEOUT_MS;
+  const concurrencyTtlMs = Math.max(5 * 60 * 1000, streamTimeoutMs + 30_000);
   return createRewriteHandler({
     rateLimiter: createRateLimiter({
       kv,
       hmacSecret: env.PATINA_QUOTA_HMAC_SECRET,
       env,
+      concurrencyTtlMs,
       logger: /** @type {any} */ (logger),
     }),
     runRewrite: async ({ req, res, request }) => {
@@ -110,23 +118,25 @@ export function createRewriteApiHandler({ env = /** @type {Record<string,string|
       const onClose = () => { if (!res.writableEnded) controller.abort(); };
       res.on?.('close', onClose);
       req.on?.('aborted', onClose);
-      const envTimeout = Number(env.PATINA_WEB_REWRITE_TIMEOUT_MS);
-      const timeout = Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : WEB_REWRITE_TIMEOUT_MS;
       const startedAt = now();
+      let result;
       try {
-        await runWebRewriteStreamImpl({
+        result = await runWebRewriteStreamImpl({
           request: { ...request, apiKey },
           emit: (frame) => res.write?.(encodeStreamFrame(frame)),
           signal: controller.signal,
-          timeout,
+          timeout: streamTimeoutMs,
         });
       } finally {
         res.off?.('close', onClose);
         req.off?.('aborted', onClose);
       }
       res.end?.();
-      // Sanitized observability ONLY: route/tier/provider/model/status/bucketed
-      // latency + char count. Never the text, prompt, output, key, or full IP.
+      // Sanitized observability ONLY: route/tier/provider/model/status/outcome/
+      // bucketed latency + char count. Never the text, prompt, output, key, or
+      // full IP. The HTTP status is a genuine 200 (frames already committed), so
+      // `outcome` — not `status` — carries whether the stream itself failed, so
+      // abuse/provider-failure/floor-failure spikes stay observable.
       logger.info?.('rewrite.metric', buildRewriteMetric({
         tier: request.tier,
         provider: request.provider,
@@ -134,6 +144,7 @@ export function createRewriteApiHandler({ env = /** @type {Record<string,string|
         status: 200,
         latencyMs: now() - startedAt,
         quotaDecision: 'allowed',
+        outcome: result && result.ok === false ? String(result.code || 'failed') : 'ok',
         charCount: typeof request.text === 'string' ? request.text.length : 0,
       }));
     },

--- a/api/rewrite.js
+++ b/api/rewrite.js
@@ -1,9 +1,10 @@
 // @ts-check
 import { createRateLimiter, createMemoryKv, isProductionPosture } from '../src/rate-limit.js';
 import { createRewriteHandler } from '../src/rewrite-handler.js';
-import { encodeStreamFrame, QUOTA_REASONS, WEB_TIERS } from '../src/web-rewrite-contract.js';
+import { encodeStreamFrame, QUOTA_REASONS, resolveTierLimits, WEB_TIERS } from '../src/web-rewrite-contract.js';
 import { buildRewriteMetric } from '../src/web-observability.js';
 import { runWebRewriteStream } from '../src/web-rewrite-stream.js';
+import { createLemonSqueezyLicenseValidator } from '../src/entitlement.js';
 
 /**
  * @param {unknown} value
@@ -26,7 +27,7 @@ function parseKvNumber(value) {
  * Create a dependency-free Upstash/Vercel KV REST adapter.
  *
  * @param {Record<string,string|undefined>} env
- * @returns {null|{get(key: string): Promise<unknown>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, decr(key: string): Promise<number>}}
+ * @returns {null|{get(key: string): Promise<unknown>, set(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, decr(key: string): Promise<number>}}
  */
 export function createRestKv(env = {}) {
   const base = env.KV_REST_API_URL;
@@ -41,10 +42,49 @@ export function createRestKv(env = {}) {
     return response.json();
   }
 
+  // Upstash/Vercel KV also accepts a command as a JSON array POSTed to the
+  // root; this is how we issue an ATOMIC "SET key value PX ttl" — a GET-path SET
+  // followed by a separate EXPIRE would leave a crash window that drops the TTL
+  // and leaks a permanent entitlement-cache entry.
+  async function command(args) {
+    const response = await globalThis.fetch(root, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify(args),
+    });
+    if (!response.ok) throw new Error('kv command failed');
+    return response.json();
+  }
+
   return {
     async get(key) {
       const data = await read(`/get/${encodeURIComponent(key)}`);
-      return data?.result;
+      const result = data?.result;
+      // Round-trip objects exactly like the in-memory KV: Upstash returns the
+      // stored value as a JSON string, so parse it back (object in -> object
+      // out) for the entitlement cache. null/missing -> undefined; a non-JSON
+      // string (a legacy/plain value) is returned verbatim; an already-parsed
+      // object passes through. incr/decr never call this, so the counter paths
+      // keep reading the raw numeric REST result via parseKvNumber unchanged.
+      if (result == null) return undefined;
+      if (typeof result === 'string') {
+        try {
+          return JSON.parse(result);
+        } catch {
+          return result;
+        }
+      }
+      return result;
+    },
+    async set(key, val, { ttlMs } = {}) {
+      const value = JSON.stringify(val);
+      // Atomic SET (+ PX expiry): one command, so a crash can't leave a
+      // TTL-less permanent entry. PX is milliseconds; floor at 1ms.
+      if (typeof ttlMs === 'number' && ttlMs > 0) {
+        await command(['SET', key, value, 'PX', String(Math.max(1, Math.ceil(ttlMs)))]);
+      } else {
+        await command(['SET', key, value]);
+      }
     },
     async incr(key, { ttlMs } = {}) {
       const encoded = encodeURIComponent(key);
@@ -86,19 +126,47 @@ export function createRewriteApiHandler({ env = /** @type {Record<string,string|
   const envTimeout = Number(env.PATINA_WEB_REWRITE_TIMEOUT_MS);
   const streamTimeoutMs = Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : WEB_REWRITE_TIMEOUT_MS;
   const concurrencyTtlMs = Math.max(5 * 60 * 1000, streamTimeoutMs + 30_000);
+  // The pro tier's revenue gate: a fail-closed Lemon Squeezy validate-only
+  // license validator sharing the rate limiter's KV. It turns the caller's
+  // Authorization: Bearer license into an HMAC subject; the raw license never
+  // leaves entitlement.js (never a return value, log line, or KV key).
+  const licenseValidator = createLemonSqueezyLicenseValidator({
+    kv,
+    hmacSecret: env.PATINA_LICENSE_HMAC_SECRET || env.PATINA_QUOTA_HMAC_SECRET,
+    env,
+    logger: /** @type {any} */ (logger),
+  });
   return createRewriteHandler({
     rateLimiter: createRateLimiter({
       kv,
       hmacSecret: env.PATINA_QUOTA_HMAC_SECRET,
       env,
       concurrencyTtlMs,
+      limits: resolveTierLimits(env),
       logger: /** @type {any} */ (logger),
     }),
+    licenseValidator,
     runRewrite: async ({ req, res, request }) => {
-      // Resolve the effective LLM key server-side: BYOK uses the caller's key;
-      // free uses the server's own provider key (never the request, which has
-      // no key on the free tier). Fail closed if the free service is unconfigured.
-      const apiKey = request.tier === WEB_TIERS.BYOK ? request.apiKey : env.PATINA_FREE_API_KEY;
+      // Resolve the effective LLM key server-side, per tier:
+      //   - byok → the caller's own key (from the validated request).
+      //   - pro  → the server's dedicated pro key (PATINA_PRO_API_KEY). Outside
+      //            production, or when PATINA_PRO_ALLOW_FREE_KEY==='true', fall
+      //            back to the free key so local/dev pro flows work; production
+      //            without a pro key fails closed (never silently spends the free
+      //            key on paid traffic).
+      //   - free → the server's own free key.
+      // The request never carries a key on free/pro (the pro license is an
+      // Authorization: Bearer entitlement resolved to a subject upstream, never a
+      // provider key). Fail closed when no usable key is configured.
+      let apiKey;
+      if (request.tier === WEB_TIERS.BYOK) {
+        apiKey = request.apiKey;
+      } else if (request.tier === WEB_TIERS.PRO) {
+        const allowFreeKey = !isProductionPosture(env) || env.PATINA_PRO_ALLOW_FREE_KEY === 'true';
+        apiKey = env.PATINA_PRO_API_KEY || (allowFreeKey ? env.PATINA_FREE_API_KEY : undefined);
+      } else {
+        apiKey = env.PATINA_FREE_API_KEY;
+      }
       if (!apiKey) {
         res.statusCode = 503;
         res.setHeader?.('Content-Type', 'application/json');

--- a/docs/internal/BACKLOG.md
+++ b/docs/internal/BACKLOG.md
@@ -1,7 +1,7 @@
 # Backlog — outstanding work
 
 > Maintainer/agent note (see `CONTRIBUTING.md` → Public vs Internal Docs). Not a
-> product contract. Snapshot as of the 6.1.0 persona-hardening line.
+> product contract. Snapshot as of the 6.2.0 release (persona line shipped).
 
 ## Released in 6.1.0 (done — for context)
 
@@ -68,10 +68,14 @@ folded into the next minor):
    (`scripts/persona-ablation.mjs`) → `source: calibrated`.
 
 ### Release / process
-7. **Next release via `dev → main` PR** (CI 6 required checks), NOT the direct-push bypass
-   used for 6.1.0. Version bump across the surfaces `release:check` gates + merge (not squash).
-8. Watch `dev` drift — keep it at/ahead of `main`; if a hotfix lands on `main`, merge
-   `main → dev` immediately (see `docs/WORKFLOW.md`).
+7. ~~**Next release via `dev → main` PR**~~ — DONE. 6.2.0 shipped via the `dev → main`
+   merge PR #588 (merge, not squash; CI required checks green), version bumped across
+   every `release:check` surface (#587), tagged `v6.2.0` → `release.yml` published
+   `patina-cli@6.2.0` + `patina-humanizer@6.2.0` to npm (provenance). GHCR image not
+   published (tag path skips it; workflow_dispatch `publish_ghcr` only).
+8. ~~**Watch `dev` drift**~~ — currently in sync (`dev` == `main` at 6.2.0). Ongoing rule
+   stands: keep `dev` at/ahead of `main`; if a hotfix lands on `main`, merge `main → dev`
+   immediately (see `docs/WORKFLOW.md`).
 
 ### Repo / branding (optional, owner decision)
 9. **Org transfer** — moving `devswha/patina` to a GitHub org would drop the personal-account

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "6.2.0"
+    "patina-cli": "6.3.0"
   },
   "license": "MIT",
   "repository": {

--- a/playground/README.md
+++ b/playground/README.md
@@ -63,6 +63,46 @@ Production domain:
 patina.vibetip.help
 ```
 
+## Tiers & environment
+
+`/api/rewrite` serves three tiers off one contract (`src/web-rewrite-contract.js`).
+All server env is set on the deployment; the browser never sees it, and every
+tier fails closed (missing config / KV / HMAC secret is denied before any
+provider call).
+
+| Tier | Auth | Metering | Provider key |
+|---|---|---|---|
+| `free` | none | IP quota (KV + HMAC) | `PATINA_FREE_API_KEY` |
+| `byok` | caller's own provider key (per request) | unmetered shared quota | caller key |
+| `pro` | `Authorization: Bearer <license_key>` | per-license quota (HMAC subject) | `PATINA_PRO_API_KEY` |
+
+**Pro tier ($9.99/mo USD)** is gated by a Lemon Squeezy license key. The server
+validates the key against Lemon Squeezy's validate-only endpoint
+(`POST /v1/licenses/validate`), caches the decision (default 5 min), and meters
+per license by an HMAC subject — the **raw license key is never stored, logged,
+put in a KV key, or forwarded to the runner**. Defaults: 20000 chars / 200 req
+per day / 3 concurrent, each env-overridable.
+
+Pro env (see `.env.example` for the full annotated list):
+
+- `LS_STORE_ID`, `LS_PRO_VARIANT_ID` — required; the validate response `meta`
+  must match. `LS_PRO_PRODUCT_ID` is an optional extra pin.
+- `PATINA_PRO_API_KEY` — required in production; when unset, production fails
+  closed (503) and never spends the free key on paid traffic. `PATINA_PRO_ALLOW_FREE_KEY=true`
+  is an explicit escape hatch that permits the `PATINA_FREE_API_KEY` fallback in
+  any posture (leave it unset in production to keep the 503; outside production
+  the free-key fallback is already on).
+- `PATINA_LICENSE_HMAC_SECRET` — license subject/KV-key secret (falls back to
+  `PATINA_QUOTA_HMAC_SECRET`).
+- `PATINA_PRO_PROVIDER` / `PATINA_PRO_MODEL` — fall back to the free provider/model.
+- `PATINA_PRO_MAX_CHARS` (20000) / `PATINA_PRO_REQ_PER_DAY` (200) /
+  `PATINA_PRO_MAX_CONCURRENT` (3).
+- `PATINA_LS_CACHE_TTL_MS` (300000) / `PATINA_LS_NEGATIVE_CACHE_TTL_MS` (60000) /
+  `PATINA_LS_TIMEOUT_MS` (2500) / `PATINA_LS_VALIDATE_RPM` (50, under LS's 60/min).
+
+Validate-only means revocation propagates within the positive-cache TTL (default
+5 min); a hard kill can shorten it by lowering `PATINA_LS_CACHE_TTL_MS`.
+
 ## Verification
 
 ```bash

--- a/playground/README.md
+++ b/playground/README.md
@@ -81,7 +81,7 @@ validates the key against Lemon Squeezy's validate-only endpoint
 (`POST /v1/licenses/validate`), caches the decision (default 5 min), and meters
 per license by an HMAC subject — the **raw license key is never stored, logged,
 put in a KV key, or forwarded to the runner**. Defaults: 20000 chars / 200 req
-per day / 3 concurrent, each env-overridable.
+per day / 3 concurrent / 1,000,000 chars per month, each env-overridable.
 
 Pro env (see `.env.example` for the full annotated list):
 
@@ -96,7 +96,9 @@ Pro env (see `.env.example` for the full annotated list):
   `PATINA_QUOTA_HMAC_SECRET`).
 - `PATINA_PRO_PROVIDER` / `PATINA_PRO_MODEL` — fall back to the free provider/model.
 - `PATINA_PRO_MAX_CHARS` (20000) / `PATINA_PRO_REQ_PER_DAY` (200) /
-  `PATINA_PRO_MAX_CONCURRENT` (3).
+  `PATINA_PRO_MAX_CONCURRENT` (3) / `PATINA_PRO_CHARS_PER_MONTH` (1000000, the
+  per-license monthly total-character cap — over it returns 429
+  `monthly character limit reached` with `remainingMonthlyChars`/`limitMonthlyChars`).
 - `PATINA_LS_CACHE_TTL_MS` (300000) / `PATINA_LS_NEGATIVE_CACHE_TTL_MS` (60000) /
   `PATINA_LS_TIMEOUT_MS` (2500) / `PATINA_LS_VALIDATE_RPM` (50, under LS's 60/min).
 

--- a/src/entitlement.js
+++ b/src/entitlement.js
@@ -1,0 +1,465 @@
+// @ts-check
+
+// Server-only Lemon Squeezy License Key entitlement core for the patina Pro tier.
+// This module is the revenue gate for the hosted "pro" tier: it turns a
+// caller-supplied license key into an allow/deny decision using Lemon Squeezy's
+// validate-only endpoint (POST /v1/licenses/validate), fronted by a fail-closed
+// admission layer that keeps patina under Lemon Squeezy's 60 req/min ceiling.
+//
+// Design invariants (all fail-closed — uncertainty NEVER grants entitlement):
+//   - Missing config, or (in production) a missing secret/shared-KV, an LS
+//     error/timeout/non-2xx/bad-body, a saturated admission bucket, or a held
+//     single-flight lock all DENY access.
+//   - The raw license key is NEVER written to a log line, an error body, a return
+//     value, or a KV key. Every KV key is an HMAC of the license; every return
+//     value carries only the HMAC "subject"; every log payload is passed through
+//     redactSecrets and only ever carries the subject.
+//
+// It deliberately reuses the quota primitives (quotaKeyHmac / isProductionPosture /
+// createMemoryKv) and the shared redaction/reason contract rather than growing a
+// parallel convention. No new runtime dependency: HMAC comes from rate-limit.js,
+// fetch from globalThis.fetch (injectable), timeouts from AbortController.
+
+import { createMemoryKv, isProductionPosture, quotaKeyHmac } from './rate-limit.js';
+import { QUOTA_REASONS, redactSecrets } from './web-rewrite-contract.js';
+
+/** Lemon Squeezy validate-only endpoint. */
+export const LS_LICENSE_VALIDATE_URL = 'https://api.lemonsqueezy.com/v1/licenses/validate';
+
+/** license_key.status values that entitle. Validate-only: an issued-but-inactive key still entitles. */
+const USABLE_STATUSES = new Set(['active', 'inactive']);
+/** license_key.status values that are explicitly revoked/lapsed. */
+const BLOCKED_STATUSES = new Set(['expired', 'disabled']);
+
+/** Default tunables (each overridable via env). */
+const DEFAULT_CACHE_TTL_MS = 300_000; // positive-result cache
+const DEFAULT_NEGATIVE_CACHE_TTL_MS = 60_000; // negative-result cache
+const DEFAULT_TIMEOUT_MS = 2_500; // LS fetch abort deadline
+const DEFAULT_VALIDATE_RPM = 50; // stays below LS's hard 60 rpm ceiling
+const LOCK_TTL_MS = 10_000; // single-flight lock self-heal window
+/** Dev-only HMAC fallback; only ever reached OUTSIDE production (prod requires a real secret). */
+const DEV_FALLBACK_SECRET = 'patina-local-license-secret';
+
+/**
+ * @typedef {{ok: true, subject: string, tier: 'pro', status: string, cache: 'hit'|'miss'}} EntitlementAllow
+ * @typedef {{ok: false, status: 401|403|503, reason: string}} EntitlementDeny
+ * @typedef {EntitlementAllow|EntitlementDeny} EntitlementResult
+ * @typedef {{get(key: string): Promise<unknown>, set(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, __memory?: boolean}} EntitlementKv
+ */
+
+/**
+ * Parse a positive integer env value, falling back when absent/invalid/<=0.
+ * @param {unknown} value
+ * @param {number} fallback
+ * @returns {number}
+ */
+function readPositiveInt(value, fallback) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+/**
+ * Extract exactly one `Bearer <token>` license from a request's headers, matching
+ * the `authorization` header name case-insensitively (and the scheme
+ * case-insensitively, per RFC 7235). Anything ambiguous — absent, blank, a
+ * non-Bearer scheme, an empty token, or more than one authorization value — fails
+ * closed. Never logs or echoes the raw header/token.
+ *
+ * @param {Record<string, string|string[]|undefined>|null|undefined} headers
+ * @returns {{ok: true, license: string}|{ok: false, status: 401, reason: string}}
+ */
+export function extractBearerLicense(headers) {
+  const missing = /** @type {{ok: false, status: 401, reason: string}} */ (
+    { ok: false, status: 401, reason: QUOTA_REASONS.LICENSE_REQUIRED }
+  );
+  if (!headers || typeof headers !== 'object') return missing;
+
+  // Case-insensitive header lookup. Two distinct authorization keys is ambiguous.
+  /** @type {string|string[]|undefined} */
+  let raw;
+  let seen = 0;
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === 'authorization') {
+      raw = value;
+      seen += 1;
+    }
+  }
+  if (seen !== 1 || raw === undefined || raw === null) return missing;
+
+  // A header array with more than one value is "multiple" -> ambiguous -> reject.
+  let value;
+  if (Array.isArray(raw)) {
+    if (raw.length !== 1) return missing;
+    value = raw[0];
+  } else {
+    value = raw;
+  }
+  if (typeof value !== 'string') return missing;
+
+  // Exactly one token: scheme, whitespace, one non-whitespace token, nothing else.
+  const match = /^Bearer\s+(\S+)$/i.exec(value.trim());
+  if (!match || !match[1]) return missing;
+  return { ok: true, license: match[1] };
+}
+
+/**
+ * Pure allow/deny evaluation of a Lemon Squeezy validate response against the
+ * configured store/variant/product. On any failed check the PUBLIC result is a
+ * generic 403 LICENSE_INVALID; the specific failing check is exposed only via the
+ * non-authoritative `detail` field (for server-side logging — never returned to
+ * the client, never contains the license).
+ *
+ * @param {any} data Parsed LS validate response body.
+ * @param {Record<string, string|undefined>} [env]
+ * @param {number} [now] Epoch ms used to evaluate expiry.
+ * @returns {{ok: true, status: string, expiresAt: number|null}|{ok: false, status: 403, reason: string, detail: string}}
+ */
+export function evaluateLicenseResponse(data, env = {}, now = Date.now()) {
+  const deny = (/** @type {string} */ detail) => (
+    /** @type {{ok: false, status: 403, reason: string, detail: string}} */ (
+      { ok: false, status: 403, reason: QUOTA_REASONS.LICENSE_INVALID, detail }
+    )
+  );
+
+  if (!data || typeof data !== 'object') return deny('malformed-response');
+  if (data.valid !== true) return deny('not-valid');
+
+  const licenseKey = data.license_key;
+  if (!licenseKey || typeof licenseKey !== 'object') return deny('missing-license_key');
+
+  const status = licenseKey.status;
+  if (typeof status !== 'string') return deny('status-missing');
+  // Both gates are asserted explicitly even though the sets are disjoint: a status
+  // in {expired,disabled} is blocked, and only {active,inactive} is entitled.
+  if (BLOCKED_STATUSES.has(status)) return deny(`status-${status}`);
+  if (!USABLE_STATUSES.has(status)) return deny('status-not-usable');
+
+  // Expiry: absent/null entitles; present must parse to a strictly future instant.
+  let expiresAt = /** @type {number|null} */ (null);
+  const rawExpiry = licenseKey.expires_at;
+  if (rawExpiry !== null && rawExpiry !== undefined) {
+    const parsed = Date.parse(rawExpiry);
+    if (!Number.isFinite(parsed) || !(parsed > now)) return deny('expired');
+    expiresAt = parsed;
+  }
+
+  const meta = data.meta;
+  if (!meta || typeof meta !== 'object') return deny('missing-meta');
+  if (String(meta.store_id) !== String(env.LS_STORE_ID)) return deny('store-mismatch');
+  if (String(meta.variant_id) !== String(env.LS_PRO_VARIANT_ID)) return deny('variant-mismatch');
+  const wantProduct = env.LS_PRO_PRODUCT_ID;
+  if (wantProduct !== undefined && wantProduct !== null && wantProduct !== '') {
+    if (String(meta.product_id) !== String(wantProduct)) return deny('product-mismatch');
+  }
+
+  return { ok: true, status, expiresAt };
+}
+
+/**
+ * Validate and interpret a cached decision. The embedded `expiresAt` (epoch ms) is
+ * authoritative on read (the KV TTL only reclaims storage): a missing/NaN/past
+ * value, or an unrecognized decision shape, is treated as a miss (returns null).
+ *
+ * @param {unknown} entry
+ * @param {number} nowMs
+ * @returns {{decision: 'allow', status: string}|{decision: 'deny', status: number, reason: string}|null}
+ */
+function readCacheEntry(entry, nowMs) {
+  if (!entry || typeof entry !== 'object') return null;
+  const e = /** @type {Record<string, unknown>} */ (entry);
+  const expiresAt = e.expiresAt;
+  if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt) || expiresAt <= nowMs) return null;
+  if (e.decision === 'allow' && typeof e.status === 'string') {
+    return { decision: 'allow', status: e.status };
+  }
+  if (e.decision === 'deny' && typeof e.status === 'number' && typeof e.reason === 'string') {
+    return { decision: 'deny', status: e.status, reason: e.reason };
+  }
+  return null;
+}
+
+/**
+ * Build a fail-closed, validate-only Lemon Squeezy license validator with a
+ * two-layer cache (positive + negative) and an admission guard (per-minute RPM
+ * bucket + per-license single-flight lock) that runs BEFORE any LS network call.
+ *
+ * @param {{
+ *   kv?: EntitlementKv|null,
+ *   hmacSecret?: string,
+ *   env?: Record<string, string|undefined>,
+ *   fetchImpl?: typeof fetch,
+ *   now?: () => number,
+ *   logger?: {warn?: (...args: unknown[]) => void, log?: (...args: unknown[]) => void},
+ * }} [options]
+ * @returns {{validate(input: {licenseKey: string}): Promise<EntitlementResult>}}
+ */
+export function createLemonSqueezyLicenseValidator({
+  kv,
+  hmacSecret,
+  env = {},
+  fetchImpl = globalThis.fetch,
+  now = () => Date.now(),
+  logger = console,
+} = {}) {
+  // Non-production fallback store, created at most once and only when no KV is
+  // injected (production already requires a real shared KV below). When a KV is
+  // injected this is that same reference.
+  const store = kv || createMemoryKv();
+
+  // Base log sink: redactSecrets scrubs secret-named keys and labelled token
+  // shapes. Per-request logging additionally routes through `warnSafe` below,
+  // which exact-substring-scrubs the current raw license (LS can echo it under an
+  // unlabelled/non-secret key that pattern redaction alone would miss).
+  const warn = (/** @type {string} */ message, /** @type {Record<string, unknown>} */ meta) => {
+    try {
+      const fn = logger && (logger.warn || logger.log);
+      if (typeof fn === 'function') fn.call(logger, message, redactSecrets(meta));
+    } catch {
+      /* logging must never throw into the request path */
+    }
+  };
+
+  const unavailable = () => /** @type {EntitlementDeny} */ (
+    { ok: false, status: 503, reason: QUOTA_REASONS.LICENSE_UNAVAILABLE }
+  );
+  const required = () => /** @type {EntitlementDeny} */ (
+    { ok: false, status: 401, reason: QUOTA_REASONS.LICENSE_REQUIRED }
+  );
+
+  /**
+   * @param {{licenseKey?: string}} [input]
+   * @returns {Promise<EntitlementResult>}
+   */
+  const validate = async (input = {}) => {
+    const licenseKey = input.licenseKey;
+    // 0. Input guard (defense in depth; the handler extracts via extractBearerLicense first).
+    if (typeof licenseKey !== 'string' || licenseKey.trim() === '') return required();
+
+    const production = isProductionPosture(env);
+
+    // 1. Fail-closed prerequisites.
+    const configuredSecret = hmacSecret || env.PATINA_LICENSE_HMAC_SECRET || env.PATINA_QUOTA_HMAC_SECRET;
+    // A memory KV in production is not a shared store: it cannot enforce the
+    // cross-instance admission guard, so treat it as unavailable (mirrors the
+    // rate limiter's production KV posture).
+    if (production && (!kv || kv.__memory)) return unavailable();
+    if (production && !configuredSecret) return unavailable();
+    // Config is required in every posture: without store/variant we cannot decide entitlement.
+    if (!env.LS_STORE_ID || !env.LS_PRO_VARIANT_ID) return unavailable();
+
+    const secret = configuredSecret || DEV_FALLBACK_SECRET;
+
+    // 2. Derive HMAC keys. The raw license never appears in any key.
+    const subject = quotaKeyHmac(secret, 'ls-license-subject', licenseKey);
+    const cacheKey = quotaKeyHmac(secret, 'ls-license-cache', licenseKey);
+    const nowMs = now();
+
+    // 3. Cache lookup. A broken cache read must NOT fail open; fall through to LS.
+    try {
+      const hit = readCacheEntry(await store.get(cacheKey), nowMs);
+      if (hit) {
+        if (hit.decision === 'allow') {
+          return { ok: true, subject, tier: 'pro', status: hit.status, cache: 'hit' };
+        }
+        return /** @type {EntitlementDeny} */ ({ ok: false, status: hit.status, reason: hit.reason });
+      }
+    } catch {
+      /* treat as a miss */
+    }
+
+    // 4. Cross-instance single-flight lock FIRST (before the RPM bucket): only
+    //    the first caller for a given license proceeds; concurrent callers fail
+    //    closed and retry into the cache the winner writes. Acquiring the lock
+    //    before charging RPM means a same-license stampede cannot exhaust the
+    //    global LS minute budget (only the winner ever charges RPM / calls LS).
+    //    A per-process in-flight map would dedupe within ONE process only and is
+    //    NOT a substitute for this shared-KV lock across instances.
+    const warnSafe = (/** @type {string} */ message, /** @type {Record<string, unknown>} */ meta) =>
+      warn(message, /** @type {Record<string, unknown>} */ (scrubLicense(meta, licenseKey)));
+
+    const timeoutMs = readPositiveInt(env.PATINA_LS_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);
+    // The lock MUST outlive the fetch it guards, or it could self-heal mid-flight
+    // and let a second instance call LS. Floor at LOCK_TTL_MS; extend past the
+    // fetch deadline when a longer timeout is configured.
+    const lockTtlMs = Math.max(LOCK_TTL_MS, timeoutMs + 5_000);
+    const lockKey = quotaKeyHmac(secret, 'ls-lock', licenseKey);
+    let lockCount;
+    try {
+      lockCount = await store.incr(lockKey, { ttlMs: lockTtlMs });
+    } catch {
+      return unavailable();
+    }
+    if (!Number.isSafeInteger(lockCount) || lockCount < 1) return unavailable();
+    if (lockCount > 1) {
+      warnSafe('entitlement: LS validate single-flight lock held', { subject, lockCount });
+      return unavailable();
+    }
+
+    // Winner path: hold the lock; release it on EVERY completion path (cache
+    // re-hit, RPM saturation, fetch success/denial/transient failure) so an
+    // immediate retry re-validates or hits the freshly written cache. Release
+    // resets the counter to 0 via set() (a guaranteed KV op): losers that
+    // incremented past 1 never decrement, so a decr-based release would leak the
+    // counter upward and wedge the lock. lockTtlMs is only the crash self-heal.
+    let lockReleased = false;
+    const releaseLock = async () => {
+      if (lockReleased) return;
+      lockReleased = true;
+      try {
+        await store.set(lockKey, 0, { ttlMs: lockTtlMs });
+      } catch {
+        /* best-effort; the TTL self-heals the lock regardless */
+      }
+    };
+
+    try {
+      // 4b. Re-read the cache now that we hold the lock: a previous winner may
+      //     have finished (and released the lock) between our miss above and our
+      //     lock acquisition. Serving its cached result closes the follower race
+      //     that would otherwise make a duplicate LS call.
+      try {
+        const hit = readCacheEntry(await store.get(cacheKey), nowMs);
+        if (hit) {
+          if (hit.decision === 'allow') {
+            return { ok: true, subject, tier: 'pro', status: hit.status, cache: 'hit' };
+          }
+          return /** @type {EntitlementDeny} */ ({ ok: false, status: hit.status, reason: hit.reason });
+        }
+      } catch {
+        /* treat as a miss */
+      }
+
+      // 4c. Per-minute RPM bucket keeps us under LS's 60 rpm ceiling. Charged
+      //     only by the winner that will actually call LS.
+      const rpmLimit = readPositiveInt(env.PATINA_LS_VALIDATE_RPM, DEFAULT_VALIDATE_RPM);
+      const minute = Math.floor(nowMs / 60_000);
+      const rpmKey = quotaKeyHmac(secret, 'ls-rpm', minute);
+      let rpmCount;
+      try {
+        rpmCount = await store.incr(rpmKey, { ttlMs: 60_000 });
+      } catch {
+        return unavailable();
+      }
+      if (!Number.isSafeInteger(rpmCount) || rpmCount < 1) return unavailable();
+      if (rpmCount > rpmLimit) {
+        warnSafe('entitlement: LS validate RPM bucket saturated', { subject, minute, rpmCount, rpmLimit });
+        return unavailable();
+      }
+
+      // 5. LS validate-only call with a hard timeout.
+      const controller = new AbortController();
+      const timer = setTimeout(() => {
+        try { controller.abort(); } catch { /* noop */ }
+      }, timeoutMs);
+      let response;
+      try {
+        response = await fetchImpl(LS_LICENSE_VALIDATE_URL, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: new globalThis.URLSearchParams({ license_key: licenseKey }).toString(),
+          signal: controller.signal,
+        });
+      } catch (err) {
+        warnSafe('entitlement: LS validate request failed', { subject, error: errorMessage(err) });
+        return unavailable();
+      } finally {
+        clearTimeout(timer);
+      }
+
+      if (!response || typeof response.ok !== 'boolean' || !response.ok) {
+        warnSafe('entitlement: LS validate non-2xx', { subject, status: response && response.status });
+        return unavailable();
+      }
+
+      let data;
+      try {
+        data = await response.json();
+      } catch (err) {
+        warnSafe('entitlement: LS validate response parse failed', { subject, error: errorMessage(err) });
+        return unavailable();
+      }
+
+      // 6. Evaluate + cache. A denial is cached negatively (bounded); a transient
+      //    503 is NEVER cached so a retry re-attempts validation.
+      const decision = evaluateLicenseResponse(data, env, nowMs);
+
+      // `=== true` (not truthiness) so the fall-through below narrows to the deny shape.
+      if (decision.ok === true) {
+        const posDefault = readPositiveInt(env.PATINA_LS_CACHE_TTL_MS, DEFAULT_CACHE_TTL_MS);
+        let ttl = posDefault;
+        if (decision.expiresAt !== null && Number.isFinite(decision.expiresAt)) {
+          const untilExpiry = decision.expiresAt - nowMs;
+          if (untilExpiry > 0) ttl = Math.min(posDefault, untilExpiry);
+        }
+        // Embedded expiresAt is authoritative on read; KV TTL is only for cleanup.
+        await safeSet(store, cacheKey, { decision: 'allow', tier: 'pro', status: decision.status, expiresAt: nowMs + ttl }, ttl, warnSafe, subject);
+        return { ok: true, subject, tier: 'pro', status: decision.status, cache: 'miss' };
+      }
+
+      const negTtl = readPositiveInt(env.PATINA_LS_NEGATIVE_CACHE_TTL_MS, DEFAULT_NEGATIVE_CACHE_TTL_MS);
+      await safeSet(store, cacheKey, { decision: 'deny', tier: 'pro', status: decision.status, reason: decision.reason, expiresAt: nowMs + negTtl }, negTtl, warnSafe, subject);
+      // The concrete failing check is logged (redacted) for triage; the return is generic.
+      warnSafe('entitlement: license denied', { subject, detail: decision.detail, response: data });
+      return /** @type {EntitlementDeny} */ ({ ok: false, status: decision.status, reason: decision.reason });
+    } finally {
+      await releaseLock();
+    }
+  };
+
+  return { validate };
+}
+
+/**
+ * Deep exact-substring scrub of a known raw license from a log payload, applied
+ * BEFORE the pattern-based redactSecrets. Lemon Squeezy can echo the license
+ * under an unlabelled or non-secret key that pattern redaction alone misses, so
+ * we replace the exact value we hold. Guarded on length so trivially short
+ * values can't over-redact unrelated text.
+ *
+ * @param {unknown} value
+ * @param {string} license
+ * @returns {unknown}
+ */
+function scrubLicense(value, license) {
+  if (typeof license !== 'string' || license.length < 4) return value;
+  const walk = (/** @type {unknown} */ v) => {
+    if (typeof v === 'string') return v.split(license).join('[REDACTED]');
+    if (Array.isArray(v)) return v.map(walk);
+    if (v && typeof v === 'object') {
+      /** @type {Record<string, unknown>} */
+      const out = {};
+      for (const [k, val] of Object.entries(v)) out[k] = walk(val);
+      return out;
+    }
+    return v;
+  };
+  return walk(value);
+}
+
+/** @param {unknown} err @returns {string} */
+function errorMessage(err) {
+  if (err && typeof err === 'object' && 'message' in err) return String(/** @type {{message: unknown}} */ (err).message);
+  return String(err);
+}
+
+/**
+ * Best-effort cache write. A caching failure must never fail an otherwise-valid
+ * decision, so errors are swallowed after a redacted log.
+ * @param {EntitlementKv} store
+ * @param {string} key
+ * @param {unknown} value
+ * @param {number} ttlMs
+ * @param {(message: string, meta: Record<string, unknown>) => void} warn
+ * @param {string} subject
+ * @returns {Promise<void>}
+ */
+async function safeSet(store, key, value, ttlMs, warn, subject) {
+  try {
+    await store.set(key, value, { ttlMs });
+  } catch (err) {
+    warn('entitlement: cache write failed', { subject, error: errorMessage(err) });
+  }
+}

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -116,18 +116,42 @@ export function isProductionPosture(env = {}) {
  * @param {{kv?: QuotaKv|null, hmacSecret?: string, env?: Record<string, string|undefined>, now?: () => number, limits?: typeof TIER_LIMITS, logger?: RateLimitLogger, concurrencyTtlMs?: number}} options
  *   `concurrencyTtlMs` is the self-healing expiry for a concurrency slot; keep it
  *   >= the maximum stream budget so a slot never expires mid-stream (defaults to 5m).
- * @returns {{check(input: {tier: string, ip?: string|null}): Promise<RateLimitResult>, acquireConcurrency(input: {tier: string, ip?: string|null}): Promise<RateLimitResult>, releaseConcurrency(input: {tier: string, ip?: string|null}): Promise<void>}}
+ * @returns {{check(input: {tier: string, ip?: string|null, subject?: string|null}): Promise<RateLimitResult>, acquireConcurrency(input: {tier: string, ip?: string|null, subject?: string|null}): Promise<RateLimitResult>, releaseConcurrency(input: {tier: string, ip?: string|null, subject?: string|null}): Promise<void>}}
  */
 export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.now(), limits = TIER_LIMITS, logger = console, concurrencyTtlMs = DEFAULT_CONCURRENCY_TTL_MS }) {
-  const getConcurrencyKey = (tier, ip) => {
-    if (tier === WEB_TIERS.BYOK) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: true, tier }) };
+  const productionGuard = () => {
     const production = isProductionPosture(env);
-    if (production && (!kv || kv.__memory)) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE }) };
-    if (production && !hmacSecret) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: QUOTA_REASONS.SECRET_UNAVAILABLE }) };
-    if (!kv) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE }) };
-    if (!ip) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 400, reason: QUOTA_REASONS.IP_UNAVAILABLE }) };
-    const secret = hmacSecret || 'patina-local-quota-secret';
-    return { ok: true, key: quotaKeyHmac(secret, 'free', 'concurrent', ip) };
+    if (production && (!kv || kv.__memory)) return /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE });
+    if (production && !hmacSecret) return /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: QUOTA_REASONS.SECRET_UNAVAILABLE });
+    if (!kv) return /** @type {RateLimitResult} */ ({ allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE });
+    return null;
+  };
+
+  // Resolve the concurrency-slot key per tier: BYOK is unmetered (allow, no-op),
+  // FREE keys on the client IP, PRO keys on the license subject (never the IP).
+  // An unknown tier is a stable 400 (defense-in-depth). The production/KV/secret
+  // guards are shared with `check` via productionGuard.
+  const getConcurrencyKey = (tier, ip, subject) => {
+    switch (tier) {
+      case WEB_TIERS.BYOK:
+        return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: true, tier }) };
+      case WEB_TIERS.FREE: {
+        const guard = productionGuard();
+        if (guard) return { ok: false, result: guard };
+        if (!ip) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 400, reason: QUOTA_REASONS.IP_UNAVAILABLE }) };
+        const secret = hmacSecret || 'patina-local-quota-secret';
+        return { ok: true, key: quotaKeyHmac(secret, 'free', 'concurrent', ip), maxConcurrent: limits.free.maxConcurrent };
+      }
+      case WEB_TIERS.PRO: {
+        const guard = productionGuard();
+        if (guard) return { ok: false, result: guard };
+        if (typeof subject !== 'string' || subject === '') return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 401, reason: QUOTA_REASONS.LICENSE_REQUIRED }) };
+        const secret = hmacSecret || 'patina-local-quota-secret';
+        return { ok: true, key: quotaKeyHmac(secret, 'pro', 'concurrent', subject), maxConcurrent: limits.pro.maxConcurrent };
+      }
+      default:
+        return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: false, status: 400, reason: 'unsupported tier' }) };
+    }
   };
 
   const releaseKey = async (key) => {
@@ -143,59 +167,95 @@ export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.n
   };
 
   return {
-    async check({ tier, ip }) {
-      if (tier === WEB_TIERS.BYOK) return { allowed: true, tier };
+    async check({ tier, ip, subject }) {
+      switch (tier) {
+        case WEB_TIERS.BYOK:
+          return { allowed: true, tier };
+        case WEB_TIERS.FREE: {
+          const guard = productionGuard();
+          if (guard) return guard;
+          if (!ip) return { allowed: false, status: 400, reason: QUOTA_REASONS.IP_UNAVAILABLE };
 
-      const production = isProductionPosture(env);
-      if (production && (!kv || kv.__memory)) return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
-      if (production && !hmacSecret) return { allowed: false, status: 503, reason: QUOTA_REASONS.SECRET_UNAVAILABLE };
-      if (!kv) return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
-      if (!ip) return { allowed: false, status: 400, reason: QUOTA_REASONS.IP_UNAVAILABLE };
+          const secret = hmacSecret || 'patina-local-quota-secret';
+          const timestamp = now();
+          const dayBucket = Math.floor(timestamp / DAY_MS);
+          const hourBucket = Math.floor(timestamp / HOUR_MS);
+          const freeLimits = limits.free;
+          const dayKey = quotaKeyHmac(secret, 'free', 'day', ip, dayBucket);
+          const hourKey = quotaKeyHmac(secret, 'free', 'hour', ip, hourBucket);
+          const dayTtlMs = (dayBucket + 1) * DAY_MS - timestamp;
+          const hourTtlMs = (hourBucket + 1) * HOUR_MS - timestamp;
 
-      const secret = hmacSecret || 'patina-local-quota-secret';
-      const timestamp = now();
-      const dayBucket = Math.floor(timestamp / DAY_MS);
-      const hourBucket = Math.floor(timestamp / HOUR_MS);
-      const freeLimits = limits.free;
-      const dayKey = quotaKeyHmac(secret, 'free', 'day', ip, dayBucket);
-      const hourKey = quotaKeyHmac(secret, 'free', 'hour', ip, hourBucket);
-      const dayTtlMs = (dayBucket + 1) * DAY_MS - timestamp;
-      const hourTtlMs = (hourBucket + 1) * HOUR_MS - timestamp;
+          try {
+            // A degraded KV adapter that resolves a malformed counter (undefined,
+            // NaN, an object, a non-integer) instead of throwing must be treated as
+            // storage-unavailable, not silently allowed: `bad > limit` is false and
+            // would otherwise fail OPEN on a public abuse boundary.
+            const dayCount = await kv.incr(dayKey, { ttlMs: dayTtlMs });
+            if (!Number.isSafeInteger(dayCount) || dayCount < 1) {
+              return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
+            }
+            if (dayCount > freeLimits.reqPerDay) {
+              return { allowed: false, status: 429, reason: QUOTA_REASONS.DAILY };
+            }
+            const hourCount = await kv.incr(hourKey, { ttlMs: hourTtlMs });
+            if (!Number.isSafeInteger(hourCount) || hourCount < 1) {
+              return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
+            }
+            if (hourCount > freeLimits.burstPerHour) {
+              return { allowed: false, status: 429, reason: QUOTA_REASONS.HOURLY };
+            }
+            return { allowed: true, tier, remainingDay: Math.max(0, freeLimits.reqPerDay - dayCount) };
+          } catch {
+            return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
+          }
+        }
+        case WEB_TIERS.PRO: {
+          const guard = productionGuard();
+          if (guard) return guard;
+          // Defense-in-depth: the contract already 401s an unauthenticated pro
+          // request, but a subject is REQUIRED here so a mis-wired caller can
+          // never meter pro traffic against a shared/absent identity.
+          if (typeof subject !== 'string' || subject === '') return { allowed: false, status: 401, reason: QUOTA_REASONS.LICENSE_REQUIRED };
 
-      try {
-        // A degraded KV adapter that resolves a malformed counter (undefined,
-        // NaN, an object, a non-integer) instead of throwing must be treated as
-        // storage-unavailable, not silently allowed: `bad > limit` is false and
-        // would otherwise fail OPEN on a public abuse boundary.
-        const dayCount = await kv.incr(dayKey, { ttlMs: dayTtlMs });
-        if (!Number.isSafeInteger(dayCount) || dayCount < 1) {
-          return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
+          const secret = hmacSecret || 'patina-local-quota-secret';
+          const timestamp = now();
+          const dayBucket = Math.floor(timestamp / DAY_MS);
+          const proLimits = limits.pro;
+          // Pro meters a daily cap only (no hourly burst), keyed on the license
+          // subject — never the IP — so usage is counted per license seat.
+          const dayKey = quotaKeyHmac(secret, 'pro', 'day', subject, dayBucket);
+          const dayTtlMs = (dayBucket + 1) * DAY_MS - timestamp;
+
+          try {
+            const dayCount = await kv.incr(dayKey, { ttlMs: dayTtlMs });
+            if (!Number.isSafeInteger(dayCount) || dayCount < 1) {
+              return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
+            }
+            if (dayCount > proLimits.reqPerDay) {
+              return { allowed: false, status: 429, reason: QUOTA_REASONS.DAILY };
+            }
+            return { allowed: true, tier, remainingDay: Math.max(0, proLimits.reqPerDay - dayCount) };
+          } catch {
+            return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
+          }
         }
-        if (dayCount > freeLimits.reqPerDay) {
-          return { allowed: false, status: 429, reason: QUOTA_REASONS.DAILY };
-        }
-        const hourCount = await kv.incr(hourKey, { ttlMs: hourTtlMs });
-        if (!Number.isSafeInteger(hourCount) || hourCount < 1) {
-          return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
-        }
-        if (hourCount > freeLimits.burstPerHour) {
-          return { allowed: false, status: 429, reason: QUOTA_REASONS.HOURLY };
-        }
-        return { allowed: true, tier, remainingDay: Math.max(0, freeLimits.reqPerDay - dayCount) };
-      } catch {
-        return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
+        default:
+          // Defense-in-depth: the contract already rejects unknown tiers; a
+          // stable 400 keeps a mis-wired caller fail-closed, never fail-open.
+          return { allowed: false, status: 400, reason: 'unsupported tier' };
       }
     },
-    async acquireConcurrency({ tier, ip }) {
-      const resolved = getConcurrencyKey(tier, ip);
+    async acquireConcurrency({ tier, ip, subject }) {
+      const resolved = getConcurrencyKey(tier, ip, subject);
       if (!resolved.ok) return resolved.result;
-      const freeLimits = limits.free;
+      const maxConcurrent = resolved.maxConcurrent;
       try {
         const activeCount = await kv.incr(resolved.key, { ttlMs: concurrencyTtlMs });
         if (!Number.isSafeInteger(activeCount) || activeCount < 1) {
           return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
         }
-        if (activeCount > freeLimits.maxConcurrent) {
+        if (activeCount > maxConcurrent) {
           await releaseKey(resolved.key);
           return { allowed: false, status: 429, reason: QUOTA_REASONS.CONCURRENT };
         }
@@ -204,8 +264,8 @@ export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.n
         return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
       }
     },
-    async releaseConcurrency({ tier, ip }) {
-      const resolved = getConcurrencyKey(tier, ip);
+    async releaseConcurrency({ tier, ip, subject }) {
+      const resolved = getConcurrencyKey(tier, ip, subject);
       if (!resolved.ok || !resolved.key) return;
       await releaseKey(resolved.key);
     },

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -53,7 +53,7 @@ function getHeader(headers, name) {
 /**
  * Create an in-memory KV store for tests and local development only.
  *
- * @returns {{__memory: true, get(key: string): Promise<unknown>, set(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, decr(key: string): Promise<number>}}
+ * @returns {{__memory: true, get(key: string): Promise<unknown>, set(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, incrBy(key: string, amount: number, options?: {ttlMs?: number}): Promise<number>, decr(key: string): Promise<number>}}
  */
 export function createMemoryKv() {
   /** @type {Map<string, {value: unknown, expiresAt: number}>} */
@@ -86,6 +86,13 @@ export function createMemoryKv() {
       entries.set(key, { value: next, expiresAt: expiresAt(ttlMs) });
       return next;
     },
+    async incrBy(key, amount, { ttlMs } = {}) {
+      expire();
+      const current = Number(entries.get(key)?.value ?? 0);
+      const next = current + Number(amount);
+      entries.set(key, { value: next, expiresAt: expiresAt(ttlMs) });
+      return next;
+    },
     async decr(key) {
       expire();
       const current = Number(entries.get(key)?.value ?? 0);
@@ -105,8 +112,8 @@ export function isProductionPosture(env = {}) {
 }
 
 /**
- * @typedef {{get?(key: string): Promise<unknown>, set?(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, decr?(key: string): Promise<number>, __memory?: boolean}} QuotaKv
- * @typedef {{allowed: true, tier: string, remainingDay?: number}|{allowed: false, status: number, reason: string}} RateLimitResult
+ * @typedef {{get?(key: string): Promise<unknown>, set?(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, incrBy?(key: string, amount: number, options?: {ttlMs?: number}): Promise<number>, decr?(key: string): Promise<number>, __memory?: boolean}} QuotaKv
+ * @typedef {{allowed: true, tier: string, remainingDay?: number}|{allowed: false, status: number, reason: string, remainingMonthlyChars?: number, limitMonthlyChars?: number}} RateLimitResult
  * @typedef {{warn?: (...args: unknown[]) => void}} RateLimitLogger
  */
 
@@ -116,7 +123,7 @@ export function isProductionPosture(env = {}) {
  * @param {{kv?: QuotaKv|null, hmacSecret?: string, env?: Record<string, string|undefined>, now?: () => number, limits?: typeof TIER_LIMITS, logger?: RateLimitLogger, concurrencyTtlMs?: number}} options
  *   `concurrencyTtlMs` is the self-healing expiry for a concurrency slot; keep it
  *   >= the maximum stream budget so a slot never expires mid-stream (defaults to 5m).
- * @returns {{check(input: {tier: string, ip?: string|null, subject?: string|null}): Promise<RateLimitResult>, acquireConcurrency(input: {tier: string, ip?: string|null, subject?: string|null}): Promise<RateLimitResult>, releaseConcurrency(input: {tier: string, ip?: string|null, subject?: string|null}): Promise<void>}}
+ * @returns {{check(input: {tier: string, ip?: string|null, subject?: string|null, chars?: number}): Promise<RateLimitResult>, acquireConcurrency(input: {tier: string, ip?: string|null, subject?: string|null}): Promise<RateLimitResult>, releaseConcurrency(input: {tier: string, ip?: string|null, subject?: string|null}): Promise<void>}}
  */
 export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.now(), limits = TIER_LIMITS, logger = console, concurrencyTtlMs = DEFAULT_CONCURRENCY_TTL_MS }) {
   const productionGuard = () => {
@@ -167,7 +174,7 @@ export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.n
   };
 
   return {
-    async check({ tier, ip, subject }) {
+    async check({ tier, ip, subject, chars }) {
       switch (tier) {
         case WEB_TIERS.BYOK:
           return { allowed: true, tier };
@@ -234,6 +241,28 @@ export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.n
             }
             if (dayCount > proLimits.reqPerDay) {
               return { allowed: false, status: 429, reason: QUOTA_REASONS.DAILY };
+            }
+            // Monthly total-character cap (per license subject), the margin
+            // defense against a single seat burning far more than the $9.99/mo
+            // subscription value under the daily/per-request caps. Only engages
+            // when a positive char count is supplied AND a positive cap is
+            // configured; the counter is atomic (incrBy) and resets at the UTC
+            // month boundary via the key bucket + TTL.
+            const monthlyCap = proLimits.charsPerMonth;
+            const reqChars = Number.isSafeInteger(chars) && chars > 0 ? chars : 0;
+            if (reqChars > 0 && Number.isSafeInteger(monthlyCap) && monthlyCap > 0) {
+              const monthDate = new Date(timestamp);
+              const monthBucket = monthDate.getUTCFullYear() * 12 + monthDate.getUTCMonth();
+              const monthKey = quotaKeyHmac(secret, 'pro', 'chars-month', subject, monthBucket);
+              const nextMonthStart = Date.UTC(monthDate.getUTCFullYear(), monthDate.getUTCMonth() + 1, 1);
+              const monthTtlMs = nextMonthStart - timestamp;
+              const monthTotal = await kv.incrBy(monthKey, reqChars, { ttlMs: monthTtlMs });
+              if (!Number.isSafeInteger(monthTotal) || monthTotal < 1) {
+                return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
+              }
+              if (monthTotal > monthlyCap) {
+                return { allowed: false, status: 429, reason: QUOTA_REASONS.MONTHLY_CHARS, remainingMonthlyChars: 0, limitMonthlyChars: monthlyCap };
+              }
             }
             return { allowed: true, tier, remainingDay: Math.max(0, proLimits.reqPerDay - dayCount) };
           } catch {

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -5,6 +5,7 @@ import { QUOTA_REASONS, TIER_LIMITS, WEB_TIERS } from './web-rewrite-contract.js
 
 const DAY_MS = 86_400_000;
 const HOUR_MS = 3_600_000;
+const DEFAULT_CONCURRENCY_TTL_MS = 5 * 60 * 1000;
 
 /**
  * Return a hex sha256 HMAC quota key for NUL-separated parts.
@@ -112,10 +113,12 @@ export function isProductionPosture(env = {}) {
 /**
  * Create a fail-closed rate limiter for the shared free proxy.
  *
- * @param {{kv?: QuotaKv|null, hmacSecret?: string, env?: Record<string, string|undefined>, now?: () => number, limits?: typeof TIER_LIMITS, logger?: RateLimitLogger}} options
+ * @param {{kv?: QuotaKv|null, hmacSecret?: string, env?: Record<string, string|undefined>, now?: () => number, limits?: typeof TIER_LIMITS, logger?: RateLimitLogger, concurrencyTtlMs?: number}} options
+ *   `concurrencyTtlMs` is the self-healing expiry for a concurrency slot; keep it
+ *   >= the maximum stream budget so a slot never expires mid-stream (defaults to 5m).
  * @returns {{check(input: {tier: string, ip?: string|null}): Promise<RateLimitResult>, acquireConcurrency(input: {tier: string, ip?: string|null}): Promise<RateLimitResult>, releaseConcurrency(input: {tier: string, ip?: string|null}): Promise<void>}}
  */
-export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.now(), limits = TIER_LIMITS, logger = console }) {
+export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.now(), limits = TIER_LIMITS, logger = console, concurrencyTtlMs = DEFAULT_CONCURRENCY_TTL_MS }) {
   const getConcurrencyKey = (tier, ip) => {
     if (tier === WEB_TIERS.BYOK) return { ok: false, result: /** @type {RateLimitResult} */ ({ allowed: true, tier }) };
     const production = isProductionPosture(env);
@@ -188,7 +191,7 @@ export function createRateLimiter({ kv, hmacSecret, env = {}, now = () => Date.n
       if (!resolved.ok) return resolved.result;
       const freeLimits = limits.free;
       try {
-        const activeCount = await kv.incr(resolved.key, { ttlMs: 5 * 60 * 1000 });
+        const activeCount = await kv.incr(resolved.key, { ttlMs: concurrencyTtlMs });
         if (!Number.isSafeInteger(activeCount) || activeCount < 1) {
           return { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
         }

--- a/src/rewrite-handler.js
+++ b/src/rewrite-handler.js
@@ -1,7 +1,8 @@
 // @ts-check
 
-import { byteLength, redactSecrets, validateRewriteRequest } from './web-rewrite-contract.js';
+import { byteLength, QUOTA_REASONS, redactSecrets, validateRewriteRequest, WEB_TIERS } from './web-rewrite-contract.js';
 import { extractClientIp } from './rate-limit.js';
+import { extractBearerLicense } from './entitlement.js';
 
 /**
  * Cancellation contract: `runRewrite` receives the raw `req`/`res`. Runtimes
@@ -12,16 +13,17 @@ import { extractClientIp } from './rate-limit.js';
  *
  * @typedef {{method?: string, headers?: Record<string, string|string[]|undefined>, body?: unknown, on?: (event: string, listener: (...args: unknown[]) => void) => unknown, off?: (event: string, listener: (...args: unknown[]) => void) => unknown, [Symbol.asyncIterator]?: () => AsyncIterator<Buffer|string|Uint8Array>}} RewriteReq
  * @typedef {{statusCode?: number, setHeader?: (name: string, value: string) => void, write?: (chunk: string) => void, end?: (body?: string) => void, on?: (event: string, listener: (...args: unknown[]) => void) => unknown, off?: (event: string, listener: (...args: unknown[]) => void) => unknown, writableEnded?: boolean, headersSent?: boolean, destroy?: () => void}} RewriteRes
- * @typedef {{check(input: {tier: string, ip: string|null}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, acquireConcurrency?(input: {tier: string, ip: string|null}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, releaseConcurrency?(input: {tier: string, ip: string|null}): Promise<void>}} RateLimiter
+ * @typedef {{check(input: {tier: string, ip: string|null, subject?: string}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, acquireConcurrency?(input: {tier: string, ip: string|null, subject?: string}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, releaseConcurrency?(input: {tier: string, ip: string|null, subject?: string}): Promise<void>}} RateLimiter
+ * @typedef {{validate(input: {licenseKey: string}): Promise<{ok: true, subject: string, tier: string, status: string, cache: string}|{ok: false, status: number, reason: string}>}} LicenseValidator
  */
 
 /**
  * Create the /api/rewrite handler shell. The LLM runner is injected by later phases.
  *
- * @param {{rateLimiter: RateLimiter, runRewrite: Function, env?: Record<string, string|undefined>, now?: () => number, logger?: {error?: (...args: unknown[]) => void}, maxBodyBytes?: number}} options
+ * @param {{rateLimiter: RateLimiter, runRewrite: Function, env?: Record<string, string|undefined>, now?: () => number, logger?: {error?: (...args: unknown[]) => void}, maxBodyBytes?: number, licenseValidator?: LicenseValidator}} options
  * @returns {(req: RewriteReq, res: RewriteRes) => Promise<unknown>}
  */
-export function createRewriteHandler({ rateLimiter, runRewrite, env = {}, now = () => Date.now(), logger = console, maxBodyBytes = 65_536 }) {
+export function createRewriteHandler({ rateLimiter, runRewrite, env = {}, now = () => Date.now(), logger = console, maxBodyBytes = 65_536, licenseValidator }) {
   if (typeof runRewrite !== 'function') throw new TypeError('runRewrite must be a function');
   if (!rateLimiter || typeof rateLimiter.check !== 'function') throw new TypeError('rateLimiter.check must be a function');
 
@@ -40,7 +42,23 @@ export function createRewriteHandler({ rateLimiter, runRewrite, env = {}, now = 
         return send(res, 400, { error: 'invalid JSON' });
       }
 
-      const validated = validateRewriteRequest(body, env);
+      // Establish the pro license source out-of-band BEFORE contract validation:
+      // a pro request MUST carry its license as an Authorization: Bearer header
+      // (never a body field, never the provider apiKey). The raw license stays in
+      // this handler frame (`bearer.license`); it is never placed on `request`,
+      // handed to runRewrite, or logged.
+      const bodyTier = body?.tier;
+      /** @type {{ok: true, license: string}|{ok: false, status: number, reason: string}|undefined} */
+      let bearer;
+      /** @type {{proLicenseSource?: string}} */
+      let options = {};
+      if (bodyTier === WEB_TIERS.PRO) {
+        bearer = extractBearerLicense(req.headers || {});
+        if (bearer.ok === false) return send(res, bearer.status, { error: bearer.reason });
+        options = { proLicenseSource: 'authorization-bearer' };
+      }
+
+      const validated = validateRewriteRequest(body, env, options);
       if (!validated.ok) {
         const fail = /** @type {{status: number, error: string}} */ (validated);
         return send(res, fail.status, { error: fail.error });
@@ -49,7 +67,30 @@ export function createRewriteHandler({ rateLimiter, runRewrite, env = {}, now = 
       const request = validated.value;
       const tier = typeof request.tier === 'string' ? request.tier : '';
       const ip = extractClientIp(req.headers || {});
-      const quota = await rateLimiter.check({ tier, ip });
+
+      // Pro tier: turn the Bearer license into an HMAC subject via LS validate-only.
+      // The subject (never the raw license) is what meters pro concurrency/quota.
+      // Fail closed if the validator is unwired, or denies/errors (401/403/503).
+      let subject;
+      if (tier === WEB_TIERS.PRO) {
+        if (!licenseValidator || typeof licenseValidator.validate !== 'function') {
+          return send(res, 503, { error: QUOTA_REASONS.LICENSE_UNAVAILABLE });
+        }
+        const ent = await licenseValidator.validate({ licenseKey: /** @type {{ok: true, license: string}} */ (bearer).license });
+        if (!ent.ok) {
+          const denied = /** @type {{status: number, reason: string}} */ (ent);
+          return send(res, denied.status, { error: denied.reason });
+        }
+        subject = ent.subject;
+      }
+
+      // For pro, hand the runner a request whose Authorization header is stripped:
+      // the raw Bearer license was already reduced to an HMAC subject above and must
+      // never reach the runner (or any log path it might grow). free/byok carry no
+      // Authorization, so they pass through unchanged. Cancellation (on/off) still
+      // delegates to the real req so 'aborted'/'close' fire normally.
+      const runnerReq = tier === WEB_TIERS.PRO ? withoutAuthorization(req) : req;
+      const quota = await rateLimiter.check({ tier, ip, subject });
       if (!quota.allowed) {
         const denied = /** @type {{status: number, reason: string}} */ (quota);
         return send(res, denied.status, { error: denied.reason });
@@ -57,10 +98,10 @@ export function createRewriteHandler({ rateLimiter, runRewrite, env = {}, now = 
 
       if (typeof rateLimiter.acquireConcurrency !== 'function') {
         // await so a runner rejection is caught by the redacted 500 handler below.
-        return await runRewrite({ req, res, request, now });
+        return await runRewrite({ req: runnerReq, res, request, now });
       }
 
-      const concurrency = await rateLimiter.acquireConcurrency({ tier, ip });
+      const concurrency = await rateLimiter.acquireConcurrency({ tier, ip, subject });
       if (!concurrency.allowed) {
         const denied = /** @type {{status: number, reason: string}} */ (concurrency);
         return send(res, denied.status, { error: denied.reason });
@@ -68,9 +109,9 @@ export function createRewriteHandler({ rateLimiter, runRewrite, env = {}, now = 
 
       try {
         // await so a runner rejection is caught by the redacted 500 handler below.
-        return await runRewrite({ req, res, request, now });
+        return await runRewrite({ req: runnerReq, res, request, now });
       } finally {
-        await rateLimiter.releaseConcurrency?.({ tier, ip });
+        await rateLimiter.releaseConcurrency?.({ tier, ip, subject });
       }
     } catch (err) {
       logger.error?.(redactSecrets({ message: String(/** @type {any} */ (err)?.message ?? err) }));
@@ -79,6 +120,29 @@ export function createRewriteHandler({ rateLimiter, runRewrite, env = {}, now = 
   };
 }
 
+
+/**
+ * Return a request view with the Authorization header removed, delegating
+ * cancellation emitter methods (on/off) to the real request. The pro handler
+ * passes this to the runner so the raw Bearer license — already reduced to an
+ * HMAC subject — never reaches the rewrite runner or a log path it might add.
+ * @param {RewriteReq} req
+ * @returns {RewriteReq}
+ */
+function withoutAuthorization(req) {
+  /** @type {Record<string, string|string[]|undefined>} */
+  const headers = {};
+  for (const [k, v] of Object.entries(req.headers || {})) {
+    if (k.toLowerCase() === 'authorization') continue;
+    headers[k] = v;
+  }
+  return {
+    method: req.method,
+    headers,
+    on: typeof req.on === 'function' ? (event, listener) => req.on?.(event, listener) : undefined,
+    off: typeof req.off === 'function' ? (event, listener) => req.off?.(event, listener) : undefined,
+  };
+}
 /** @param {RewriteRes} res */
 function setSecurityHeaders(res) {
   res.setHeader?.('Cache-Control', 'no-store');

--- a/src/rewrite-handler.js
+++ b/src/rewrite-handler.js
@@ -11,7 +11,7 @@ import { extractClientIp } from './rate-limit.js';
  * optional so bare serverless/test mocks keep working.
  *
  * @typedef {{method?: string, headers?: Record<string, string|string[]|undefined>, body?: unknown, on?: (event: string, listener: (...args: unknown[]) => void) => unknown, off?: (event: string, listener: (...args: unknown[]) => void) => unknown, [Symbol.asyncIterator]?: () => AsyncIterator<Buffer|string|Uint8Array>}} RewriteReq
- * @typedef {{statusCode?: number, setHeader?: (name: string, value: string) => void, write?: (chunk: string) => void, end?: (body?: string) => void, on?: (event: string, listener: (...args: unknown[]) => void) => unknown, off?: (event: string, listener: (...args: unknown[]) => void) => unknown, writableEnded?: boolean}} RewriteRes
+ * @typedef {{statusCode?: number, setHeader?: (name: string, value: string) => void, write?: (chunk: string) => void, end?: (body?: string) => void, on?: (event: string, listener: (...args: unknown[]) => void) => unknown, off?: (event: string, listener: (...args: unknown[]) => void) => unknown, writableEnded?: boolean, headersSent?: boolean, destroy?: () => void}} RewriteRes
  * @typedef {{check(input: {tier: string, ip: string|null}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, acquireConcurrency?(input: {tier: string, ip: string|null}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, releaseConcurrency?(input: {tier: string, ip: string|null}): Promise<void>}} RateLimiter
  */
 
@@ -93,6 +93,15 @@ function setSecurityHeaders(res) {
  * @returns {undefined}
  */
 export function send(res, status, obj) {
+  // If the response is already committed (an exception escaped after a stream
+  // started writing frames), re-setting status/headers would throw
+  // ERR_HTTP_HEADERS_SENT inside the caller's catch and reject the handler
+  // promise. Fail closed by tearing down the socket: the client's stream
+  // contract already reads a truncated (no `done`) response as an error.
+  if (res.headersSent || res.writableEnded) {
+    res.destroy?.();
+    return undefined;
+  }
   res.statusCode = status;
   res.setHeader?.('Cache-Control', 'no-store');
   res.setHeader?.('X-Content-Type-Options', 'nosniff');

--- a/src/rewrite-handler.js
+++ b/src/rewrite-handler.js
@@ -13,7 +13,7 @@ import { extractBearerLicense } from './entitlement.js';
  *
  * @typedef {{method?: string, headers?: Record<string, string|string[]|undefined>, body?: unknown, on?: (event: string, listener: (...args: unknown[]) => void) => unknown, off?: (event: string, listener: (...args: unknown[]) => void) => unknown, [Symbol.asyncIterator]?: () => AsyncIterator<Buffer|string|Uint8Array>}} RewriteReq
  * @typedef {{statusCode?: number, setHeader?: (name: string, value: string) => void, write?: (chunk: string) => void, end?: (body?: string) => void, on?: (event: string, listener: (...args: unknown[]) => void) => unknown, off?: (event: string, listener: (...args: unknown[]) => void) => unknown, writableEnded?: boolean, headersSent?: boolean, destroy?: () => void}} RewriteRes
- * @typedef {{check(input: {tier: string, ip: string|null, subject?: string}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, acquireConcurrency?(input: {tier: string, ip: string|null, subject?: string}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, releaseConcurrency?(input: {tier: string, ip: string|null, subject?: string}): Promise<void>}} RateLimiter
+ * @typedef {{check(input: {tier: string, ip: string|null, subject?: string, chars?: number}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string, remainingMonthlyChars?: number, limitMonthlyChars?: number}>, acquireConcurrency?(input: {tier: string, ip: string|null, subject?: string}): Promise<{allowed: true, tier: string}|{allowed: false, status: number, reason: string}>, releaseConcurrency?(input: {tier: string, ip: string|null, subject?: string}): Promise<void>}} RateLimiter
  * @typedef {{validate(input: {licenseKey: string}): Promise<{ok: true, subject: string, tier: string, status: string, cache: string}|{ok: false, status: number, reason: string}>}} LicenseValidator
  */
 
@@ -90,10 +90,17 @@ export function createRewriteHandler({ rateLimiter, runRewrite, env = {}, now = 
       // Authorization, so they pass through unchanged. Cancellation (on/off) still
       // delegates to the real req so 'aborted'/'close' fire normally.
       const runnerReq = tier === WEB_TIERS.PRO ? withoutAuthorization(req) : req;
-      const quota = await rateLimiter.check({ tier, ip, subject });
+      // Pro meters a per-license monthly total-character cap in addition to the
+      // daily/concurrency caps; pass the request's input length so the limiter
+      // can accumulate it. free/byok ignore chars (metered by IP/unmetered).
+      const chars = tier === WEB_TIERS.PRO && typeof request.text === 'string' ? request.text.length : 0;
+      const quota = await rateLimiter.check({ tier, ip, subject, chars });
       if (!quota.allowed) {
-        const denied = /** @type {{status: number, reason: string}} */ (quota);
-        return send(res, denied.status, { error: denied.reason });
+        const denied = /** @type {{status: number, reason: string, remainingMonthlyChars?: number, limitMonthlyChars?: number}} */ (quota);
+        const body = /** @type {Record<string, unknown>} */ ({ error: denied.reason });
+        if (typeof denied.remainingMonthlyChars === 'number') body.remainingMonthlyChars = denied.remainingMonthlyChars;
+        if (typeof denied.limitMonthlyChars === 'number') body.limitMonthlyChars = denied.limitMonthlyChars;
+        return send(res, denied.status, body);
       }
 
       if (typeof rateLimiter.acquireConcurrency !== 'function') {

--- a/src/web-observability.js
+++ b/src/web-observability.js
@@ -49,7 +49,7 @@ export function charBucket(count) {
 export function buildRewriteMetric({ route = '/api/rewrite', tier, provider, model, status, latencyMs, quotaDecision, charCount, outcome } = {}) {
   return {
     route: String(route),
-    tier: tier === 'free' || tier === 'byok' ? tier : 'unknown',
+    tier: tier === 'free' || tier === 'byok' || tier === 'pro' ? tier : 'unknown',
     provider: provider ? String(provider) : 'unknown',
     model: model ? String(model) : 'unknown',
     status: Number.isFinite(Number(status)) ? Number(status) : 0,

--- a/src/web-observability.js
+++ b/src/web-observability.js
@@ -10,8 +10,11 @@
 
 /** The complete set of fields a rewrite metric may contain. */
 export const METRIC_FIELDS = Object.freeze([
-  'route', 'tier', 'provider', 'model', 'status', 'latencyBucket', 'quotaDecision', 'charBucket',
+  'route', 'tier', 'provider', 'model', 'status', 'latencyBucket', 'quotaDecision', 'charBucket', 'outcome',
 ]);
+
+/** Closed set of stream outcomes; anything else normalizes to 'n/a' so the field can never carry free-form text. */
+const OUTCOME_VALUES = Object.freeze(new Set(['ok', 'stream_failed', 'scoring_failed', 'floor_failed']));
 
 /** Bucket a latency (ms) into a coarse band so timings are not individually identifying. */
 export function latencyBucket(ms) {
@@ -40,10 +43,10 @@ export function charBucket(count) {
  * are read; any extra keys passed in are ignored, so text/prompt/key/IP can
  * never flow through.
  *
- * @param {{route?:string, tier?:string, provider?:string, model?:string, status?:number, latencyMs?:number, quotaDecision?:string, charCount?:number}} [input]
- * @returns {{route:string, tier:string, provider:string, model:string, status:number, latencyBucket:string, quotaDecision:string, charBucket:string}}
+ * @param {{route?:string, tier?:string, provider?:string, model?:string, status?:number, latencyMs?:number, quotaDecision?:string, charCount?:number, outcome?:string}} [input]
+ * @returns {{route:string, tier:string, provider:string, model:string, status:number, latencyBucket:string, quotaDecision:string, charBucket:string, outcome:string}}
  */
-export function buildRewriteMetric({ route = '/api/rewrite', tier, provider, model, status, latencyMs, quotaDecision, charCount } = {}) {
+export function buildRewriteMetric({ route = '/api/rewrite', tier, provider, model, status, latencyMs, quotaDecision, charCount, outcome } = {}) {
   return {
     route: String(route),
     tier: tier === 'free' || tier === 'byok' ? tier : 'unknown',
@@ -53,6 +56,7 @@ export function buildRewriteMetric({ route = '/api/rewrite', tier, provider, mod
     latencyBucket: latencyBucket(latencyMs),
     quotaDecision: quotaDecision ? String(quotaDecision) : 'n/a',
     charBucket: charBucket(charCount),
+    outcome: OUTCOME_VALUES.has(String(outcome)) ? String(outcome) : 'n/a',
   };
 }
 

--- a/src/web-rewrite-contract.js
+++ b/src/web-rewrite-contract.js
@@ -124,7 +124,7 @@ export const PROVIDER_PRESETS = Object.freeze({
   }),
   claude: Object.freeze({
     baseURL: 'https://api.anthropic.com/v1',
-    models: Object.freeze(['claude-sonnet-4-5', 'claude-opus-4-1', 'claude-haiku-4-5']),
+    models: Object.freeze(['claude-sonnet-5', 'claude-sonnet-4-5', 'claude-opus-4-1', 'claude-haiku-4-5']),
   }),
   deepseek: Object.freeze({
     baseURL: 'https://api.deepseek.com/v1',

--- a/src/web-rewrite-contract.js
+++ b/src/web-rewrite-contract.js
@@ -15,8 +15,8 @@
 /** Languages the rewrite pipeline supports. */
 export const SUPPORTED_LANGS = Object.freeze(['ko', 'en', 'zh', 'ja']);
 
-/** Service tiers. `free` is the abuse-bounded shared proxy; `byok` uses the user's own key. */
-export const WEB_TIERS = Object.freeze({ FREE: 'free', BYOK: 'byok' });
+/** Service tiers. `free` is the abuse-bounded shared proxy; `byok` uses the user's own key; `pro` is the licensed hosted tier (server key, LS validate-only gated). */
+export const WEB_TIERS = Object.freeze({ FREE: 'free', BYOK: 'byok', PRO: 'pro' });
 
 /** Turn kinds. `first` is the one-shot rewrite; `refine` is a conversational follow-up. */
 export const REWRITE_MODES = Object.freeze({ FIRST: 'first', REFINE: 'refine' });
@@ -37,7 +37,36 @@ export const FIDELITY_FLOOR = 70;
 export const TIER_LIMITS = Object.freeze({
   free: Object.freeze({ maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 2 }),
   byok: Object.freeze({ maxChars: 20000, maxConcurrent: 2 }),
+  pro: Object.freeze({ maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 }),
 });
+
+/**
+ * Resolve the effective per-tier caps, applying optional env overrides to the
+ * `pro` tier only; `free`/`byok` are always the frozen defaults. Isomorphic and
+ * import-free — the server passes its process env, the browser/tests pass `{}`
+ * (or an explicit override map). Returns a fresh frozen object shaped exactly
+ * like TIER_LIMITS (free/byok/pro keys). Invalid overrides (non-integer, zero,
+ * or negative) fall back to the default so a malformed env can never widen a cap.
+ *
+ * @param {Record<string,string|undefined>} [env]
+ * @returns {typeof TIER_LIMITS}
+ */
+export function resolveTierLimits(env = {}) {
+  const readPositiveInt = (env, name, fallback) => {
+    const n = Number(env[name]);
+    return Number.isInteger(n) && n > 0 ? n : fallback;
+  };
+  const { pro } = TIER_LIMITS;
+  return Object.freeze({
+    free: TIER_LIMITS.free,
+    byok: TIER_LIMITS.byok,
+    pro: Object.freeze({
+      maxChars: readPositiveInt(env, 'PATINA_PRO_MAX_CHARS', pro.maxChars),
+      reqPerDay: readPositiveInt(env, 'PATINA_PRO_REQ_PER_DAY', pro.reqPerDay),
+      maxConcurrent: readPositiveInt(env, 'PATINA_PRO_MAX_CONCURRENT', pro.maxConcurrent),
+    }),
+  });
+}
 
 /**
  * Conversation context caps. The client holds the thread (no-store server); the
@@ -60,6 +89,9 @@ export const QUOTA_REASONS = Object.freeze({
   STORAGE_UNAVAILABLE: 'quota storage unavailable',
   SECRET_UNAVAILABLE: 'quota secret unavailable',
   SERVICE_UNAVAILABLE: 'rewrite service unavailable',
+  LICENSE_REQUIRED: 'license required',
+  LICENSE_INVALID: 'license not entitled',
+  LICENSE_UNAVAILABLE: 'license validation unavailable',
 });
 
 /**
@@ -155,11 +187,11 @@ export function isWebPersonaAllowed(lang, id) {
  * Keys whose values are secrets and must be redacted before logging. Matched by
  * normalized substring (lowercased, separators stripped) so families like
  * apiKey/openaiApiKey/x-api-key, access_token/refreshToken, client_secret, and
- * password/credential/authorization/bearer are all caught — over-redacting is
+ * password/credential/authorization/bearer/license are all caught — over-redacting is
  * the safe failure for a key-handling boundary.
  */
 const SECRET_KEY_MARKERS = Object.freeze([
-  'apikey', 'token', 'secret', 'password', 'passwd', 'credential', 'authorization', 'bearer',
+  'apikey', 'token', 'secret', 'password', 'passwd', 'credential', 'authorization', 'bearer', 'license',
 ]);
 function isSecretKey(key) {
   const norm = String(key).toLowerCase().replace(/[_-]/g, '');
@@ -167,7 +199,7 @@ function isSecretKey(key) {
 }
 /**
  * Inline secret shapes inside free-form strings (Bearer tokens, OpenAI keys),
- * plus labelled secrets (`apiKey=...`, `x-api-key: ...`, `token=...`) that
+ * plus labelled secrets (`apiKey=...`, `x-api-key: ...`, `token=...`, `license_key=...`) that
  * upstream provider error messages embed regardless of key format (#565).
  * The value part is bounded (no nested quantifiers) so a hostile error string
  * cannot trigger catastrophic backtracking; over-redacting is the safe
@@ -180,6 +212,7 @@ const SECRET_VALUE_RES = [
   /\b(?:access|refresh)[-_]?token\s*[:=]\s*[^\s"'`&,;]{6,}/gi,
   /\bclient[-_]?secret\s*[:=]\s*[^\s"'`&,;]{6,}/gi,
   /\b(?:token|secret|password|passwd|credential|authorization)\s*[:=]\s*[^\s"'`&,;]{6,}/gi,
+  /\blicense[-_]?key\s*[:=]\s*[^\s"'`&,;]{6,}/gi,
 ];
 const REDACTED = '[REDACTED]';
 
@@ -220,6 +253,8 @@ export function redactSecrets(value) {
  * - free: provider/model come from env (PATINA_FREE_PROVIDER/PATINA_FREE_MODEL),
  *   defaulting to the first preset; the request body cannot choose them.
  * - byok: provider+model must both be on the PROVIDER_PRESETS allowlist.
+ * - pro: like free, pinned by env (PATINA_PRO_* falling back to PATINA_FREE_*);
+ *   the request body cannot choose provider/model.
  * The base URL is ALWAYS taken from the preset, never from the request body.
  *
  * @param {{tier?:string, provider?:string, model?:string}} req
@@ -240,6 +275,14 @@ export function resolveProviderModel({ tier, provider, model } = {}, env = {}) {
     if (!preset) return { ok: false, error: 'free provider not configured' };
     const m = env.PATINA_FREE_MODEL || preset.models[0];
     if (!preset.models.includes(m)) return { ok: false, error: 'free model not allowlisted' };
+    return { ok: true, tier, provider: p, model: m, baseURL: preset.baseURL };
+  }
+  if (tier === WEB_TIERS.PRO) {
+    const p = env.PATINA_PRO_PROVIDER || env.PATINA_FREE_PROVIDER || 'openai';
+    const preset = presetFor(p);
+    if (!preset) return { ok: false, error: 'pro provider not configured' };
+    const m = env.PATINA_PRO_MODEL || env.PATINA_FREE_MODEL || preset.models[0];
+    if (!preset.models.includes(m)) return { ok: false, error: 'pro model not allowlisted' };
     return { ok: true, tier, provider: p, model: m, baseURL: preset.baseURL };
   }
   if (tier === WEB_TIERS.BYOK) {
@@ -283,13 +326,17 @@ export function normalizeHistory(history) {
 /**
  * Validate an inbound /api/rewrite request body against the contract.
  * Returns a normalized value on success, or an error plus the HTTP status the
- * handler should reply with (400 bad request, 413 payload too large).
+ * handler should reply with (400 bad request, 401 unauthorized, 413 payload too large).
  *
  * @param {unknown} body
  * @param {Record<string,string|undefined>} [env]
+ * @param {{proLicenseSource?:string}} [options] Out-of-band request facts the
+ *   handler has already established (e.g. that a pro license arrived as an
+ *   Authorization: Bearer header). Optional — existing 2-arg callers are
+ *   unaffected and behave exactly as before.
  * @returns {{ok:true, value:object}|{ok:false, status:number, error:string}}
  */
-export function validateRewriteRequest(body, env = {}) {
+export function validateRewriteRequest(body, env = {}, options = {}) {
   if (!body || typeof body !== 'object' || Array.isArray(body)) {
     return { ok: false, status: 400, error: 'request body must be a JSON object' };
   }
@@ -301,14 +348,32 @@ export function validateRewriteRequest(body, env = {}) {
   if (!SUPPORTED_LANGS.includes(lang)) {
     return { ok: false, status: 400, error: `lang must be one of ${SUPPORTED_LANGS.join(', ')}` };
   }
-  if (tier !== WEB_TIERS.FREE && tier !== WEB_TIERS.BYOK) {
-    return { ok: false, status: 400, error: 'tier must be "free" or "byok"' };
+  if (tier !== WEB_TIERS.FREE && tier !== WEB_TIERS.BYOK && tier !== WEB_TIERS.PRO) {
+    return { ok: false, status: 400, error: 'tier must be "free", "byok", or "pro"' };
   }
   if (typeof text !== 'string' || text.trim().length === 0) {
     return { ok: false, status: 400, error: 'text must be a non-empty string' };
   }
 
-  const limits = TIER_LIMITS[tier];
+  // Pro tier gates on the license credential BEFORE char caps or provider/model
+  // resolution, so an unauthenticated pro request always fails closed with 401
+  // LICENSE_REQUIRED and never leaks limit/config state ahead of the auth
+  // boundary. The license is an entitlement (the handler verifies it via LS
+  // validate-only from an Authorization: Bearer header), never a provider key
+  // and never a body field.
+  if (tier === WEB_TIERS.PRO) {
+    if (/** @type {any} */ (body).apiKey != null) {
+      return { ok: false, status: 400, error: 'pro tier must not include an apiKey; the license is sent as Authorization: Bearer' };
+    }
+    if (/** @type {any} */ (body).licenseKey != null || /** @type {any} */ (body).license_key != null) {
+      return { ok: false, status: 400, error: 'pro tier license must be sent as Authorization: Bearer, not in the body' };
+    }
+    if (options.proLicenseSource !== 'authorization-bearer') {
+      return { ok: false, status: 401, error: QUOTA_REASONS.LICENSE_REQUIRED };
+    }
+  }
+
+  const limits = resolveTierLimits(env)[tier];
   if (text.length > limits.maxChars) {
     return { ok: false, status: 413, error: `text exceeds ${limits.maxChars} characters for tier ${tier}` };
   }

--- a/src/web-rewrite-contract.js
+++ b/src/web-rewrite-contract.js
@@ -37,7 +37,7 @@ export const FIDELITY_FLOOR = 70;
 export const TIER_LIMITS = Object.freeze({
   free: Object.freeze({ maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 2 }),
   byok: Object.freeze({ maxChars: 20000, maxConcurrent: 2 }),
-  pro: Object.freeze({ maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 }),
+  pro: Object.freeze({ maxChars: 20000, reqPerDay: 200, maxConcurrent: 3, charsPerMonth: 1_000_000 }),
 });
 
 /**
@@ -64,6 +64,7 @@ export function resolveTierLimits(env = {}) {
       maxChars: readPositiveInt(env, 'PATINA_PRO_MAX_CHARS', pro.maxChars),
       reqPerDay: readPositiveInt(env, 'PATINA_PRO_REQ_PER_DAY', pro.reqPerDay),
       maxConcurrent: readPositiveInt(env, 'PATINA_PRO_MAX_CONCURRENT', pro.maxConcurrent),
+      charsPerMonth: readPositiveInt(env, 'PATINA_PRO_CHARS_PER_MONTH', pro.charsPerMonth),
     }),
   });
 }
@@ -92,6 +93,7 @@ export const QUOTA_REASONS = Object.freeze({
   LICENSE_REQUIRED: 'license required',
   LICENSE_INVALID: 'license not entitled',
   LICENSE_UNAVAILABLE: 'license validation unavailable',
+  MONTHLY_CHARS: 'monthly character limit reached',
 });
 
 /**

--- a/src/web-rewrite-stream.js
+++ b/src/web-rewrite-stream.js
@@ -17,9 +17,19 @@ function rawScore(score, field) {
   return /** @type {any} */ (score)?.[field];
 }
 
-/** @param {unknown} err */
-function safeError(err) {
-  return String(redactSecrets(/** @type {any} */ (err)?.message ?? err ?? 'unknown error'));
+/**
+ * @param {unknown} err
+ * @param {string} [secret] Request-scoped API key to scrub verbatim, on top of
+ *   pattern-based redaction. Covers provider key formats (e.g. GLM `id.secret`)
+ *   that carry no `sk-`/`Bearer`/label marker for the regex to catch, so a key
+ *   echoed in a provider error body never reaches an error frame or a log line.
+ */
+function safeError(err, secret) {
+  let out = String(redactSecrets(/** @type {any} */ (err)?.message ?? err ?? 'unknown error'));
+  if (typeof secret === 'string' && secret.length >= 8 && out.includes(secret)) {
+    out = out.split(secret).join('[REDACTED]');
+  }
+  return out;
 }
 
 /** @param {unknown} value */
@@ -94,7 +104,7 @@ export async function runWebRewriteStream({
     });
     rewrite = formatRewriteBodyForBrowser(streamResult.text);
   } catch (err) {
-    const error = safeError(err);
+    const error = safeError(err, request.apiKey);
     emit({ type: STREAM_FRAME_TYPES.ERROR, code: 'stream_failed', error });
     return { ok: false, code: 'stream_failed', error };
   }
@@ -119,7 +129,7 @@ export async function runWebRewriteStream({
     // A scoring failure (including an abort during scoring) must terminate as
     // a clean NDJSON error frame — never bubble to the handler's JSON 500,
     // which would append a non-frame tail to an already-started stream.
-    const error = safeError(err);
+    const error = safeError(err, request.apiKey);
     emit({ type: STREAM_FRAME_TYPES.ERROR, code: 'scoring_failed', error });
     return { ok: false, code: 'scoring_failed', error };
   }

--- a/tests/unit/entitlement.redteam.test.js
+++ b/tests/unit/entitlement.redteam.test.js
@@ -1,0 +1,622 @@
+// @ts-nocheck
+// ---------------------------------------------------------------------------
+// Adversarial red-team suite for the patina Pro entitlement core (G002 gate).
+//
+// This file deliberately targets the GAPS *beyond* the 27 happy/contract tests
+// in entitlement.test.js. Every case tries to BREAK a fail-closed invariant:
+//   (1) cache poisoning      -> malformed cached decisions must MISS (never
+//                               grant, never throw), even when written under the
+//                               correct HMAC key by an omniscient attacker.
+//   (2) admission bypass      -> a degraded KV whose incr() returns
+//                               NaN/negative/0/object/string/Infinity/float, or
+//                               throws, must fail closed (503, LS never called).
+//   (3) single-flight race    -> N concurrent misses call LS exactly once; a
+//                               failed winner releases the lock so a retry can
+//                               re-validate; a successful winner is served from
+//                               cache (no LS re-call).
+//   (4) key leakage           -> the raw license never lands in a return value,
+//                               a KV key, a cached value, or a (redacted) log,
+//                               even when LS echoes it in objects/strings/nested
+//                               structures/error messages.
+//   (5) evaluateLicenseResponse robustness against hostile response shapes.
+//   (6) extractBearerLicense robustness against hostile header shapes.
+//
+// Injected dependencies only: fetchImpl (with a call counter), a fixed clock,
+// and either createMemoryKv() or a hand-built degraded KV. NO real network.
+//
+// Each adversarial case is recorded (id/scenario/expectedBehavior/verdict) and
+// the machine-readable report is written to artifacts/pro-qa/g002-redteam.json
+// on process exit so the report survives a `node --test` self-check regardless
+// of individual pass/fail.
+// ---------------------------------------------------------------------------
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import {
+  createLemonSqueezyLicenseValidator,
+  evaluateLicenseResponse,
+  extractBearerLicense,
+} from '../../src/entitlement.js';
+import { createMemoryKv, quotaKeyHmac } from '../../src/rate-limit.js';
+import { QUOTA_REASONS } from '../../src/web-rewrite-contract.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures (mirrors entitlement.test.js so the two suites stay isomorphic)
+// ---------------------------------------------------------------------------
+
+const FIXED_NOW = 1_700_000_000_000;
+const SECRET = 'unit-test-license-secret';
+const HEX64 = /^[a-f0-9]{64}$/;
+const GOOD_META = Object.freeze({ store_id: 55555, variant_id: 98765, product_id: 4242 });
+
+function baseEnv(overrides = {}) {
+  return { LS_STORE_ID: '55555', LS_PRO_VARIANT_ID: '98765', ...overrides };
+}
+function pastIso(offsetMs = 3_600_000) {
+  return new Date(FIXED_NOW - offsetMs).toISOString();
+}
+function okBody(over = {}) {
+  return {
+    valid: over.valid !== undefined ? over.valid : true,
+    error: null,
+    license_key: { status: 'active', expires_at: null, ...(over.license_key || {}) },
+    meta: { ...GOOD_META, ...(over.meta || {}) },
+  };
+}
+function lsResponse(body, { status = 200, ok, throwJson = false } = {}) {
+  return {
+    ok: ok === undefined ? status >= 200 && status < 300 : ok,
+    status,
+    async json() {
+      if (throwJson) throw new Error('Unexpected end of JSON input');
+      return body;
+    },
+  };
+}
+function spyFetch(responder) {
+  const calls = [];
+  const fetchImpl = async (url, opts) => {
+    calls.push({ url, opts });
+    return responder(url, opts, calls.length);
+  };
+  fetchImpl.calls = calls;
+  return fetchImpl;
+}
+function spyKv() {
+  const inner = createMemoryKv();
+  const keys = [];
+  const values = [];
+  return {
+    __memory: true,
+    _keys: keys,
+    _values: values,
+    async get(key) { keys.push(key); return inner.get(key); },
+    async set(key, val, opts) { keys.push(key); values.push(val); return inner.set(key, val, opts); },
+    async incr(key, opts) { keys.push(key); return inner.incr(key, opts); },
+    async decr(key) { keys.push(key); return inner.decr(key); },
+  };
+}
+function spyLogger() {
+  const entries = [];
+  return {
+    _entries: entries,
+    warn: (...args) => entries.push(args),
+    log: (...args) => entries.push(args),
+  };
+}
+function makeValidator({ kv, env, fetchImpl, logger, hmacSecret = SECRET, now = () => FIXED_NOW } = {}) {
+  return createLemonSqueezyLicenseValidator({
+    kv: kv === undefined ? createMemoryKv() : kv,
+    hmacSecret,
+    env: env || baseEnv(),
+    fetchImpl,
+    now,
+    logger,
+  });
+}
+
+// A KV whose get() always misses and whose incr() returns a poisoned value.
+// The 1st incr in validate() is the RPM bucket, the 2nd is the single-flight
+// lock, so `rpm`/`lock` let a case target a specific admission guard.
+// { value } => incr returns that value; { throw:true } => incr throws.
+function degradedKv({ rpm, lock } = {}) {
+  let n = 0;
+  return {
+    async get() { return undefined; },
+    async set() { /* noop */ },
+    async incr() {
+      n += 1;
+      const spec = n === 1 ? rpm : lock;
+      if (spec && spec.throw) throw new Error('kv incr exploded');
+      return spec ? spec.value : 1; // default: a healthy first increment
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Case recorder + artifact emitter
+// ---------------------------------------------------------------------------
+
+const CASES = [];
+function record(id, scenario, expectedBehavior, verdict, note) {
+  CASES.push({ id, scenario, expectedBehavior, verdict, ...(note ? { note } : {}) });
+}
+
+/** Register one adversarial case as a node:test that also records its verdict. */
+function check(id, scenario, expectedBehavior, fn) {
+  test(`[${id}] ${scenario}`, async (t) => {
+    try {
+      await fn(t);
+      record(id, scenario, expectedBehavior, 'pass');
+    } catch (err) {
+      record(id, scenario, expectedBehavior, 'fail', String((err && err.message) || err));
+      throw err;
+    }
+  });
+}
+
+const ARTIFACT_PATH = 'artifacts/pro-qa/g002-redteam.json';
+process.on('exit', () => {
+  const pass = CASES.filter((c) => c.verdict === 'pass').length;
+  const fail = CASES.length - pass;
+  const report = {
+    schemaVersion: 1,
+    kind: 'algorithm-boundary-report',
+    surface: 'algorithm',
+    tests: CASES.length,
+    pass,
+    fail,
+    cases: CASES,
+  };
+  try {
+    mkdirSync(dirname(ARTIFACT_PATH), { recursive: true });
+    writeFileSync(ARTIFACT_PATH, JSON.stringify(report, null, 2));
+  } catch { /* best-effort: the node:test verdict is still authoritative */ }
+});
+
+// ===========================================================================
+// Scenario 1 - cache poisoning: malformed cached decisions must MISS
+// ===========================================================================
+// Threat model: the KV key is an HMAC the attacker cannot forge, so we model
+// the STRONGEST attacker (one who knows SECRET) writing directly at the derived
+// cache key. Even then, a malformed/hostile cached value must be treated as a
+// miss (readCacheEntry -> null): no wrong allow, no throw, always re-validate.
+
+function cacheKeyFor(license) {
+  return quotaKeyHmac(SECRET, 'ls-license-cache', license);
+}
+
+// Control A: a WELL-FORMED positive entry MUST be served from cache. This proves
+// the HMAC key derivation used by the poison cases below is correct, so their
+// "miss" outcomes are meaningful (not a false pass from a wrong key).
+check('C1-ctrl-allow', 'cache: a well-formed allow entry is served as a hit', 'cache HIT, ok:true, LS never called', async () => {
+  const kv = createMemoryKv();
+  const license = 'LK-c1-ctrl-allow';
+  await kv.set(cacheKeyFor(license), { decision: 'allow', tier: 'pro', status: 'active', expiresAt: FIXED_NOW + 60_000 }, { ttlMs: 600_000 });
+  const fetchImpl = spyFetch(() => { throw new Error('must not fetch on a cache hit'); });
+  const res = await makeValidator({ kv, fetchImpl }).validate({ licenseKey: license });
+  assert.equal(res.ok, true);
+  assert.equal(res.cache, 'hit');
+  assert.equal(res.status, 'active');
+  assert.equal(fetchImpl.calls.length, 0);
+});
+
+// Control B: a WELL-FORMED negative entry MUST be served from cache (403).
+check('C1-ctrl-deny', 'cache: a well-formed deny entry is served as a hit', 'cache HIT, 403, LS never called', async () => {
+  const kv = createMemoryKv();
+  const license = 'LK-c1-ctrl-deny';
+  await kv.set(cacheKeyFor(license), { decision: 'deny', tier: 'pro', status: 403, reason: QUOTA_REASONS.LICENSE_INVALID, expiresAt: FIXED_NOW + 60_000 }, { ttlMs: 600_000 });
+  const fetchImpl = spyFetch(() => { throw new Error('must not fetch on a cache hit'); });
+  const res = await makeValidator({ kv, fetchImpl }).validate({ licenseKey: license });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 403);
+  assert.equal(fetchImpl.calls.length, 0);
+});
+
+// Poisoned ALLOW entries: each must be ignored (miss). We make LS DENY, so if
+// the poison were honored the result would wrongly be ok:true. A 403 + exactly
+// one fetch proves: (a) no wrong allow, (b) the cache missed and we re-validated.
+const POISON_ALLOWS = {
+  'C1-a: allow missing status': { decision: 'allow', expiresAt: FIXED_NOW + 60_000 },
+  'C1-b: allow non-string status': { decision: 'allow', status: 200, expiresAt: FIXED_NOW + 60_000 },
+  'C1-c: allow missing expiresAt': { decision: 'allow', status: 'active' },
+  'C1-d: allow expiresAt as string': { decision: 'allow', status: 'active', expiresAt: String(FIXED_NOW + 60_000) },
+  'C1-e: allow expiresAt NaN': { decision: 'allow', status: 'active', expiresAt: NaN },
+  'C1-f: allow expiresAt Infinity': { decision: 'allow', status: 'active', expiresAt: Infinity },
+  'C1-g: allow expiresAt in the past': { decision: 'allow', status: 'active', expiresAt: FIXED_NOW - 1_000 },
+  'C1-h: allow expiresAt exactly now (<= now boundary)': { decision: 'allow', status: 'active', expiresAt: FIXED_NOW },
+  'C1-i: allow illegal decision value': { decision: 'grant', status: 'active', expiresAt: FIXED_NOW + 60_000 },
+  'C1-j: entry is a bare string': 'allow',
+  'C1-k: entry is a number': 123,
+  'C1-l: entry is a boolean': true,
+  'C1-m: entry is an array': [{ decision: 'allow', status: 'active', expiresAt: FIXED_NOW + 60_000 }],
+};
+for (const [label, poison] of Object.entries(POISON_ALLOWS)) {
+  const id = label.split(':')[0];
+  check(id, `cache poison ignored: ${label.split(': ')[1]}`, 'treated as miss -> re-validates -> LS denial honored (403), no throw', async () => {
+    const kv = createMemoryKv();
+    const license = `LK-${id}`;
+    await kv.set(cacheKeyFor(license), poison, { ttlMs: 600_000 });
+    const fetchImpl = spyFetch(() => lsResponse(okBody({ valid: false }))); // LS denies
+    const res = await makeValidator({ kv, fetchImpl }).validate({ licenseKey: license });
+    assert.equal(res.ok, false, 'poisoned allow must NOT grant');
+    assert.equal(res.status, 403);
+    assert.equal(fetchImpl.calls.length, 1, 'malformed cache must miss and re-validate against LS');
+  });
+}
+
+// Poisoned DENY entries also miss -> re-validate. LS entitles, so a well-formed
+// re-validation returns ok:true (proves the garbage deny was not honored either).
+const POISON_DENIES = {
+  'C1-n: deny non-number status': { decision: 'deny', status: '403', reason: QUOTA_REASONS.LICENSE_INVALID, expiresAt: FIXED_NOW + 60_000 },
+  'C1-o: deny non-string reason': { decision: 'deny', status: 403, reason: 42, expiresAt: FIXED_NOW + 60_000 },
+};
+for (const [label, poison] of Object.entries(POISON_DENIES)) {
+  const id = label.split(':')[0];
+  check(id, `cache poison ignored: ${label.split(': ')[1]}`, 'treated as miss -> re-validates -> LS entitlement honored (ok, miss)', async () => {
+    const kv = createMemoryKv();
+    const license = `LK-${id}`;
+    await kv.set(cacheKeyFor(license), poison, { ttlMs: 600_000 });
+    const fetchImpl = spyFetch(() => lsResponse(okBody()));
+    const res = await makeValidator({ kv, fetchImpl }).validate({ licenseKey: license });
+    assert.equal(res.ok, true);
+    assert.equal(res.cache, 'miss');
+    assert.equal(fetchImpl.calls.length, 1);
+  });
+}
+
+// ===========================================================================
+// Scenario 2 - admission bypass: a degraded KV must fail closed (503)
+// ===========================================================================
+
+// Control: a healthy KV under the SAME env reaches LS. This proves config is
+// valid, so every 503 below is attributable to the admission guard, not config.
+check('C2-ctrl', 'admission: a healthy KV reaches LS', 'ok:true, LS called once (config is valid)', async () => {
+  const healthy = { async get() { return undefined; }, async set() {}, async incr() { return 1; } };
+  const fetchImpl = spyFetch(() => lsResponse(okBody()));
+  const res = await makeValidator({ kv: healthy, fetchImpl }).validate({ licenseKey: 'LK-c2-ctrl' });
+  assert.equal(res.ok, true);
+  assert.equal(fetchImpl.calls.length, 1);
+});
+
+const DEGRADED_RPM = {
+  'C2-a: RPM incr -> NaN': { value: NaN },
+  'C2-b: RPM incr -> negative': { value: -1 },
+  'C2-c: RPM incr -> zero': { value: 0 },
+  'C2-d: RPM incr -> object': { value: {} },
+  'C2-e: RPM incr -> string': { value: '5' },
+  'C2-f: RPM incr -> Infinity': { value: Infinity },
+  'C2-g: RPM incr -> float': { value: 1.5 },
+  'C2-h: RPM incr -> throws': { throw: true },
+};
+for (const [label, rpm] of Object.entries(DEGRADED_RPM)) {
+  const id = label.split(':')[0];
+  check(id, `admission bypass blocked: ${label.split(': ')[1]}`, 'fail closed 503 LICENSE_UNAVAILABLE, LS never called', async () => {
+    const fetchImpl = spyFetch(() => { throw new Error('must not reach LS under a degraded RPM bucket'); });
+    const res = await makeValidator({ kv: degradedKv({ rpm }), fetchImpl }).validate({ licenseKey: `LK-${id}` });
+    assert.equal(res.ok, false);
+    assert.equal(res.status, 503);
+    assert.equal(res.reason, QUOTA_REASONS.LICENSE_UNAVAILABLE);
+    assert.equal(fetchImpl.calls.length, 0);
+  });
+}
+
+const DEGRADED_LOCK = {
+  'C2-i: lock incr -> NaN': { value: NaN },
+  'C2-j: lock incr -> zero': { value: 0 },
+  'C2-k: lock incr -> object': { value: {} },
+  'C2-l: lock incr -> string': { value: '1' },
+  'C2-m: lock incr -> throws': { throw: true },
+};
+for (const [label, lock] of Object.entries(DEGRADED_LOCK)) {
+  const id = label.split(':')[0];
+  check(id, `admission bypass blocked: ${label.split(': ')[1]} (RPM healthy)`, 'fail closed 503 LICENSE_UNAVAILABLE, LS never called', async () => {
+    const fetchImpl = spyFetch(() => { throw new Error('must not reach LS under a degraded lock'); });
+    // rpm healthy (1) so the case isolates the single-flight lock guard.
+    const res = await makeValidator({ kv: degradedKv({ rpm: { value: 1 }, lock }), fetchImpl }).validate({ licenseKey: `LK-${id}` });
+    assert.equal(res.ok, false);
+    assert.equal(res.status, 503);
+    assert.equal(res.reason, QUOTA_REASONS.LICENSE_UNAVAILABLE);
+    assert.equal(fetchImpl.calls.length, 0);
+  });
+}
+
+// ===========================================================================
+// Scenario 3 - single-flight race
+// ===========================================================================
+
+function lockKeyFor(license) {
+  return quotaKeyHmac(SECRET, 'ls-lock', license);
+}
+
+check('C3-a', 'single-flight: N concurrent misses call LS exactly once', 'LS called once; 1 winner (miss); N-1 losers fail closed 503', async () => {
+  const N = 8;
+  // The winner's fetch resolves on a macrotask so every loser returns 503 first.
+  const fetchImpl = spyFetch(async () => { await new Promise((r) => setTimeout(r, 15)); return lsResponse(okBody()); });
+  const validator = makeValidator({ fetchImpl });
+  const license = 'LK-c3-concurrent';
+  const results = await Promise.all(Array.from({ length: N }, () => validator.validate({ licenseKey: license })));
+  assert.equal(fetchImpl.calls.length, 1, 'exactly one instance may call LS');
+  const winners = results.filter((r) => r.ok);
+  assert.equal(winners.length, 1, 'exactly one winner');
+  assert.equal(winners[0].cache, 'miss');
+  assert.equal(results.filter((r) => !r.ok && r.status === 503).length, N - 1, 'losers fail closed');
+});
+
+check('C3-b', 'single-flight: a failed winner (non-2xx) releases the lock for retry', 'lock reset to 0; retry re-validates against LS and succeeds', async () => {
+  const kv = createMemoryKv();
+  let attempt = 0;
+  const fetchImpl = spyFetch(() => {
+    attempt += 1;
+    return attempt === 1 ? lsResponse({ error: 'upstream 500' }, { status: 500 }) : lsResponse(okBody());
+  });
+  const validator = makeValidator({ kv, fetchImpl });
+  const license = 'LK-c3-fail-retry';
+
+  const first = await validator.validate({ licenseKey: license });
+  assert.equal(first.status, 503, 'a failed winner denies transiently (never cached)');
+  assert.equal(await kv.get(lockKeyFor(license)), 0, 'the lock must be released (reset to 0) after a failure');
+
+  const retry = await validator.validate({ licenseKey: license });
+  assert.equal(retry.ok, true, 'a subsequent caller becomes the winner and re-validates');
+  assert.equal(fetchImpl.calls.length, 2, 'a transient failure must not be cached');
+});
+
+check('C3-c', 'single-flight: a timed-out winner releases the lock for retry', 'timeout -> 503 -> lock released -> retry succeeds', async () => {
+  const kv = createMemoryKv();
+  let attempt = 0;
+  const fetchImpl = spyFetch((_url, opts) => {
+    attempt += 1;
+    if (attempt === 1) return new Promise((_res, rej) => opts.signal.addEventListener('abort', () => rej(new Error('The operation was aborted'))));
+    return lsResponse(okBody());
+  });
+  const validator = makeValidator({ kv, fetchImpl, env: baseEnv({ PATINA_LS_TIMEOUT_MS: '15' }) });
+  const license = 'LK-c3-timeout-retry';
+
+  const first = await validator.validate({ licenseKey: license });
+  assert.equal(first.status, 503);
+  assert.equal(await kv.get(lockKeyFor(license)), 0, 'lock released even after a timeout in the winner path');
+
+  const retry = await validator.validate({ licenseKey: license });
+  assert.equal(retry.ok, true);
+  assert.equal(fetchImpl.calls.length, 2);
+});
+
+check('C3-d', 'single-flight: a successful winner serves late arrivals from cache', 'winner writes positive cache; late caller is a HIT (no LS re-call)', async () => {
+  const fetchImpl = spyFetch(() => lsResponse(okBody()));
+  const validator = makeValidator({ fetchImpl });
+  const license = 'LK-c3-late-hit';
+  const winner = await validator.validate({ licenseKey: license });
+  assert.equal(winner.ok, true);
+  assert.equal(winner.cache, 'miss');
+  const late = await validator.validate({ licenseKey: license });
+  assert.equal(late.ok, true);
+  assert.equal(late.cache, 'hit');
+  assert.equal(fetchImpl.calls.length, 1, 'a late arrival must hit cache, not re-call LS');
+});
+
+check('C3-e', 'single-flight: a denying winner serves late arrivals from negative cache', 'winner writes negative cache; late caller is a 403 HIT (no LS re-call)', async () => {
+  const fetchImpl = spyFetch(() => lsResponse(okBody({ valid: false })));
+  const validator = makeValidator({ fetchImpl });
+  const license = 'LK-c3-late-deny';
+  const winner = await validator.validate({ licenseKey: license });
+  assert.equal(winner.ok, false);
+  assert.equal(winner.status, 403);
+  const late = await validator.validate({ licenseKey: license });
+  assert.equal(late.status, 403);
+  assert.equal(fetchImpl.calls.length, 1, 'a late arrival must hit the negative cache, not re-call LS');
+});
+
+// ===========================================================================
+// Scenario 4 - key leakage: the raw license never leaks (beyond the 2 existing
+// security tests: here we exercise recursion into meta, the deny-path KV key
+// enumeration, and an isolated free-form error echo).
+// ===========================================================================
+
+const LEAK_LICENSE = 'LKX-9f8e7d6c-DEAD-BEEF-CAFE-000000000001';
+
+check('C4-a', 'key leakage: allow path never exposes the license (return/keys/values/logs)', 'subject-only return, all KV keys HMAC hex, no raw license anywhere', async () => {
+  const kv = spyKv();
+  const logger = spyLogger();
+  const fetchImpl = spyFetch(() => lsResponse(okBody({ license_key: { status: 'active', expires_at: null, key: LEAK_LICENSE } })));
+  const res = await makeValidator({ kv, logger, fetchImpl }).validate({ licenseKey: LEAK_LICENSE });
+  assert.equal(res.ok, true);
+  assert.equal(res.cache, 'miss');
+  assert.match(res.subject, HEX64);
+  assert.equal(JSON.stringify(res).includes(LEAK_LICENSE), false, 'return value leaked the license');
+  assert.ok(kv._keys.length >= 3, 'expected cache/rpm/lock KV keys');
+  for (const key of kv._keys) {
+    assert.match(key, HEX64, `KV key is not an HMAC digest: ${key}`);
+    assert.equal(key.includes(LEAK_LICENSE), false, 'a KV key leaked the license');
+  }
+  assert.equal(JSON.stringify(kv._values).includes(LEAK_LICENSE), false, 'a cached value leaked the license');
+  assert.equal(JSON.stringify(logger._entries).includes(LEAK_LICENSE), false, 'a log payload leaked the license');
+});
+
+check('C4-b', 'key leakage: deny path redacts echoes in objects, nested meta, and error strings', 'redactSecrets scrubs every echo; keys HMAC hex; return/cache clean', async () => {
+  const kv = spyKv();
+  const logger = spyLogger();
+  // status 'expired' -> denial is reached and the FULL body is logged (redacted).
+  // The license is echoed in: the license_key object, a nested license-named
+  // block inside meta, and a free-form error string (both label= and Bearer forms).
+  const fetchImpl = spyFetch(() => lsResponse({
+    valid: true,
+    error: `rejected: license_key=${LEAK_LICENSE}; auth Bearer ${LEAK_LICENSE}`,
+    license_key: { status: 'expired', key: LEAK_LICENSE, key_short: LEAK_LICENSE },
+    meta: { ...GOOD_META, license_detail: { raw: LEAK_LICENSE }, activation: { license: LEAK_LICENSE } },
+  }));
+  const res = await makeValidator({ kv, logger, fetchImpl }).validate({ licenseKey: LEAK_LICENSE });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 403);
+  assert.equal(JSON.stringify(res).includes(LEAK_LICENSE), false, 'return value leaked the license');
+
+  assert.ok(logger._entries.length > 0, 'a denial must be logged for triage');
+  const logs = JSON.stringify(logger._entries);
+  assert.equal(logs.includes(LEAK_LICENSE), false, 'raw license leaked into logs');
+  assert.ok(logs.includes('[REDACTED]'), 'echoed license must be redacted');
+
+  for (const key of kv._keys) assert.match(key, HEX64, `KV key is not an HMAC digest: ${key}`);
+  assert.equal(JSON.stringify(kv._values).includes(LEAK_LICENSE), false, 'a cached value leaked the license');
+});
+
+check('C4-c', 'key leakage: denial whose ONLY echo is a labelled free-form error string', 'string-shape redaction alone scrubs the license from logs', async () => {
+  const logger = spyLogger();
+  const fetchImpl = spyFetch(() => lsResponse({
+    valid: false,
+    error: `License validation failed for license_key=${LEAK_LICENSE} (not found)`,
+    license_key: null,
+    meta: GOOD_META,
+  }));
+  const res = await makeValidator({ logger, fetchImpl }).validate({ licenseKey: LEAK_LICENSE });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 403);
+  const logs = JSON.stringify(logger._entries);
+  assert.equal(logs.includes(LEAK_LICENSE), false, 'raw license leaked into logs via the error string');
+  assert.ok(logs.includes('[REDACTED]'), 'the echoed license must be redacted');
+});
+
+// ===========================================================================
+// Scenario 5 - evaluateLicenseResponse: hostile response shapes -> 403, no throw
+// (the type-coercion cases below MUST still entitle: number vs string ids match
+// via String() comparison)
+// ===========================================================================
+
+function assertDeny(res, label) {
+  assert.equal(res.ok, false, label);
+  assert.equal(res.status, 403, label);
+  assert.equal(res.reason, QUOTA_REASONS.LICENSE_INVALID, label);
+}
+
+check('C5-a', 'evaluate: valid must be strictly true (no truthy coercion)', 'every non-true `valid` -> 403 not-valid, no throw', () => {
+  for (const valid of [1, 'true', {}, [], 0, 'active', 'yes']) {
+    assertDeny(evaluateLicenseResponse(okBody({ valid }), baseEnv(), FIXED_NOW), `valid=${JSON.stringify(valid)}`);
+  }
+});
+
+check('C5-b', 'evaluate: non-string status -> 403', 'number/null/absent/object status -> 403, no throw', () => {
+  assertDeny(evaluateLicenseResponse(okBody({ license_key: { status: 200 } }), baseEnv(), FIXED_NOW), 'status number');
+  assertDeny(evaluateLicenseResponse(okBody({ license_key: { status: null } }), baseEnv(), FIXED_NOW), 'status null');
+  assertDeny(evaluateLicenseResponse(evaluateBodyNoStatus(), baseEnv(), FIXED_NOW), 'status absent');
+  assertDeny(evaluateLicenseResponse(okBody({ license_key: { status: {} } }), baseEnv(), FIXED_NOW), 'status object');
+});
+function evaluateBodyNoStatus() {
+  return { valid: true, error: null, license_key: { expires_at: null }, meta: { ...GOOD_META } };
+}
+
+check('C5-c', 'evaluate: status is case- and whitespace-sensitive', 'ACTIVE/Active/ active/active /empty/unknown -> 403 (only exact active|inactive entitle)', () => {
+  for (const status of ['ACTIVE', 'Active', ' active', 'active ', '', 'pending', 'ACTIVE ', 'inactive ']) {
+    assertDeny(evaluateLicenseResponse(okBody({ license_key: { status } }), baseEnv(), FIXED_NOW), `status=${JSON.stringify(status)}`);
+  }
+});
+
+check('C5-d', 'evaluate: hostile expires_at shapes fail closed', 'past/garbage/empty/0/numeric-epoch/bool/exact-now -> 403 expired', () => {
+  const shapes = [pastIso(), 'not-a-date', '', 0, FIXED_NOW + 3_600_000, true, new Date(FIXED_NOW).toISOString()];
+  for (const expires_at of shapes) {
+    assertDeny(evaluateLicenseResponse(okBody({ license_key: { status: 'active', expires_at } }), baseEnv(), FIXED_NOW), `expires_at=${JSON.stringify(expires_at)}`);
+  }
+});
+
+check('C5-e', 'evaluate: numeric vs string store/variant ids MUST match via String()', 'number ids equal string env ids -> ok:true (no false deny)', () => {
+  const numeric = evaluateLicenseResponse(okBody({ meta: { store_id: 55555, variant_id: 98765 } }), baseEnv(), FIXED_NOW);
+  assert.equal(numeric.ok, true, 'numeric ids must coerce-match the string env');
+  const stringed = evaluateLicenseResponse(okBody({ meta: { store_id: '55555', variant_id: '98765' } }), baseEnv(), FIXED_NOW);
+  assert.equal(stringed.ok, true, 'string ids must match');
+  // and product id coercion when configured
+  const prod = evaluateLicenseResponse(okBody({ meta: { store_id: 55555, variant_id: 98765, product_id: 4242 } }), baseEnv({ LS_PRO_PRODUCT_ID: '4242' }), FIXED_NOW);
+  assert.equal(prod.ok, true, 'numeric product id must coerce-match');
+});
+
+check('C5-f', 'evaluate: mismatched store/variant ids -> 403', 'store/variant mismatch -> 403, no throw', () => {
+  assertDeny(evaluateLicenseResponse(okBody({ meta: { store_id: 55556 } }), baseEnv(), FIXED_NOW), 'store mismatch');
+  assertDeny(evaluateLicenseResponse(okBody({ meta: { variant_id: 99999 } }), baseEnv(), FIXED_NOW), 'variant mismatch');
+});
+
+check('C5-g', 'evaluate: hostile license_key shapes -> 403', 'string/number/array license_key -> 403, no throw', () => {
+  assertDeny(evaluateLicenseResponse({ valid: true, license_key: 'raw-string', meta: GOOD_META }, baseEnv(), FIXED_NOW), 'license_key string');
+  assertDeny(evaluateLicenseResponse({ valid: true, license_key: 12345, meta: GOOD_META }, baseEnv(), FIXED_NOW), 'license_key number');
+  assertDeny(evaluateLicenseResponse({ valid: true, license_key: ['active'], meta: GOOD_META }, baseEnv(), FIXED_NOW), 'license_key array');
+});
+
+check('C5-h', 'evaluate: hostile meta shapes -> 403', 'null/string/array/number/absent meta -> 403, no throw', () => {
+  assertDeny(evaluateLicenseResponse({ valid: true, license_key: { status: 'active' }, meta: null }, baseEnv(), FIXED_NOW), 'meta null');
+  assertDeny(evaluateLicenseResponse({ valid: true, license_key: { status: 'active' }, meta: 'x' }, baseEnv(), FIXED_NOW), 'meta string');
+  assertDeny(evaluateLicenseResponse({ valid: true, license_key: { status: 'active' }, meta: [] }, baseEnv(), FIXED_NOW), 'meta array');
+  assertDeny(evaluateLicenseResponse({ valid: true, license_key: { status: 'active' }, meta: 7 }, baseEnv(), FIXED_NOW), 'meta number');
+  assertDeny(evaluateLicenseResponse({ valid: true, license_key: { status: 'active' } }, baseEnv(), FIXED_NOW), 'meta absent');
+});
+
+check('C5-i', 'evaluate: non-object top-level data -> 403, no throw', 'null/undefined/string/number/array/bool -> 403 malformed', () => {
+  for (const data of [null, undefined, 'nope', 42, [], true]) {
+    const res = evaluateLicenseResponse(data, baseEnv(), FIXED_NOW);
+    assert.equal(res.ok, false, `data=${JSON.stringify(data)}`);
+    assert.equal(res.status, 403, `data=${JSON.stringify(data)}`);
+  }
+});
+
+// ===========================================================================
+// Scenario 6 - extractBearerLicense: hostile header shapes fail closed (401);
+// valid-but-unusual shapes (case-insensitive scheme, extra whitespace,
+// single-element array) still parse. Targets the gaps left by the existing
+// suite: non-string values, hostile arrays, present-but-nullish values,
+// multi-space/mixed-case schemes, and duplicate case-variant keys.
+// ===========================================================================
+
+const DENIED_401 = { ok: false, status: 401, reason: QUOTA_REASONS.LICENSE_REQUIRED };
+
+check('C6-a', 'extract: scheme without a token fails closed', "'Bearer' / 'Bearer   ' -> 401", () => {
+  assert.deepEqual(extractBearerLicense({ authorization: 'Bearer' }), DENIED_401);
+  assert.deepEqual(extractBearerLicense({ authorization: 'Bearer   ' }), DENIED_401);
+});
+
+check('C6-b', 'extract: lowercase scheme still parses', "'bearer x' -> ok 'x'", () => {
+  assert.deepEqual(extractBearerLicense({ authorization: 'bearer LK-lower' }), { ok: true, license: 'LK-lower' });
+});
+
+check('C6-c', 'extract: multiple spaces between scheme and token', "'Bearer  x' (double space) -> ok 'x'", () => {
+  assert.deepEqual(extractBearerLicense({ authorization: 'Bearer  LK-double' }), { ok: true, license: 'LK-double' });
+});
+
+check('C6-d', 'extract: mixed-case scheme still parses', "'BeArEr x' -> ok 'x'", () => {
+  assert.deepEqual(extractBearerLicense({ authorization: 'BeArEr LK-mixed' }), { ok: true, license: 'LK-mixed' });
+});
+
+check('C6-e', 'extract: leading/trailing whitespace is trimmed', "'  Bearer x  ' -> ok 'x'", () => {
+  assert.deepEqual(extractBearerLicense({ authorization: '  Bearer LK-pad  ' }), { ok: true, license: 'LK-pad' });
+});
+
+check('C6-f', 'extract: single-element array is one value', "['Bearer solo'] -> ok 'solo'", () => {
+  assert.deepEqual(extractBearerLicense({ authorization: ['Bearer LK-solo'] }), { ok: true, license: 'LK-solo' });
+});
+
+check('C6-g', 'extract: hostile array shapes fail closed', 'empty / non-string element / multiple -> 401', () => {
+  assert.deepEqual(extractBearerLicense({ authorization: [] }), DENIED_401);
+  assert.deepEqual(extractBearerLicense({ authorization: [12345] }), DENIED_401);
+  assert.deepEqual(extractBearerLicense({ authorization: [{}] }), DENIED_401);
+  assert.deepEqual(extractBearerLicense({ authorization: ['Bearer a', 'Bearer b'] }), DENIED_401);
+});
+
+check('C6-h', 'extract: non-string header value fails closed', 'number / boolean / object value -> 401', () => {
+  assert.deepEqual(extractBearerLicense({ authorization: 12345 }), DENIED_401);
+  assert.deepEqual(extractBearerLicense({ authorization: true }), DENIED_401);
+  assert.deepEqual(extractBearerLicense({ authorization: { token: 'x' } }), DENIED_401);
+});
+
+check('C6-i', 'extract: a present-but-nullish authorization value fails closed', '{authorization:null|undefined} -> 401', () => {
+  assert.deepEqual(extractBearerLicense({ authorization: null }), DENIED_401);
+  assert.deepEqual(extractBearerLicense({ authorization: undefined }), DENIED_401);
+});
+
+check('C6-j', 'extract: duplicate authorization keys (any case) are ambiguous', 'two/three case-variant keys -> 401', () => {
+  assert.deepEqual(extractBearerLicense({ authorization: 'Bearer a', Authorization: 'Bearer b' }), DENIED_401);
+  assert.deepEqual(extractBearerLicense({ authorization: 'Bearer a', Authorization: 'Bearer b', AUTHORIZATION: 'Bearer c' }), DENIED_401);
+});
+
+check('C6-k', 'extract: non-object headers fail closed', 'null / undefined / string / number headers -> 401', () => {
+  assert.deepEqual(extractBearerLicense(null), DENIED_401);
+  assert.deepEqual(extractBearerLicense(undefined), DENIED_401);
+  assert.deepEqual(extractBearerLicense('authorization: Bearer x'), DENIED_401);
+  assert.deepEqual(extractBearerLicense(42), DENIED_401);
+});

--- a/tests/unit/entitlement.test.js
+++ b/tests/unit/entitlement.test.js
@@ -1,0 +1,572 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createLemonSqueezyLicenseValidator,
+  evaluateLicenseResponse,
+  extractBearerLicense,
+  LS_LICENSE_VALIDATE_URL,
+} from '../../src/entitlement.js';
+import { createMemoryKv, quotaKeyHmac } from '../../src/rate-limit.js';
+import { QUOTA_REASONS } from '../../src/web-rewrite-contract.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures / helpers
+// ---------------------------------------------------------------------------
+
+const FIXED_NOW = 1_700_000_000_000;
+const SECRET = 'unit-test-license-secret';
+const HEX64 = /^[a-f0-9]{64}$/;
+
+const GOOD_META = Object.freeze({ store_id: 55555, variant_id: 98765, product_id: 4242 });
+
+function baseEnv(overrides = {}) {
+  return { LS_STORE_ID: '55555', LS_PRO_VARIANT_ID: '98765', ...overrides };
+}
+
+function futureIso(offsetMs = 3_600_000) {
+  return new Date(FIXED_NOW + offsetMs).toISOString();
+}
+
+function pastIso(offsetMs = 3_600_000) {
+  return new Date(FIXED_NOW - offsetMs).toISOString();
+}
+
+/** A well-formed, entitled LS validate body; override any slice. */
+function okBody(over = {}) {
+  return {
+    valid: over.valid !== undefined ? over.valid : true,
+    error: null,
+    license_key: { status: 'active', expires_at: null, ...(over.license_key || {}) },
+    meta: { ...GOOD_META, ...(over.meta || {}) },
+  };
+}
+
+/** A fake `fetch` Response. */
+function lsResponse(body, { status = 200, ok, throwJson = false } = {}) {
+  return {
+    ok: ok === undefined ? status >= 200 && status < 300 : ok,
+    status,
+    async json() {
+      if (throwJson) throw new Error('Unexpected end of JSON input');
+      return body;
+    },
+  };
+}
+
+/** A fetch spy that records every call and delegates to `responder`. */
+function spyFetch(responder) {
+  const calls = [];
+  const fetchImpl = async (url, opts) => {
+    calls.push({ url, opts });
+    return responder(url, opts, calls.length);
+  };
+  fetchImpl.calls = calls;
+  return fetchImpl;
+}
+
+/** A KV that records every key it sees plus every value it stores. */
+function spyKv() {
+  const inner = createMemoryKv();
+  const keys = [];
+  const values = [];
+  return {
+    __memory: true,
+    _keys: keys,
+    _values: values,
+    async get(key) { keys.push(key); return inner.get(key); },
+    async set(key, val, opts) { keys.push(key); values.push(val); return inner.set(key, val, opts); },
+    async incr(key, opts) { keys.push(key); return inner.incr(key, opts); },
+    async decr(key) { keys.push(key); return inner.decr(key); },
+  };
+}
+
+/** A logger that captures every (redacted) payload it is handed. */
+function spyLogger() {
+  const entries = [];
+  return {
+    _entries: entries,
+    warn: (...args) => entries.push(args),
+    log: (...args) => entries.push(args),
+  };
+}
+
+function makeValidator({ kv, env, fetchImpl, logger, hmacSecret = SECRET, now = () => FIXED_NOW } = {}) {
+  return createLemonSqueezyLicenseValidator({
+    kv: kv === undefined ? createMemoryKv() : kv,
+    hmacSecret,
+    env: env || baseEnv(),
+    fetchImpl,
+    now,
+    logger,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// extractBearerLicense
+// ---------------------------------------------------------------------------
+
+test('extractBearerLicense: parses exactly one Bearer token', () => {
+  assert.deepEqual(extractBearerLicense({ authorization: 'Bearer LK-123-abc' }), { ok: true, license: 'LK-123-abc' });
+  // surrounding whitespace and multi-space separators are tolerated
+  assert.deepEqual(extractBearerLicense({ authorization: '  Bearer\tLK-tab  ' }), { ok: true, license: 'LK-tab' });
+  // single-element array is one value
+  assert.deepEqual(extractBearerLicense({ authorization: ['Bearer LK-solo'] }), { ok: true, license: 'LK-solo' });
+});
+
+test('extractBearerLicense: header name and scheme are case-insensitive', () => {
+  assert.deepEqual(extractBearerLicense({ Authorization: 'Bearer LK-cap' }), { ok: true, license: 'LK-cap' });
+  assert.deepEqual(extractBearerLicense({ AUTHORIZATION: 'Bearer LK-upper' }), { ok: true, license: 'LK-upper' });
+  assert.deepEqual(extractBearerLicense({ authorization: 'bearer LK-lower-scheme' }), { ok: true, license: 'LK-lower-scheme' });
+});
+
+test('extractBearerLicense: missing / blank / non-Bearer / empty / multiple all fail closed with 401', () => {
+  const denied = { ok: false, status: 401, reason: QUOTA_REASONS.LICENSE_REQUIRED };
+  assert.deepEqual(extractBearerLicense({}), denied); // none
+  assert.deepEqual(extractBearerLicense(undefined), denied); // no headers
+  assert.deepEqual(extractBearerLicense(null), denied);
+  assert.deepEqual(extractBearerLicense({ authorization: '   ' }), denied); // whitespace only
+  assert.deepEqual(extractBearerLicense({ authorization: 'Basic abc123def' }), denied); // non-Bearer
+  assert.deepEqual(extractBearerLicense({ authorization: 'Token abc123def' }), denied); // non-Bearer
+  assert.deepEqual(extractBearerLicense({ authorization: 'Bearer' }), denied); // empty (no token)
+  assert.deepEqual(extractBearerLicense({ authorization: 'Bearer    ' }), denied); // empty (trailing space)
+  assert.deepEqual(extractBearerLicense({ authorization: 'Bearer a b' }), denied); // more than one token
+  assert.deepEqual(extractBearerLicense({ authorization: ['Bearer a', 'Bearer b'] }), denied); // multiple values (array)
+  assert.deepEqual(extractBearerLicense({ authorization: 'Bearer x', Authorization: 'Bearer y' }), denied); // multiple values (keys)
+});
+
+// ---------------------------------------------------------------------------
+// evaluateLicenseResponse (pure)
+// ---------------------------------------------------------------------------
+
+test('evaluateLicenseResponse: entitled active/inactive keys pass', () => {
+  const active = evaluateLicenseResponse(okBody(), baseEnv(), FIXED_NOW);
+  assert.equal(active.ok, true);
+  assert.equal(active.status, 'active');
+  assert.equal(active.expiresAt, null);
+
+  const inactive = evaluateLicenseResponse(okBody({ license_key: { status: 'inactive' } }), baseEnv(), FIXED_NOW);
+  assert.equal(inactive.ok, true);
+  assert.equal(inactive.status, 'inactive');
+
+  const future = evaluateLicenseResponse(okBody({ license_key: { status: 'active', expires_at: futureIso() } }), baseEnv(), FIXED_NOW);
+  assert.equal(future.ok, true);
+  assert.equal(future.expiresAt, Date.parse(futureIso()));
+});
+
+test('evaluateLicenseResponse: every failed check returns a generic 403 LICENSE_INVALID', () => {
+  const env = baseEnv();
+  const cases = {
+    'valid:false': okBody({ valid: false }),
+    'expired status': okBody({ license_key: { status: 'expired' } }),
+    'disabled status': okBody({ license_key: { status: 'disabled' } }),
+    'unknown status': okBody({ license_key: { status: 'pending' } }),
+    'expired timestamp': okBody({ license_key: { status: 'active', expires_at: pastIso() } }),
+    'unparseable timestamp': okBody({ license_key: { status: 'active', expires_at: 'not-a-date' } }),
+    'store mismatch': okBody({ meta: { store_id: 1 } }),
+    'variant mismatch': okBody({ meta: { variant_id: 1 } }),
+    'malformed body': null,
+    'missing license_key': { valid: true, meta: GOOD_META },
+    'missing meta': { valid: true, license_key: { status: 'active' } },
+  };
+  for (const [label, body] of Object.entries(cases)) {
+    const res = evaluateLicenseResponse(body, env, FIXED_NOW);
+    assert.equal(res.ok, false, label);
+    assert.equal(res.status, 403, label);
+    assert.equal(res.reason, QUOTA_REASONS.LICENSE_INVALID, label);
+  }
+});
+
+test('evaluateLicenseResponse: product id is only enforced when configured', () => {
+  const body = okBody({ meta: { product_id: 4242 } });
+  // not configured -> product ignored -> pass
+  assert.equal(evaluateLicenseResponse(body, baseEnv(), FIXED_NOW).ok, true);
+  // configured + matching -> pass
+  assert.equal(evaluateLicenseResponse(body, baseEnv({ LS_PRO_PRODUCT_ID: '4242' }), FIXED_NOW).ok, true);
+  // configured + mismatching -> 403
+  const mismatch = evaluateLicenseResponse(body, baseEnv({ LS_PRO_PRODUCT_ID: '9999' }), FIXED_NOW);
+  assert.equal(mismatch.ok, false);
+  assert.equal(mismatch.status, 403);
+  assert.equal(mismatch.reason, QUOTA_REASONS.LICENSE_INVALID);
+});
+
+// ---------------------------------------------------------------------------
+// Exported constant
+// ---------------------------------------------------------------------------
+
+test('LS_LICENSE_VALIDATE_URL points at the validate-only endpoint', () => {
+  assert.equal(LS_LICENSE_VALIDATE_URL, 'https://api.lemonsqueezy.com/v1/licenses/validate');
+});
+
+// ---------------------------------------------------------------------------
+// validate: happy path + caching
+// ---------------------------------------------------------------------------
+
+test('validate: entitled license passes on miss, then serves from cache without re-fetching', async () => {
+  const fetchImpl = spyFetch(() => lsResponse(okBody()));
+  const validator = makeValidator({ fetchImpl });
+
+  const first = await validator.validate({ licenseKey: 'LK-active-0001' });
+  assert.equal(first.ok, true);
+  assert.equal(first.tier, 'pro');
+  assert.equal(first.status, 'active');
+  assert.equal(first.cache, 'miss');
+  assert.match(first.subject, HEX64);
+  assert.equal(fetchImpl.calls.length, 1);
+
+  const second = await validator.validate({ licenseKey: 'LK-active-0001' });
+  assert.equal(second.ok, true);
+  assert.equal(second.cache, 'hit');
+  assert.equal(second.subject, first.subject);
+  assert.equal(fetchImpl.calls.length, 1, 'cache hit must not call LS again');
+});
+
+test('validate: LS request uses the validate-only endpoint, POST form body, and correct headers', async () => {
+  const fetchImpl = spyFetch(() => lsResponse(okBody()));
+  const validator = makeValidator({ fetchImpl });
+
+  await validator.validate({ licenseKey: 'LK-shape-0001' });
+  const { url, opts } = fetchImpl.calls[0];
+  assert.equal(url, LS_LICENSE_VALIDATE_URL);
+  assert.equal(opts.method, 'POST');
+  assert.equal(opts.headers.Accept, 'application/json');
+  assert.equal(opts.headers['Content-Type'], 'application/x-www-form-urlencoded');
+  assert.equal(opts.body, 'license_key=LK-shape-0001');
+  assert.ok(opts.signal, 'AbortSignal must be wired for the timeout');
+});
+
+test('validate: inactive-but-issued license still entitles (validate-only, not activation)', async () => {
+  const fetchImpl = spyFetch(() => lsResponse(okBody({ license_key: { status: 'inactive' } })));
+  const validator = makeValidator({ fetchImpl });
+  const res = await validator.validate({ licenseKey: 'LK-inactive-0001' });
+  assert.equal(res.ok, true);
+  assert.equal(res.status, 'inactive');
+  assert.equal(res.cache, 'miss');
+});
+
+test('validate: negative decisions resolve to 403 LICENSE_INVALID and are cached', async () => {
+  const cases = {
+    'expired status': okBody({ license_key: { status: 'expired' } }),
+    'disabled status': okBody({ license_key: { status: 'disabled' } }),
+    'expired timestamp': okBody({ license_key: { status: 'active', expires_at: pastIso() } }),
+    'store mismatch': okBody({ meta: { store_id: 999 } }),
+    'variant mismatch': okBody({ meta: { variant_id: 111 } }),
+    'valid:false': okBody({ valid: false }),
+  };
+  for (const [label, body] of Object.entries(cases)) {
+    const fetchImpl = spyFetch(() => lsResponse(body));
+    const validator = makeValidator({ fetchImpl });
+    const res = await validator.validate({ licenseKey: `LK-deny-${label.replace(/\s+/g, '-')}` });
+    assert.equal(res.ok, false, label);
+    assert.equal(res.status, 403, label);
+    assert.equal(res.reason, QUOTA_REASONS.LICENSE_INVALID, label);
+    // negative cache: a repeat is served without a second LS call
+    const again = await validator.validate({ licenseKey: `LK-deny-${label.replace(/\s+/g, '-')}` });
+    assert.equal(again.status, 403, `${label} (cached)`);
+    assert.equal(fetchImpl.calls.length, 1, `${label}: negative result must be cached`);
+  }
+});
+
+test('validate: product mismatch is rejected only when LS_PRO_PRODUCT_ID is configured', async () => {
+  const body = okBody({ meta: { product_id: 4242 } });
+
+  const mismatchFetch = spyFetch(() => lsResponse(body));
+  const mismatch = makeValidator({ env: baseEnv({ LS_PRO_PRODUCT_ID: '9999' }), fetchImpl: mismatchFetch });
+  const rejected = await mismatch.validate({ licenseKey: 'LK-prod-mismatch' });
+  assert.equal(rejected.ok, false);
+  assert.equal(rejected.status, 403);
+
+  const matchFetch = spyFetch(() => lsResponse(body));
+  const match = makeValidator({ env: baseEnv({ LS_PRO_PRODUCT_ID: '4242' }), fetchImpl: matchFetch });
+  assert.equal((await match.validate({ licenseKey: 'LK-prod-match' })).ok, true);
+});
+
+test('validate: a positive cache entry expires and re-validates against LS', async () => {
+  let clock = FIXED_NOW;
+  const fetchImpl = spyFetch(() => lsResponse(okBody()));
+  const validator = makeValidator({ fetchImpl, env: baseEnv({ PATINA_LS_CACHE_TTL_MS: '1000' }), now: () => clock });
+
+  assert.equal((await validator.validate({ licenseKey: 'LK-ttl' })).cache, 'miss');
+  clock += 500; // still within TTL
+  assert.equal((await validator.validate({ licenseKey: 'LK-ttl' })).cache, 'hit');
+  clock += 600; // now past the 1000ms TTL (embedded expiresAt is authoritative)
+  assert.equal((await validator.validate({ licenseKey: 'LK-ttl' })).cache, 'miss');
+  assert.equal(fetchImpl.calls.length, 2);
+});
+
+// ---------------------------------------------------------------------------
+// validate: fail-closed prerequisites
+// ---------------------------------------------------------------------------
+
+test('validate: missing store/variant config fails closed with 503 and never fetches', async () => {
+  const fetchImpl = spyFetch(() => { throw new Error('must not fetch'); });
+  const noStore = makeValidator({ env: { LS_PRO_VARIANT_ID: '98765' }, fetchImpl });
+  assert.deepEqual(await noStore.validate({ licenseKey: 'LK-noconfig' }), {
+    ok: false, status: 503, reason: QUOTA_REASONS.LICENSE_UNAVAILABLE,
+  });
+
+  const noVariant = makeValidator({ env: { LS_STORE_ID: '55555' }, fetchImpl });
+  assert.equal((await noVariant.validate({ licenseKey: 'LK-noconfig' })).status, 503);
+  assert.equal(fetchImpl.calls.length, 0);
+});
+
+test('validate: production requires a real secret and a shared (non-memory) KV', async () => {
+  const prodEnv = { NODE_ENV: 'production', LS_STORE_ID: '55555', LS_PRO_VARIANT_ID: '98765' };
+  const realKv = { async get() { return undefined; }, async set() {}, async incr() { return 1; } };
+  const fetchImpl = spyFetch(() => { throw new Error('must not fetch under prod guard'); });
+  const denied = { ok: false, status: 503, reason: QUOTA_REASONS.LICENSE_UNAVAILABLE };
+
+  const noSecret = createLemonSqueezyLicenseValidator({ kv: realKv, env: prodEnv, fetchImpl, now: () => FIXED_NOW });
+  assert.deepEqual(await noSecret.validate({ licenseKey: 'LK-prod' }), denied);
+
+  const noKv = createLemonSqueezyLicenseValidator({ kv: null, hmacSecret: SECRET, env: prodEnv, fetchImpl, now: () => FIXED_NOW });
+  assert.deepEqual(await noKv.validate({ licenseKey: 'LK-prod' }), denied);
+
+  const memoryKv = createLemonSqueezyLicenseValidator({ kv: createMemoryKv(), hmacSecret: SECRET, env: prodEnv, fetchImpl, now: () => FIXED_NOW });
+  assert.deepEqual(await memoryKv.validate({ licenseKey: 'LK-prod' }), denied);
+
+  assert.equal(fetchImpl.calls.length, 0);
+});
+
+test('validate: a missing/blank license key is a 401 LICENSE_REQUIRED', async () => {
+  const fetchImpl = spyFetch(() => { throw new Error('must not fetch'); });
+  const validator = makeValidator({ fetchImpl });
+  assert.deepEqual(await validator.validate({ licenseKey: '' }), { ok: false, status: 401, reason: QUOTA_REASONS.LICENSE_REQUIRED });
+  assert.deepEqual(await validator.validate({ licenseKey: '   ' }), { ok: false, status: 401, reason: QUOTA_REASONS.LICENSE_REQUIRED });
+  assert.deepEqual(await validator.validate({}), { ok: false, status: 401, reason: QUOTA_REASONS.LICENSE_REQUIRED });
+  assert.equal(fetchImpl.calls.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// validate: LS transport failures -> 503, never cached
+// ---------------------------------------------------------------------------
+
+test('validate: LS timeout fails closed with 503 after exactly one fetch', async () => {
+  const fetchImpl = spyFetch((_url, opts) => new Promise((_resolve, reject) => {
+    opts.signal.addEventListener('abort', () => reject(new Error('The operation was aborted')));
+  }));
+  const validator = makeValidator({ fetchImpl, env: baseEnv({ PATINA_LS_TIMEOUT_MS: '15' }) });
+  const res = await validator.validate({ licenseKey: 'LK-timeout' });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 503);
+  assert.equal(res.reason, QUOTA_REASONS.LICENSE_UNAVAILABLE);
+  assert.equal(fetchImpl.calls.length, 1);
+});
+
+test('validate: LS network exception fails closed with 503', async () => {
+  const fetchImpl = spyFetch(() => { throw new Error('ECONNREFUSED'); });
+  const validator = makeValidator({ fetchImpl });
+  const res = await validator.validate({ licenseKey: 'LK-throw' });
+  assert.equal(res.status, 503);
+  assert.equal(res.reason, QUOTA_REASONS.LICENSE_UNAVAILABLE);
+  assert.equal(fetchImpl.calls.length, 1);
+});
+
+test('validate: LS non-2xx fails closed with 503', async () => {
+  const fetchImpl = spyFetch(() => lsResponse({ error: 'rate limited' }, { status: 429 }));
+  const validator = makeValidator({ fetchImpl });
+  const res = await validator.validate({ licenseKey: 'LK-500' });
+  assert.equal(res.status, 503);
+  assert.equal(res.reason, QUOTA_REASONS.LICENSE_UNAVAILABLE);
+  assert.equal(fetchImpl.calls.length, 1);
+});
+
+test('validate: LS malformed JSON fails closed with 503', async () => {
+  const fetchImpl = spyFetch(() => lsResponse(null, { status: 200, throwJson: true }));
+  const validator = makeValidator({ fetchImpl });
+  const res = await validator.validate({ licenseKey: 'LK-badjson' });
+  assert.equal(res.status, 503);
+  assert.equal(res.reason, QUOTA_REASONS.LICENSE_UNAVAILABLE);
+  assert.equal(fetchImpl.calls.length, 1);
+});
+
+test('validate: a transient 503 is not cached and re-attempts on retry', async () => {
+  let attempt = 0;
+  const fetchImpl = spyFetch(() => {
+    attempt += 1;
+    if (attempt === 1) throw new Error('transient outage');
+    return lsResponse(okBody());
+  });
+  const validator = makeValidator({ fetchImpl });
+  assert.equal((await validator.validate({ licenseKey: 'LK-retry' })).status, 503);
+  const retry = await validator.validate({ licenseKey: 'LK-retry' });
+  assert.equal(retry.ok, true, 'a 503 must not be cached; the retry re-validates');
+  assert.equal(fetchImpl.calls.length, 2);
+});
+
+// ---------------------------------------------------------------------------
+// validate: admission guard
+// ---------------------------------------------------------------------------
+
+test('admission: exceeding the per-minute RPM bucket denies without calling LS', async () => {
+  const fetchImpl = spyFetch(() => lsResponse(okBody()));
+  const validator = makeValidator({ fetchImpl, env: baseEnv({ PATINA_LS_VALIDATE_RPM: '2' }) });
+
+  // Distinct licenses -> each is a fresh miss that consumes one shared per-minute token.
+  assert.equal((await validator.validate({ licenseKey: 'LK-rpm-a' })).ok, true); // count 1
+  assert.equal((await validator.validate({ licenseKey: 'LK-rpm-b' })).ok, true); // count 2
+  const third = await validator.validate({ licenseKey: 'LK-rpm-c' }); // count 3 > 2
+  assert.equal(third.ok, false);
+  assert.equal(third.status, 503);
+  assert.equal(third.reason, QUOTA_REASONS.LICENSE_UNAVAILABLE);
+  assert.equal(fetchImpl.calls.length, 2, 'the saturating call must not reach LS');
+});
+
+test('admission: the RPM bucket resets in a new minute', async () => {
+  let clock = FIXED_NOW;
+  const fetchImpl = spyFetch(() => lsResponse(okBody()));
+  const validator = makeValidator({ fetchImpl, env: baseEnv({ PATINA_LS_VALIDATE_RPM: '1' }), now: () => clock });
+
+  assert.equal((await validator.validate({ licenseKey: 'LK-min-a' })).ok, true);
+  assert.equal((await validator.validate({ licenseKey: 'LK-min-b' })).status, 503); // same minute, over budget
+  clock += 60_000; // next minute -> fresh bucket
+  assert.equal((await validator.validate({ licenseKey: 'LK-min-c' })).ok, true);
+  assert.equal(fetchImpl.calls.length, 2);
+});
+
+test('admission: a held single-flight lock denies without calling LS', async () => {
+  const kv = createMemoryKv();
+  const license = 'LK-lock-0001';
+  const fetchImpl = spyFetch(() => lsResponse(okBody()));
+  const validator = makeValidator({ kv, fetchImpl });
+
+  // Simulate another instance mid-validation by pre-incrementing the shared lock key.
+  const lockKey = quotaKeyHmac(SECRET, 'ls-lock', license);
+  await kv.incr(lockKey, { ttlMs: 10_000 }); // -> 1; the validator's incr then returns 2 (>1)
+
+  const res = await validator.validate({ licenseKey: license });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 503);
+  assert.equal(res.reason, QUOTA_REASONS.LICENSE_UNAVAILABLE);
+  assert.equal(fetchImpl.calls.length, 0);
+});
+
+test('admission: concurrent misses for one license call LS exactly once (single-flight)', async () => {
+  const fetchImpl = spyFetch(() => lsResponse(okBody()));
+  const validator = makeValidator({ fetchImpl });
+  const license = 'LK-concurrent-0001';
+
+  const results = await Promise.all([
+    validator.validate({ licenseKey: license }),
+    validator.validate({ licenseKey: license }),
+    validator.validate({ licenseKey: license }),
+    validator.validate({ licenseKey: license }),
+    validator.validate({ licenseKey: license }),
+  ]);
+
+  assert.equal(fetchImpl.calls.length, 1, 'exactly one instance may call LS');
+  assert.equal(results.filter((r) => r.ok).length, 1, 'exactly one winner');
+  assert.equal(results.filter((r) => !r.ok && r.status === 503).length, 4, 'losers fail closed and retry into cache');
+});
+
+// ---------------------------------------------------------------------------
+// Security: the raw license never leaks
+// ---------------------------------------------------------------------------
+
+test('security: the raw license never appears in return values, KV keys, cached values, or logs', async () => {
+  const kv = spyKv();
+  const logger = spyLogger();
+  const license = 'LK-SECRET-9f8e7d6c-DEADBEEFCAFE';
+  // LS echoes the key back inside the (secret-named) license_key object.
+  const fetchImpl = spyFetch(() => lsResponse(okBody({ license_key: { status: 'active', expires_at: null, key: license } })));
+  const validator = makeValidator({ kv, logger, fetchImpl });
+
+  const res = await validator.validate({ licenseKey: license });
+  assert.equal(res.ok, true);
+
+  // (a) return value carries only the HMAC subject
+  assert.equal(JSON.stringify(res).includes(license), false);
+  assert.match(res.subject, HEX64);
+
+  // (b) every KV key is an HMAC hex digest, never the raw license
+  assert.ok(kv._keys.length > 0);
+  for (const key of kv._keys) {
+    assert.match(key, HEX64, `KV key is not an HMAC digest: ${key}`);
+    assert.equal(key.includes(license), false);
+  }
+
+  // (c) cached values carry no raw license
+  assert.equal(JSON.stringify(kv._values).includes(license), false);
+
+  // (d) logs carry no raw license
+  assert.equal(JSON.stringify(logger._entries).includes(license), false);
+});
+
+test('security: a denied LS response that echoes the license is redacted before logging', async () => {
+  const logger = spyLogger();
+  const license = 'LK-ECHO-1a2b3c4d-5e6f7a8b9c0d';
+  const fetchImpl = spyFetch(() => lsResponse({
+    valid: false,
+    error: `license_key=${license} is not active`, // echoed inside a free-form string
+    license_key: { status: 'inactive', key: license }, // echoed inside a secret-named object
+    meta: GOOD_META,
+  }));
+  const validator = makeValidator({ logger, fetchImpl });
+
+  const res = await validator.validate({ licenseKey: license });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 403);
+
+  assert.ok(logger._entries.length > 0, 'a denial must be logged for triage');
+  const serialized = JSON.stringify(logger._entries);
+  assert.equal(serialized.includes(license), false, 'raw license leaked into logs');
+  assert.ok(serialized.includes('[REDACTED]'), 'the echoed license must be redacted');
+});
+
+test('regression(B1): re-read after acquiring the single-flight lock serves a winner-populated cache without a second LS call', async () => {
+  const licenseKey = 'LIC-REREAD-0001';
+  const cacheKey = quotaKeyHmac(SECRET, 'ls-license-cache', licenseKey);
+  const allowEntry = { decision: 'allow', tier: 'pro', status: 'active', expiresAt: FIXED_NOW + 100_000 };
+  const inner = createMemoryKv();
+  let cacheGets = 0;
+  // Simulate the B1 race: the FIRST cache read (before the lock) misses, but a
+  // previous winner finishes and writes the cache before our post-lock re-read.
+  const kv = {
+    __memory: true,
+    async get(key) {
+      if (key === cacheKey) { cacheGets += 1; return cacheGets >= 2 ? allowEntry : undefined; }
+      return inner.get(key);
+    },
+    async set(key, val, opts) { return inner.set(key, val, opts); },
+    async incr(key, opts) { return inner.incr(key, opts); },
+    async decr(key) { return inner.decr(key); },
+  };
+  const fetchImpl = spyFetch(() => lsResponse(okBody()));
+  const res = await makeValidator({ kv, fetchImpl }).validate({ licenseKey });
+  assert.equal(res.ok, true);
+  assert.equal(res.cache, 'hit');
+  assert.equal(fetchImpl.calls.length, 0, 're-read cache hit must not call LS');
+  assert.ok(cacheGets >= 2, 'the winner path must re-read the cache after acquiring the lock');
+});
+
+test('regression(B2): a denied LS body that echoes the raw license under a non-secret key is scrubbed from logs', async () => {
+  const licenseKey = 'LK-ECHO-abcdef0123456789';
+  const logger = spyLogger();
+  // valid:false denial whose free-form `error` echoes the raw license verbatim
+  // under a non-secret key that pattern redaction alone would NOT catch.
+  const body = { valid: false, error: `license ${licenseKey} was rejected`, license_key: { status: 'active', expires_at: null }, meta: { ...GOOD_META } };
+  const fetchImpl = spyFetch(() => lsResponse(body));
+  const res = await makeValidator({ fetchImpl, logger }).validate({ licenseKey });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 403);
+  const logged = JSON.stringify(logger._entries);
+  assert.equal(logged.includes(licenseKey), false, 'the raw license must never reach a log line');
+  assert.match(logged, /\[REDACTED\]/);
+});
+
+test('regression(B3): a same-license single-flight loser fails closed WITHOUT charging the global RPM bucket', async () => {
+  const licenseKey = 'LIC-LOSER-0001';
+  const lockKey = quotaKeyHmac(SECRET, 'ls-lock', licenseKey);
+  const rpmKey = quotaKeyHmac(SECRET, 'ls-rpm', Math.floor(FIXED_NOW / 60_000));
+  const kv = spyKv();
+  await kv.incr(lockKey); // a prior winner already holds the lock (counter = 1)
+  const rpmBefore = kv._keys.filter((k) => k === rpmKey).length;
+  const fetchImpl = spyFetch(() => lsResponse(okBody()));
+  const res = await makeValidator({ kv, fetchImpl }).validate({ licenseKey }); // our incr -> 2 => loser
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 503);
+  assert.equal(res.reason, QUOTA_REASONS.LICENSE_UNAVAILABLE);
+  assert.equal(fetchImpl.calls.length, 0, 'a single-flight loser must not call LS');
+  const rpmTouches = kv._keys.filter((k) => k === rpmKey).length - rpmBefore;
+  assert.equal(rpmTouches, 0, 'a single-flight loser must not consume the global RPM bucket');
+});

--- a/tests/unit/rate-limit.redteam.test.js
+++ b/tests/unit/rate-limit.redteam.test.js
@@ -8,7 +8,8 @@ import {
   quotaKeyHmac,
 } from '../../src/rate-limit.js';
 import { createRewriteHandler } from '../../src/rewrite-handler.js';
-import { WEB_TIERS } from '../../src/web-rewrite-contract.js';
+import { QUOTA_REASONS, TIER_LIMITS, WEB_TIERS } from '../../src/web-rewrite-contract.js';
+import { createRestKv } from '../../api/rewrite.js';
 
 function makeRes() {
   return {
@@ -305,4 +306,335 @@ test('category 7 stream body DoS: async body over maxBodyBytes aborts at 413 bef
   assert.equal(calls, 0);
   assert.ok(yielded < 4, `stream should stop before all chunks are consumed; yielded ${yielded}`);
   assertNoStore(res);
+});
+
+// ---------------------------------------------------------------------------
+// G003 red-team: pro subject metering (src/rate-limit.js switch(tier)) +
+// createRestKv atomicity/coercion (api/rewrite.js). These probe gaps beyond the
+// existing unit suite. Product code is frozen; tests assert the OBSERVED
+// contract and any deviation from the expected security contract is a FINDING.
+// ---------------------------------------------------------------------------
+
+const PRO = WEB_TIERS.PRO;
+const FREE = WEB_TIERS.FREE;
+const BYOK = WEB_TIERS.BYOK;
+
+/** Wrap createMemoryKv counting incr/decr so a compensating decr is observable. */
+function spyMemoryKv() {
+  const mem = createMemoryKv();
+  const counts = { incr: 0, decr: 0 };
+  return {
+    counts,
+    get: (key) => mem.get(key),
+    async incr(key, opts) { counts.incr += 1; return mem.incr(key, opts); },
+    async decr(key) { counts.decr += 1; return mem.decr(key); },
+  };
+}
+
+/** Swap globalThis.fetch for the duration of `run`, always restoring it. */
+async function withMockFetch(fetchImpl, run) {
+  const original = globalThis.fetch;
+  globalThis.fetch = /** @type {any} */ (fetchImpl);
+  try {
+    return await run();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+/** Faithful Upstash/Vercel REST mock: POST SET stores verbatim; GET returns it. */
+function restKvMock() {
+  const store = new Map();
+  const posts = [];
+  const reads = [];
+  const fetchImpl = async (url, init) => {
+    const u = String(url);
+    if (init && init.method === 'POST') {
+      const args = JSON.parse(String(init.body));
+      posts.push({ args, headers: init.headers });
+      if (args[0] === 'SET') store.set(args[1], args[2]);
+      return { ok: true, async json() { return { result: 'OK' }; } };
+    }
+    reads.push(u);
+    const m = u.match(/\/get\/(.+)$/);
+    if (m) {
+      const key = decodeURIComponent(m[1]);
+      return { ok: true, async json() { return { result: store.has(key) ? store.get(key) : null }; } };
+    }
+    return { ok: true, async json() { return { result: null }; } };
+  };
+  return { fetchImpl, posts, reads, store };
+}
+
+test('category 8 pro subject injection: falsy AND truthy non-string subjects both fail closed with 401', async () => {
+  const need401 = { allowed: false, status: 401, reason: QUOTA_REASONS.LICENSE_REQUIRED };
+
+  // Every non-string (or empty-string) subject must fail closed with 401 on
+  // BOTH the metering check and the concurrency-slot acquire. The guard is a
+  // strict `typeof subject !== 'string' || subject === ''`, closing the earlier
+  // falsy-only defense-in-depth gap where a truthy non-string subject (object/
+  // array/non-zero number) slipped past and was String()-coerced, collapsing
+  // distinct license objects onto one shared '[object Object]' bucket.
+  for (const subject of [undefined, null, '', 0, Number.NaN, { license: 'A' }, ['x'], 42, true]) {
+    const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0 });
+    assert.deepEqual(await limiter.check({ tier: PRO, subject: /** @type {any} */ (subject), ip: '203.0.113.7' }), need401, `check subject=${String(subject)}`);
+    assert.deepEqual(await limiter.acquireConcurrency({ tier: PRO, subject: /** @type {any} */ (subject), ip: '203.0.113.7' }), need401, `acquire subject=${String(subject)}`);
+  }
+});
+
+test('category 9 pro is subject-keyed and never IP-keyed: same subject/diff IP shares a bucket, diff subject/same IP does not', async () => {
+  const limits = {
+    free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 2 },
+    byok: { maxChars: 20000, maxConcurrent: 2 },
+    pro: { maxChars: 20000, reqPerDay: 1, maxConcurrent: 3 },
+  };
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0, limits });
+  // Same subject, different IPs (and a missing IP) all hit the SAME bucket.
+  assert.equal((await limiter.check({ tier: PRO, subject: 'seat-1', ip: '203.0.113.1' })).allowed, true);
+  assert.deepEqual(await limiter.check({ tier: PRO, subject: 'seat-1', ip: '198.51.100.9' }), { allowed: false, status: 429, reason: QUOTA_REASONS.DAILY });
+  assert.deepEqual(await limiter.check({ tier: PRO, subject: 'seat-1' }), { allowed: false, status: 429, reason: QUOTA_REASONS.DAILY });
+  // A DIFFERENT subject on the SAME IP is a fresh bucket (the IP is irrelevant).
+  assert.equal((await limiter.check({ tier: PRO, subject: 'seat-2', ip: '203.0.113.1' })).allowed, true);
+
+  // The pro keys are derived from the subject only and never leak the raw
+  // subject/IP; adding an IP can never change the day key.
+  const dayKey = quotaKeyHmac('secret', 'pro', 'day', 'seat-1', 0);
+  assert.match(dayKey, /^[a-f0-9]{64}$/);
+  assert.equal(dayKey.includes('seat-1'), false);
+  assert.equal(quotaKeyHmac('secret', 'pro', 'concurrent', 'seat-1').includes('203.0.113.1'), false);
+});
+
+test('category 10 pro daily boundary: the request AT the cap is allowed with remainingDay 0 and the next crosses to 429 DAILY', async () => {
+  assert.equal(TIER_LIMITS.pro.reqPerDay, 200, 'boundary pinned to the frozen default (200)');
+  const cap = TIER_LIMITS.pro.reqPerDay;
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0 });
+  const subject = 'seat-boundary';
+  let last;
+  for (let i = 0; i < cap; i += 1) last = await limiter.check({ tier: PRO, subject });
+  assert.deepEqual(last, { allowed: true, tier: PRO, remainingDay: 0 }, 'the 200th (== cap) is allowed with 0 remaining');
+  assert.deepEqual(await limiter.check({ tier: PRO, subject }), { allowed: false, status: 429, reason: QUOTA_REASONS.DAILY }, 'the 201st crosses the cap');
+});
+
+test('category 11 pro concurrency boundary: N acquire, the (N+1)th is compensated by a decr and denied, and a release re-admits', async () => {
+  assert.equal(TIER_LIMITS.pro.maxConcurrent, 3, 'boundary pinned to the frozen default (3)');
+  const cap = TIER_LIMITS.pro.maxConcurrent;
+  const kv = spyMemoryKv();
+  const limiter = createRateLimiter({ kv, hmacSecret: 'secret', now: () => 0 });
+  const subject = 'seat-conc';
+  for (let i = 0; i < cap; i += 1) {
+    assert.deepEqual(await limiter.acquireConcurrency({ tier: PRO, subject }), { allowed: true, tier: PRO }, `slot ${i + 1}`);
+  }
+  assert.deepEqual(await limiter.acquireConcurrency({ tier: PRO, subject }), { allowed: false, status: 429, reason: QUOTA_REASONS.CONCURRENT });
+
+  // The over-limit acquire incremented THEN COMPENSATED with a decr, so the live
+  // counter never leaks past the cap (cap+1 incr, 1 decr => cap). Without the
+  // compensating decr the slot would be permanently poisoned and lock everyone out.
+  const key = quotaKeyHmac('secret', 'pro', 'concurrent', subject);
+  assert.equal(await kv.get(key), cap, 'counter compensated back to the cap, not stuck at cap+1');
+  assert.equal(kv.counts.incr, cap + 1);
+  assert.equal(kv.counts.decr, 1);
+
+  // Releasing one slot frees capacity and re-admits.
+  await limiter.releaseConcurrency({ tier: PRO, subject });
+  assert.equal(await kv.get(key), cap - 1);
+  assert.deepEqual(await limiter.acquireConcurrency({ tier: PRO, subject }), { allowed: true, tier: PRO });
+});
+
+test('category 12 pro degraded KV never fails open: NaN/negative/zero/object/undefined/throwing incr all deny with 503 on check and acquire', async () => {
+  const fail503 = { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE };
+  const badReturns = [Number.NaN, -1, -999, 0, {}, undefined];
+  for (const bad of badReturns) {
+    const limiter = createRateLimiter({ kv: { async incr() { return /** @type {any} */ (bad); }, async decr() { return 0; } }, hmacSecret: 'secret', now: () => 0 });
+    assert.deepEqual(await limiter.check({ tier: PRO, subject: 'seat' }), fail503, `check incr->${String(bad)}`);
+    assert.deepEqual(await limiter.acquireConcurrency({ tier: PRO, subject: 'seat' }), fail503, `acquire incr->${String(bad)}`);
+  }
+  const thrower = createRateLimiter({ kv: { async incr() { throw new Error('kv down'); }, async decr() {} }, hmacSecret: 'secret', now: () => 0 });
+  assert.deepEqual(await thrower.check({ tier: PRO, subject: 'seat' }), fail503, 'check incr throws');
+  assert.deepEqual(await thrower.acquireConcurrency({ tier: PRO, subject: 'seat' }), fail503, 'acquire incr throws');
+});
+
+test('category 13 free tier no-regression: IP-keyed metering ignores subject, fails closed, and never embeds the raw IP in a key', async () => {
+  const ip = '203.0.113.60';
+
+  // Fail-closed in production without a durable KV; exact shape/reason unchanged.
+  const prod = createRateLimiter({ kv: null, hmacSecret: 'secret', env: { NODE_ENV: 'production' } });
+  assert.deepEqual(await prod.check({ tier: FREE, ip }), { allowed: false, status: 503, reason: QUOTA_REASONS.STORAGE_UNAVAILABLE });
+  // Missing IP is a stable 400 even if a bogus subject is supplied.
+  assert.deepEqual(await createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret' }).check({ tier: FREE, ip: null, subject: /** @type {any} */ ('ignored') }), { allowed: false, status: 400, reason: QUOTA_REASONS.IP_UNAVAILABLE });
+
+  // The daily cap (5) is enforced per IP and a supplied subject is IGNORED: the
+  // 6th request with a DIFFERENT subject but the SAME IP is still 429 DAILY.
+  // burstPerHour is lifted so the daily cap (not the hourly burst) is the gate.
+  const limits = { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 99 }, byok: { maxChars: 20000, maxConcurrent: 2 }, pro: { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 } };
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0, limits });
+  for (let i = 0; i < 5; i += 1) {
+    assert.equal((await limiter.check({ tier: FREE, ip, subject: /** @type {any} */ (`seat-${i}`) })).allowed, true, `free request ${i + 1}`);
+  }
+  assert.deepEqual(await limiter.check({ tier: FREE, ip, subject: /** @type {any} */ ('brand-new-subject') }), { allowed: false, status: 429, reason: QUOTA_REASONS.DAILY });
+
+  // A first free response shape is exactly {allowed, tier, remainingDay}.
+  const fresh = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0 });
+  assert.deepEqual(await fresh.check({ tier: FREE, ip, subject: /** @type {any} */ ('ignored') }), { allowed: true, tier: FREE, remainingDay: 4 });
+
+  // Free concurrency (max 1) enforces; a subject can neither widen nor bypass it.
+  const conc = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0 });
+  assert.deepEqual(await conc.acquireConcurrency({ tier: FREE, ip, subject: /** @type {any} */ ('x') }), { allowed: true, tier: FREE });
+  assert.deepEqual(await conc.acquireConcurrency({ tier: FREE, ip, subject: /** @type {any} */ ('y') }), { allowed: false, status: 429, reason: QUOTA_REASONS.CONCURRENT });
+  await conc.releaseConcurrency({ tier: FREE, ip });
+  assert.deepEqual(await conc.acquireConcurrency({ tier: FREE, ip }), { allowed: true, tier: FREE });
+
+  // Every free key is a 64-hex HMAC that never leaks the raw IP.
+  for (const key of [
+    quotaKeyHmac('secret', 'free', 'day', ip, 0),
+    quotaKeyHmac('secret', 'free', 'hour', ip, 0),
+    quotaKeyHmac('secret', 'free', 'concurrent', ip),
+  ]) {
+    assert.match(key, /^[a-f0-9]{64}$/);
+    assert.equal(key.includes(ip), false);
+  }
+});
+
+test('category 14 byok tier no-regression: unmetered allow/no-op that never touches the KV, regardless of ip/subject', async () => {
+  const boom = {
+    async get() { throw new Error('byok must not read kv'); },
+    async set() { throw new Error('byok must not write kv'); },
+    async incr() { throw new Error('byok must not meter'); },
+    async decr() { throw new Error('byok must not release'); },
+  };
+  const limiter = createRateLimiter({ kv: boom, hmacSecret: 'secret', env: { NODE_ENV: 'production' }, now: () => 0 });
+
+  // Unmetered allow on check even in production with a hostile kv and any identity.
+  assert.deepEqual(await limiter.check({ tier: BYOK, ip: null, subject: null }), { allowed: true, tier: BYOK });
+  assert.deepEqual(await limiter.check({ tier: BYOK, ip: '203.0.113.9', subject: /** @type {any} */ ('ignored') }), { allowed: true, tier: BYOK });
+  // Concurrency acquire is a no-op allow; release is a no-op. Neither hits kv, so
+  // `boom` never throwing proves the byok path never touches storage.
+  assert.deepEqual(await limiter.acquireConcurrency({ tier: BYOK, ip: '203.0.113.9', subject: /** @type {any} */ ('ignored') }), { allowed: true, tier: BYOK });
+  await limiter.releaseConcurrency({ tier: BYOK, ip: '203.0.113.9', subject: /** @type {any} */ ('ignored') });
+});
+
+test('category 15 createRestKv set/get: atomic single-command SET(+PX) round-trips objects/arrays/nested/special chars; get coerces; !ok throws', async () => {
+  const { fetchImpl, posts } = restKvMock();
+  await withMockFetch(fetchImpl, async () => {
+    const kv = createRestKv({ KV_REST_API_URL: 'https://kv.example.test/', KV_REST_API_TOKEN: 'token' });
+    assert.ok(kv);
+
+    const cases = [
+      { key: 'obj', val: { decision: 'allow', tier: 'pro', nested: { a: 1 } } },
+      { key: 'arr', val: [1, 'two', { three: 3 }, null, true] },
+      { key: 'deep', val: { a: { b: { c: { d: [{ e: 'f' }] } } } } },
+      { key: 'special chars', val: { s: 'quote"\ttab\nnewline\\backslash\u0000nul😀emoji', k: '한국어' } },
+      { key: 'json-looking-string', val: '{"not":"an object"}' },
+      { key: 'num', val: 42 },
+      { key: 'bool', val: false },
+    ];
+    for (const { key, val } of cases) {
+      posts.length = 0;
+      await kv.set(key, val, { ttlMs: 300_000 });
+      // Atomic: exactly ONE POST carrying SET ... PX ms (never SET then EXPIRE),
+      // so a crash cannot leave a TTL-less permanent entitlement-cache entry.
+      assert.equal(posts.length, 1, `set ${key} is a single atomic command`);
+      assert.deepEqual(posts[0].args, ['SET', key, JSON.stringify(val), 'PX', '300000'], `set ${key} args`);
+      assert.equal(posts[0].headers?.['Content-Type'], 'application/json');
+      assert.equal(posts[0].headers?.Authorization, 'Bearer token');
+      // Round-trip: object/array/nested come back deep-equal; a JSON-looking
+      // string comes back as the SAME string (never double-parsed into an object).
+      assert.deepEqual(await kv.get(key), val, `round-trip ${key}`);
+    }
+
+    // No TTL / non-positive TTL => plain SET, PX omitted.
+    for (const arg of [undefined, { ttlMs: 0 }, { ttlMs: -5 }]) {
+      posts.length = 0;
+      await kv.set('k', { a: 1 }, /** @type {any} */ (arg));
+      assert.deepEqual(posts[0].args, ['SET', 'k', JSON.stringify({ a: 1 })], `ttl=${JSON.stringify(arg)} omits PX`);
+    }
+    // A positive fractional TTL is floored to >= 1ms so a sub-ms cache entry
+    // never silently becomes permanent; a >1 fractional TTL uses ceil.
+    posts.length = 0;
+    await kv.set('k', { a: 1 }, { ttlMs: 0.4 });
+    assert.deepEqual(posts[0].args, ['SET', 'k', JSON.stringify({ a: 1 }), 'PX', '1'], 'fractional ttl floors to 1ms');
+    posts.length = 0;
+    await kv.set('k', { a: 1 }, { ttlMs: 1500.2 });
+    assert.deepEqual(posts[0].args, ['SET', 'k', JSON.stringify({ a: 1 }), 'PX', '1501'], 'fractional ttl uses ceil');
+  });
+
+  // get() coercion on non-object REST results: null -> undefined; non-JSON string
+  // -> verbatim; valid numeric string -> number; invalid-JSON numeric string
+  // (leading zero) -> verbatim string (JSON.parse fails, value is not dropped).
+  await withMockFetch(async (url, init) => {
+    if (init && init.method === 'POST') return { ok: true, async json() { return { result: 'OK' }; } };
+    const u = String(url);
+    if (u.endsWith('/null')) return { ok: true, async json() { return { result: null }; } };
+    if (u.endsWith('/legacy')) return { ok: true, async json() { return { result: 'plain-legacy-value' }; } };
+    if (u.endsWith('/num')) return { ok: true, async json() { return { result: '7' }; } };
+    if (u.endsWith('/leadingzero')) return { ok: true, async json() { return { result: '007' }; } };
+    return { ok: true, async json() { return { result: null }; } };
+  }, async () => {
+    const kv = createRestKv({ KV_REST_API_URL: 'https://kv.example.test', KV_REST_API_TOKEN: 'token' });
+    assert.equal(await kv.get('null'), undefined);
+    assert.equal(await kv.get('legacy'), 'plain-legacy-value');
+    assert.equal(await kv.get('num'), 7);
+    assert.equal(await kv.get('leadingzero'), '007');
+  });
+
+  // A non-ok REST response is fail-closed: get throws (read) and set throws (command).
+  await withMockFetch(async () => ({ ok: false, status: 500, async json() { return {}; } }), async () => {
+    const kv = createRestKv({ KV_REST_API_URL: 'https://kv.example.test', KV_REST_API_TOKEN: 'token' });
+    await assert.rejects(() => kv.get('k'), /kv request failed/);
+    await assert.rejects(() => kv.set('k', { a: 1 }), /kv command failed/);
+    await assert.rejects(() => kv.set('k', { a: 1 }, { ttlMs: 1000 }), /kv command failed/);
+  });
+});
+
+test('category 16 createRestKv incr/decr: numeric REST path is parsed independently of get and fails closed on an invalid counter', async () => {
+  // incr parses number|numeric-string|nested {result} via parseKvNumber and
+  // issues a SEPARATE /expire only when a positive ttl is supplied (counter path
+  // is unaffected by get()'s JSON-parsing round-trip).
+  {
+    const calls = [];
+    await withMockFetch(async (url) => {
+      const u = String(url);
+      calls.push(u);
+      if (u.includes('/incr/')) return { ok: true, async json() { return { result: '7' }; } };
+      if (u.includes('/expire/')) return { ok: true, async json() { return { result: 1 }; } };
+      if (u.includes('/decr/')) return { ok: true, async json() { return { result: { result: 3 } }; } };
+      return { ok: true, async json() { return { result: null }; } };
+    }, async () => {
+      const kv = createRestKv({ KV_REST_API_URL: 'https://kv.example.test', KV_REST_API_TOKEN: 'token' });
+      assert.equal(await kv.incr('c', { ttlMs: 60_000 }), 7, 'numeric-string incr result parses to a number');
+      assert.deepEqual(calls, ['https://kv.example.test/incr/c', 'https://kv.example.test/expire/c/60'], 'incr + expire, 60s = ceil(60000/1000)');
+      calls.length = 0;
+      assert.equal(await kv.incr('c'), 7, 'incr without a ttl issues no expire');
+      assert.deepEqual(calls, ['https://kv.example.test/incr/c']);
+      assert.equal(await kv.decr('c'), 3, 'nested {result} decr result parses to a number');
+    });
+  }
+
+  // A malformed counter (non-numeric, null, non-integer, object) fails closed by
+  // THROWING -- never silently returns a bogus count the limiter would trust
+  // (the limiter converts that throw into a 503, verified in category 12).
+  for (const bad of [{ result: 'not-a-number' }, { result: null }, { result: 1.5 }, { result: {} }, {}]) {
+    await withMockFetch(async () => ({ ok: true, async json() { return bad; } }), async () => {
+      const kv = createRestKv({ KV_REST_API_URL: 'https://kv.example.test', KV_REST_API_TOKEN: 'token' });
+      await assert.rejects(() => kv.incr('c'), /kv incr returned invalid counter/, `incr rejects ${JSON.stringify(bad)}`);
+      await assert.rejects(() => kv.decr('c'), /kv decr returned invalid counter/, `decr rejects ${JSON.stringify(bad)}`);
+    });
+  }
+
+  // The adapter is null (not a partial object) when REST env is absent, so the
+  // rate-limiter treats it as storage-unavailable rather than a broken adapter.
+  assert.equal(createRestKv({}), null);
+  assert.equal(createRestKv({ KV_REST_API_URL: 'https://kv.example.test' }), null);
+  assert.equal(createRestKv({ KV_REST_API_TOKEN: 'token' }), null);
+});
+
+test('category 17 unknown/malformed tier is a stable 400 on check and acquire, and a silent no-op on release', async () => {
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0 });
+  const expected = { allowed: false, status: 400, reason: 'unsupported tier' };
+  const tiers = ['enterprise', 'admin', 'PRO', 'FREE', 'Byok', ' free', 'free ', 'pro\u0000', null, undefined, 123, {}, []];
+  for (const tier of tiers) {
+    assert.deepEqual(await limiter.check({ tier: /** @type {any} */ (tier), ip: '203.0.113.99', subject: 'x' }), expected, `check tier=${String(tier)}`);
+    assert.deepEqual(await limiter.acquireConcurrency({ tier: /** @type {any} */ (tier), ip: '203.0.113.99', subject: 'x' }), expected, `acquire tier=${String(tier)}`);
+    // release must never throw for an unknown tier (no key resolved => no-op).
+    await limiter.releaseConcurrency({ tier: /** @type {any} */ (tier), ip: '203.0.113.99', subject: 'x' });
+  }
 });

--- a/tests/unit/rate-limit.test.js
+++ b/tests/unit/rate-limit.test.js
@@ -201,6 +201,9 @@ test('QUOTA_REASONS values stay backward-compatible with the emitted reason stri
     STORAGE_UNAVAILABLE: 'quota storage unavailable',
     SECRET_UNAVAILABLE: 'quota secret unavailable',
     SERVICE_UNAVAILABLE: 'rewrite service unavailable',
+    LICENSE_REQUIRED: 'license required',
+    LICENSE_INVALID: 'license not entitled',
+    LICENSE_UNAVAILABLE: 'license validation unavailable',
   });
 });
 
@@ -240,4 +243,113 @@ test('abuse accounting is pinned: an hourly-denied attempt still consumes daily 
     status: 429,
     reason: QUOTA_REASONS.DAILY,
   });
+});
+
+test('pro tier meters a subject-keyed daily quota (200 pass, 201st is 429 DAILY) and never uses the IP', async () => {
+  // Default TIER_LIMITS.pro.reqPerDay is 200. No IP is ever supplied: pro is
+  // metered on the license subject, so it works with subject alone.
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0 });
+  const subject = 'lic-subject-abc';
+  const first = await limiter.check({ tier: WEB_TIERS.PRO, subject });
+  assert.deepEqual(first, { allowed: true, tier: WEB_TIERS.PRO, remainingDay: 199 });
+  for (let i = 1; i < 200; i += 1) {
+    assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject })).allowed, true, `pro daily request ${i + 1} should be allowed`);
+  }
+  assert.deepEqual(await limiter.check({ tier: WEB_TIERS.PRO, subject }), {
+    allowed: false,
+    status: 429,
+    reason: QUOTA_REASONS.DAILY,
+  });
+});
+
+test('pro quota is keyed on the subject, not the IP: differing IPs share one subject bucket', async () => {
+  const limiter = createRateLimiter({
+    kv: createMemoryKv(),
+    hmacSecret: 'secret',
+    now: () => 0,
+    limits: {
+      free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 2 },
+      byok: { maxChars: 20000, maxConcurrent: 2 },
+      pro: { maxChars: 20000, reqPerDay: 2, maxConcurrent: 3 },
+    },
+  });
+  const subject = 'lic-subject-shared';
+  // Same subject, different IPs: all count against the SAME subject bucket, so
+  // the 3rd is denied even though every IP differs (and the last has none).
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, ip: '203.0.113.1' })).allowed, true);
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, ip: '203.0.113.2' })).allowed, true);
+  assert.deepEqual(await limiter.check({ tier: WEB_TIERS.PRO, subject }), {
+    allowed: false,
+    status: 429,
+    reason: QUOTA_REASONS.DAILY,
+  });
+});
+
+test('pro concurrency is subject-keyed: 3 slots pass, the 4th is 429 CONCURRENT, and a release re-admits', async () => {
+  // Default TIER_LIMITS.pro.maxConcurrent is 3.
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0 });
+  const subject = 'lic-subject-conc';
+  assert.deepEqual(await limiter.acquireConcurrency({ tier: WEB_TIERS.PRO, subject }), { allowed: true, tier: WEB_TIERS.PRO });
+  assert.equal((await limiter.acquireConcurrency({ tier: WEB_TIERS.PRO, subject })).allowed, true);
+  assert.equal((await limiter.acquireConcurrency({ tier: WEB_TIERS.PRO, subject })).allowed, true);
+  assert.deepEqual(await limiter.acquireConcurrency({ tier: WEB_TIERS.PRO, subject }), {
+    allowed: false,
+    status: 429,
+    reason: QUOTA_REASONS.CONCURRENT,
+  });
+  await limiter.releaseConcurrency({ tier: WEB_TIERS.PRO, subject });
+  assert.equal((await limiter.acquireConcurrency({ tier: WEB_TIERS.PRO, subject })).allowed, true);
+});
+
+test('pro tier fails closed with 401 LICENSE_REQUIRED when no subject is supplied (defense-in-depth)', async () => {
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0 });
+  const expected = { allowed: false, status: 401, reason: QUOTA_REASONS.LICENSE_REQUIRED };
+  assert.deepEqual(await limiter.check({ tier: WEB_TIERS.PRO, subject: undefined }), expected);
+  assert.deepEqual(await limiter.check({ tier: WEB_TIERS.PRO, subject: '' }), expected);
+  assert.deepEqual(await limiter.acquireConcurrency({ tier: WEB_TIERS.PRO, subject: null }), expected);
+});
+
+test('pro tier fails closed with 503 in production without durable KV or without an HMAC secret', async () => {
+  const subject = 'lic-subject-prod';
+  const noKv = createRateLimiter({ kv: null, hmacSecret: 'secret', env: { NODE_ENV: 'production' } });
+  assert.deepEqual(await noKv.check({ tier: WEB_TIERS.PRO, subject }), {
+    allowed: false,
+    status: 503,
+    reason: QUOTA_REASONS.STORAGE_UNAVAILABLE,
+  });
+
+  const memoryKv = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', env: { VERCEL: '1' } });
+  assert.deepEqual(await memoryKv.check({ tier: WEB_TIERS.PRO, subject }), {
+    allowed: false,
+    status: 503,
+    reason: QUOTA_REASONS.STORAGE_UNAVAILABLE,
+  });
+
+  const noSecret = createRateLimiter({ kv: { async incr() { return 1; } }, env: { VERCEL_ENV: 'production' } });
+  assert.deepEqual(await noSecret.check({ tier: WEB_TIERS.PRO, subject }), {
+    allowed: false,
+    status: 503,
+    reason: QUOTA_REASONS.SECRET_UNAVAILABLE,
+  });
+});
+
+test('an unknown tier is a stable 400 on check and concurrency (defense-in-depth)', async () => {
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0 });
+  const expected = { allowed: false, status: 400, reason: 'unsupported tier' };
+  assert.deepEqual(await limiter.check({ tier: 'enterprise', ip: '203.0.113.99', subject: 'x' }), expected);
+  assert.deepEqual(await limiter.acquireConcurrency({ tier: '', ip: '203.0.113.99' }), expected);
+});
+
+test('pro subject guard rejects truthy non-string subjects with 401 (defense-in-depth, fail-closed)', async () => {
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0 });
+  for (const bad of [{}, [], 123, true]) {
+    const chk = await limiter.check({ tier: WEB_TIERS.PRO, ip: '203.0.113.50', subject: /** @type {any} */ (bad) });
+    assert.equal(chk.allowed, false);
+    assert.equal(chk.status, 401);
+    assert.equal(chk.reason, QUOTA_REASONS.LICENSE_REQUIRED);
+    const acq = await limiter.acquireConcurrency({ tier: WEB_TIERS.PRO, ip: '203.0.113.50', subject: /** @type {any} */ (bad) });
+    assert.equal(acq.allowed, false);
+    assert.equal(acq.status, 401);
+    assert.equal(acq.reason, QUOTA_REASONS.LICENSE_REQUIRED);
+  }
 });

--- a/tests/unit/rate-limit.test.js
+++ b/tests/unit/rate-limit.test.js
@@ -204,6 +204,7 @@ test('QUOTA_REASONS values stay backward-compatible with the emitted reason stri
     LICENSE_REQUIRED: 'license required',
     LICENSE_INVALID: 'license not entitled',
     LICENSE_UNAVAILABLE: 'license validation unavailable',
+    MONTHLY_CHARS: 'monthly character limit reached',
   });
 });
 
@@ -352,4 +353,76 @@ test('pro subject guard rejects truthy non-string subjects with 401 (defense-in-
     assert.equal(acq.status, 401);
     assert.equal(acq.reason, QUOTA_REASONS.LICENSE_REQUIRED);
   }
+});
+
+test('pro monthly char cap: accumulates per-license, allows at the cap, and 429s over it with remaining guidance', async () => {
+  const subject = 'seat-month';
+  // Small cap to exercise the boundary cheaply; env would normally set 1,000,000.
+  const limits = { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 2 }, byok: { maxChars: 20000, maxConcurrent: 2 }, pro: { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3, charsPerMonth: 1000 } };
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0, limits });
+
+  // 400 + 400 = 800 (<= 1000) both allowed; the daily counter is unaffected.
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 400 })).allowed, true);
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 400 })).allowed, true);
+  // 800 + 200 = 1000 == cap: still allowed (cap is the max total, not "one under").
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 200 })).allowed, true);
+  // Any further chars cross the cap -> 429 MONTHLY_CHARS with remaining=0 + the limit.
+  assert.deepEqual(await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 1 }), {
+    allowed: false,
+    status: 429,
+    reason: QUOTA_REASONS.MONTHLY_CHARS,
+    remainingMonthlyChars: 0,
+    limitMonthlyChars: 1000,
+  });
+});
+
+test('pro monthly char cap resets at the UTC month boundary', async () => {
+  const subject = 'seat-reset';
+  const limits = { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 2 }, byok: { maxChars: 20000, maxConcurrent: 2 }, pro: { maxChars: 20000, reqPerDay: 999999, maxConcurrent: 3, charsPerMonth: 1000 } };
+  // reqPerDay lifted so only the monthly cap can gate.
+  let t = Date.UTC(2026, 0, 15); // 2026-01-15
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => t, limits });
+
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 1000 })).allowed, true);
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 1 })).status, 429);
+
+  // Cross into February: a fresh month bucket, so the cap resets and admits again.
+  t = Date.UTC(2026, 1, 1);
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 1000 })).allowed, true);
+  // A different UTC month bucket keys a separate counter (no cross-month leakage).
+  assert.equal((await limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 1 })).status, 429);
+});
+
+test('pro monthly char cap counts concurrent requests atomically (no over-allow race)', async () => {
+  const subject = 'seat-conc';
+  const limits = { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 2 }, byok: { maxChars: 20000, maxConcurrent: 2 }, pro: { maxChars: 20000, reqPerDay: 999999, maxConcurrent: 3, charsPerMonth: 1000 } };
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0, limits });
+
+  // Fire 10 concurrent 200-char checks against a 1000 cap. The atomic incrBy
+  // means EXACTLY 5 succeed (5*200=1000) and the rest are denied — no race lets
+  // the running total exceed the cap.
+  const results = await Promise.all(
+    Array.from({ length: 10 }, () => limiter.check({ tier: WEB_TIERS.PRO, subject, chars: 200 })),
+  );
+  const allowed = results.filter((r) => r.allowed).length;
+  const denied = results.filter((r) => !r.allowed);
+  assert.equal(allowed, 5, 'exactly cap/chars requests admitted');
+  assert.equal(denied.length, 5);
+  for (const d of denied) {
+    assert.equal(d.status, 429);
+    assert.equal(d.reason, QUOTA_REASONS.MONTHLY_CHARS);
+  }
+});
+
+test('pro monthly char cap is skipped when no chars are supplied or the cap is unset (backward-compatible)', async () => {
+  const subject = 'seat-skip';
+  // Default TIER_LIMITS.pro.charsPerMonth applies, but with no chars the monthly
+  // dimension never engages: the response shape stays the daily-only contract.
+  const limiter = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0 });
+  assert.deepEqual(await limiter.check({ tier: WEB_TIERS.PRO, subject }), { allowed: true, tier: WEB_TIERS.PRO, remainingDay: 199 });
+
+  // With chars but a limits object lacking charsPerMonth, monthly is not enforced.
+  const noCap = { free: { maxChars: 4000, maxConcurrent: 1, reqPerDay: 5, burstPerHour: 2 }, byok: { maxChars: 20000, maxConcurrent: 2 }, pro: { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 } };
+  const limiter2 = createRateLimiter({ kv: createMemoryKv(), hmacSecret: 'secret', now: () => 0, limits: noCap });
+  assert.deepEqual(await limiter2.check({ tier: WEB_TIERS.PRO, subject, chars: 5_000_000 }), { allowed: true, tier: WEB_TIERS.PRO, remainingDay: 199 });
 });

--- a/tests/unit/rate-limit.test.js
+++ b/tests/unit/rate-limit.test.js
@@ -164,6 +164,20 @@ test('free concurrency limit rejects a second active slot and releases after com
   assert.equal((await limiter.acquireConcurrency({ tier: WEB_TIERS.FREE, ip: '203.0.113.30' })).allowed, true);
 });
 
+test('concurrency slot TTL defaults to 5m and honors an override so an extended stream never expires the slot', async () => {
+  const defaultCalls = [];
+  const defaultKv = { async incr(_key, opts) { defaultCalls.push(opts); return 1; }, async decr() { return 0; } };
+  const defaultLimiter = createRateLimiter({ kv: defaultKv, hmacSecret: 'secret', now: () => 0 });
+  await defaultLimiter.acquireConcurrency({ tier: WEB_TIERS.FREE, ip: '203.0.113.40' });
+  assert.equal(defaultCalls[0].ttlMs, 5 * 60 * 1000);
+
+  const overrideCalls = [];
+  const overrideKv = { async incr(_key, opts) { overrideCalls.push(opts); return 1; }, async decr() { return 0; } };
+  const overrideLimiter = createRateLimiter({ kv: overrideKv, hmacSecret: 'secret', now: () => 0, concurrencyTtlMs: 12 * 60 * 1000 });
+  await overrideLimiter.acquireConcurrency({ tier: WEB_TIERS.FREE, ip: '203.0.113.40' });
+  assert.equal(overrideCalls[0].ttlMs, 12 * 60 * 1000);
+});
+
 test('BYOK concurrency bypasses shared free slot limit', async () => {
   const limiter = createRateLimiter({
     kv: createMemoryKv(),

--- a/tests/unit/rewrite-api.test.js
+++ b/tests/unit/rewrite-api.test.js
@@ -257,3 +257,238 @@ test('a clean close after end does not abort the runner signal', async () => {
   res.emitClose();
   assert.equal(seenSignal.aborted, false, 'clean completion must not abort');
 });
+
+test('REST KV round-trips an object via an atomic SET+PX command and JSON-parses get', async () => {
+  const posts = [];
+  let stored = null;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = /** @type {any} */ (async (url, init) => {
+    if (init && init.method === 'POST') {
+      const args = JSON.parse(String(init.body));
+      posts.push({ url: String(url), args, contentType: init.headers?.['Content-Type'], auth: init.headers?.Authorization });
+      stored = args[2]; // the value of ['SET', key, value, 'PX', ms]
+      return { ok: true, async json() { return { result: 'OK' }; } };
+    }
+    // Upstash GET returns the stored value as a JSON string.
+    return { ok: true, async json() { return { result: stored }; } };
+  });
+  try {
+    const kv = createRestKv({ KV_REST_API_URL: 'https://kv.example.test/', KV_REST_API_TOKEN: 'token' });
+    assert.ok(kv);
+    const entry = { decision: 'allow', tier: 'pro', status: 'active', expiresAt: 123 };
+    await kv.set('cache key', entry, { ttlMs: 300_000 });
+    // Atomic SET+expiry: a single POST command carrying ['SET', key, JSON, 'PX', ms].
+    assert.equal(posts.length, 1);
+    assert.equal(posts[0].url, 'https://kv.example.test');
+    assert.deepEqual(posts[0].args, ['SET', 'cache key', JSON.stringify(entry), 'PX', '300000']);
+    assert.equal(posts[0].contentType, 'application/json');
+    assert.equal(posts[0].auth, 'Bearer token');
+    // get() parses the stored JSON string back into the original object, exactly
+    // like createMemoryKv (object in -> object out) so the entitlement cache works.
+    assert.deepEqual(await kv.get('cache key'), entry);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('REST KV set without a TTL omits PX; get is undefined for null and verbatim for a non-JSON result', async () => {
+  const posts = [];
+  const results = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = /** @type {any} */ (async (_url, init) => {
+    if (init && init.method === 'POST') {
+      posts.push(JSON.parse(String(init.body)));
+      return { ok: true, async json() { return { result: 'OK' }; } };
+    }
+    return { ok: true, async json() { return results.shift(); } };
+  });
+  try {
+    const kv = createRestKv({ KV_REST_API_URL: 'https://kv.example.test', KV_REST_API_TOKEN: 'token' });
+    assert.ok(kv);
+
+    await kv.set('k', { a: 1 }); // no ttl -> plain SET, no PX
+    assert.deepEqual(posts[0], ['SET', 'k', JSON.stringify({ a: 1 })]);
+
+    // A null result (missing key) reads back as undefined, matching memory KV.
+    results.push({ result: null });
+    assert.equal(await kv.get('missing'), undefined);
+
+    // A non-JSON string result is returned verbatim (never thrown, never dropped).
+    results.push({ result: 'plain-value' });
+    assert.equal(await kv.get('legacy'), 'plain-value');
+
+    // A numeric string parses back to a number (JSON.parse succeeds).
+    results.push({ result: '0' });
+    assert.equal(await kv.get('counter'), 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+/** A globalThis.fetch stub returning a valid Lemon Squeezy validate-only response. */
+function validLsFetch() {
+  return /** @type {any} */ (async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return { valid: true, license_key: { status: 'active' }, meta: { store_id: '42', variant_id: '99' } };
+    },
+  }));
+}
+
+test('pro tier: a valid license streams with the server pro key and a pro-tier metric (no license leak)', async () => {
+  const RAW = 'LS-LICENSE-RAW-777';
+  const env = {
+    NODE_ENV: 'test',
+    PATINA_FREE_PROVIDER: 'openai', PATINA_FREE_MODEL: 'gpt-5.5',
+    PATINA_FREE_API_KEY: 'sk-server-free-key',
+    PATINA_PRO_API_KEY: 'sk-server-pro-key',
+    PATINA_LICENSE_HMAC_SECRET: 'license-secret',
+    LS_STORE_ID: '42', LS_PRO_VARIANT_ID: '99',
+  };
+  const metrics = [];
+  const logger = { info: (evt, fields) => metrics.push({ evt, fields }), error() {}, warn() {}, debug() {} };
+  let seenKey;
+  let seenTier;
+  const injected = async ({ request, emit }) => {
+    seenKey = request.apiKey;
+    seenTier = request.tier;
+    emit({ type: 'done', rewrite: 'ok' });
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = validLsFetch();
+  try {
+    // Validator captures globalThis.fetch at construction, so replace it first.
+    const api = createRewriteApiHandler({ env, runWebRewriteStreamImpl: injected, logger });
+    const res = makeRes();
+    await api({
+      method: 'POST',
+      headers: { 'x-real-ip': '203.0.113.50', authorization: `Bearer ${RAW}` },
+      body: JSON.stringify({ mode: 'first', lang: 'en', tier: 'pro', text: 'Rewrite this sentence.' }),
+    }, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.getHeader('content-type'), 'application/x-ndjson');
+    const lines = res.chunks.join('').trim().split('\n').map((l) => JSON.parse(l));
+    assert.deepEqual(lines.map((f) => f.type), ['done']);
+    // The server pro key reaches the runner — never the free key, never the license.
+    assert.equal(seenKey, 'sk-server-pro-key');
+    assert.equal(seenTier, 'pro');
+    // Observability preserves the pro tier and never carries the raw license.
+    const metric = metrics.find((m) => m.evt === 'rewrite.metric');
+    assert.ok(metric, 'a rewrite.metric must be emitted');
+    assert.equal(metric.fields.tier, 'pro');
+    assert.equal(JSON.stringify(metric.fields).includes(RAW), false);
+    // The license never appears in the NDJSON stream either.
+    assert.equal(res.chunks.join('').includes(RAW), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('pro tier: fails closed with 503 when no pro key and no free-key fallback are configured', async () => {
+  const RAW = 'LS-LICENSE-RAW-nokey';
+  const env = {
+    NODE_ENV: 'test',
+    PATINA_FREE_PROVIDER: 'openai', PATINA_FREE_MODEL: 'gpt-5.5',
+    // no PATINA_PRO_API_KEY, no PATINA_FREE_API_KEY -> nothing to fall back to.
+    PATINA_LICENSE_HMAC_SECRET: 'license-secret',
+    LS_STORE_ID: '42', LS_PRO_VARIANT_ID: '99',
+  };
+  let runnerCalled = false;
+  const injected = async () => { runnerCalled = true; };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = validLsFetch();
+  try {
+    const api = createRewriteApiHandler({ env, runWebRewriteStreamImpl: injected });
+    const res = makeRes();
+    await api({
+      method: 'POST',
+      headers: { 'x-real-ip': '203.0.113.51', authorization: `Bearer ${RAW}` },
+      body: JSON.stringify({ mode: 'first', lang: 'en', tier: 'pro', text: 'Rewrite this sentence.' }),
+    }, res);
+    assert.equal(res.statusCode, 503);
+    assert.equal(runnerCalled, false, 'runner must not run without a usable pro key');
+    assert.match(res.chunks.join(''), /rewrite service unavailable/);
+    assert.doesNotMatch(res.chunks.join(''), /"type"/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('pro tier: outside production a valid license falls back to the free key when no pro key is set', async () => {
+  const RAW = 'LS-LICENSE-RAW-fallback';
+  const env = {
+    NODE_ENV: 'test',
+    PATINA_FREE_PROVIDER: 'openai', PATINA_FREE_MODEL: 'gpt-5.5',
+    PATINA_FREE_API_KEY: 'sk-server-free-key',
+    // no PATINA_PRO_API_KEY -> non-production allows the free key as a dev fallback.
+    PATINA_LICENSE_HMAC_SECRET: 'license-secret',
+    LS_STORE_ID: '42', LS_PRO_VARIANT_ID: '99',
+  };
+  let seenKey;
+  const injected = async ({ request, emit }) => { seenKey = request.apiKey; emit({ type: 'done', rewrite: 'ok' }); };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = validLsFetch();
+  try {
+    const api = createRewriteApiHandler({ env, runWebRewriteStreamImpl: injected });
+    const res = makeRes();
+    await api({
+      method: 'POST',
+      headers: { 'x-real-ip': '203.0.113.52', authorization: `Bearer ${RAW}` },
+      body: JSON.stringify({ mode: 'first', lang: 'en', tier: 'pro', text: 'Rewrite this sentence.' }),
+    }, res);
+    assert.equal(res.statusCode, 200);
+    assert.equal(seenKey, 'sk-server-free-key', 'non-production pro falls back to the free key');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('pro tier: in production, no pro key + present free key + no allow-flag returns 503 and never spends the free key on paid traffic', async () => {
+  const RAW = 'LS-LICENSE-RAW-prodpolicy';
+  const env = {
+    NODE_ENV: 'production',
+    KV_REST_API_URL: 'https://kv.example.test',
+    KV_REST_API_TOKEN: 'kv-token',
+    PATINA_QUOTA_HMAC_SECRET: 'quota-secret',
+    PATINA_LICENSE_HMAC_SECRET: 'license-secret',
+    PATINA_FREE_PROVIDER: 'openai', PATINA_FREE_MODEL: 'gpt-5.5',
+    PATINA_FREE_API_KEY: 'sk-server-free-key',
+    // No PATINA_PRO_API_KEY and no PATINA_PRO_ALLOW_FREE_KEY: paid traffic MUST NOT
+    // silently spend the free key in production.
+    LS_STORE_ID: '42', LS_PRO_VARIANT_ID: '99',
+  };
+  let runnerCalled = false;
+  const injected = async () => { runnerCalled = true; };
+  const originalFetch = globalThis.fetch;
+  // One mock serves both the LS validate call and the Upstash KV REST adapter so
+  // entitlement + rate limiting pass in production and the flow reaches the
+  // server-key resolution (where the policy denial happens).
+  globalThis.fetch = /** @type {any} */ (async (url) => {
+    const u = String(url);
+    if (u.includes('api.lemonsqueezy.com')) {
+      return { ok: true, status: 200, async json() { return { valid: true, license_key: { status: 'active' }, meta: { store_id: '42', variant_id: '99' } }; } };
+    }
+    if (u.includes('/incr/')) return { ok: true, async json() { return { result: 1 }; } };
+    if (u.includes('/decr/')) return { ok: true, async json() { return { result: 0 }; } };
+    if (u.includes('/expire/')) return { ok: true, async json() { return { result: 1 }; } };
+    if (u.includes('/get/')) return { ok: true, async json() { return { result: null }; } };
+    return { ok: true, async json() { return { result: 'OK' }; } }; // command SET
+  });
+  try {
+    const api = createRewriteApiHandler({ env, runWebRewriteStreamImpl: injected });
+    const res = makeRes();
+    await api({
+      method: 'POST',
+      headers: { 'x-real-ip': '203.0.113.53', authorization: `Bearer ${RAW}` },
+      body: JSON.stringify({ mode: 'first', lang: 'en', tier: 'pro', text: 'Rewrite this sentence.' }),
+    }, res);
+    assert.equal(res.statusCode, 503, 'production pro without a pro key must fail closed');
+    assert.equal(runnerCalled, false, 'the free key must never serve paid traffic in production');
+    assert.match(res.chunks.join(''), /rewrite service unavailable/);
+    assert.doesNotMatch(res.chunks.join(''), new RegExp(RAW));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/unit/rewrite-api.test.js
+++ b/tests/unit/rewrite-api.test.js
@@ -119,6 +119,25 @@ test('the entrypoint emits a sanitized rewrite metric (no text/key/IP) on succes
   assert.equal('apiKey' in metric.fields, false);
 });
 
+test('the rewrite metric records the stream outcome so a failed stream is not logged as success', async () => {
+  const env = { NODE_ENV: 'test', PATINA_FREE_PROVIDER: 'openai', PATINA_FREE_MODEL: 'gpt-5.5', PATINA_FREE_API_KEY: 'sk-server-free-key' };
+  const metrics = [];
+  const logger = { info: (evt, fields) => metrics.push({ evt, fields }), error() {}, warn() {}, debug() {} };
+  const injected = async ({ emit }) => {
+    emit({ type: 'start', provider: 'openai', model: 'gpt-5.5' });
+    emit({ type: 'error', code: 'stream_failed', error: 'provider down' });
+    return { ok: false, code: 'stream_failed', error: 'provider down' };
+  };
+  const api = createRewriteApiHandler({ env, runWebRewriteStreamImpl: injected, logger });
+  const res = makeRes();
+  await api(makeReq(), res);
+
+  const metric = metrics.find((m) => m.evt === 'rewrite.metric');
+  assert.ok(metric, 'a rewrite.metric must be emitted even when the stream fails');
+  assert.equal(metric.fields.status, 200, 'the HTTP response genuinely committed 200');
+  assert.equal(metric.fields.outcome, 'stream_failed', 'but the stream failure must stay observable');
+});
+
 test('free tier fails closed with 503 when the server free API key is unconfigured', async () => {
   const env = { NODE_ENV: 'test', PATINA_FREE_PROVIDER: 'openai', PATINA_FREE_MODEL: 'gpt-5.5' }; // no PATINA_FREE_API_KEY
   let runnerCalled = false;

--- a/tests/unit/rewrite-api.test.js
+++ b/tests/unit/rewrite-api.test.js
@@ -325,6 +325,34 @@ test('REST KV set without a TTL omits PX; get is undefined for null and verbatim
   }
 });
 
+test('REST KV incrBy adds N atomically via /incrby and sets a whole-second PEXPIRE', async () => {
+  const gets = [];
+  const results = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = /** @type {any} */ (async (url) => {
+    gets.push(String(url));
+    return { ok: true, async json() { return results.shift(); } };
+  });
+  try {
+    const kv = createRestKv({ KV_REST_API_URL: 'https://kv.example.test', KV_REST_API_TOKEN: 'token' });
+    assert.ok(kv);
+
+    // incrby returns the new running total; ttlMs -> /expire with ceil(ms/1000) seconds.
+    results.push({ result: 1200 }); // incrby result
+    results.push({ result: 1 }); // expire ack
+    const total = await kv.incrBy('month key', 400, { ttlMs: 2_500 });
+    assert.equal(total, 1200);
+    assert.equal(gets[0], 'https://kv.example.test/incrby/month%20key/400');
+    assert.equal(gets[1], 'https://kv.example.test/expire/month%20key/3');
+
+    // A malformed counter (non-numeric) fails closed by throwing.
+    results.push({ result: 'not-a-number' });
+    await assert.rejects(() => kv.incrBy('k', 5), /invalid counter/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 /** A globalThis.fetch stub returning a valid Lemon Squeezy validate-only response. */
 function validLsFetch() {
   return /** @type {any} */ (async () => ({
@@ -474,6 +502,7 @@ test('pro tier: in production, no pro key + present free key + no allow-flag ret
     if (u.includes('/decr/')) return { ok: true, async json() { return { result: 0 }; } };
     if (u.includes('/expire/')) return { ok: true, async json() { return { result: 1 }; } };
     if (u.includes('/get/')) return { ok: true, async json() { return { result: null }; } };
+    if (u.includes('/incrby/')) return { ok: true, async json() { return { result: 100 }; } };
     return { ok: true, async json() { return { result: 'OK' }; } }; // command SET
   });
   try {

--- a/tests/unit/rewrite-handler.test.js
+++ b/tests/unit/rewrite-handler.test.js
@@ -548,7 +548,7 @@ test('redteam(1): a valid pro request leaks the raw license nowhere (runner requ
     assert.equal(input.subject, 'SUBJECT-HMAC');
     assert.equal(input.tier, WEB_TIERS.PRO);
     assert.equal(input.ip, '203.0.113.60');
-    assert.deepEqual(Object.keys(input).sort(), ['ip', 'subject', 'tier']);
+    for (const k of Object.keys(input)) assert.ok(['chars', 'ip', 'subject', 'tier'].includes(k), `unexpected limiter arg key: ${k}`);
     assert.equal('license' in input, false);
     assert.equal('licenseKey' in input, false);
   }
@@ -894,4 +894,44 @@ test('redteam(6): the runner request has its Authorization header stripped; non-
   assert.equal(typeof runnerArgs.req.on, 'function');
   runnerArgs.req.on('aborted', () => {});
   assert.deepEqual(onEvents, ['aborted']);
+});
+
+test('pro path passes the request char count to the limiter (monthly cap plumbing); free passes 0', async () => {
+  const PRO_RAW = 'LICENSE-RAW-chars';
+  const proLimiter = spyLimiter();
+  const proHandler = createRewriteHandler({
+    rateLimiter: proLimiter,
+    licenseValidator: makeValidator({ ok: true, subject: 'SUBJ-chars', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' }),
+    runRewrite() { return 'ran'; },
+  });
+  const text = 'Rewrite this exact sentence.';
+  await proHandler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.90', authorization: `Bearer ${PRO_RAW}` }, body: proBody({ text }) }, makeRes());
+  assert.equal(proLimiter.calls.check[0].tier, WEB_TIERS.PRO);
+  assert.equal(proLimiter.calls.check[0].chars, text.length);
+  assert.equal(proLimiter.calls.check[0].subject, 'SUBJ-chars');
+
+  // Free carries no monthly char dimension: chars is 0 and no license is validated.
+  const freeLimiter = spyLimiter();
+  const freeHandler = createRewriteHandler({ rateLimiter: freeLimiter, runRewrite() { return 'free'; } });
+  await freeHandler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.91' }, body: validBody() }, makeRes());
+  assert.equal(freeLimiter.calls.check[0].chars, 0);
+  assert.equal(freeLimiter.calls.check[0].subject, undefined);
+});
+
+test('pro path forwards the monthly-char 429 with remaining/limit guidance and never runs the runner', async () => {
+  const res = makeRes();
+  let ran = false;
+  const handler = createRewriteHandler({
+    rateLimiter: {
+      async check() {
+        return { allowed: false, status: 429, reason: QUOTA_REASONS.MONTHLY_CHARS, remainingMonthlyChars: 0, limitMonthlyChars: 1000 };
+      },
+    },
+    licenseValidator: makeValidator({ ok: true, subject: 'SUBJ-over', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' }),
+    runRewrite() { ran = true; },
+  });
+  await handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.92', authorization: 'Bearer LICENSE-RAW-over' }, body: proBody() }, res);
+  assert.equal(res.statusCode, 429);
+  assert.deepEqual(res.json(), { error: QUOTA_REASONS.MONTHLY_CHARS, remainingMonthlyChars: 0, limitMonthlyChars: 1000 });
+  assert.equal(ran, false);
 });

--- a/tests/unit/rewrite-handler.test.js
+++ b/tests/unit/rewrite-handler.test.js
@@ -270,3 +270,37 @@ test('BYOK concurrent requests bypass free concurrency limit', async () => {
   assert.equal(firstRes.statusCode, 200);
   assert.equal(secondRes.statusCode, 200);
 });
+test('send() tears down an already-committed response instead of throwing ERR_HTTP_HEADERS_SENT', async () => {
+  let destroyed = false;
+  const res = {
+    statusCode: 0,
+    headersSent: false,
+    writableEnded: false,
+    setHeader() {
+      // Mirror Node: mutating headers after they are flushed throws.
+      if (this.headersSent) throw new Error('ERR_HTTP_HEADERS_SENT');
+    },
+    write() {
+      // Writing the first frame commits the response (headers flushed).
+      this.headersSent = true;
+    },
+    end() {
+      if (this.headersSent) throw new Error('ERR_HTTP_HEADERS_SENT');
+    },
+    destroy() { destroyed = true; },
+  };
+  const handler = createRewriteHandler({
+    rateLimiter: allowedLimiter(),
+    runRewrite({ res: r }) {
+      r.write('{"type":"start"}\n'); // stream started -> response committed
+      throw new Error('boom after the first frame');
+    },
+    logger: { error() {} },
+  });
+
+  await assert.doesNotReject(
+    handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.24' }, body: validBody() }, res),
+    'a committed-response 500 path must not re-throw ERR_HTTP_HEADERS_SENT',
+  );
+  assert.equal(destroyed, true, 'a committed response must be torn down, not re-headered');
+});

--- a/tests/unit/rewrite-handler.test.js
+++ b/tests/unit/rewrite-handler.test.js
@@ -4,7 +4,7 @@ import { setImmediate } from 'node:timers';
 
 import { createRewriteHandler } from '../../src/rewrite-handler.js';
 import { createMemoryKv, createRateLimiter } from '../../src/rate-limit.js';
-import { WEB_TIERS } from '../../src/web-rewrite-contract.js';
+import { QUOTA_REASONS, WEB_TIERS } from '../../src/web-rewrite-contract.js';
 
 function makeRes() {
   return {
@@ -47,6 +47,34 @@ function deferred() {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+/** A rate limiter that records every check/acquire/release call for assertions. */
+function spyLimiter() {
+  const calls = { check: [], acquire: [], release: [] };
+  return {
+    calls,
+    async check(input) { calls.check.push(input); return { allowed: true, tier: input.tier }; },
+    async acquireConcurrency(input) { calls.acquire.push(input); return { allowed: true, tier: input.tier }; },
+    async releaseConcurrency(input) { calls.release.push(input); },
+  };
+}
+
+/** A license validator stub that records its input and returns a fixed decision. */
+function makeValidator(result) {
+  const state = { calls: 0, lastInput: undefined };
+  return {
+    state,
+    async validate(input) {
+      state.calls += 1;
+      state.lastInput = input;
+      return result;
+    },
+  };
+}
+
+function proBody(overrides = {}) {
+  return { mode: 'first', lang: 'en', tier: WEB_TIERS.PRO, text: 'Rewrite this sentence.', ...overrides };
 }
 
 
@@ -303,4 +331,567 @@ test('send() tears down an already-committed response instead of throwing ERR_HT
     'a committed-response 500 path must not re-throw ERR_HTTP_HEADERS_SENT',
   );
   assert.equal(destroyed, true, 'a committed response must be torn down, not re-headered');
+});
+
+test('pro path: valid Bearer + valid license runs the rewrite metered by the license subject', async () => {
+  const res = makeRes();
+  const limiter = spyLimiter();
+  const validator = makeValidator({ ok: true, subject: 'S', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' });
+  const RAW = 'LICENSE-RAW-abc123';
+  let runnerArgs;
+  const logs = [];
+  const handler = createRewriteHandler({
+    rateLimiter: limiter,
+    licenseValidator: validator,
+    runRewrite(args) { runnerArgs = args; return 'ran'; },
+    logger: { error(v) { logs.push(v); } },
+  });
+
+  const result = await handler({
+    method: 'POST',
+    headers: { 'x-real-ip': '203.0.113.40', authorization: `Bearer ${RAW}` },
+    body: proBody(),
+  }, res);
+
+  assert.equal(result, 'ran');
+  // The license is validated exactly once, by its raw value.
+  assert.equal(validator.state.calls, 1);
+  assert.deepEqual(validator.state.lastInput, { licenseKey: RAW });
+  // Metered by the HMAC subject on every limiter call — never the client IP.
+  assert.equal(limiter.calls.check[0].tier, WEB_TIERS.PRO);
+  assert.equal(limiter.calls.check[0].subject, 'S');
+  assert.equal(limiter.calls.acquire[0].subject, 'S');
+  assert.equal(limiter.calls.release[0].subject, 'S');
+  // The runner's validated request carries no raw license and no resolved key.
+  assert.equal(runnerArgs.request.apiKey, undefined);
+  assert.equal('license' in runnerArgs.request, false);
+  assert.equal('licenseKey' in runnerArgs.request, false);
+  assert.equal(JSON.stringify(runnerArgs.request).includes(RAW), false);
+  // No error path fired, so nothing — least of all the license — was logged.
+  assert.equal(JSON.stringify(logs).includes(RAW), false);
+});
+
+test('pro path: a missing Bearer license is 401 LICENSE_REQUIRED before validate or the runner', async () => {
+  const res = makeRes();
+  const limiter = spyLimiter();
+  const validator = makeValidator({ ok: true, subject: 'S', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' });
+  let ran = false;
+  const handler = createRewriteHandler({
+    rateLimiter: limiter,
+    licenseValidator: validator,
+    runRewrite() { ran = true; },
+  });
+  await handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.41' }, body: proBody() }, res);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.json(), { error: QUOTA_REASONS.LICENSE_REQUIRED });
+  assert.equal(validator.state.calls, 0);
+  assert.equal(ran, false);
+  assert.equal(limiter.calls.check.length, 0);
+});
+
+test('pro path: an invalid license returns the validator 403/reason and skips the runner', async () => {
+  const res = makeRes();
+  const limiter = spyLimiter();
+  const validator = makeValidator({ ok: false, status: 403, reason: QUOTA_REASONS.LICENSE_INVALID });
+  const RAW = 'LICENSE-RAW-invalid';
+  let ran = false;
+  const handler = createRewriteHandler({
+    rateLimiter: limiter,
+    licenseValidator: validator,
+    runRewrite() { ran = true; },
+  });
+  await handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.42', authorization: `Bearer ${RAW}` }, body: proBody() }, res);
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.json(), { error: QUOTA_REASONS.LICENSE_INVALID });
+  assert.equal(ran, false);
+  assert.equal(limiter.calls.check.length, 0);
+  // The denial body never echoes the raw license.
+  assert.equal(res.ended.includes(RAW), false);
+});
+
+test('pro path: an unavailable validator result returns 503 and skips the runner', async () => {
+  const res = makeRes();
+  const validator = makeValidator({ ok: false, status: 503, reason: QUOTA_REASONS.LICENSE_UNAVAILABLE });
+  let ran = false;
+  const handler = createRewriteHandler({
+    rateLimiter: spyLimiter(),
+    licenseValidator: validator,
+    runRewrite() { ran = true; },
+  });
+  await handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.43', authorization: 'Bearer LICENSE-RAW-unavail' }, body: proBody() }, res);
+  assert.equal(res.statusCode, 503);
+  assert.deepEqual(res.json(), { error: QUOTA_REASONS.LICENSE_UNAVAILABLE });
+  assert.equal(ran, false);
+});
+
+test('pro path: a missing licenseValidator fails closed with 503 LICENSE_UNAVAILABLE', async () => {
+  const res = makeRes();
+  let ran = false;
+  const handler = createRewriteHandler({
+    rateLimiter: spyLimiter(),
+    runRewrite() { ran = true; },
+  }); // no licenseValidator injected
+  await handler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.44', authorization: 'Bearer LICENSE-RAW-x' }, body: proBody() }, res);
+  assert.equal(res.statusCode, 503);
+  assert.deepEqual(res.json(), { error: QUOTA_REASONS.LICENSE_UNAVAILABLE });
+  assert.equal(ran, false);
+});
+
+test('free and byok stay metered without a license subject (no regression)', async () => {
+  // FREE: a validator is present but must never be consulted for a non-pro tier.
+  const freeLimiter = spyLimiter();
+  const freeValidator = makeValidator({ ok: false, status: 503, reason: 'must-not-be-called' });
+  const freeRes = makeRes();
+  let freeRan = false;
+  const freeHandler = createRewriteHandler({
+    rateLimiter: freeLimiter,
+    licenseValidator: freeValidator,
+    runRewrite() { freeRan = true; return 'free-ran'; },
+  });
+  const freeResult = await freeHandler({ method: 'POST', headers: { 'x-real-ip': '203.0.113.45' }, body: validBody() }, freeRes);
+  assert.equal(freeResult, 'free-ran');
+  assert.equal(freeRan, true);
+  assert.equal(freeValidator.state.calls, 0);
+  assert.equal(freeLimiter.calls.check[0].tier, WEB_TIERS.FREE);
+  assert.equal(freeLimiter.calls.check[0].ip, '203.0.113.45');
+  assert.equal(freeLimiter.calls.check[0].subject, undefined);
+  assert.equal(freeLimiter.calls.acquire[0].subject, undefined);
+  assert.equal(freeLimiter.calls.release[0].subject, undefined);
+
+  // BYOK: no validator needed; still no subject on any limiter call.
+  const byokLimiter = spyLimiter();
+  const byokRes = makeRes();
+  const byokHandler = createRewriteHandler({
+    rateLimiter: byokLimiter,
+    runRewrite() { return 'byok-ran'; },
+  });
+  const byokResult = await byokHandler(
+    { method: 'POST', headers: { 'x-real-ip': '203.0.113.46' }, body: validBody({ tier: WEB_TIERS.BYOK, provider: 'openai', model: 'gpt-5.5', apiKey: 'sk-caller-byok' }) },
+    byokRes,
+  );
+  assert.equal(byokResult, 'byok-ran');
+  assert.equal(byokLimiter.calls.check[0].tier, WEB_TIERS.BYOK);
+  assert.equal(byokLimiter.calls.check[0].subject, undefined);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// G004 red-team: adversarial pro-path license-isolation + fail-closed matrix.
+// Product code is unchanged; every dependency (rateLimiter, licenseValidator,
+// runRewrite, req/res) is an injected mock/spy. These target gaps beyond the
+// existing pro happy-path/denial tests above.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A pro-capable spy limiter that can deny at check or acquire, records every
+ * input, and logs call order (with the runner able to push 'run').
+ */
+function proSpyLimiter({ denyCheck, denyAcquire } = {}) {
+  const calls = { check: [], acquire: [], release: [] };
+  const order = [];
+  return {
+    calls,
+    order,
+    async check(input) {
+      calls.check.push(input);
+      order.push('check');
+      return denyCheck ? { allowed: false, status: denyCheck.status, reason: denyCheck.reason } : { allowed: true, tier: input.tier };
+    },
+    async acquireConcurrency(input) {
+      calls.acquire.push(input);
+      order.push('acquire');
+      return denyAcquire ? { allowed: false, status: denyAcquire.status, reason: denyAcquire.reason } : { allowed: true, tier: input.tier };
+    },
+    async releaseConcurrency(input) {
+      calls.release.push(input);
+      order.push('release');
+    },
+  };
+}
+
+/** A distinctive raw license used to assert it never escapes the handler frame. */
+const PRO_RAW = 'LICENSE-RAW-e2e-DEADBEEF-4b2f-secret-token';
+
+test('redteam(1): a valid pro request leaks the raw license nowhere (runner request, limiter args, response body, logs) — only the HMAC subject meters', async () => {
+  const res = makeRes();
+  const limiter = proSpyLimiter();
+  const validator = makeValidator({ ok: true, subject: 'SUBJECT-HMAC', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' });
+  const logs = [];
+  let runnerArgs;
+  const handler = createRewriteHandler({
+    rateLimiter: limiter,
+    licenseValidator: validator,
+    // A realistic runner: echo the *validated request* it receives into the body.
+    runRewrite(args) {
+      runnerArgs = args;
+      args.res.statusCode = 200;
+      args.res.end(JSON.stringify({ echoed: args.request }));
+      return 'ran';
+    },
+    logger: { error(v) { logs.push(v); } },
+  });
+
+  const result = await handler({
+    method: 'POST',
+    headers: { 'x-real-ip': '203.0.113.60', authorization: `Bearer ${PRO_RAW}` },
+    body: proBody(),
+  }, res);
+
+  assert.equal(result, 'ran');
+  // Only the validator ever sees the raw license, and exactly once.
+  assert.equal(validator.state.calls, 1);
+  assert.deepEqual(validator.state.lastInput, { licenseKey: PRO_RAW });
+
+  // (b) Every limiter arg is metered by the HMAC subject and carries NO license material.
+  const limiterInputs = [...limiter.calls.check, ...limiter.calls.acquire, ...limiter.calls.release];
+  assert.equal(limiterInputs.length, 3);
+  for (const input of limiterInputs) {
+    assert.equal(input.subject, 'SUBJECT-HMAC');
+    assert.equal(input.tier, WEB_TIERS.PRO);
+    assert.equal(input.ip, '203.0.113.60');
+    assert.deepEqual(Object.keys(input).sort(), ['ip', 'subject', 'tier']);
+    assert.equal('license' in input, false);
+    assert.equal('licenseKey' in input, false);
+  }
+  assert.equal(JSON.stringify(limiter.calls).includes(PRO_RAW), false);
+
+  // (a) The runner's validated request has no raw license and no resolved key.
+  assert.equal(runnerArgs.request.apiKey, undefined);
+  assert.equal('license' in runnerArgs.request, false);
+  assert.equal('licenseKey' in runnerArgs.request, false);
+  assert.equal(JSON.stringify(runnerArgs.request).includes(PRO_RAW), false);
+
+  // (c) The response body the client sees never contains the raw license.
+  assert.equal(res.ended.includes(PRO_RAW), false);
+  assert.equal(res.json().echoed.apiKey, undefined);
+
+  // (d) Nothing (least of all the license) is logged on the success path.
+  assert.equal(logs.length, 0);
+  assert.equal(JSON.stringify(logs).includes(PRO_RAW), false);
+});
+
+test('redteam(2): every malformed pro Authorization (absent/blank/non-Bearer/no-token/multi-key/multi-value) is 401 LICENSE_REQUIRED before validate or the runner', async () => {
+  const cases = [
+    { name: 'absent', headers: { 'x-real-ip': '203.0.113.61' } },
+    { name: 'blank', headers: { 'x-real-ip': '203.0.113.61', authorization: '' } },
+    { name: 'non-Bearer scheme', headers: { 'x-real-ip': '203.0.113.61', authorization: 'Basic QWxhZGRpbjpvcGVu' } },
+    { name: 'scheme with no token', headers: { 'x-real-ip': '203.0.113.61', authorization: 'Bearer' } },
+    { name: 'multiple header keys', headers: { 'x-real-ip': '203.0.113.61', authorization: 'Bearer aaaaaaaa', Authorization: 'Bearer bbbbbbbb' } },
+    { name: 'multiple header values', headers: { 'x-real-ip': '203.0.113.61', authorization: ['Bearer aaaaaaaa', 'Bearer bbbbbbbb'] } },
+  ];
+  for (const c of cases) {
+    const res = makeRes();
+    const limiter = proSpyLimiter();
+    const validator = makeValidator({ ok: true, subject: 'S', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' });
+    let ran = false;
+    const handler = createRewriteHandler({
+      rateLimiter: limiter,
+      licenseValidator: validator,
+      runRewrite() { ran = true; },
+    });
+    await handler({ method: 'POST', headers: c.headers, body: proBody() }, res);
+    assert.equal(res.statusCode, 401, `${c.name}: status`);
+    assert.deepEqual(res.json(), { error: QUOTA_REASONS.LICENSE_REQUIRED }, `${c.name}: reason`);
+    assert.equal(validator.state.calls, 0, `${c.name}: validator must not run`);
+    assert.equal(limiter.calls.check.length, 0, `${c.name}: limiter.check must not run`);
+    assert.equal(ran, false, `${c.name}: runner must not run`);
+    assert.equal(res.headers['cache-control'], 'no-store', `${c.name}: no-store`);
+  }
+});
+
+test('redteam(2): a validator denial (401/403/503) is passed through verbatim and skips both the limiter and the runner', async () => {
+  const denials = [
+    { status: 401, reason: 'license authentication failed' },
+    { status: 403, reason: QUOTA_REASONS.LICENSE_INVALID },
+    { status: 503, reason: QUOTA_REASONS.LICENSE_UNAVAILABLE },
+  ];
+  for (const d of denials) {
+    const res = makeRes();
+    const limiter = proSpyLimiter();
+    const validator = makeValidator({ ok: false, status: d.status, reason: d.reason });
+    let ran = false;
+    const handler = createRewriteHandler({
+      rateLimiter: limiter,
+      licenseValidator: validator,
+      runRewrite() { ran = true; },
+    });
+    await handler({
+      method: 'POST',
+      headers: { 'x-real-ip': '203.0.113.62', authorization: `Bearer ${PRO_RAW}` },
+      body: proBody(),
+    }, res);
+    assert.equal(res.statusCode, d.status, `status ${d.status}`);
+    assert.deepEqual(res.json(), { error: d.reason }, `reason ${d.status}`);
+    assert.equal(validator.state.calls, 1, `validator consulted ${d.status}`);
+    assert.equal(limiter.calls.check.length, 0, `no metering ${d.status}`);
+    assert.equal(ran, false, `no runner ${d.status}`);
+    assert.equal(res.ended.includes(PRO_RAW), false, `no license in body ${d.status}`);
+    assert.equal(res.headers['cache-control'], 'no-store', `no-store ${d.status}`);
+  }
+});
+
+test('redteam(2): an unwired validator (absent, empty, or non-function validate) fails closed with 503 LICENSE_UNAVAILABLE even with a valid Bearer', async () => {
+  for (const injected of [undefined, {}, { validate: 'not-a-function' }]) {
+    const res = makeRes();
+    const limiter = proSpyLimiter();
+    let ran = false;
+    const handler = createRewriteHandler({
+      rateLimiter: limiter,
+      licenseValidator: injected,
+      runRewrite() { ran = true; },
+    });
+    await handler({
+      method: 'POST',
+      headers: { 'x-real-ip': '203.0.113.63', authorization: `Bearer ${PRO_RAW}` },
+      body: proBody(),
+    }, res);
+    assert.equal(res.statusCode, 503);
+    assert.deepEqual(res.json(), { error: QUOTA_REASONS.LICENSE_UNAVAILABLE });
+    assert.equal(ran, false);
+    assert.equal(limiter.calls.check.length, 0);
+    assert.equal(res.ended.includes(PRO_RAW), false);
+    assert.equal(res.headers['cache-control'], 'no-store');
+  }
+});
+
+test('redteam(2): a throwing validator is caught as a redacted generic 500 — no license in the body, redacted in the log, runner and limiter never reached', async () => {
+  const res = makeRes();
+  const limiter = proSpyLimiter();
+  const logs = [];
+  let ran = false;
+  // A careless validator that echoes the bearer credential into its error text.
+  const validator = {
+    calls: 0,
+    validate(input) {
+      this.calls += 1;
+      throw new Error(`LS upstream 500 for Bearer ${input.licenseKey}`);
+    },
+  };
+  const handler = createRewriteHandler({
+    rateLimiter: limiter,
+    licenseValidator: validator,
+    runRewrite() { ran = true; },
+    logger: { error(v) { logs.push(v); } },
+  });
+  await handler({
+    method: 'POST',
+    headers: { 'x-real-ip': '203.0.113.64', authorization: `Bearer ${PRO_RAW}` },
+    body: proBody(),
+  }, res);
+  assert.equal(validator.calls, 1);
+  assert.equal(res.statusCode, 500);
+  assert.deepEqual(res.json(), { error: 'internal error' }); // generic, no internals
+  assert.equal(res.ended.includes(PRO_RAW), false); // license never in the response body
+  assert.equal(ran, false); // runner never reached
+  assert.equal(limiter.calls.check.length, 0); // metering never reached
+  // Defense-in-depth: the logged message is passed through redactSecrets.
+  assert.equal(JSON.stringify(logs).includes(PRO_RAW), false);
+  assert.match(JSON.stringify(logs), /\[REDACTED\]/);
+  assert.equal(res.headers['cache-control'], 'no-store');
+});
+
+test('redteam(3): a pro check denial skips acquire, the runner, and release (subject threaded into check)', async () => {
+  const res = makeRes();
+  const limiter = proSpyLimiter({ denyCheck: { status: 429, reason: QUOTA_REASONS.DAILY } });
+  const validator = makeValidator({ ok: true, subject: 'SUBJ', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' });
+  let ran = false;
+  const handler = createRewriteHandler({
+    rateLimiter: limiter,
+    licenseValidator: validator,
+    runRewrite() { ran = true; },
+  });
+  await handler({
+    method: 'POST',
+    headers: { 'x-real-ip': '203.0.113.65', authorization: `Bearer ${PRO_RAW}` },
+    body: proBody(),
+  }, res);
+  assert.equal(res.statusCode, 429);
+  assert.deepEqual(res.json(), { error: QUOTA_REASONS.DAILY });
+  assert.equal(ran, false);
+  assert.equal(limiter.calls.check.length, 1);
+  assert.equal(limiter.calls.check[0].subject, 'SUBJ');
+  assert.equal(limiter.calls.acquire.length, 0);
+  assert.equal(limiter.calls.release.length, 0);
+});
+
+test('redteam(3): a pro acquire denial skips the runner and does NOT release (release only pairs a granted slot)', async () => {
+  const res = makeRes();
+  const limiter = proSpyLimiter({ denyAcquire: { status: 429, reason: QUOTA_REASONS.CONCURRENT } });
+  const validator = makeValidator({ ok: true, subject: 'SUBJ', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' });
+  let ran = false;
+  const handler = createRewriteHandler({
+    rateLimiter: limiter,
+    licenseValidator: validator,
+    runRewrite() { ran = true; },
+  });
+  await handler({
+    method: 'POST',
+    headers: { 'x-real-ip': '203.0.113.66', authorization: `Bearer ${PRO_RAW}` },
+    body: proBody(),
+  }, res);
+  assert.equal(res.statusCode, 429);
+  assert.deepEqual(res.json(), { error: QUOTA_REASONS.CONCURRENT });
+  assert.equal(ran, false);
+  assert.equal(limiter.calls.check.length, 1);
+  assert.equal(limiter.calls.acquire.length, 1);
+  assert.equal(limiter.calls.acquire[0].subject, 'SUBJ');
+  assert.equal(limiter.calls.release.length, 0); // key contract: no release without a granted slot
+});
+
+test('redteam(3): the pro success path threads the subject through check→acquire→run→release in order', async () => {
+  const res = makeRes();
+  const limiter = proSpyLimiter();
+  const validator = makeValidator({ ok: true, subject: 'SUBJ', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' });
+  const handler = createRewriteHandler({
+    rateLimiter: limiter,
+    licenseValidator: validator,
+    runRewrite() { limiter.order.push('run'); return 'ran'; },
+  });
+  const result = await handler({
+    method: 'POST',
+    headers: { 'x-real-ip': '203.0.113.67', authorization: `Bearer ${PRO_RAW}` },
+    body: proBody(),
+  }, res);
+  assert.equal(result, 'ran');
+  assert.deepEqual(limiter.order, ['check', 'acquire', 'run', 'release']);
+  assert.equal(limiter.calls.release.length, 1);
+  assert.equal(limiter.calls.release[0].subject, 'SUBJ');
+});
+
+test('redteam(3): when the pro runner throws, release still runs in finally (subject-scoped) and the handler returns a redacted 500', async () => {
+  const res = makeRes();
+  const limiter = proSpyLimiter();
+  const validator = makeValidator({ ok: true, subject: 'SUBJ', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' });
+  const logs = [];
+  const handler = createRewriteHandler({
+    rateLimiter: limiter,
+    licenseValidator: validator,
+    runRewrite() { limiter.order.push('run'); throw new Error('runner exploded'); },
+    logger: { error(v) { logs.push(v); } },
+  });
+  await handler({
+    method: 'POST',
+    headers: { 'x-real-ip': '203.0.113.68', authorization: `Bearer ${PRO_RAW}` },
+    body: proBody(),
+  }, res);
+  assert.equal(res.statusCode, 500);
+  assert.deepEqual(res.json(), { error: 'internal error' });
+  assert.equal(limiter.calls.release.length, 1);
+  assert.equal(limiter.calls.release[0].subject, 'SUBJ');
+  assert.deepEqual(limiter.order, ['check', 'acquire', 'run', 'release']);
+});
+
+test('redteam(4): free and byok ignore an attacker-supplied Authorization header — no validator, no subject, no license in the runner request', async () => {
+  // FREE: a validator is injected but must never be consulted; the stray Bearer is ignored.
+  const freeLimiter = proSpyLimiter();
+  const freeValidator = makeValidator({ ok: false, status: 503, reason: 'must-not-run' });
+  const freeRes = makeRes();
+  let freeArgs;
+  const freeHandler = createRewriteHandler({
+    rateLimiter: freeLimiter,
+    licenseValidator: freeValidator,
+    runRewrite(args) { freeArgs = args; return 'free-ran'; },
+  });
+  const freeResult = await freeHandler({
+    method: 'POST',
+    headers: { 'x-real-ip': '203.0.113.70', authorization: `Bearer ${PRO_RAW}` },
+    body: validBody(),
+  }, freeRes);
+  assert.equal(freeResult, 'free-ran');
+  assert.equal(freeValidator.state.calls, 0);
+  assert.equal(freeLimiter.calls.check[0].tier, WEB_TIERS.FREE);
+  assert.equal(freeLimiter.calls.check[0].ip, '203.0.113.70');
+  assert.equal(freeLimiter.calls.check[0].subject, undefined);
+  assert.equal(freeLimiter.calls.acquire[0].subject, undefined);
+  assert.equal(freeLimiter.calls.release[0].subject, undefined);
+  assert.equal(freeArgs.request.apiKey, undefined);
+  assert.equal('license' in freeArgs.request, false);
+  assert.equal(JSON.stringify(freeArgs.request).includes(PRO_RAW), false);
+
+  // BYOK: the caller key stays in the body; the stray Bearer is ignored; still no validator/subject.
+  const byokLimiter = proSpyLimiter();
+  const byokValidator = makeValidator({ ok: false, status: 503, reason: 'must-not-run' });
+  const byokRes = makeRes();
+  let byokArgs;
+  const byokHandler = createRewriteHandler({
+    rateLimiter: byokLimiter,
+    licenseValidator: byokValidator,
+    runRewrite(args) { byokArgs = args; return 'byok-ran'; },
+  });
+  const byokResult = await byokHandler({
+    method: 'POST',
+    headers: { 'x-real-ip': '203.0.113.71', authorization: `Bearer ${PRO_RAW}` },
+    body: validBody({ tier: WEB_TIERS.BYOK, provider: 'openai', model: 'gpt-5.5', apiKey: 'sk-caller-byok-key' }),
+  }, byokRes);
+  assert.equal(byokResult, 'byok-ran');
+  assert.equal(byokValidator.state.calls, 0);
+  assert.equal(byokLimiter.calls.check[0].tier, WEB_TIERS.BYOK);
+  assert.equal(byokLimiter.calls.check[0].subject, undefined);
+  assert.equal(byokArgs.request.apiKey, 'sk-caller-byok-key');
+  assert.equal('license' in byokArgs.request, false);
+  assert.equal(JSON.stringify(byokArgs.request).includes(PRO_RAW), false);
+});
+
+test('redteam(5): pro fail-closed responses (401/403/503) carry the full no-store security header set', async () => {
+  // 401 — missing Bearer.
+  const res401 = makeRes();
+  const h401 = createRewriteHandler({
+    rateLimiter: proSpyLimiter(),
+    licenseValidator: makeValidator({ ok: true, subject: 'S', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' }),
+    runRewrite() {},
+  });
+  await h401({ method: 'POST', headers: { 'x-real-ip': '203.0.113.72' }, body: proBody() }, res401);
+
+  // 403 — invalid license.
+  const res403 = makeRes();
+  const h403 = createRewriteHandler({
+    rateLimiter: proSpyLimiter(),
+    licenseValidator: makeValidator({ ok: false, status: 403, reason: QUOTA_REASONS.LICENSE_INVALID }),
+    runRewrite() {},
+  });
+  await h403({ method: 'POST', headers: { 'x-real-ip': '203.0.113.72', authorization: `Bearer ${PRO_RAW}` }, body: proBody() }, res403);
+
+  // 503 — validator unavailable.
+  const res503 = makeRes();
+  const h503 = createRewriteHandler({ rateLimiter: proSpyLimiter(), runRewrite() {} });
+  await h503({ method: 'POST', headers: { 'x-real-ip': '203.0.113.72', authorization: `Bearer ${PRO_RAW}` }, body: proBody() }, res503);
+
+  for (const [label, res, status] of [['401', res401, 401], ['403', res403, 403], ['503', res503, 503]]) {
+    assert.equal(res.statusCode, status, `${label}: status`);
+    assert.equal(res.headers['cache-control'], 'no-store', `${label}: cache-control`);
+    assert.equal(res.headers['x-content-type-options'], 'nosniff', `${label}: nosniff`);
+    assert.equal(res.headers['content-type'], 'application/json', `${label}: content-type`);
+  }
+});
+
+test('redteam(6): the runner request has its Authorization header stripped; non-secret headers and on/off delegation survive', async () => {
+  const res = makeRes();
+  const limiter = proSpyLimiter();
+  const validator = makeValidator({ ok: true, subject: 'SUBJ', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' });
+  let runnerArgs;
+  const onEvents = [];
+  const realReq = {
+    method: 'POST',
+    headers: { 'x-real-ip': '203.0.113.80', authorization: `Bearer ${PRO_RAW}`, 'content-type': 'application/json' },
+    body: proBody(),
+    on: (event) => { onEvents.push(event); },
+    off: () => {},
+  };
+  const handler = createRewriteHandler({
+    rateLimiter: limiter,
+    licenseValidator: validator,
+    runRewrite(args) { runnerArgs = args; args.res.statusCode = 200; args.res.end('ok'); return 'ran'; },
+  });
+  await handler(realReq, res);
+
+  // The runner must never observe the raw Bearer license through req.headers.
+  const runnerHeaders = runnerArgs.req.headers || {};
+  for (const k of Object.keys(runnerHeaders)) {
+    assert.notEqual(k.toLowerCase(), 'authorization', `runner req retained header ${k}`);
+  }
+  assert.equal(JSON.stringify(runnerArgs.req).includes(PRO_RAW), false);
+  // Non-secret headers survive, and cancellation (on) delegates to the REAL req.
+  assert.equal(runnerHeaders['x-real-ip'], '203.0.113.80');
+  assert.equal(typeof runnerArgs.req.on, 'function');
+  runnerArgs.req.on('aborted', () => {});
+  assert.deepEqual(onEvents, ['aborted']);
 });

--- a/tests/unit/web-observability.test.js
+++ b/tests/unit/web-observability.test.js
@@ -68,6 +68,14 @@ test('buildRewriteMetric normalizes unknown tier/provider/model/status defensive
   assert.equal(m.quotaDecision, 'n/a');
 });
 
+test('buildRewriteMetric preserves the pro tier (revenue-gate observability)', () => {
+  assert.equal(buildRewriteMetric({ tier: 'pro' }).tier, 'pro');
+  // Still allowlisted alongside free/byok; anything else normalizes to unknown.
+  assert.equal(buildRewriteMetric({ tier: 'enterprise' }).tier, 'unknown');
+  assert.equal(buildRewriteMetric({ tier: 'free' }).tier, 'free');
+  assert.equal(buildRewriteMetric({ tier: 'byok' }).tier, 'byok');
+});
+
 test('sanitizeMetric drops any non-allowlisted field', () => {
   const out = sanitizeMetric(/** @type {any} */ ({ tier: 'free', status: 200, apiKey: 'sk-x', text: 'secret', evil: 1 }));
   assert.deepEqual(Object.keys(out).sort(), ['status', 'tier']);

--- a/tests/unit/web-rewrite-contract.redteam.test.js
+++ b/tests/unit/web-rewrite-contract.redteam.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
   CONTEXT_LIMITS,
   PROVIDER_PRESETS,
+  QUOTA_REASONS,
   REWRITE_MODES,
   STREAM_FRAME_TYPES,
   TIER_LIMITS,
@@ -14,6 +15,7 @@ import {
   parseStreamFrame,
   redactSecrets,
   resolveProviderModel,
+  resolveTierLimits,
   validateRewriteRequest,
 } from '../../src/web-rewrite-contract.js';
 
@@ -226,4 +228,271 @@ test('redteam: type confusion inputs reject cleanly with 400/413 and never throw
   }, 400);
 
   assertRejectsCleanly({ mode: REWRITE_MODES.FIRST, lang: 'en', tier: WEB_TIERS.FREE, text: 'x'.repeat(TIER_LIMITS.free.maxChars + 1) }, 413);
+});
+
+test('redteam: pro tier rejects licenseKey/license_key/apiKey smuggled in the body and never leaks the license', () => {
+  const proBase = { mode: REWRITE_MODES.FIRST, lang: 'en', tier: WEB_TIERS.PRO, text: 'Rewrite this for a pro user.' };
+  const validHeader = { proLicenseSource: 'authorization-bearer' };
+  const licenseValue = 'LK-TOPSECRET-1234567890';
+
+  // A body-carried license is rejected with 400 even when a valid Authorization
+  // header is also present, and the raw license never appears in the result.
+  for (const field of ['licenseKey', 'license_key']) {
+    const r = validateRewriteRequest({ ...proBase, [field]: licenseValue }, {}, validHeader);
+    assert.equal(r.ok, false, `${field} smuggling should be rejected`);
+    assert.equal(r.status, 400);
+    assert.match(r.error, /Authorization: Bearer/);
+    assert.equal(JSON.stringify(r).includes(licenseValue), false, `${field} value leaked into the result`);
+  }
+
+  // A pro request must not carry a provider apiKey either (rejected, not silently dropped).
+  const withApiKey = validateRewriteRequest({ ...proBase, apiKey: 'sk-should-not-be-here' }, {}, validHeader);
+  assert.equal(withApiKey.ok, false);
+  assert.equal(withApiKey.status, 400);
+  assert.equal(JSON.stringify(withApiKey).includes('sk-should-not-be-here'), false);
+
+  // Even a fully valid pro request never echoes a license/apiKey field in its normalized value.
+  const ok = validateRewriteRequest(proBase, {}, validHeader);
+  assert.equal(ok.ok, true);
+  assert.equal('licenseKey' in ok.value, false);
+  assert.equal('license_key' in ok.value, false);
+  assert.equal(ok.value.apiKey, undefined);
+});
+
+test('redteam: pro tier fails closed with 401 LICENSE_REQUIRED for missing/typo/case/whitespace/object proLicenseSource', () => {
+  const proBase = { mode: REWRITE_MODES.FIRST, lang: 'en', tier: WEB_TIERS.PRO, text: 'Pro request.' };
+  const badSources = [
+    '',
+    'authorization_bearer',
+    'authorizationbearer',
+    'Authorization-Bearer',
+    'AUTHORIZATION-BEARER',
+    ' authorization-bearer ',
+    'authorization-bearer\n',
+    'bearer',
+    'authorization-bearer ',
+    123,
+    true,
+    ['authorization-bearer'],
+    { toString: () => 'authorization-bearer' },
+    { proLicenseSource: 'authorization-bearer' },
+  ];
+  for (const src of badSources) {
+    const r = validateRewriteRequest(proBase, {}, { proLicenseSource: src });
+    assert.equal(r.ok, false, `unexpected pass for proLicenseSource=${JSON.stringify(src)}`);
+    assert.equal(r.status, 401, `expected 401 for proLicenseSource=${JSON.stringify(src)}`);
+    assert.equal(r.error, QUOTA_REASONS.LICENSE_REQUIRED);
+  }
+
+  // Missing options entirely (2-arg and empty-object calls) also fails closed.
+  for (const r of [validateRewriteRequest(proBase), validateRewriteRequest(proBase, {}), validateRewriteRequest(proBase, {}, {})]) {
+    assert.equal(r.ok, false);
+    assert.equal(r.status, 401);
+    assert.equal(r.error, QUOTA_REASONS.LICENSE_REQUIRED);
+  }
+
+  // Only the exact string unlocks pro.
+  assert.equal(validateRewriteRequest(proBase, {}, { proLicenseSource: 'authorization-bearer' }).ok, true);
+});
+
+test('redteam: pro-like and mis-cased tier strings are rejected with 400 (no fuzzy tier matching)', () => {
+  const badTiers = ['pro ', ' pro', 'PRO', 'Pro', 'pro\t', 'pro\n', 'proo', 'pr0', 'pro-tier', 'proish', 'FREE', 'Byok', 'BYOK', 123, 0, true, {}, ['pro'], null];
+  for (const tier of badTiers) {
+    const r = validateRewriteRequest({ mode: REWRITE_MODES.FIRST, lang: 'en', tier, text: 'hi' }, {}, { proLicenseSource: 'authorization-bearer' });
+    assert.equal(r.ok, false, `unexpected pass for tier=${JSON.stringify(tier)}`);
+    assert.equal(r.status, 400, `expected 400 for tier=${JSON.stringify(tier)}`);
+    assert.match(r.error, /tier must be/);
+  }
+});
+
+test('redteam: malformed pro env caps fall back to defaults, free/byok stay frozen, and the body cannot raise the 413 threshold', () => {
+  const proDefault = TIER_LIMITS.pro.maxChars;
+
+  // Malformed overrides must fall back to the frozen default: never widen, never
+  // become unbounded (Infinity/NaN must not slip through as a cap).
+  const malformed = ['-5000', '0', '', '   ', 'abc', 'NaN', 'Infinity', '-Infinity', '1e999', '4000.5', '4000abc', 'null', '0x'];
+  for (const v of malformed) {
+    const limits = resolveTierLimits({ PATINA_PRO_MAX_CHARS: v });
+    assert.equal(limits.pro.maxChars, proDefault, `override ${JSON.stringify(v)} unexpectedly changed pro.maxChars`);
+    assert.ok(Number.isFinite(limits.pro.maxChars) && Number.isInteger(limits.pro.maxChars) && limits.pro.maxChars > 0);
+  }
+  // Non-string junk (object) also falls back.
+  assert.equal(resolveTierLimits({ PATINA_PRO_MAX_CHARS: {} }).pro.maxChars, proDefault);
+  assert.equal(resolveTierLimits({ PATINA_PRO_REQ_PER_DAY: 'abc', PATINA_PRO_MAX_CONCURRENT: '-2' }).pro.reqPerDay, TIER_LIMITS.pro.reqPerDay);
+  assert.equal(resolveTierLimits({ PATINA_PRO_MAX_CONCURRENT: '-2' }).pro.maxConcurrent, TIER_LIMITS.pro.maxConcurrent);
+
+  // A pro env override NEVER touches free/byok caps (override blast radius is pro-only).
+  const huge = resolveTierLimits({ PATINA_PRO_MAX_CHARS: '999999999', PATINA_PRO_REQ_PER_DAY: '999999999', PATINA_PRO_MAX_CONCURRENT: '999999999' });
+  assert.equal(huge.free.maxChars, TIER_LIMITS.free.maxChars);
+  assert.equal(huge.byok.maxChars, TIER_LIMITS.byok.maxChars);
+
+  // Boundary: genuinely large *valid* positive integers are honored by design. These
+  // come only from operator-controlled env (never the attacker-controlled body), so
+  // they are not a 413 bypass. This pins the malformed=>fallback vs valid=>honored line.
+  assert.equal(resolveTierLimits({ PATINA_PRO_MAX_CHARS: '1000000000' }).pro.maxChars, 1000000000);
+  assert.equal(resolveTierLimits({ PATINA_PRO_MAX_CHARS: '1e9' }).pro.maxChars, 1e9);
+
+  // The request body cannot raise its own 413 threshold: junk body fields shaped like
+  // config are ignored, so text one char over the resolved cap is always 413.
+  const overByOne = validateRewriteRequest(
+    {
+      mode: REWRITE_MODES.FIRST,
+      lang: 'en',
+      tier: WEB_TIERS.PRO,
+      text: 'x'.repeat(proDefault + 1),
+      maxChars: 10 ** 9,
+      limits: { pro: { maxChars: 10 ** 9 } },
+      PATINA_PRO_MAX_CHARS: '999999999',
+    },
+    {},
+    { proLicenseSource: 'authorization-bearer' },
+  );
+  assert.equal(overByOne.ok, false);
+  assert.equal(overByOne.status, 413);
+
+  // At exactly the resolved cap it passes, confirming the cap is the default (not widened).
+  const atCap = validateRewriteRequest(
+    { mode: REWRITE_MODES.FIRST, lang: 'en', tier: WEB_TIERS.PRO, text: 'x'.repeat(proDefault) },
+    {},
+    { proLicenseSource: 'authorization-bearer' },
+  );
+  assert.equal(atCap.ok, true);
+});
+
+test('redteam: resolveProviderModel pro ignores body provider/model and rejects prototype/unlisted env picks without throwing', () => {
+  // Body-supplied provider/model are IGNORED for pro — server env/defaults win.
+  for (const inj of [
+    { provider: 'claude', model: 'claude-opus-4-1' },
+    { provider: '__proto__', model: 'constructor' },
+    { provider: 'evil-host', model: 'attacker-model' },
+    { provider: 123, model: {} },
+    { provider: ['openai'], model: null },
+  ]) {
+    let r;
+    assert.doesNotThrow(() => { r = resolveProviderModel({ tier: WEB_TIERS.PRO, ...inj }, {}); });
+    assert.equal(r.ok, true, `pro body injection ${JSON.stringify(inj)} should resolve from env defaults`);
+    assert.equal(r.provider, 'openai');
+    assert.equal(r.model, PROVIDER_PRESETS.openai.models[0]);
+    assert.equal(r.baseURL, PROVIDER_PRESETS.openai.baseURL);
+  }
+
+  // Prototype-polluting / unlisted env provider names resolve to a clean rejection, never a throw.
+  for (const provider of ['__proto__', 'constructor', 'prototype', 'toString', 'hasOwnProperty', 'evil-host']) {
+    let r;
+    assert.doesNotThrow(() => { r = resolveProviderModel({ tier: WEB_TIERS.PRO }, { PATINA_PRO_PROVIDER: provider }); });
+    assert.equal(r.ok, false, `env provider ${provider} must be rejected`);
+    assert.equal('error' in r, true);
+    assert.equal(typeof r.error, 'string');
+  }
+
+  // Unlisted / prototype env model resolves to a clean rejection (valid provider, bad model).
+  for (const model of ['attacker-model', '__proto__', 'constructor', 'toString']) {
+    let r;
+    assert.doesNotThrow(() => { r = resolveProviderModel({ tier: WEB_TIERS.PRO }, { PATINA_PRO_MODEL: model }); });
+    assert.equal(r.ok, false, `env model ${model} must be rejected`);
+  }
+
+  // End-to-end: a pro request with body provider/model injection resolves to the env default.
+  const req = validateRewriteRequest(
+    { mode: REWRITE_MODES.FIRST, lang: 'en', tier: WEB_TIERS.PRO, text: 'hi', provider: 'claude', model: 'claude-opus-4-1' },
+    {},
+    { proLicenseSource: 'authorization-bearer' },
+  );
+  assert.equal(req.ok, true);
+  assert.equal(req.value.provider, 'openai');
+  assert.equal(req.value.baseURL, PROVIDER_PRESETS.openai.baseURL);
+  assert.notEqual(req.value.model, 'claude-opus-4-1');
+});
+
+test('redteam: redactSecrets masks license keys (nested/array/casing/inline/tab/Bearer), preserves sk-/Bearer masking, and never mutates input', () => {
+  const marker = 'ZZTOPSECRETVALUE';
+  const input = {
+    licenseKey: `LK-${marker}-1`,
+    license_key: `LK-${marker}-2`,
+    LICENSE_KEY: `LK-${marker}-3`,
+    'License-Key': `LK-${marker}-4`,
+    nested: { inner: { licenseKey: `LK-${marker}-6` } },
+    arr: [{ license_key: `LK-${marker}-7` }, 'harmless-visible', { note: 'ok' }],
+    inlineEq: `boom license_key=LIVE-${marker}-8 tail`,
+    tabbed: `f1\tlicense_key=LIVE-${marker}-10\tf2`,
+    authHeader: `Authorization: Bearer LIVE-${marker}-11`,
+    upstreamLog: `upstream returned Bearer LIVE-${marker}-12 rejected`,
+    skLine: `leak sk-${marker}abcdef12 here`,
+    harmless: 'this stays visible',
+  };
+  const before = JSON.stringify(input);
+  const out = redactSecrets(input);
+  const flat = JSON.stringify(out);
+
+  // No fragment of any license/secret value survives anywhere in the output.
+  assert.equal(flat.includes(marker), false, 'a secret value fragment survived redaction');
+  assert.equal(flat.includes('[REDACTED]'), true);
+
+  // Secret-named keys (all casings) are fully masked, including nested and inside arrays.
+  assert.equal(out.licenseKey, '[REDACTED]');
+  assert.equal(out.license_key, '[REDACTED]');
+  assert.equal(out.LICENSE_KEY, '[REDACTED]');
+  assert.equal(out['License-Key'], '[REDACTED]');
+  assert.equal(out.nested.inner.licenseKey, '[REDACTED]');
+  assert.equal(out.arr[0].license_key, '[REDACTED]');
+
+  // Inline license shapes on non-secret keys are masked while non-secret text is preserved.
+  assert.match(out.inlineEq, /^boom \[REDACTED\] tail$/);
+  assert.match(out.tabbed, /^f1\t\[REDACTED\]\tf2$/);
+  assert.equal(out.authHeader.includes(marker), false);
+  assert.equal(out.upstreamLog.includes(marker), false);
+  assert.match(out.upstreamLog, /^upstream returned \[REDACTED\] rejected$/);
+
+  // Regression guard: existing sk-/Bearer masking still fires unchanged.
+  assert.match(out.skLine, /^leak \[REDACTED\] here$/);
+
+  // Non-secret content stays visible (over-redaction is bounded to secret shapes/keys).
+  assert.equal(out.harmless, 'this stays visible');
+  assert.equal(out.arr[1], 'harmless-visible');
+  assert.equal(out.arr[2].note, 'ok');
+
+  // Input object is never mutated.
+  assert.equal(JSON.stringify(input), before, 'redactSecrets must not mutate caller input');
+});
+
+test('redteam: free and byok requests are unaffected by the pro contract (no regression)', () => {
+  // free: valid request resolves from env, no apiKey echoed, no license needed.
+  const free = validateRewriteRequest({ mode: REWRITE_MODES.FIRST, lang: 'en', tier: WEB_TIERS.FREE, text: 'Free rewrite.' });
+  assert.equal(free.ok, true);
+  assert.equal(free.value.tier, WEB_TIERS.FREE);
+  assert.equal(free.value.apiKey, undefined);
+  assert.equal(free.value.provider, 'openai');
+
+  // free: apiKey smuggling still 400 (unchanged behavior).
+  const freeKey = validateRewriteRequest({ mode: REWRITE_MODES.FIRST, lang: 'en', tier: WEB_TIERS.FREE, text: 'x', apiKey: 'sk-x' });
+  assert.equal(freeKey.ok, false);
+  assert.equal(freeKey.status, 400);
+
+  // free: the pro-only license gate does not bleed into free (no header required).
+  assert.equal(validateRewriteRequest({ mode: REWRITE_MODES.FIRST, lang: 'en', tier: WEB_TIERS.FREE, text: 'x' }, {}, {}).ok, true);
+
+  // byok: valid request preserves the caller apiKey and allowlisted provider/model.
+  const byok = validateRewriteRequest(validByok);
+  assert.equal(byok.ok, true);
+  assert.equal(byok.value.tier, WEB_TIERS.BYOK);
+  assert.equal(byok.value.apiKey, validByok.apiKey);
+  assert.equal(byok.value.provider, 'openai');
+  assert.equal(byok.value.model, 'gpt-4.1-mini');
+  assert.equal(byok.value.baseURL, PROVIDER_PRESETS.openai.baseURL);
+
+  // byok: missing apiKey still 400 (unchanged).
+  const { apiKey: _drop, ...noKey } = validByok;
+  const byokNoKey = validateRewriteRequest(noKey);
+  assert.equal(byokNoKey.ok, false);
+  assert.equal(byokNoKey.status, 400);
+
+  // byok: unlisted provider still 400 (unchanged).
+  const byokBadProvider = validateRewriteRequest({ ...validByok, provider: 'evil-host' });
+  assert.equal(byokBadProvider.ok, false);
+  assert.equal(byokBadProvider.status, 400);
+
+  // byok does NOT require a pro license source — passing one changes nothing.
+  const byokWithProSource = validateRewriteRequest(validByok, {}, { proLicenseSource: 'authorization-bearer' });
+  assert.equal(byokWithProSource.ok, true);
+  assert.deepEqual(byokWithProSource.value, byok.value);
 });

--- a/tests/unit/web-rewrite-contract.test.js
+++ b/tests/unit/web-rewrite-contract.test.js
@@ -8,7 +8,9 @@ import {
   MPS_FLOOR,
   FIDELITY_FLOOR,
   TIER_LIMITS,
+  resolveTierLimits,
   CONTEXT_LIMITS,
+  QUOTA_REASONS,
   STREAM_FRAME_TYPES,
   PROVIDER_PRESETS,
   WEB_PERSONAS,
@@ -333,7 +335,7 @@ test('evaluateFloors fails closed on missing or non-numeric scores', () => {
 
 test('REWRITE_MODES and WEB_TIERS expose the documented values', () => {
   assert.deepEqual(REWRITE_MODES, { FIRST: 'first', REFINE: 'refine' });
-  assert.deepEqual(WEB_TIERS, { FREE: 'free', BYOK: 'byok' });
+  assert.deepEqual(WEB_TIERS, { FREE: 'free', BYOK: 'byok', PRO: 'pro' });
 });
 
 test('redactSecrets masks labelled provider secrets in free-form strings (#565)', () => {
@@ -351,4 +353,269 @@ test('redactSecrets masks labelled provider secrets in free-form strings (#565)'
   }
   // Benign prose without labelled values survives untouched.
   assert.equal(redactSecrets('no secrets here, just text'), 'no secrets here, just text');
+});
+
+// --- pro tier (licensed hosted tier, LS validate-only gated) -----------------
+// The pro tier extends the contract WITHOUT touching free/byok: the license is
+// an entitlement (verified out-of-band as Authorization: Bearer), never a
+// provider key, and must never surface in the body or the normalized value.
+function proFirst(overrides = {}) {
+  return { mode: 'first', lang: 'ko', tier: 'pro', text: '안녕하세요 프로 테스트 문장입니다.', ...overrides };
+}
+
+test('WEB_TIERS exposes the pro tier value', () => {
+  assert.equal(WEB_TIERS.PRO, 'pro');
+});
+
+test('TIER_LIMITS.pro documents the pro caps without regressing free/byok', () => {
+  assert.deepEqual(TIER_LIMITS.pro, { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 });
+  // Free/byok caps are unchanged by the pro extension.
+  assert.equal(TIER_LIMITS.free.maxChars, 4000);
+  assert.equal(TIER_LIMITS.byok.maxChars, 20000);
+});
+
+test('resolveTierLimits returns the defaults when no env overrides are present', () => {
+  const limits = resolveTierLimits();
+  assert.deepEqual(limits.pro, { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 });
+  assert.equal(limits.free.maxChars, 4000);
+  assert.equal(limits.byok.maxChars, 20000);
+  // An empty env behaves identically to the no-arg call.
+  assert.deepEqual(resolveTierLimits({}).pro, limits.pro);
+});
+
+test('resolveTierLimits applies positive-integer pro env overrides', () => {
+  const limits = resolveTierLimits({
+    PATINA_PRO_MAX_CHARS: '50000',
+    PATINA_PRO_REQ_PER_DAY: '1000',
+    PATINA_PRO_MAX_CONCURRENT: '8',
+  });
+  assert.deepEqual(limits.pro, { maxChars: 50000, reqPerDay: 1000, maxConcurrent: 8 });
+  // Free/byok stay pinned to the defaults regardless of pro env.
+  assert.equal(limits.free.maxChars, 4000);
+  assert.equal(limits.byok.maxChars, 20000);
+});
+
+test('resolveTierLimits falls back to defaults for invalid pro overrides', () => {
+  for (const bad of ['0', '-5', 'abc', '3.5', '', ' ', undefined]) {
+    const limits = resolveTierLimits({
+      PATINA_PRO_MAX_CHARS: bad,
+      PATINA_PRO_REQ_PER_DAY: bad,
+      PATINA_PRO_MAX_CONCURRENT: bad,
+    });
+    assert.deepEqual(
+      limits.pro,
+      { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 },
+      `invalid override ${JSON.stringify(bad)} must fall back to the default`,
+    );
+  }
+});
+
+test('resolveTierLimits returns a frozen object shaped like TIER_LIMITS', () => {
+  const limits = resolveTierLimits({ PATINA_PRO_MAX_CHARS: '9999' });
+  assert.ok(Object.isFrozen(limits));
+  assert.ok(Object.isFrozen(limits.pro));
+  assert.deepEqual(Object.keys(limits).sort(), ['byok', 'free', 'pro']);
+});
+
+test('resolveProviderModel resolves the pro tier from PATINA_PRO_* env', () => {
+  const r = resolveProviderModel(
+    { tier: WEB_TIERS.PRO, provider: 'evil', model: 'evil-model' },
+    { PATINA_PRO_PROVIDER: 'claude', PATINA_PRO_MODEL: 'claude-opus-4-1' },
+  );
+  assert.equal(r.ok, true);
+  assert.equal(r.tier, 'pro');
+  assert.equal(r.provider, 'claude');
+  assert.equal(r.model, 'claude-opus-4-1');
+  assert.equal(r.baseURL, PROVIDER_PRESETS.claude.baseURL);
+  // Body-provided provider/model are ignored for pro (server-pinned like free).
+  assert.notEqual(r.model, 'evil-model');
+});
+
+test('resolveProviderModel falls back to PATINA_FREE_* then defaults for pro', () => {
+  // PRO env absent -> FREE env is the fallback source.
+  const viaFree = resolveProviderModel(
+    { tier: WEB_TIERS.PRO },
+    { PATINA_FREE_PROVIDER: 'deepseek', PATINA_FREE_MODEL: 'deepseek-chat' },
+  );
+  assert.equal(viaFree.ok, true);
+  assert.equal(viaFree.provider, 'deepseek');
+  assert.equal(viaFree.model, 'deepseek-chat');
+
+  // Nothing configured -> default openai + first allowlisted model.
+  const viaDefault = resolveProviderModel({ tier: WEB_TIERS.PRO }, {});
+  assert.equal(viaDefault.ok, true);
+  assert.equal(viaDefault.provider, 'openai');
+  assert.equal(viaDefault.model, PROVIDER_PRESETS.openai.models[0]);
+  assert.equal(viaDefault.baseURL, PROVIDER_PRESETS.openai.baseURL);
+});
+
+test('resolveProviderModel rejects unlisted pro provider/model cleanly', () => {
+  const badProvider = resolveProviderModel({ tier: WEB_TIERS.PRO }, { PATINA_PRO_PROVIDER: 'nope' });
+  assert.equal(badProvider.ok, false);
+  assert.match(badProvider.error, /pro provider not configured/);
+
+  const badModel = resolveProviderModel({ tier: WEB_TIERS.PRO }, { PATINA_PRO_MODEL: 'ghost-model' });
+  assert.equal(badModel.ok, false);
+  assert.match(badModel.error, /pro model not allowlisted/);
+
+  // A poisoned prototype name resolves to a clean rejection, never throws.
+  assert.doesNotThrow(() => resolveProviderModel({ tier: WEB_TIERS.PRO }, { PATINA_PRO_PROVIDER: '__proto__' }));
+  assert.equal(resolveProviderModel({ tier: WEB_TIERS.PRO }, { PATINA_PRO_PROVIDER: '__proto__' }).ok, false);
+});
+
+test('validateRewriteRequest accepts a pro request whose license arrived as Authorization: Bearer', () => {
+  const r = validateRewriteRequest(proFirst(), {}, { proLicenseSource: 'authorization-bearer' });
+  assert.equal(r.ok, true);
+  assert.equal(r.value.tier, 'pro');
+  // The server key is resolved later by the handler; the contract returns no key.
+  assert.equal(r.value.apiKey, undefined);
+  // A raw license must NEVER surface in the normalized value.
+  assert.equal('licenseKey' in r.value, false);
+  assert.equal('license_key' in r.value, false);
+  assert.equal('license' in r.value, false);
+  // Provider/model are pinned like the free path.
+  assert.equal(r.value.provider, 'openai');
+  assert.equal(r.value.baseURL, PROVIDER_PRESETS.openai.baseURL);
+});
+
+test('validateRewriteRequest allows pro text up to the 20000-char cap', () => {
+  const atCap = validateRewriteRequest(
+    proFirst({ text: 'a'.repeat(TIER_LIMITS.pro.maxChars) }),
+    {},
+    { proLicenseSource: 'authorization-bearer' },
+  );
+  assert.equal(atCap.ok, true);
+
+  const overCap = validateRewriteRequest(
+    proFirst({ text: 'a'.repeat(TIER_LIMITS.pro.maxChars + 1) }),
+    {},
+    { proLicenseSource: 'authorization-bearer' },
+  );
+  assert.equal(overCap.ok, false);
+  assert.equal(overCap.status, 413);
+});
+
+test('validateRewriteRequest honors a pro maxChars env override', () => {
+  const env = { PATINA_PRO_MAX_CHARS: '30000' };
+  // 25000 chars is over the default 20000 but under the overridden 30000.
+  const ok = validateRewriteRequest(
+    proFirst({ text: 'a'.repeat(25000) }),
+    env,
+    { proLicenseSource: 'authorization-bearer' },
+  );
+  assert.equal(ok.ok, true);
+
+  const over = validateRewriteRequest(
+    proFirst({ text: 'a'.repeat(30001) }),
+    env,
+    { proLicenseSource: 'authorization-bearer' },
+  );
+  assert.equal(over.ok, false);
+  assert.equal(over.status, 413);
+});
+
+test('validateRewriteRequest fails closed with 401 when the pro license source is missing', () => {
+  // No options -> the backward-compatible 2-arg call cannot assert a bearer source.
+  const noOpts = validateRewriteRequest(proFirst());
+  assert.equal(noOpts.ok, false);
+  assert.equal(noOpts.status, 401);
+  assert.equal(noOpts.error, QUOTA_REASONS.LICENSE_REQUIRED);
+
+  // A wrong source value is equally rejected.
+  const wrong = validateRewriteRequest(proFirst(), {}, { proLicenseSource: 'query-param' });
+  assert.equal(wrong.status, 401);
+  assert.equal(wrong.error, QUOTA_REASONS.LICENSE_REQUIRED);
+});
+
+test('validateRewriteRequest rejects a pro request carrying an apiKey', () => {
+  const r = validateRewriteRequest(
+    proFirst({ apiKey: 'sk-should-not-be-here' }),
+    {},
+    { proLicenseSource: 'authorization-bearer' },
+  );
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 400);
+});
+
+test('validateRewriteRequest rejects a pro license smuggled in the body (400, not the header)', () => {
+  for (const field of ['licenseKey', 'license_key']) {
+    const r = validateRewriteRequest(
+      proFirst({ [field]: 'lic-abcdef123456' }),
+      {},
+      { proLicenseSource: 'authorization-bearer' },
+    );
+    assert.equal(r.ok, false, `${field} in body must be rejected`);
+    assert.equal(r.status, 400);
+    assert.match(r.error, /Authorization: Bearer/);
+  }
+});
+
+test('QUOTA_REASONS exposes stable license denial strings without changing existing ones', () => {
+  assert.equal(QUOTA_REASONS.LICENSE_REQUIRED, 'license required');
+  assert.equal(QUOTA_REASONS.LICENSE_INVALID, 'license not entitled');
+  assert.equal(QUOTA_REASONS.LICENSE_UNAVAILABLE, 'license validation unavailable');
+  // Pre-existing reason strings are untouched.
+  assert.equal(QUOTA_REASONS.DAILY, 'daily quota exceeded');
+  assert.equal(QUOTA_REASONS.SERVICE_UNAVAILABLE, 'rewrite service unavailable');
+});
+
+test('redactSecrets masks license keys and inline license_key labels', () => {
+  const out = /** @type {any} */ (redactSecrets({
+    licenseKey: 'lic-cafebabe12345678',
+    license_key: 'lic-deadbeef99999999',
+    nested: { message: 'activation failed: license_key=abcdef123 rejected' },
+    safe: 'keep-me',
+  }));
+  const json = JSON.stringify(out);
+  assert.doesNotMatch(json, /lic-cafebabe12345678/);
+  assert.doesNotMatch(json, /lic-deadbeef99999999/);
+  assert.doesNotMatch(json, /abcdef123/);
+  assert.equal(out.licenseKey, '[REDACTED]');
+  assert.equal(out.license_key, '[REDACTED]');
+  assert.ok(out.nested.message.includes('[REDACTED]'));
+  assert.equal(out.safe, 'keep-me');
+
+  // The bare labelled string form is masked too.
+  assert.equal(redactSecrets('license_key=abcdef123'), '[REDACTED]');
+});
+
+test('redactSecrets keeps masking bearer/sk- shapes after the license extension', () => {
+  const out = /** @type {any} */ (redactSecrets({
+    Authorization: 'Bearer sk-live-abcdefghij',
+    stray: 'inline sk-deadbeefcafef00d here',
+    note: 'no secret',
+  }));
+  const json = JSON.stringify(out);
+  assert.doesNotMatch(json, /sk-live-abcdefghij/);
+  assert.doesNotMatch(json, /sk-deadbeefcafef00d/);
+  assert.equal(out.note, 'no secret');
+});
+
+test('validateRewriteRequest: unauthenticated pro fails closed with 401 BEFORE char-cap/provider errors (auth gate dominant)', () => {
+  const env = { PATINA_FREE_PROVIDER: 'openai', PATINA_FREE_MODEL: 'gpt-5.5' };
+  const base = { mode: 'first', lang: 'en', tier: 'pro' };
+
+  // over-cap text + no bearer source -> 401 LICENSE_REQUIRED, not 413
+  const overCap = validateRewriteRequest({ ...base, text: 'x'.repeat(20001) }, env, {});
+  assert.equal(overCap.ok, false);
+  assert.equal(overCap.status, 401);
+  assert.equal(overCap.error, QUOTA_REASONS.LICENSE_REQUIRED);
+
+  // misconfigured pro provider env + no bearer source -> 401, not a 400 provider error
+  const badEnv = validateRewriteRequest({ ...base, text: 'hi' }, { PATINA_PRO_PROVIDER: 'not-a-provider' }, {});
+  assert.equal(badEnv.ok, false);
+  assert.equal(badEnv.status, 401);
+  assert.equal(badEnv.error, QUOTA_REASONS.LICENSE_REQUIRED);
+
+  // pro apiKey rejected with a pro-specific 400 message (never the free-tier wording)
+  const withKey = validateRewriteRequest({ ...base, text: 'hi', apiKey: 'sk-x' }, env, { proLicenseSource: 'authorization-bearer' });
+  assert.equal(withKey.ok, false);
+  assert.equal(withKey.status, 400);
+  assert.match(withKey.error, /pro tier must not include an apiKey/);
+  assert.doesNotMatch(withKey.error, /free tier/);
+
+  // authenticated pro over-cap still 413 (the cap applies only AFTER auth passes)
+  const authOverCap = validateRewriteRequest({ ...base, text: 'x'.repeat(20001) }, env, { proLicenseSource: 'authorization-bearer' });
+  assert.equal(authOverCap.ok, false);
+  assert.equal(authOverCap.status, 413);
 });

--- a/tests/unit/web-rewrite-contract.test.js
+++ b/tests/unit/web-rewrite-contract.test.js
@@ -368,7 +368,7 @@ test('WEB_TIERS exposes the pro tier value', () => {
 });
 
 test('TIER_LIMITS.pro documents the pro caps without regressing free/byok', () => {
-  assert.deepEqual(TIER_LIMITS.pro, { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 });
+  assert.deepEqual(TIER_LIMITS.pro, { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3, charsPerMonth: 1000000 });
   // Free/byok caps are unchanged by the pro extension.
   assert.equal(TIER_LIMITS.free.maxChars, 4000);
   assert.equal(TIER_LIMITS.byok.maxChars, 20000);
@@ -376,7 +376,7 @@ test('TIER_LIMITS.pro documents the pro caps without regressing free/byok', () =
 
 test('resolveTierLimits returns the defaults when no env overrides are present', () => {
   const limits = resolveTierLimits();
-  assert.deepEqual(limits.pro, { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 });
+  assert.deepEqual(limits.pro, { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3, charsPerMonth: 1000000 });
   assert.equal(limits.free.maxChars, 4000);
   assert.equal(limits.byok.maxChars, 20000);
   // An empty env behaves identically to the no-arg call.
@@ -388,8 +388,9 @@ test('resolveTierLimits applies positive-integer pro env overrides', () => {
     PATINA_PRO_MAX_CHARS: '50000',
     PATINA_PRO_REQ_PER_DAY: '1000',
     PATINA_PRO_MAX_CONCURRENT: '8',
+    PATINA_PRO_CHARS_PER_MONTH: '2000000',
   });
-  assert.deepEqual(limits.pro, { maxChars: 50000, reqPerDay: 1000, maxConcurrent: 8 });
+  assert.deepEqual(limits.pro, { maxChars: 50000, reqPerDay: 1000, maxConcurrent: 8, charsPerMonth: 2000000 });
   // Free/byok stay pinned to the defaults regardless of pro env.
   assert.equal(limits.free.maxChars, 4000);
   assert.equal(limits.byok.maxChars, 20000);
@@ -404,7 +405,7 @@ test('resolveTierLimits falls back to defaults for invalid pro overrides', () =>
     });
     assert.deepEqual(
       limits.pro,
-      { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3 },
+      { maxChars: 20000, reqPerDay: 200, maxConcurrent: 3, charsPerMonth: 1000000 },
       `invalid override ${JSON.stringify(bad)} must fall back to the default`,
     );
   }

--- a/tests/unit/web-rewrite-contract.test.js
+++ b/tests/unit/web-rewrite-contract.test.js
@@ -431,6 +431,37 @@ test('resolveProviderModel resolves the pro tier from PATINA_PRO_* env', () => {
   assert.notEqual(r.model, 'evil-model');
 });
 
+test('PROVIDER_PRESETS.claude includes claude-sonnet-5 as the flagship default', () => {
+  assert.ok(PROVIDER_PRESETS.claude.models.includes('claude-sonnet-5'));
+  // Flagship is first, so it is the claude preset default (models[0]).
+  assert.equal(PROVIDER_PRESETS.claude.models[0], 'claude-sonnet-5');
+  // The prior sonnet/opus/haiku ids remain allowlisted (no regression).
+  for (const m of ['claude-sonnet-4-5', 'claude-opus-4-1', 'claude-haiku-4-5']) {
+    assert.ok(PROVIDER_PRESETS.claude.models.includes(m));
+  }
+});
+
+test('resolveProviderModel pins the Pro tier to claude-sonnet-5 from PATINA_PRO_* env', () => {
+  const r = resolveProviderModel(
+    { tier: WEB_TIERS.PRO, provider: 'evil', model: 'evil-model' },
+    { PATINA_PRO_PROVIDER: 'claude', PATINA_PRO_MODEL: 'claude-sonnet-5' },
+  );
+  assert.equal(r.ok, true);
+  assert.equal(r.tier, 'pro');
+  assert.equal(r.provider, 'claude');
+  assert.equal(r.model, 'claude-sonnet-5');
+  assert.equal(r.baseURL, PROVIDER_PRESETS.claude.baseURL);
+  assert.notEqual(r.model, 'evil-model');
+});
+
+test('resolveProviderModel accepts a byok claude-sonnet-5 request', () => {
+  const r = resolveProviderModel({ tier: WEB_TIERS.BYOK, provider: 'claude', model: 'claude-sonnet-5' });
+  assert.equal(r.ok, true);
+  assert.equal(r.provider, 'claude');
+  assert.equal(r.model, 'claude-sonnet-5');
+  assert.equal(r.baseURL, PROVIDER_PRESETS.claude.baseURL);
+});
+
 test('resolveProviderModel falls back to PATINA_FREE_* then defaults for pro', () => {
   // PRO env absent -> FREE env is the fallback source.
   const viaFree = resolveProviderModel(

--- a/tests/unit/web-rewrite-stream.redteam.test.js
+++ b/tests/unit/web-rewrite-stream.redteam.test.js
@@ -5,6 +5,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { callLLMStream } from '../../src/streaming-api.js';
 import { runWebRewriteStream } from '../../src/web-rewrite-stream.js';
+import { redactSecrets } from '../../src/web-rewrite-contract.js';
 import { createRestKv, createRewriteApiHandler } from '../../api/rewrite.js';
 
 const baseRequest = {
@@ -204,6 +205,28 @@ test('redteam key leak scrubs stream_failed errors and emitted frames never expo
   assertNoDone(frames);
   const serialized = JSON.stringify({ frames, result });
   assert.doesNotMatch(serialized, /sk-LEAK/);
+  for (const frame of frames) assertNoSecretFields(frame);
+});
+
+test('redteam key leak scrubs an unlabelled provider key (GLM id.secret) that no redaction pattern matches', async () => {
+  // GLM keys are `id.secret` with no sk-/Bearer/label marker, so the pattern
+  // redactor (SECRET_VALUE_RES) cannot catch them echoed in an error body — only
+  // the request-scoped exact-substring scrub in safeError can.
+  const glmKey = '6a1b2c3d4e5f60718293.aZ9xY8wV7uT6sR5q';
+  // Sanity: pattern-based redaction alone leaves this key intact (proves the gap).
+  assert.equal(String(redactSecrets(`echoed ${glmKey}`)).includes(glmKey), true);
+
+  const { frames, result } = await runStream({
+    request: { ...baseRequest, apiKey: glmKey },
+    callLLMStream: async () => { throw new Error(`401 invalid api key: ${glmKey}`); },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'stream_failed');
+  assertNoDone(frames);
+  const serialized = JSON.stringify({ frames, result });
+  assert.doesNotMatch(serialized, /aZ9xY8wV7uT6sR5q/);
+  assert.equal(serialized.includes(glmKey), false);
   for (const frame of frames) assertNoSecretFields(frame);
 });
 


### PR DESCRIPTION
## Release 6.3.0 — dev → main

Promotes the integrated `dev` line to production. **Merge, not squash** (bundles several features; keeps per-feature history).

### Included since 6.2.0

- **Hosted Pro tier** ($9.99/mo USD) on `/api/rewrite` — Lemon Squeezy **validate-only** license gate (`Authorization: Bearer <license_key>` → `POST /v1/licenses/validate`, 5-min positive / 1-min negative cache, per-license HMAC-subject metering). Fail-closed everywhere; the raw license key is never stored, logged, put in a KV key, forwarded to the runner, or returned. Existing `free` (IP quota) and `byok` (caller key) contracts unchanged and pinned by tests. (PR #591)
- **Claude Sonnet 5** added to the provider allowlist; Pro pins `PATINA_PRO_PROVIDER=claude` / `PATINA_PRO_MODEL=claude-sonnet-5`. (PR #592)
- **Per-license monthly character cap** (`PATINA_PRO_CHARS_PER_MONTH`, default 1,000,000) — margin defense against a single seat outspending the subscription; atomic UTC-month-bucketed counter, 429 `monthly character limit reached` with remaining/limit guidance. (PR #593)
- **6.3.0 version-sync** across all gated surfaces + CHANGELOG. (PR #594)

`src/features/*` (deterministic layer) untouched. No new runtime dependencies.

### Verification

- Full matrix CI runs on this PR (lint / test on Node 18·20·22·lts / quality gate).
- Local pre-flight: `release:check` OK for 6.3.0, `npm test` 1342 pass / 0 fail / 1 skip, `npm run lint` green.

### Deploy

- Vercel Production env is injected (incl. `PATINA_PRO_API_KEY`) by the operator. Merging promotes `main`, which Vercel deploys to patina.vibetip.help.
- npm publish / git tag are intentionally **not** part of this PR (out of the requested scope; can follow separately if the CLI package should ship 6.3.0 too).
