### PR TITLE
chore(release): 6.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "patina",
       "source": "./",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "description": "Strip the AI packaging, keep the meaning. Detect and rewrite AI writing patterns across KO/EN/ZH/JA with MPS/fidelity checks. Runs the root SKILL.md as the /patina skill.",
       "homepage": "https://github.com/devswha/patina",
       "repository": "https://github.com/devswha/patina",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.schemastore.org/claude-code-plugin-manifest.json",
   "name": "patina",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese so text reads as if a human wrote it. Meaning-preservation (MPS) verified, audit-friendly. The root SKILL.md is loaded as the /patina skill.",
   "author": {
     "name": "devswha",

--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -1,4 +1,4 @@
-version: "6.3.0"
+version: "6.3.1"
 language: ko              # Korean (default) -- auto-loads all ko-*.md patterns
                           # language: en      -- English -- auto-loads all en-*.md patterns
                           # language: zh      -- Chinese -- auto-loads all zh-*.md patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ All notable changes to patina. Dates are release dates (YYYY-MM-DD).
 Semver rationale: patch | minor | major — explain whether this changes patterns, schemas, CLI behavior, or docs only.
 ```
 
+## 6.3.1 — 2026-07-07
+
+**Launch polish for the hosted playground and README — no CLI/engine changes.**
+
+Semver rationale: patch — hosted playground (landing) and documentation only; `src/`, `api/`, the rewrite contract, and CLI behavior are unchanged. Ships the accumulated launch-prep so production reflects the current landing before the payment-open launch.
+
+### Added
+
+- **Landing pricing + Pro CTA**: the playground gains a Pricing section (Free / API / Pro $9.99/mo) and a launch-gated Pro button. `PRO_CHECKOUT_URL` stays empty until payments open, so the CTA renders as a non-clickable "coming soon" chip and never ships a dead link.
+- **First-party UTM attribution**: `utm_*`/`ref` params on the landing URL are captured client-side and appended to the Pro checkout link, so paid conversions can be attributed to their launch source — within the self-only CSP and no-telemetry posture (no third-party calls).
+
+### Changed
+
+- **README launch polish**: demo-first hero using a real production-hosted capture (`assets/demo/patina-demo-live-en.gif`) on the first screen; the Pro mention is trimmed to an open-core-standard one line that links to the landing pricing (no price/limits in the README).
+
+### Fixed
+
+- **Stale playground hint**: the composer hint (static and the per-language I18N copy in `chatgpt.js`) still described a local-CLI/preview-values demo; it now accurately states that rewrites run the real patina pipeline server-side with live MPS/fidelity scoring.
+
 ## 6.3.0 — 2026-07-07
 
 **Hosted Pro tier: a Lemon Squeezy license-gated paid tier ($9.99/mo USD) on `/api/rewrite`, on Claude Sonnet 5, with a per-license monthly character cap.**

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <a href="#quick-start"><img alt="Skill: Claude Code | Codex | Cursor | OpenCode" src="https://img.shields.io/badge/Skill-Claude%20Code%20%7C%20Codex%20%7C%20Cursor%20%7C%20OpenCode-blueviolet"></a>
   <a href="https://github.com/devswha/patina"><img alt="Languages: KO | EN | ZH | JA" src="https://img.shields.io/badge/Languages-KO%20%7C%20EN%20%7C%20ZH%20%7C%20JA-green"></a>
-  <a href="CHANGELOG.md"><img alt="Version 6.3.0" src="https://img.shields.io/badge/version-6.3.0-blue"></a>
+  <a href="CHANGELOG.md"><img alt="Version 6.3.1" src="https://img.shields.io/badge/version-6.3.1-blue"></a>
 </p>
 
 <p align="center">
@@ -202,7 +202,7 @@ If meaning drifts, the change is retried or rolled back. Deterministic analysis 
 
 ```yaml
 # .patina.default.yaml
-version: "6.3.0"
+version: "6.3.1"
 language: ko              # ko | en | zh | ja
 profile: default
 output: rewrite           # rewrite | diff | audit | score

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patina
-version: 6.3.0
+version: 6.3.1
 description: Detect and rewrite AI writing patterns in Korean, English, Chinese, and Japanese text so it reads as if a human wrote it. Meaning-preservation (MPS) verified.
 allowed-tools:
   - Read

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patina-cli",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "AI text humanizer CLI — detects and removes AI writing patterns",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/patina-humanizer/package.json
+++ b/packages/patina-humanizer/package.json
@@ -1,13 +1,13 @@
 {
   "name": "patina-humanizer",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "SEO-friendly alias for patina-cli",
   "type": "module",
   "bin": {
     "patina-humanizer": "bin/patina-humanizer.js"
   },
   "dependencies": {
-    "patina-cli": "6.3.0"
+    "patina-cli": "6.3.1"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Patch version-sync bump to 6.3.1 across all gated surfaces + CHANGELOG. Ships accumulated launch polish (landing pricing + launch-gated Pro CTA, UTM attribution, live production demo hero, corrected playground hint) — no src/api/contract/CLI changes. release:check OK, lint green.