### PR TITLE
fix(pro): no quota charge on concurrency rejection + production requires explicit pro provider/model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,7 +69,9 @@ PATINA_RUNTIME_CLI=your-runtime-cli-binary
 # to PATINA_QUOTA_HMAC_SECRET when unset.
 # PATINA_LICENSE_HMAC_SECRET=your-long-random-secret
 
-# Pro provider/model (fall back to PATINA_FREE_PROVIDER/MODEL, then preset).
+# Pro provider/model — REQUIRED in production (missing values fail pro requests
+# closed with 503; no silent fallback to the free provider/model). Outside
+# production they fall back to PATINA_FREE_PROVIDER/MODEL, then the preset.
 # Both must be on the PROVIDER_PRESETS allowlist. Pro ships on Claude Sonnet 5.
 # PATINA_PRO_PROVIDER=claude
 # PATINA_PRO_MODEL=claude-sonnet-5

--- a/playground/README.md
+++ b/playground/README.md
@@ -94,7 +94,9 @@ Pro env (see `.env.example` for the full annotated list):
   the free-key fallback is already on).
 - `PATINA_LICENSE_HMAC_SECRET` — license subject/KV-key secret (falls back to
   `PATINA_QUOTA_HMAC_SECRET`).
-- `PATINA_PRO_PROVIDER` / `PATINA_PRO_MODEL` — fall back to the free provider/model.
+- `PATINA_PRO_PROVIDER` / `PATINA_PRO_MODEL` — **required in production** (a
+  missing value fails pro requests closed instead of silently serving the free
+  provider/model); outside production they fall back to the free provider/model.
 - `PATINA_PRO_MAX_CHARS` (20000) / `PATINA_PRO_REQ_PER_DAY` (200) /
   `PATINA_PRO_MAX_CONCURRENT` (3) / `PATINA_PRO_CHARS_PER_MONTH` (1000000, the
   per-license monthly total-character cap — over it returns 429

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { createHmac } from 'node:crypto';
-import { QUOTA_REASONS, TIER_LIMITS, WEB_TIERS } from './web-rewrite-contract.js';
+import { isProductionPosture, QUOTA_REASONS, TIER_LIMITS, WEB_TIERS } from './web-rewrite-contract.js';
 
 const DAY_MS = 86_400_000;
 const HOUR_MS = 3_600_000;
@@ -103,13 +103,10 @@ export function createMemoryKv() {
   };
 }
 
-/**
- * @param {Record<string, string|undefined>} [env]
- * @returns {boolean}
- */
-export function isProductionPosture(env = {}) {
-  return env.NODE_ENV === 'production' || env.VERCEL_ENV === 'production' || env.VERCEL === '1';
-}
+// isProductionPosture's definition lives in web-rewrite-contract.js (the shared
+// base module) so the contract's provider resolution can use it without an
+// import cycle; re-exported here for existing importers.
+export { isProductionPosture };
 
 /**
  * @typedef {{get?(key: string): Promise<unknown>, set?(key: string, val: unknown, options?: {ttlMs?: number}): Promise<void>, incr(key: string, options?: {ttlMs?: number}): Promise<number>, incrBy?(key: string, amount: number, options?: {ttlMs?: number}): Promise<number>, decr?(key: string): Promise<number>, __memory?: boolean}} QuotaKv

--- a/src/rewrite-handler.js
+++ b/src/rewrite-handler.js
@@ -94,20 +94,27 @@ export function createRewriteHandler({ rateLimiter, runRewrite, env = {}, now = 
       // daily/concurrency caps; pass the request's input length so the limiter
       // can accumulate it. free/byok ignore chars (metered by IP/unmetered).
       const chars = tier === WEB_TIERS.PRO && typeof request.text === 'string' ? request.text.length : 0;
-      const quota = await rateLimiter.check({ tier, ip, subject, chars });
-      if (!quota.allowed) {
-        const denied = /** @type {{status: number, reason: string, remainingMonthlyChars?: number, limitMonthlyChars?: number}} */ (quota);
+
+      /** @param {{status: number, reason: string, remainingMonthlyChars?: number, limitMonthlyChars?: number}} denied */
+      const sendQuotaDenied = (denied) => {
         const body = /** @type {Record<string, unknown>} */ ({ error: denied.reason });
         if (typeof denied.remainingMonthlyChars === 'number') body.remainingMonthlyChars = denied.remainingMonthlyChars;
         if (typeof denied.limitMonthlyChars === 'number') body.limitMonthlyChars = denied.limitMonthlyChars;
         return send(res, denied.status, body);
-      }
+      };
 
       if (typeof rateLimiter.acquireConcurrency !== 'function') {
+        const quota = await rateLimiter.check({ tier, ip, subject, chars });
+        if (!quota.allowed) return sendQuotaDenied(/** @type {{status: number, reason: string}} */ (quota));
         // await so a runner rejection is caught by the redacted 500 handler below.
         return await runRewrite({ req: runnerReq, res, request, now });
       }
 
+      // The concurrency slot is acquired BEFORE check() charges the daily/monthly
+      // counters: those counters increment fail-closed with no refund path, so
+      // charging first would bill a request the concurrency gate then rejects
+      // with 429 (and bill again on the retry). Holding the slot for the extra
+      // quota round-trips costs milliseconds and is the cheaper unfairness.
       const concurrency = await rateLimiter.acquireConcurrency({ tier, ip, subject });
       if (!concurrency.allowed) {
         const denied = /** @type {{status: number, reason: string}} */ (concurrency);
@@ -115,6 +122,8 @@ export function createRewriteHandler({ rateLimiter, runRewrite, env = {}, now = 
       }
 
       try {
+        const quota = await rateLimiter.check({ tier, ip, subject, chars });
+        if (!quota.allowed) return sendQuotaDenied(/** @type {{status: number, reason: string}} */ (quota));
         // await so a runner rejection is caught by the redacted 500 handler below.
         return await runRewrite({ req: runnerReq, res, request, now });
       } finally {

--- a/src/web-rewrite-contract.js
+++ b/src/web-rewrite-contract.js
@@ -15,6 +15,17 @@
 /** Languages the rewrite pipeline supports. */
 export const SUPPORTED_LANGS = Object.freeze(['ko', 'en', 'zh', 'ja']);
 
+/**
+ * Whether the env describes a production deployment. Shared by the rate
+ * limiter, the entitlement layer (both via rate-limit.js's re-export), and the
+ * pro provider resolution below, so "production" means one thing everywhere.
+ * @param {Record<string, string|undefined>} [env]
+ * @returns {boolean}
+ */
+export function isProductionPosture(env = {}) {
+  return env.NODE_ENV === 'production' || env.VERCEL_ENV === 'production' || env.VERCEL === '1';
+}
+
 /** Service tiers. `free` is the abuse-bounded shared proxy; `byok` uses the user's own key; `pro` is the licensed hosted tier (server key, LS validate-only gated). */
 export const WEB_TIERS = Object.freeze({ FREE: 'free', BYOK: 'byok', PRO: 'pro' });
 
@@ -255,8 +266,9 @@ export function redactSecrets(value) {
  * - free: provider/model come from env (PATINA_FREE_PROVIDER/PATINA_FREE_MODEL),
  *   defaulting to the first preset; the request body cannot choose them.
  * - byok: provider+model must both be on the PROVIDER_PRESETS allowlist.
- * - pro: like free, pinned by env (PATINA_PRO_* falling back to PATINA_FREE_*);
- *   the request body cannot choose provider/model.
+ * - pro: pinned by env (PATINA_PRO_*); in production both must be set explicitly
+ *   (no free fallback — see the tier branch), outside production PATINA_FREE_*
+ *   then the preset default fill in. The request body cannot choose provider/model.
  * The base URL is ALWAYS taken from the preset, never from the request body.
  *
  * @param {{tier?:string, provider?:string, model?:string}} req
@@ -280,10 +292,18 @@ export function resolveProviderModel({ tier, provider, model } = {}, env = {}) {
     return { ok: true, tier, provider: p, model: m, baseURL: preset.baseURL };
   }
   if (tier === WEB_TIERS.PRO) {
-    const p = env.PATINA_PRO_PROVIDER || env.PATINA_FREE_PROVIDER || 'openai';
+    // Pro is server-pinned like free, but in production it NEVER falls back to
+    // the free provider/model: paying traffic silently running on the free
+    // model would break the advertised contract, so a missing PATINA_PRO_PROVIDER
+    // or PATINA_PRO_MODEL fails closed instead. Outside production the free-env
+    // fallback stays for local playground/test convenience.
+    const production = isProductionPosture(env);
+    const p = env.PATINA_PRO_PROVIDER || (production ? undefined : (env.PATINA_FREE_PROVIDER || 'openai'));
+    if (!p) return { ok: false, error: 'pro provider not configured' };
     const preset = presetFor(p);
     if (!preset) return { ok: false, error: 'pro provider not configured' };
-    const m = env.PATINA_PRO_MODEL || env.PATINA_FREE_MODEL || preset.models[0];
+    const m = env.PATINA_PRO_MODEL || (production ? undefined : (env.PATINA_FREE_MODEL || preset.models[0]));
+    if (!m) return { ok: false, error: 'pro model not configured' };
     if (!preset.models.includes(m)) return { ok: false, error: 'pro model not allowlisted' };
     return { ok: true, tier, provider: p, model: m, baseURL: preset.baseURL };
   }
@@ -394,7 +414,15 @@ export function validateRewriteRequest(body, env = {}, options = {}) {
   const provider = /** @type {any} */ (body).provider;
   const model = /** @type {any} */ (body).model;
   const resolved = resolveProviderModel({ tier, provider, model }, env);
-  if (!resolved.ok) return { ok: false, status: 400, error: 'error' in resolved ? resolved.error : 'provider not allowed' };
+  if (!resolved.ok) {
+    const error = 'error' in resolved ? resolved.error : 'provider not allowed';
+    // A pro-tier "not configured" failure is a server-side misconfiguration
+    // (production requires explicit PATINA_PRO_PROVIDER/MODEL), never something
+    // the client sent wrong: surface it as 503 so operators see an availability
+    // signal, not a client-error blip. All other resolution failures stay 400.
+    const status = tier === WEB_TIERS.PRO && /not configured/.test(error) ? 503 : 400;
+    return { ok: false, status, error };
+  }
 
   const apiKey = /** @type {any} */ (body).apiKey;
   if (tier === WEB_TIERS.BYOK) {

--- a/tests/unit/rewrite-api.test.js
+++ b/tests/unit/rewrite-api.test.js
@@ -483,6 +483,9 @@ test('pro tier: in production, no pro key + present free key + no allow-flag ret
     PATINA_LICENSE_HMAC_SECRET: 'license-secret',
     PATINA_FREE_PROVIDER: 'openai', PATINA_FREE_MODEL: 'gpt-5.5',
     PATINA_FREE_API_KEY: 'sk-server-free-key',
+    // Provider/model ARE configured (production requires them explicitly), so the
+    // flow reaches the server-KEY policy this test is about.
+    PATINA_PRO_PROVIDER: 'claude', PATINA_PRO_MODEL: 'claude-sonnet-5',
     // No PATINA_PRO_API_KEY and no PATINA_PRO_ALLOW_FREE_KEY: paid traffic MUST NOT
     // silently spend the free key in production.
     LS_STORE_ID: '42', LS_PRO_VARIANT_ID: '99',

--- a/tests/unit/rewrite-handler.test.js
+++ b/tests/unit/rewrite-handler.test.js
@@ -689,7 +689,7 @@ test('redteam(2): a throwing validator is caught as a redacted generic 500 — n
   assert.equal(res.headers['cache-control'], 'no-store');
 });
 
-test('redteam(3): a pro check denial skips acquire, the runner, and release (subject threaded into check)', async () => {
+test('redteam(3): a pro check denial (after the slot is held) skips the runner and releases the slot', async () => {
   const res = makeRes();
   const limiter = proSpyLimiter({ denyCheck: { status: 429, reason: QUOTA_REASONS.DAILY } });
   const validator = makeValidator({ ok: true, subject: 'SUBJ', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' });
@@ -709,11 +709,11 @@ test('redteam(3): a pro check denial skips acquire, the runner, and release (sub
   assert.equal(ran, false);
   assert.equal(limiter.calls.check.length, 1);
   assert.equal(limiter.calls.check[0].subject, 'SUBJ');
-  assert.equal(limiter.calls.acquire.length, 0);
-  assert.equal(limiter.calls.release.length, 0);
+  // The slot was acquired before the quota charge and must be released on the denial.
+  assert.deepEqual(limiter.order, ['acquire', 'check', 'release']);
 });
 
-test('redteam(3): a pro acquire denial skips the runner and does NOT release (release only pairs a granted slot)', async () => {
+test('redteam(3): a pro acquire denial skips the quota charge, the runner, and release (no billing on a 429 slot rejection)', async () => {
   const res = makeRes();
   const limiter = proSpyLimiter({ denyAcquire: { status: 429, reason: QUOTA_REASONS.CONCURRENT } });
   const validator = makeValidator({ ok: true, subject: 'SUBJ', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' });
@@ -731,13 +731,15 @@ test('redteam(3): a pro acquire denial skips the runner and does NOT release (re
   assert.equal(res.statusCode, 429);
   assert.deepEqual(res.json(), { error: QUOTA_REASONS.CONCURRENT });
   assert.equal(ran, false);
-  assert.equal(limiter.calls.check.length, 1);
+  // Core billing-fairness contract: a request refused at the concurrency gate
+  // must never charge the daily/monthly counters (check has no refund path).
+  assert.equal(limiter.calls.check.length, 0);
   assert.equal(limiter.calls.acquire.length, 1);
   assert.equal(limiter.calls.acquire[0].subject, 'SUBJ');
   assert.equal(limiter.calls.release.length, 0); // key contract: no release without a granted slot
 });
 
-test('redteam(3): the pro success path threads the subject through check→acquire→run→release in order', async () => {
+test('redteam(3): the pro success path threads the subject through acquire→check→run→release in order', async () => {
   const res = makeRes();
   const limiter = proSpyLimiter();
   const validator = makeValidator({ ok: true, subject: 'SUBJ', tier: WEB_TIERS.PRO, status: 'active', cache: 'miss' });
@@ -752,7 +754,8 @@ test('redteam(3): the pro success path threads the subject through check→acqui
     body: proBody(),
   }, res);
   assert.equal(result, 'ran');
-  assert.deepEqual(limiter.order, ['check', 'acquire', 'run', 'release']);
+  assert.deepEqual(limiter.order, ['acquire', 'check', 'run', 'release']);
+  assert.equal(limiter.calls.check[0].subject, 'SUBJ');
   assert.equal(limiter.calls.release.length, 1);
   assert.equal(limiter.calls.release[0].subject, 'SUBJ');
 });
@@ -777,7 +780,7 @@ test('redteam(3): when the pro runner throws, release still runs in finally (sub
   assert.deepEqual(res.json(), { error: 'internal error' });
   assert.equal(limiter.calls.release.length, 1);
   assert.equal(limiter.calls.release[0].subject, 'SUBJ');
-  assert.deepEqual(limiter.order, ['check', 'acquire', 'run', 'release']);
+  assert.deepEqual(limiter.order, ['acquire', 'check', 'run', 'release']);
 });
 
 test('redteam(4): free and byok ignore an attacker-supplied Authorization header — no validator, no subject, no license in the runner request', async () => {

--- a/tests/unit/web-rewrite-contract.test.js
+++ b/tests/unit/web-rewrite-contract.test.js
@@ -463,8 +463,8 @@ test('resolveProviderModel accepts a byok claude-sonnet-5 request', () => {
   assert.equal(r.baseURL, PROVIDER_PRESETS.claude.baseURL);
 });
 
-test('resolveProviderModel falls back to PATINA_FREE_* then defaults for pro', () => {
-  // PRO env absent -> FREE env is the fallback source.
+test('resolveProviderModel falls back to PATINA_FREE_* then defaults for pro OUTSIDE production only', () => {
+  // Non-production convenience: PRO env absent -> FREE env is the fallback source.
   const viaFree = resolveProviderModel(
     { tier: WEB_TIERS.PRO },
     { PATINA_FREE_PROVIDER: 'deepseek', PATINA_FREE_MODEL: 'deepseek-chat' },
@@ -479,6 +479,53 @@ test('resolveProviderModel falls back to PATINA_FREE_* then defaults for pro', (
   assert.equal(viaDefault.provider, 'openai');
   assert.equal(viaDefault.model, PROVIDER_PRESETS.openai.models[0]);
   assert.equal(viaDefault.baseURL, PROVIDER_PRESETS.openai.baseURL);
+});
+
+test('resolveProviderModel in production requires explicit PATINA_PRO_PROVIDER and PATINA_PRO_MODEL (no free fallback)', () => {
+  // Every production posture signal must enforce the same strictness.
+  for (const posture of [{ NODE_ENV: 'production' }, { VERCEL_ENV: 'production' }, { VERCEL: '1' }]) {
+    // Missing provider fails closed even when the free tier is fully configured:
+    // paying traffic must never silently run on the free provider/model.
+    const noProvider = resolveProviderModel(
+      { tier: WEB_TIERS.PRO },
+      { ...posture, PATINA_FREE_PROVIDER: 'openai', PATINA_FREE_MODEL: PROVIDER_PRESETS.openai.models[0] },
+    );
+    assert.equal(noProvider.ok, false);
+    assert.match(noProvider.error, /pro provider not configured/);
+
+    // Provider set but model missing fails closed too (no preset-default model).
+    const noModel = resolveProviderModel(
+      { tier: WEB_TIERS.PRO },
+      { ...posture, PATINA_PRO_PROVIDER: 'claude', PATINA_FREE_MODEL: PROVIDER_PRESETS.openai.models[0] },
+    );
+    assert.equal(noModel.ok, false);
+    assert.match(noModel.error, /pro model not configured/);
+
+    // Both set explicitly -> resolves exactly as configured.
+    const configured = resolveProviderModel(
+      { tier: WEB_TIERS.PRO },
+      { ...posture, PATINA_PRO_PROVIDER: 'claude', PATINA_PRO_MODEL: 'claude-sonnet-5' },
+    );
+    assert.equal(configured.ok, true);
+    assert.equal(configured.provider, 'claude');
+    assert.equal(configured.model, 'claude-sonnet-5');
+  }
+});
+
+test('validateRewriteRequest surfaces a production pro misconfiguration as 503, never a client 400', () => {
+  const body = { mode: 'first', lang: 'en', tier: WEB_TIERS.PRO, text: 'Rewrite this sentence.' };
+  const r = validateRewriteRequest(body, { NODE_ENV: 'production' }, { proLicenseSource: 'authorization-bearer' });
+  assert.equal(r.ok, false);
+  assert.equal(r.status, 503, 'missing pro env is a server availability problem, not a client error');
+  assert.match(r.error, /pro provider not configured/);
+
+  // A byok allowlist rejection is still the client\'s 400.
+  const byok = validateRewriteRequest(
+    { mode: 'first', lang: 'en', tier: WEB_TIERS.BYOK, text: 'hi', provider: 'nope', model: 'ghost', apiKey: 'sk-x' },
+    { NODE_ENV: 'production' },
+  );
+  assert.equal(byok.ok, false);
+  assert.equal(byok.status, 400);
 });
 
 test('resolveProviderModel rejects unlisted pro provider/model cleanly', () => {


### PR DESCRIPTION
Items 5–6 from today's Pro-path audit.

## 1. Concurrency gate no longer burns quota (billing fairness)

`rewrite-handler.js` charged the daily counter and the monthly character counter (`check()`) **before** acquiring the concurrency slot, and `check()` has no refund path. A Pro user firing 4 concurrent requests (cap 3) had all 4 billed against 200/day and 1M chars/month even though one was 429-rejected and never ran — and its retry billed again.

The handler now acquires the slot first, then charges quota inside the `try`; a quota denial while holding the slot releases it in `finally`. Holding the slot for the extra quota round-trips costs milliseconds. Behavior notes: a request that is over daily quota **and** at the concurrency cap now sees `CONCURRENT` instead of `DAILY` (both 429); a provider failure after a successful start still consumes quota (unchanged — a refund there would be gameable via stream cancellation).

## 2. Pro never silently serves the free model in production

`resolveProviderModel` fell back `PATINA_PRO_PROVIDER → PATINA_FREE_PROVIDER → 'openai'` (same for model). One forgotten env var in production meant paying customers silently got the free model while the UI advertises Claude Sonnet 5. In production posture both `PATINA_PRO_*` vars are now required; a missing one fails pro requests closed, surfaced as **503** by `validateRewriteRequest` (server misconfiguration — an operator availability signal, not a client 400). Non-production keeps the fallback chain for local playground/test convenience. This matches the launch runbook, which already lists both vars as required.

`isProductionPosture` moved into `web-rewrite-contract.js` (the shared base module) and is re-exported from `rate-limit.js`, so "production" stays single-sourced without an import cycle.

## Tests

- acquire-denial path asserts `check` is **never called** (the fairness contract), success/denial orderings updated to `acquire→check→run→release`
- production posture (all three signals: NODE_ENV / VERCEL_ENV / VERCEL) × {no provider, no model, both set} for pro resolution
- `validateRewriteRequest` production misconfig → 503; byok allowlist rejection stays 400
- the existing "free key never serves paid traffic" e2e test now configures provider/model so it still exercises the server-key policy it was written for
- Full suite: 1347 pass / 0 fail; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)