### PR TITLE
fix(entitlement): 403 verdict for LS invalid-key 4xx + drop customer PII from deny logs

### DIFF
--- a/src/entitlement.js
+++ b/src/entitlement.js
@@ -369,17 +369,36 @@ export function createLemonSqueezyLicenseValidator({
         clearTimeout(timer);
       }
 
-      if (!response || typeof response.ok !== 'boolean' || !response.ok) {
-        warnSafe('entitlement: LS validate non-2xx', { subject, status: response && response.status });
-        return unavailable();
-      }
+      if (!response || typeof response.ok !== 'boolean') return unavailable();
 
+      // Non-2xx: LS answers an unknown/malformed key with a 4xx whose body still
+      // carries `valid: false` (e.g. 404 "license_key not found"). That is a
+      // definitive license verdict, not an outage, so it falls through to the
+      // deny path below (403 + negative cache) — treating it as a 503 would break
+      // the client contract AND leave every same-key retry re-charging the global
+      // LS RPM bucket. A 429 (LS's own rate limit), any 5xx, or a 4xx without a
+      // parseable valid:false body stays a transient 503 and is never cached.
+      /** @type {any} */
       let data;
-      try {
-        data = await response.json();
-      } catch (err) {
-        warnSafe('entitlement: LS validate response parse failed', { subject, error: errorMessage(err) });
-        return unavailable();
+      if (!response.ok) {
+        const status = response.status;
+        const verdictCandidate = typeof status === 'number' && status >= 400 && status < 500 && status !== 429;
+        let body = null;
+        if (verdictCandidate) {
+          try { body = await response.json(); } catch { body = null; }
+        }
+        if (!body || typeof body !== 'object' || body.valid !== false) {
+          warnSafe('entitlement: LS validate non-2xx', { subject, status });
+          return unavailable();
+        }
+        data = body;
+      } else {
+        try {
+          data = await response.json();
+        } catch (err) {
+          warnSafe('entitlement: LS validate response parse failed', { subject, error: errorMessage(err) });
+          return unavailable();
+        }
       }
 
       // 6. Evaluate + cache. A denial is cached negatively (bounded); a transient
@@ -401,8 +420,11 @@ export function createLemonSqueezyLicenseValidator({
 
       const negTtl = readPositiveInt(env.PATINA_LS_NEGATIVE_CACHE_TTL_MS, DEFAULT_NEGATIVE_CACHE_TTL_MS);
       await safeSet(store, cacheKey, { decision: 'deny', tier: 'pro', status: decision.status, reason: decision.reason, expiresAt: nowMs + negTtl }, negTtl, warnSafe, subject);
-      // The concrete failing check is logged (redacted) for triage; the return is generic.
-      warnSafe('entitlement: license denied', { subject, detail: decision.detail, response: data });
+      // The concrete failing check (plus LS's own error string, if any) is logged
+      // for triage; the FULL LS body is never logged — its `meta` carries customer
+      // PII (customer_email / customer_name) that secret-name redaction won't catch.
+      const lsError = data && typeof data.error === 'string' ? data.error : undefined;
+      warnSafe('entitlement: license denied', { subject, detail: decision.detail, error: lsError });
       return /** @type {EntitlementDeny} */ ({ ok: false, status: decision.status, reason: decision.reason });
     } finally {
       await releaseLock();

--- a/tests/unit/entitlement.test.js
+++ b/tests/unit/entitlement.test.js
@@ -371,6 +371,39 @@ test('validate: LS non-2xx fails closed with 503', async () => {
   assert.equal(fetchImpl.calls.length, 1);
 });
 
+test('validate: LS 4xx with a valid:false body is a definitive 403 denial and is negative-cached', async () => {
+  // LS answers an unknown key with 404 + {"valid": false, "error": "license_key not found."}
+  const fetchImpl = spyFetch(() => lsResponse({ valid: false, error: 'license_key not found.' }, { status: 404 }));
+  const validator = makeValidator({ fetchImpl });
+
+  const res = await validator.validate({ licenseKey: 'LK-unknown-key' });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 403, 'an invalid key is a license verdict, not an availability failure');
+  assert.equal(res.reason, QUOTA_REASONS.LICENSE_INVALID);
+
+  const retry = await validator.validate({ licenseKey: 'LK-unknown-key' });
+  assert.equal(retry.status, 403);
+  assert.equal(fetchImpl.calls.length, 1, 'the verdict must be negative-cached; retries must not re-charge the RPM bucket');
+});
+
+test('validate: LS 429 / 5xx / opaque 4xx stay transient 503 and are never cached', async () => {
+  const responders = [
+    ['429 rate limit', () => lsResponse({ valid: false, error: 'rate limited' }, { status: 429 })],
+    ['500 outage', () => lsResponse({ valid: false }, { status: 500 })],
+    ['404 unparseable body', () => lsResponse(null, { status: 404, throwJson: true })],
+    ['400 without valid:false', () => lsResponse({ error: 'bad request' }, { status: 400 })],
+  ];
+  for (const [label, respond] of responders) {
+    const fetchImpl = spyFetch(respond);
+    const validator = makeValidator({ fetchImpl });
+    const res = await validator.validate({ licenseKey: 'LK-transient' });
+    assert.equal(res.status, 503, `${label}: must fail closed as unavailable`);
+    assert.equal(res.reason, QUOTA_REASONS.LICENSE_UNAVAILABLE, label);
+    await validator.validate({ licenseKey: 'LK-transient' });
+    assert.equal(fetchImpl.calls.length, 2, `${label}: a transient failure must not be cached`);
+  }
+});
+
 test('validate: LS malformed JSON fails closed with 503', async () => {
   const fetchImpl = spyFetch(() => lsResponse(null, { status: 200, throwJson: true }));
   const validator = makeValidator({ fetchImpl });
@@ -511,6 +544,26 @@ test('security: a denied LS response that echoes the license is redacted before 
   const serialized = JSON.stringify(logger._entries);
   assert.equal(serialized.includes(license), false, 'raw license leaked into logs');
   assert.ok(serialized.includes('[REDACTED]'), 'the echoed license must be redacted');
+});
+
+test('security: a denial log never contains customer PII from the LS meta block', async () => {
+  const logger = spyLogger();
+  // A revoked/mismatched key of a REAL customer: LS echoes their email + name in meta.
+  const fetchImpl = spyFetch(() => lsResponse({
+    valid: false,
+    error: 'license_key not found.',
+    license_key: { status: 'active', expires_at: null },
+    meta: { ...GOOD_META, customer_email: 'buyer@example.com', customer_name: 'Real Buyer' },
+  }));
+  const res = await makeValidator({ fetchImpl, logger }).validate({ licenseKey: 'LK-pii-check' });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 403);
+
+  assert.ok(logger._entries.length > 0, 'the denial must still be logged for triage');
+  const logged = JSON.stringify(logger._entries);
+  assert.equal(logged.includes('buyer@example.com'), false, 'customer email leaked into logs');
+  assert.equal(logged.includes('Real Buyer'), false, 'customer name leaked into logs');
+  assert.ok(logged.includes('not-valid'), 'the triage detail must survive the PII cut');
 });
 
 test('regression(B1): re-read after acquiring the single-flight lock serves a winner-populated cache without a second LS call', async () => {


### PR DESCRIPTION
Two pre-launch fixes in `src/entitlement.js`, found in today's audit of the Pro path.

## 1. Invalid license returned 503 instead of 403 (launch blocker)

Lemon Squeezy's validate endpoint answers an unknown/malformed key with a **4xx whose body still carries `valid: false`** (e.g. 404 `license_key not found`). The validator treated every non-2xx as an outage → uncached 503 `LICENSE_UNAVAILABLE`. Consequences:

- The launch-runbook smoke test (bogus key → **403**) would fail on launch day.
- No negative cache on that path meant every same-key retry re-charged the global LS validate RPM bucket (50/min) — a cheap denial-of-onboarding lever against legitimate first-time Pro validations.

Now a 4xx with a parseable `valid:false` body falls through to the normal deny path: **403 `LICENSE_INVALID` + negative cache**. A 429 (LS's own rate limit), any 5xx, or a 4xx without a parseable `valid:false` body remains a transient, never-cached 503. Residual: cycling *distinct* bogus keys still charges RPM per key (inherent — unseen keys can't be cached) and stays bounded by the admission bucket.

## 2. Customer PII in deny logs

The deny path logged the **entire LS response** (`response: data`). Its `meta` block carries `customer_email` / `customer_name`, and `redactSecrets` only strips secret-*named* keys — so real customers' PII (revoked/expired subscribers, or same-store customers of another product) landed in production logs, contradicting the runbook's no-PII guarantee. The log now keeps only the failing-check `detail` plus LS's own `error` string (still license-scrubbed + pattern-redacted; the existing `[REDACTED]` echo tests keep passing on it).

## Tests

- LS 404 + `valid:false` → 403, negative-cached (exactly one fetch across retry)
- 429 / 500 / unparseable-4xx / 4xx-without-verdict → 503, never cached
- deny log contains neither `customer_email` nor `customer_name`, but keeps the triage detail
- Full suite: 1345 pass / 0 fail; lint clean. Sibling sweep found no other full-response logging sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)