### PR TITLE
docs(exit-codes): document exit 4 (persona safety gate) and 130

### DIFF
--- a/docs/EXIT-CODES.md
+++ b/docs/EXIT-CODES.md
@@ -8,6 +8,42 @@ patina uses stable exit codes so CI and editor integrations can distinguish cont
 | `1` | Runtime/backend failure: API/auth/backend errors, failed doctor blockers, invalid runtime setup, or unexpected exceptions. |
 | `2` | Input/usage failure: unknown flags, missing required option values, empty stdin, or `--no-interactive` with no input. |
 | `3` | Score gate exceeded. `--score --exit-on <n>` completed, but `overall > n`. |
+| `4` | Persona safety gate failed on a rewrite: meaning may have drifted. **The rewrite is still printed to stdout.** |
+| `130` | Interrupted (SIGINT / Ctrl-C). |
+
+Codes are merged with `Math.max` when more than one applies, so a run that both
+exceeds a score gate and hits a runtime error reports the stricter code.
+
+> A backend subprocess exiting `75` (`EX_TEMPFAIL`) is a *retryable storm* signal
+> that batch mode acts on internally; it is not a patina exit code.
+
+## Persona safety gate (exit `4`)
+
+Rewrites run through a persona (Korean defaults to the conservative `preserve`
+persona; other languages opt in with `--persona`) are checked against three
+meaning-and-facts signals. Any one of them failing exits `4`:
+
+| Signal | Fails when |
+|---|---|
+| `mps` | meaning-preservation score below the floor (`ouroboros.mps-floor`, default 70) |
+| `fidelity` | fidelity score below the floor (`ouroboros.fidelity-floor`, default 70) |
+| `numbers` | a number present in the source is missing from the rewrite |
+
+Exit `4` is **enforcing but non-destructive**: patina prints the rewrite anyway
+and warns on stderr (`[patina] persona safety gate failed: ...`) so a human can
+review it. Automation should treat `4` as "output produced, needs review" — not
+as a runtime failure, and not as clean success.
+
+```bash
+patina --lang ko draft.md; echo "exit=$?"   # exit=4 when a year or figure vanished
+```
+
+Because MPS/fidelity come from a model call, exit `4` is not deterministic across
+runs of the same input. Suppressing stderr with `--quiet` hides the reason but
+does not change the exit code.
+
+Voice-match and surface-churn results are **advisory only**: they warn on stderr
+and never change the exit code.
 
 ## Score gates
 


### PR DESCRIPTION
`docs/EXIT-CODES.md` listed only 0–3. patina actually also exits **4** and **130**.

## Exit 4 — the surprising one

A rewrite whose persona safety gate fails (`mps` or `fidelity` below floor, or a source number missing from the output — `src/personas/gates.js:79-81`) sets `process.exitCode = 4` (`src/cli/run.js:343`) but **still prints the rewrite to stdout**: it is enforcing yet deliberately non-destructive.

That combination is a trap for automation. Any tool that treats non-zero as failure silently discards exactly the outputs where meaning drifted. I hit this building the rewrite-efficacy research harness — it was throwing away the gate-failing rewrites, which would have biased its meaning-preservation pass rate toward a perfect 100%.

Verified on a real Korean sample (rewrite drops the year "2026년"): 1 of 3 runs exits 4 with reason `numbers`, and the rewrite text is present on stdout in all three.

## What the doc now says

- exit `4` table row + a section listing the three gate signals and their floors
- exit `4` is **non-deterministic** (MPS/fidelity come from a model call), and `--quiet` hides the stderr reason but not the code
- voice-match / surface-churn stay **advisory** and never change the exit code (`src/cli/run.js:345`)
- exit `130` (SIGINT) — also previously missing, though `patina --help` mentions it
- codes merge with `Math.max` (`getProcessExitCode`, `run.js:343`) — verified in source
- a backend subprocess's `75` (`EX_TEMPFAIL`) is a batch storm signal, **not** a patina exit code (`src/cli/batch.js:137-141`), so it stays out of the table

Docs-only. Verified exit 2 (no input / bad flag) behaves as documented; exit 4 verified directly as above. lint + `precommit-score` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)