### PR TITLE
feat(web,docs): launch prep — pricing, Pro CTA, UTM, demo-first README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,13 @@
   <a href="https://patina.vibetip.help/"><b>Try it in the browser — no install</b></a>
 </p>
 
-patina is a deterministic, pattern-based humanizer for Korean, English, Chinese, and Japanese. It finds AI-sounding phrasing and rewrites it without changing the claim, numbers, polarity, or causation.
-
-It is not a black-box paraphraser, authorship detector, or detector-bypass tool. patina is built for allowed AI-assisted drafting where the author wants cleaner voice, an audit trail, and meaning-preservation checks.
-
-## Demo
-
-Paste AI-sounding text into the **[playground](https://patina.vibetip.help/)** and patina rewrites it in place. The meaning floors verify the rewrite (**MPS 100 / Fidelity 75** here — the "30 templates" fact survives), and the deterministic AI signal is measured before → after: the hot-paragraph ratio falls **100 → 0** while the hype ("thrilled to announce", "revolutionize your workflow", "unlock their full potential") is gone.
-
 <p align="center">
   <img src="https://raw.githubusercontent.com/devswha/patina/main/assets/demo/patina-playground-en.gif" alt="Animated patina playground demo: an AI-sounding template-pack announcement is pasted into the web playground, rewritten naturally while keeping the 30-templates fact, and verified with MPS 100, Fidelity 75, and a deterministic AI-signal drop from 100 to 0" width="820">
 </p>
+
+<p align="center"><em>Paste AI-sounding text → patina rewrites it in place, keeps the facts (the "30 templates" number survives), and drops the deterministic AI signal 100 → 0 (MPS 100 / Fidelity 75).</em></p>
+
+patina is a deterministic, pattern-based humanizer for Korean, English, Chinese, and Japanese. It finds AI-sounding phrasing and rewrites it without changing the claim, numbers, polarity, or causation. It is not a black-box paraphraser, authorship detector, or detector-bypass tool — it is built for allowed AI-assisted drafting where the author wants cleaner voice, an audit trail, and meaning-preservation checks.
 
 More examples: [Before/After Gallery](docs/EXAMPLES.md) ([한국어](docs/EXAMPLES_KR.md)) · [CLI transcript](docs/DEMO.md).
 

--- a/playground/chatgpt.css
+++ b/playground/chatgpt.css
@@ -258,6 +258,26 @@ a { color: inherit; }
 .cta__btn { background: var(--accent); color: var(--on-accent); border: 0; border-radius: 9999px; padding: 14px 28px; font-size: 16px; font-weight: 600; font-family: inherit; cursor: pointer; box-shadow: var(--inset); transition: background .15s; }
 .cta__btn:hover { background: var(--accent-press); }
 
+/* pricing */
+.pricing { max-width: var(--page); margin: 0 auto; padding: 104px 24px; }
+.pricing__grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; align-items: stretch; }
+.price { position: relative; display: flex; flex-direction: column; background: var(--bg-cream); border: 1px solid var(--border); border-radius: 16px; padding: 28px 24px; }
+.price--pro { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent), 0 12px 30px rgba(0, 0, 0, .25); }
+.price__badge { position: absolute; top: -11px; left: 24px; font-family: var(--mono); font-size: 11px; letter-spacing: .04em; color: var(--on-accent); background: var(--accent); border-radius: 9999px; padding: 4px 12px; }
+.price__name { font-size: 15px; font-weight: 600; letter-spacing: .02em; text-transform: uppercase; color: var(--text-dim); margin: 0 0 10px; }
+.price__cost { font-size: 40px; font-weight: 600; letter-spacing: -1.4px; line-height: 1; margin: 0 0 20px; }
+.price__cost span { font-size: 16px; font-weight: 500; color: var(--text-faint); letter-spacing: 0; }
+.price__feats { list-style: none; margin: 0 0 24px; padding: 0; display: flex; flex-direction: column; gap: 10px; flex: 1 1 auto; }
+.price__feats li { position: relative; padding-left: 22px; color: var(--text-dim); font-size: 14px; line-height: 1.5; }
+.price__feats li::before { content: "✓"; position: absolute; left: 0; color: var(--accent); font-weight: 600; }
+.price__cta { display: inline-flex; align-items: center; justify-content: center; text-align: center; text-decoration: none; font-family: inherit; font-size: 14px; font-weight: 600; border-radius: 9999px; padding: 12px 18px; cursor: pointer; border: 1px solid var(--border-strong); background: transparent; color: var(--text); transition: background .15s, border-color .15s, opacity .15s; }
+.price__cta:hover { background: var(--bg-hover); }
+.price__cta--pro { background: var(--accent); color: var(--on-accent); border-color: transparent; box-shadow: var(--inset); }
+.price__cta--pro:hover { background: var(--accent-press); }
+.price__cta.is-soon { background: var(--bg-elev); color: var(--text-faint); border-color: var(--border); cursor: default; box-shadow: none; }
+.price__cta.is-soon:hover { background: var(--bg-elev); }
+.pricing__note { color: var(--text-faint); font-size: 13px; line-height: 1.65; margin: 20px 0 0; max-width: 740px; }
+
 .foot { max-width: var(--page); margin: 0 auto; padding: 40px 24px 56px; border-top: 1px solid var(--border); display: flex; align-items: center; gap: 20px; flex-wrap: wrap; }
 .foot__brand { display: flex; align-items: center; gap: 8px; font-weight: 700; }
 .foot__links { display: flex; gap: 18px; flex-wrap: wrap; }
@@ -415,8 +435,9 @@ details.foldout > summary:focus-visible,
   .ctl__label { display: none; }
   .how__grid { grid-template-columns: 1fr; gap: 28px; }
   .bench__cards { grid-template-columns: repeat(2, 1fr); }
+  .pricing__grid { grid-template-columns: 1fr; }
   .hero__title { letter-spacing: -1px; }
-  .how, .examples, .bench, .cta { padding: 72px 24px; }
+  .how, .examples, .bench, .cta, .pricing { padding: 72px 24px; }
 }
 @media (max-width: 820px) {
   .sidebar { position: absolute; z-index: 30; height: 100%; box-shadow: 4px 0 24px rgba(0,0,0,.12); }

--- a/playground/chatgpt.js
+++ b/playground/chatgpt.js
@@ -270,6 +270,71 @@ function el(tag, cls, text) {
   return n;
 }
 
+// ---------- launch: pricing CTAs, Pro checkout, UTM attribution ----------
+// Flip PRO_CHECKOUT_URL to the live Lemon Squeezy checkout link once payments
+// open. While it is empty the Pro CTA stays a non-clickable "coming soon" chip,
+// so the launch page never ships a dead buy button. UTM params from the landing
+// URL are captured client-side and appended to the checkout link so paid-tier
+// conversions can be attributed to their launch source (no third-party calls;
+// stays within the self-only CSP and no-telemetry posture).
+const PRO_CHECKOUT_URL = '';
+const PRO_PRICE = '$9.99/mo';
+const UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'ref'];
+
+function captureUtm() {
+  try {
+    const params = new globalThis.URLSearchParams(globalThis.location.search);
+    const found = {};
+    for (const k of UTM_KEYS) {
+      const v = params.get(k);
+      if (v) found[k] = v.slice(0, 128);
+    }
+    if (Object.keys(found).length) globalThis.sessionStorage.setItem('patina_utm', JSON.stringify(found));
+  } catch { /* URL / sessionStorage unavailable — attribution is best-effort */ }
+}
+
+function proCheckoutHref() {
+  if (!PRO_CHECKOUT_URL) return '';
+  try {
+    const url = new globalThis.URL(PRO_CHECKOUT_URL);
+    const stored = JSON.parse(globalThis.sessionStorage.getItem('patina_utm') || '{}');
+    for (const [k, v] of Object.entries(stored)) url.searchParams.set(k, String(v));
+    return url.toString();
+  } catch { return PRO_CHECKOUT_URL; }
+}
+
+function wireProCta() {
+  const btn = $('#pro-buy');
+  if (!btn) return;
+  const href = proCheckoutHref();
+  if (href) {
+    btn.setAttribute('href', href);
+    btn.setAttribute('target', '_blank');
+    btn.removeAttribute('aria-disabled');
+    btn.classList.remove('is-soon');
+    btn.textContent = `Upgrade to Pro — ${PRO_PRICE}`;
+  } else {
+    btn.removeAttribute('href');
+    btn.setAttribute('aria-disabled', 'true');
+    btn.classList.add('is-soon');
+    btn.textContent = 'Pro — coming soon';
+  }
+}
+
+function wirePricingCtas() {
+  const free = $('#price-free');
+  if (free) free.addEventListener('click', () => { globalThis.scrollTo({ top: 0, behavior: 'smooth' }); els.heroInput?.focus(); });
+  const byok = $('#price-byok');
+  if (byok) byok.addEventListener('click', () => {
+    els.tier.value = WEB_TIERS.BYOK;
+    syncTier();
+    updateHeroSend();
+    updateChatSend();
+    globalThis.scrollTo({ top: 0, behavior: 'smooth' });
+    els.apiKey?.focus();
+  });
+}
+
 // ---------- provider / tier ----------
 function populateProviders() {
   els.provider.innerHTML = '';
@@ -931,6 +996,9 @@ populateProviders();
 syncTier();
 renderSuggest();
 renderExamples();
+captureUtm();
+wireProCta();
+wirePricingCtas();
 onLangChange();
 newConvo();
 showLanding();

--- a/playground/index.html
+++ b/playground/index.html
@@ -22,6 +22,7 @@
         <a href="https://github.com/devswha/patina">GitHub</a>
         <a href="https://github.com/devswha/patina/tree/main/docs">Docs</a>
         <a href="#examples">Examples</a>
+        <a href="#pricing">Pricing</a>
         <a href="https://github.com/devswha/patina/blob/main/docs/benchmarks/latest.md">Benchmark</a>
         <a href="https://github.com/devswha/patina/blob/main/docs/ETHICS.md">Ethics</a>
       </nav>
@@ -154,6 +155,51 @@
         <a class="bench__link" href="https://github.com/devswha/patina/blob/main/docs/benchmarks/latest.md">Read the full report →</a>
       </section>
 
+      <section class="pricing" id="pricing">
+        <div class="sec__head">
+          <p class="eyebrow"><span>pricing</span></p>
+          <h2 class="sec__title">Simple pricing</h2>
+          <p class="sec__lede">Try it free in the browser, bring your own key, or go Pro for higher limits on Claude Sonnet 5.</p>
+        </div>
+        <div class="pricing__grid">
+          <div class="price">
+            <h3 class="price__name">Free</h3>
+            <p class="price__cost">$0</p>
+            <ul class="price__feats">
+              <li>Browser playground</li>
+              <li>5 rewrites / day</li>
+              <li>Up to 4,000 characters</li>
+              <li>KO · EN · ZH · JA</li>
+            </ul>
+            <button class="price__cta" type="button" id="price-free">Try it now ↑</button>
+          </div>
+          <div class="price">
+            <h3 class="price__name">API</h3>
+            <p class="price__cost">Your key</p>
+            <ul class="price__feats">
+              <li>Bring your own provider key</li>
+              <li>Up to 20,000 characters</li>
+              <li>Key stays in your browser</li>
+              <li>Never stored or logged</li>
+            </ul>
+            <button class="price__cta" type="button" id="price-byok">Use API mode</button>
+          </div>
+          <div class="price price--pro">
+            <div class="price__badge">Most capable</div>
+            <h3 class="price__name">Pro</h3>
+            <p class="price__cost">$9.99<span>/mo</span></p>
+            <ul class="price__feats">
+              <li>Claude Sonnet 5</li>
+              <li>200 rewrites / day</li>
+              <li>Up to 20,000 characters</li>
+              <li>1,000,000 characters / month</li>
+            </ul>
+            <a class="price__cta price__cta--pro is-soon" id="pro-buy" role="button" aria-disabled="true" rel="noopener">Pro — coming soon</a>
+          </div>
+        </div>
+        <p class="pricing__note">Pro is a licensed hosted tier. After checkout you receive a license key to use via the CLI or API; playground license sign-in is coming next.</p>
+      </section>
+
       <section class="cta">
         <div class="cta__inner">
           <h2 class="cta__title">Paste your own and see</h2>
@@ -166,6 +212,7 @@
         <div class="foot__brand"><img class="foot__icon" src="/assets/brand/patina-mark.svg" alt="" width="20" height="20" /> patina</div>
         <nav class="foot__links" aria-label="Footer">
           <a href="https://github.com/devswha/patina">GitHub</a>
+          <a href="#pricing">Pricing</a>
           <a href="https://github.com/devswha/patina/blob/main/docs/ETHICS.md">Ethics</a>
           <a href="https://github.com/devswha/patina/blob/main/docs/benchmarks/latest.md">Benchmark</a>
           <a href="https://github.com/devswha/patina/tree/main/docs">Docs</a>
@@ -205,7 +252,7 @@
             </button>
           </form>
           <p class="composer__error" id="composer-error" role="alert" hidden></p>
-          <p class="composer__hint">patina changes only the wording — never the claim, numbers, or causation. This demo rewrites via a local CLI; MPS/fidelity are preview values.</p>
+          <p class="composer__hint">patina changes only the wording — never the claim, numbers, or causation. Rewrites run the real patina pipeline server-side; MPS/fidelity are scored live.</p>
         </div>
       </main>
     </div>


### PR DESCRIPTION
Launch conversion prep (P0). **Landing**: Pricing section (Free/API/Pro $9.99/mo), launch-gated Pro buy button (PRO_CHECKOUT_URL empty → 'coming soon' until LS payments open; flip to activate), first-party UTM capture appended to the Pro checkout link for source attribution (self-only CSP, no telemetry), Free/API CTA wiring, accurate composer hint, nav/footer Pricing links. **README**: demo-first hero (before/after GIF on the first screen under the Try-in-browser link). CSP unchanged (buy button is a plain link). Local: npm test 1342 pass/0 fail/1 skip, npm run lint green. Production go-live is the separate dev→main release at payment open.