### PR TITLE
feat(pro-packs): licensed pack delivery — private-repo serving + patina pack CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,3 +94,16 @@ PATINA_RUNTIME_CLI=your-runtime-cli-binary
 # it unset in production to keep the fail-closed 503. Outside production the
 # free-key fallback is already on without this flag.
 # PATINA_PRO_ALLOW_FREE_KEY=true
+
+# --- Pro pack delivery (api/packs.js) --------------------------------------
+# Read-only fine-grained GitHub PAT scoped to the PRIVATE pack repo (contents:
+# read). Without it the endpoint fails closed with 503 PACKS_UNAVAILABLE.
+# PATINA_PACKS_GITHUB_TOKEN=
+# PATINA_PACKS_REPO=devswha/patina-pro-packs
+# PATINA_PACKS_REF=main
+# PATINA_PACKS_CACHE_TTL_MS=300000       # upstream (GitHub) KV cache TTL
+# PATINA_PACKS_REQ_PER_DAY=200           # per-license daily download cap
+
+# CLI side (patina pack): the pro license key and optional endpoint override.
+# PATINA_LICENSE_KEY=
+# PATINA_PACKS_URL=https://patina.vibetip.help/api/packs

--- a/api/packs.js
+++ b/api/packs.js
@@ -1,0 +1,24 @@
+// @ts-check
+// Vercel function: licensed pro-pack delivery. All logic lives in
+// src/pack-handler.js (testable); this file only wires production deps,
+// mirroring api/rewrite.js.
+
+import { createRestKv } from './rewrite.js';
+import { createMemoryKv, isProductionPosture } from '../src/rate-limit.js';
+import { createLemonSqueezyLicenseValidator } from '../src/entitlement.js';
+import { createPackHandler } from '../src/pack-handler.js';
+
+export function createPacksApiHandler({ env = /** @type {Record<string,string|undefined>} */ (process.env), logger = console } = {}) {
+  const restKv = createRestKv(env);
+  const kv = isProductionPosture(env) ? restKv : (restKv ?? createMemoryKv());
+  const licenseValidator = createLemonSqueezyLicenseValidator({
+    kv,
+    hmacSecret: env.PATINA_LICENSE_HMAC_SECRET || env.PATINA_QUOTA_HMAC_SECRET,
+    env,
+    logger: /** @type {any} */ (logger),
+  });
+  return createPackHandler({ env, kv: /** @type {any} */ (kv), licenseValidator, logger });
+}
+
+const handler = createPacksApiHandler();
+export default handler;

--- a/docs/PRO-PACKS.md
+++ b/docs/PRO-PACKS.md
@@ -1,0 +1,59 @@
+# Pro packs
+
+Licensed pattern/persona/lexicon packs, delivered from a private repository to
+patina Pro users. They are not in the public repo, not in the npm tarball, and
+not baked into any deploy artifact — the only copy a client ever holds is the
+one installed into its own gitignored `custom/` directory.
+
+## Why this design
+
+patina's core assets are readable text by necessity (the skill surface is
+prose an LLM must read), so binaries or obfuscation cannot protect them. What
+works is not shipping them: pro packs live in a private repo and are served
+per-request to holders of a valid license. The public repo keeps the engine
+and the seed packs; the pro tier gets the calibrated, research-backed ones.
+
+## Using it (Pro users)
+
+```bash
+export PATINA_LICENSE_KEY=<your patina Pro license key>   # same key as the hosted API
+patina pack list                 # what's available, what's installed
+patina pack install ko-structure # one pack
+patina pack install --all        # everything your license covers
+```
+
+Or persist the key in `.patina.yaml`:
+
+```yaml
+license-key: <key>
+# packs-url: https://patina.vibetip.help/api/packs   # override only for self-hosting
+```
+
+Installed packs land in `custom/` and are picked up automatically with the
+same precedence the loaders already give user files:
+
+| kind | destination | discovery |
+|---|---|---|
+| `pattern` | `custom/patterns/<id>.md` | merged with `patterns/`; same filename → custom wins |
+| `persona` | `custom/personas/<lang>/<id>.md` | preferred over built-in personas |
+| `lexicon` | `custom/lexicon/ai-<lang>.md` | preferred over `lexicon/`; refuses to overwrite an existing file without `--force` |
+
+Every download is integrity-checked: the CLI recomputes the file's sha256 and
+compares it against the server manifest before writing anything.
+
+## Operating it (maintainer)
+
+- Content lives in the private repo (`PATINA_PACKS_REPO`, default
+  `devswha/patina-pro-packs`): pack files plus a `manifest.json` listing
+  `{id, path, version, lang, kind, description, sha256}` per pack. The
+  manifest's sha256 must match the file content exactly — the endpoint refuses
+  to serve a mismatch, so publish file + manifest in the same commit.
+- Pack ids are `[a-z0-9-]`, and pattern-pack ids must start with their `lang`
+  (`ko-structure`), because the id doubles as the discoverable filename.
+- The endpoint (`api/packs.js`) authenticates with the same Lemon Squeezy
+  validate-only flow as the rewrite API (`Authorization: Bearer <license>`),
+  meters downloads per license per UTC day, and caches upstream reads in KV.
+  Env: see the "Pro pack delivery" block in `.env.example`.
+- Fail-closed properties: no GitHub token → 503 (never a per-license verdict
+  it can't honor); upstream failures are never cached; manifest entries that
+  fail shape validation are dropped server-side.

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../patina/node_modules

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,7 @@
 import { getRepoRoot } from './config.js';
 import { runDoctor } from './commands/doctor.js';
 import { runPersona } from './commands/persona.js';
+import { runPack } from './commands/pack.js';
 import { handleAuth, printBackendStatus } from './commands/auth.js';
 import { parseArgs, validateModeExclusivity, validateServeRequest, validatePreviewRequest, validateOutputRouting, validateTransformRequest, validatePersonaRequest, validateVerifyRequest, validateXliffRequest, printHelp } from './cli/args.js';
 import { runDefault } from './cli/run.js';
@@ -36,6 +37,9 @@ export async function main(args) {
   }
   if (args[0] === 'persona') {
     return runPersona(args.slice(1));
+  }
+  if (args[0] === 'pack') {
+    return runPack(args.slice(1));
   }
   if (args[0] === 'init') {
     throw inputError(

--- a/src/cli/args.js
+++ b/src/cli/args.js
@@ -741,6 +741,8 @@ COMMANDS
   patina persona new <id>  Author a reusable custom voice persona (from a writing
                           sample, a description, or a blank template)
   patina persona list      List built-in and custom personas per language
+  patina pack list         List licensed pro packs (needs PATINA_LICENSE_KEY)
+  patina pack install <id> Install a pro pack into custom/
 
 MODES
   --diff                  Show changes pattern by pattern

--- a/src/commands/pack.js
+++ b/src/commands/pack.js
@@ -1,0 +1,231 @@
+// `patina pack` — install licensed pro packs into custom/.
+//
+// The client half of src/pack-handler.js. A pro license (Lemon Squeezy key,
+// the same one the hosted rewrite API takes) is presented as a Bearer token;
+// the server resolves it and streams pack content that is not part of the
+// public repo or the npm tarball. Installed packs land in custom/, which every
+// loader already prefers over the built-in directories and which is gitignored.
+//
+// Subcommands:
+//   patina pack list                      available + installed state
+//   patina pack install <id...> | --all   download, verify sha256, write
+//
+// License resolution order: --license <key> > PATINA_LICENSE_KEY env >
+// `license-key:` in .patina.yaml. Endpoint: --url > PATINA_PACKS_URL env >
+// `packs-url:` in config > the hosted default.
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
+
+import { getRepoRoot, loadConfig } from '../config.js';
+import { inputError, runtimeError } from '../errors.js';
+
+
+export const DEFAULT_PACKS_URL = 'https://patina.vibetip.help/api/packs';
+const PACK_ID_RE = /^[a-z0-9][a-z0-9-]{1,63}$/;
+const KNOWN_KINDS = new Set(['pattern', 'persona', 'lexicon']);
+
+const sha256 = (s) => createHash('sha256').update(s, 'utf8').digest('hex');
+
+function takeValue(args, i, flag) {
+  const v = args[i + 1];
+  if (v === undefined || v.startsWith('-')) {
+    throw inputError(`${flag} requires a value`, `Missing value after ${flag}.`, `Pass ${flag} <value>.`);
+  }
+  return [v, i + 1];
+}
+
+function parsePackArgs(args) {
+  const parsed = { sub: null, ids: [], all: false, json: false, force: false, url: null, license: null };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!parsed.sub && !arg.startsWith('-')) { parsed.sub = arg; continue; }
+    if (arg === '--all') parsed.all = true;
+    else if (arg === '--json') parsed.json = true;
+    else if (arg === '--force') parsed.force = true;
+    else if (arg === '--url') { const [v, ni] = takeValue(args, i, arg); parsed.url = v; i = ni; }
+    else if (arg === '--license') { const [v, ni] = takeValue(args, i, arg); parsed.license = v; i = ni; }
+    else if (arg.startsWith('-')) {
+      throw inputError(`unknown pack option ${arg}`, 'Supported: --all, --json, --force, --url <url>, --license <key>.', 'Run `patina pack` for usage.');
+    } else {
+      parsed.ids.push(arg);
+    }
+  }
+  return parsed;
+}
+
+function resolveSettings(parsed) {
+  let config = {};
+  try {
+    config = loadConfig() || {};
+  } catch { /* pack commands must work without a valid config file */ }
+  const url = parsed.url || process.env.PATINA_PACKS_URL || config['packs-url'] || DEFAULT_PACKS_URL;
+  const license = parsed.license || process.env.PATINA_LICENSE_KEY || config['license-key'] || null;
+  return { url, license };
+}
+
+async function apiGet(url, license, { fetchImpl = globalThis.fetch } = {}) {
+  let response;
+  try {
+    response = await fetchImpl(url, { headers: { authorization: `Bearer ${license}` } });
+  } catch (err) {
+    throw runtimeError('pack server unreachable', String(err?.message ?? err), 'Check your network or --url.');
+  }
+  let body = null;
+  try { body = await response.json(); } catch { /* non-JSON error body */ }
+  if (response.ok) return body;
+
+  const reason = body?.reason || `HTTP ${response.status}`;
+  if (response.status === 401) {
+    throw inputError('a pro license is required', 'The pack server did not receive a license.', 'Set PATINA_LICENSE_KEY (or `license-key:` in .patina.yaml) to your patina Pro license key.');
+  }
+  if (response.status === 403) {
+    throw inputError('license rejected', `The pack server rejected this license (${reason}).`, 'Check the key, or its status in your Lemon Squeezy receipt email.');
+  }
+  if (response.status === 429) {
+    throw runtimeError('pack download limit reached', `Daily cap hit (${reason}).`, 'Try again tomorrow (UTC) or raise the cap server-side.');
+  }
+  throw runtimeError('pack server unavailable', `The pack server answered ${response.status} (${reason}).`, 'Try again in a few minutes.');
+}
+
+/**
+ * Destination for one pack. Filenames come from the server-validated pack id
+ * (never a client- or manifest-supplied path), then are containment-checked.
+ */
+function destinationFor(pack, repoRoot) {
+  if (!PACK_ID_RE.test(pack.id)) throw runtimeError('invalid pack id from server', `id: ${JSON.stringify(pack.id)}`, 'Report this; the manifest is malformed.');
+  if (!KNOWN_KINDS.has(pack.kind)) throw runtimeError(`unknown pack kind '${pack.kind}'`, 'This CLI version does not know how to install it.', 'Update patina and retry.');
+
+  let dir;
+  let file;
+  if (pack.kind === 'pattern') {
+    // loadPatterns discovers `{lang}-*.md`; pack ids are lang-prefixed by
+    // convention so the id doubles as the filename.
+    if (!pack.id.startsWith(`${pack.lang}-`)) {
+      throw runtimeError('pack id/lang mismatch', `Pattern pack id '${pack.id}' must start with '${pack.lang}-' to be discoverable.`, 'Report this; the manifest is malformed.');
+    }
+    dir = resolve(repoRoot, 'custom', 'patterns');
+    file = `${pack.id}.md`;
+  } else if (pack.kind === 'persona') {
+    dir = resolve(repoRoot, 'custom', 'personas', pack.lang);
+    file = `${pack.id}.md`;
+  } else {
+    // The lexicon loader reads exactly custom/lexicon/ai-{lang}.md.
+    dir = resolve(repoRoot, 'custom', 'lexicon');
+    file = `ai-${pack.lang}.md`;
+  }
+  const path = resolve(dir, file);
+  if (!path.startsWith(resolve(repoRoot, 'custom') + sep)) {
+    throw runtimeError('pack destination escaped custom/', `id: ${pack.id}`, 'Report this; refusing to write.');
+  }
+  return { dir, path, file };
+}
+
+async function listPacks({ url, license, json, out, repoRoot, fetchImpl }) {
+  const manifest = await apiGet(url, license, { fetchImpl });
+  const packs = Array.isArray(manifest?.packs) ? manifest.packs : [];
+  const rows = packs.map((p) => {
+    let installed = false;
+    try { installed = existsSync(destinationFor(p, repoRoot).path); } catch { /* unknown kind on old CLI */ }
+    return { ...p, installed };
+  });
+  if (json) {
+    out(JSON.stringify({ packs: rows }, null, 2));
+    return;
+  }
+  if (!rows.length) {
+    out('No packs published yet.');
+    return;
+  }
+  out('id                              kind      lang  version   installed');
+  for (const p of rows) {
+    out(`${p.id.padEnd(32)}${String(p.kind).padEnd(10)}${String(p.lang).padEnd(6)}${String(p.version).padEnd(10)}${p.installed ? 'yes' : '-'}`);
+  }
+}
+
+async function installPacks({ ids, all, force, url, license, json, out, repoRoot, fetchImpl }) {
+  const manifest = await apiGet(url, license, { fetchImpl });
+  const available = Array.isArray(manifest?.packs) ? manifest.packs : [];
+  const wanted = all ? available.map((p) => p.id) : ids;
+  if (!wanted.length) {
+    throw inputError('nothing to install', 'Pass one or more pack ids, or --all.', 'Run `patina pack list` to see what is available.');
+  }
+
+  const results = [];
+  for (const id of wanted) {
+    if (!available.some((p) => p.id === id)) {
+      throw inputError(`unknown pack '${id}'`, 'It is not in the server manifest.', 'Run `patina pack list` for available ids.');
+    }
+    const pack = await apiGet(`${url}?id=${encodeURIComponent(id)}`, license, { fetchImpl });
+    if (typeof pack?.content !== 'string' || !pack.content.trim()) {
+      throw runtimeError(`pack '${id}' arrived empty`, 'The server returned no content.', 'Try again; report if it persists.');
+    }
+    // End-to-end integrity: what we write is what the manifest promised.
+    const digest = sha256(pack.content);
+    if (digest !== pack.sha256) {
+      throw runtimeError(`pack '${id}' failed integrity check`, `sha256 ${digest} != manifest ${pack.sha256}.`, 'Retry; a mid-publish read can cause this once.');
+    }
+    const dest = destinationFor(pack, repoRoot);
+    if (existsSync(dest.path) && !force && pack.kind === 'lexicon') {
+      // ai-{lang}.md is a fixed filename the user may already maintain by hand;
+      // never clobber it silently.
+      throw inputError(`custom lexicon already exists (${dest.file})`, 'Installing this pack would overwrite your custom lexicon.', 'Re-run with --force to overwrite, or merge manually.');
+    }
+    mkdirSync(dest.dir, { recursive: true });
+    writeFileSync(dest.path, pack.content);
+    results.push({ id, version: pack.version, path: dest.path });
+    if (!json) out(`installed ${id}@${pack.version} -> ${dest.path}`);
+  }
+  if (json) out(JSON.stringify({ installed: results }, null, 2));
+}
+
+function printPackHelp(out) {
+  out(`patina pack — licensed pro pack manager
+
+Usage:
+  patina pack list [--json]
+  patina pack install <id...> [--force] [--json]
+  patina pack install --all [--force]
+
+Options:
+  --url <url>        pack server (default ${DEFAULT_PACKS_URL})
+  --license <key>    pro license key (prefer PATINA_LICENSE_KEY or 'license-key:' in .patina.yaml)
+  --force            overwrite an existing custom lexicon
+  --json             machine-readable output
+
+Packs install into custom/ (gitignored) and are picked up automatically:
+patterns into custom/patterns/, personas into custom/personas/<lang>/,
+lexicons as custom/lexicon/ai-<lang>.md.`);
+}
+
+/**
+ * Entry point for `patina pack …`.
+ * @param {string[]} args CLI arguments after the `pack` literal.
+ * @param {{fetchImpl?: typeof globalThis.fetch, repoRoot?: string}} [deps] test injection
+ */
+export async function runPack(args, { fetchImpl = globalThis.fetch, repoRoot = getRepoRoot() } = {}) {
+  const parsed = parsePackArgs(args);
+  const out = (s) => console.log(s);
+
+  if (!parsed.sub || parsed.sub === 'help') {
+    printPackHelp(out);
+    return;
+  }
+  if (!['list', 'install'].includes(parsed.sub)) {
+    throw inputError(`unknown pack subcommand '${parsed.sub}'`, 'Supported: list, install.', 'Run `patina pack` for usage.');
+  }
+
+  const { url, license } = resolveSettings(parsed);
+  if (!license) {
+    throw inputError(
+      'a pro license is required',
+      'patina pack needs your patina Pro license key.',
+      'Set PATINA_LICENSE_KEY, add `license-key:` to .patina.yaml, or pass --license <key>.'
+    );
+  }
+
+  const ctx = { ...parsed, url, license, out, repoRoot, fetchImpl };
+  if (parsed.sub === 'list') return listPacks(ctx);
+  return installPacks(ctx);
+}

--- a/src/loader.js
+++ b/src/loader.js
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { resolve, sep } from 'node:path';
 import yaml from 'js-yaml';
 import { validateProfileName } from './security.js';
@@ -38,7 +38,10 @@ export function splitFrontmatter(content) {
 }
 
 /**
- * Load language-specific pattern packs from patterns/{lang}-*.md.
+ * Load language-specific pattern packs from patterns/{lang}-*.md, plus any
+ * user or pro packs in custom/patterns/{lang}-*.md. On a filename collision
+ * the custom pack wins (same precedence the persona and lexicon loaders give
+ * custom/), so an installed pack can also override a built-in one.
  *
  * @param {string} repoRoot Repository root path.
  * @param {string} lang Language code, such as ko, en, zh, or ja.
@@ -50,20 +53,28 @@ export function splitFrontmatter(content) {
  */
 export function loadPatterns(repoRoot, lang, skipPatterns = []) {
   const patternsDir = resolve(repoRoot, 'patterns');
-  const files = readdirSync(patternsDir)
-    .filter((f) => f.startsWith(`${lang}-`) && f.endsWith('.md'))
-    .filter((f) => {
-      const packName = f.slice(0, -3);
-      return !skipPatterns.includes(packName);
-    })
-    .sort();
+  const customDir = resolve(repoRoot, 'custom', 'patterns');
+
+  const discover = (dir) => {
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir)
+      .filter((f) => f.startsWith(`${lang}-`) && f.endsWith('.md'))
+      .filter((f) => !skipPatterns.includes(f.slice(0, -3)))
+      .map((f) => ({ file: f, path: resolve(dir, f) }));
+  };
+
+  // custom/ entries shadow built-ins with the same filename.
+  const byFile = new Map();
+  for (const entry of discover(patternsDir)) byFile.set(entry.file, entry);
+  for (const entry of discover(customDir)) byFile.set(entry.file, entry);
+  const entries = [...byFile.values()].sort((a, b) => a.file.localeCompare(b.file));
 
   const packs = [];
-  for (const file of files) {
-    const content = loadFile(resolve(patternsDir, file));
+  for (const entry of entries) {
+    const content = loadFile(entry.path);
     const { frontmatter, body } = splitFrontmatter(content);
     packs.push({
-      file,
+      file: entry.file,
       frontmatter,
       body,
       isStructure: frontmatter?.phase === 'structure',

--- a/src/pack-handler.js
+++ b/src/pack-handler.js
@@ -1,0 +1,222 @@
+// @ts-check
+// Licensed pack delivery — the server half of `patina pack`.
+//
+// Pro-only pattern/persona/lexicon packs live in a PRIVATE repository and are
+// served here to licensed users; they are never part of the public repo or the
+// npm tarball, which is what actually prevents copying (a binary or obfuscation
+// step would not — the skill surface has to stay readable prose).
+//
+// Trust model, mirroring src/rewrite-handler.js:
+//   - the caller presents `Authorization: Bearer <license_key>`;
+//   - the same fail-closed Lemon Squeezy validator used by the rewrite API
+//     turns it into an HMAC subject (the raw key never leaves entitlement.js);
+//   - downloads are metered per subject per UTC day;
+//   - pack ids come from the server-side manifest only — the client never
+//     supplies a path, so there is no traversal surface;
+//   - upstream (GitHub contents API on the private repo) is cached in KV so a
+//     burst of installs cannot exhaust the GitHub rate limit.
+//
+// Env (see .env.example):
+//   PATINA_PACKS_GITHUB_TOKEN  read-only fine-grained PAT for the private repo (required)
+//   PATINA_PACKS_REPO          owner/name of the private repo (default devswha/patina-pro-packs)
+//   PATINA_PACKS_REF           git ref to serve (default main)
+//   PATINA_PACKS_CACHE_TTL_MS  upstream cache TTL (default 300000)
+//   PATINA_PACKS_REQ_PER_DAY   per-license daily download cap (default 200)
+
+import { createHash } from 'node:crypto';
+
+import { extractBearerLicense } from './entitlement.js';
+import { QUOTA_REASONS } from './web-rewrite-contract.js';
+
+export const DEFAULT_PACKS_REPO = 'devswha/patina-pro-packs';
+export const DEFAULT_PACKS_REF = 'main';
+export const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+export const DEFAULT_REQ_PER_DAY = 200;
+/** Pack kinds the CLI knows how to install; anything else is rejected here. */
+export const PACK_KINDS = new Set(['pattern', 'persona', 'lexicon']);
+export const PACKS_REASONS = Object.freeze({
+  PACKS_UNAVAILABLE: 'PACKS_UNAVAILABLE',
+  PACK_NOT_FOUND: 'PACK_NOT_FOUND',
+  DAILY_DOWNLOADS: 'DAILY_DOWNLOADS',
+});
+
+const sha256 = (/** @type {string} */ s) => createHash('sha256').update(s, 'utf8').digest('hex');
+
+/**
+ * @param {unknown} value
+ * @param {number} fallback
+ * @returns {number}
+ */
+function readPositiveInt(value, fallback) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+/**
+ * Validate one manifest entry from the private repo. The manifest is trusted
+ * content (we publish it), but validating shape here keeps a malformed commit
+ * from turning into a confusing client-side failure.
+ * @param {any} p
+ * @returns {boolean}
+ */
+export function isValidPackEntry(p) {
+  return Boolean(
+    p && typeof p === 'object'
+    && typeof p.id === 'string' && /^[a-z0-9][a-z0-9-]{1,63}$/.test(p.id)
+    && typeof p.path === 'string' && !p.path.includes('..') && !p.path.startsWith('/')
+    && typeof p.version === 'string'
+    && typeof p.lang === 'string'
+    && PACK_KINDS.has(p.kind)
+    && typeof p.sha256 === 'string' && /^[0-9a-f]{64}$/.test(p.sha256)
+  );
+}
+
+/**
+ * @param {{
+ *   env?: Record<string,string|undefined>,
+ *   kv: {get(k:string):Promise<any>, set(k:string,v:any,o?:{ttlMs?:number}):Promise<void>, incr(k:string,o?:{ttlMs?:number}):Promise<number>},
+ *   licenseValidator: {validate(i:{licenseKey?:string}):Promise<any>},
+ *   fetchImpl?: typeof globalThis.fetch,
+ *   now?: () => number,
+ *   logger?: {warn?: Function, error?: Function},
+ * }} options
+ */
+export function createPackHandler({
+  env = {},
+  kv,
+  licenseValidator,
+  fetchImpl = globalThis.fetch,
+  now = () => Date.now(),
+  logger = console,
+}) {
+  const repo = env.PATINA_PACKS_REPO || DEFAULT_PACKS_REPO;
+  const ref = env.PATINA_PACKS_REF || DEFAULT_PACKS_REF;
+  const token = env.PATINA_PACKS_GITHUB_TOKEN;
+  const cacheTtlMs = readPositiveInt(env.PATINA_PACKS_CACHE_TTL_MS, DEFAULT_CACHE_TTL_MS);
+  const reqPerDay = readPositiveInt(env.PATINA_PACKS_REQ_PER_DAY, DEFAULT_REQ_PER_DAY);
+
+  const warn = (/** @type {string} */ message, /** @type {Record<string, unknown>} */ meta = {}) => {
+    try {
+      if (typeof logger?.warn === 'function') logger.warn(message, meta);
+    } catch { /* logging must never throw into the request path */ }
+  };
+
+  /**
+   * Fetch one file from the private repo via the contents API, KV-cached.
+   * @param {string} path
+   * @returns {Promise<string>}
+   */
+  async function fetchRepoFile(path) {
+    const cacheKey = `packs:file:${ref}:${path}`;
+    const cached = await kv.get(cacheKey).catch(() => undefined);
+    if (typeof cached === 'string') return cached;
+
+    const url = `https://api.github.com/repos/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`;
+    const response = await fetchImpl(url, {
+      headers: {
+        authorization: `Bearer ${token}`,
+        accept: 'application/vnd.github.raw+json',
+        'user-agent': 'patina-packs',
+        'x-github-api-version': '2022-11-28',
+      },
+    });
+    if (!response.ok) {
+      // Never cache upstream failures: a transient GitHub 5xx must not pin a
+      // pack into "missing" for a whole TTL window.
+      throw Object.assign(new Error(`upstream ${response.status} for ${path}`), { upstreamStatus: response.status });
+    }
+    const text = await response.text();
+    await kv.set(cacheKey, text, { ttlMs: cacheTtlMs }).catch(() => {});
+    return text;
+  }
+
+  async function loadManifest() {
+    const raw = await fetchRepoFile('manifest.json');
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw Object.assign(new Error('manifest is not valid JSON'), { upstreamStatus: 502 });
+    }
+    const packs = Array.isArray(parsed?.packs) ? parsed.packs.filter(isValidPackEntry) : [];
+    const skipped = Array.isArray(parsed?.packs) ? parsed.packs.length - packs.length : 0;
+    if (skipped > 0) warn('packs: manifest entries skipped as malformed', { skipped });
+    return { packs };
+  }
+
+  const send = (/** @type {any} */ res, /** @type {number} */ status, /** @type {object} */ body) => {
+    res.statusCode = status;
+    res.setHeader('content-type', 'application/json; charset=utf-8');
+    res.setHeader('cache-control', 'no-store');
+    res.end(JSON.stringify(body));
+  };
+
+  return async function handler(/** @type {any} */ req, /** @type {any} */ res) {
+    if (req.method !== 'GET') {
+      res.setHeader('allow', 'GET');
+      return send(res, 405, { error: 'method not allowed' });
+    }
+
+    // Fail closed before touching auth: a pack endpoint with no upstream
+    // credentials must not report per-license verdicts it cannot honor.
+    if (!token) return send(res, 503, { reason: PACKS_REASONS.PACKS_UNAVAILABLE });
+
+    const extracted = extractBearerLicense(req.headers || {});
+    if (!extracted.ok) return send(res, 401, { reason: QUOTA_REASONS.LICENSE_REQUIRED });
+    const verdict = await licenseValidator.validate({ licenseKey: extracted.license });
+    if (!verdict?.ok) {
+      return send(res, verdict?.status || 403, { reason: verdict?.reason || QUOTA_REASONS.LICENSE_INVALID });
+    }
+
+    // Per-license daily download meter (UTC day bucket). The subject is
+    // already an HMAC — never the raw license.
+    const day = new Date(now()).toISOString().slice(0, 10);
+    let used;
+    try {
+      used = await kv.incr(`packs:dl:${verdict.subject}:${day}`, { ttlMs: 48 * 60 * 60 * 1000 });
+    } catch {
+      return send(res, 503, { reason: PACKS_REASONS.PACKS_UNAVAILABLE });
+    }
+    if (used > reqPerDay) return send(res, 429, { reason: PACKS_REASONS.DAILY_DOWNLOADS });
+
+    const requestUrl = new URL(req.url || '/', 'http://localhost');
+    const id = requestUrl.searchParams.get('id');
+
+    try {
+      const manifest = await loadManifest();
+      if (!id) {
+        return send(res, 200, {
+          ref,
+          packs: manifest.packs.map(({ id: packId, version, kind, lang, description, sha256: digest }) => (
+            { id: packId, version, kind, lang, description: description || '', sha256: digest }
+          )),
+        });
+      }
+
+      const pack = manifest.packs.find((/** @type {any} */ p) => p.id === id);
+      if (!pack) return send(res, 404, { reason: PACKS_REASONS.PACK_NOT_FOUND });
+
+      const content = await fetchRepoFile(pack.path);
+      const digest = sha256(content);
+      if (digest !== pack.sha256) {
+        // Integrity mismatch between manifest and blob (mid-publish read or a
+        // bad commit). Serving it would put an unverifiable file on disk
+        // client-side; refuse instead.
+        warn('packs: manifest/content sha mismatch', { id, expected: pack.sha256, actual: digest });
+        return send(res, 503, { reason: PACKS_REASONS.PACKS_UNAVAILABLE });
+      }
+      return send(res, 200, {
+        id: pack.id,
+        version: pack.version,
+        kind: pack.kind,
+        lang: pack.lang,
+        sha256: pack.sha256,
+        content,
+      });
+    } catch (err) {
+      const upstream = /** @type {any} */ (err)?.upstreamStatus;
+      warn('packs: upstream failure', { upstream: upstream ?? null });
+      return send(res, 503, { reason: PACKS_REASONS.PACKS_UNAVAILABLE });
+    }
+  };
+}

--- a/tests/unit/pack-command.test.js
+++ b/tests/unit/pack-command.test.js
@@ -1,0 +1,146 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, existsSync, readFileSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runPack } from '../../src/commands/pack.js';
+import { loadPatterns } from '../../src/loader.js';
+
+const sha256 = (s) => createHash('sha256').update(s, 'utf8').digest('hex');
+const PACK_BODY = '---\nversion: 1.0.0\npatterns: 1\n---\n\n## KO-S1: sample\n';
+
+function serverFetch({ manifestPacks, contents }) {
+  return async (url, opts = {}) => {
+    const auth = opts.headers?.authorization || '';
+    if (!auth.startsWith('Bearer ') || auth === 'Bearer ') {
+      return { ok: false, status: 401, json: async () => ({ reason: 'LICENSE_REQUIRED' }) };
+    }
+    const u = new URL(String(url));
+    const id = u.searchParams.get('id');
+    if (!id) return { ok: true, status: 200, json: async () => ({ packs: manifestPacks }) };
+    const pack = contents[id];
+    if (!pack) return { ok: false, status: 404, json: async () => ({ reason: 'PACK_NOT_FOUND' }) };
+    return { ok: true, status: 200, json: async () => pack };
+  };
+}
+
+function fixture() {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'patina-pack-'));
+  const manifestPacks = [
+    { id: 'ko-structure', version: '1.0.0', kind: 'pattern', lang: 'ko', description: 'structural tells', sha256: sha256(PACK_BODY) },
+    { id: 'ko-pro-lex', version: '2.0.0', kind: 'lexicon', lang: 'ko', description: 'pro lexicon', sha256: sha256('lex body') },
+  ];
+  const contents = {
+    'ko-structure': { id: 'ko-structure', version: '1.0.0', kind: 'pattern', lang: 'ko', sha256: sha256(PACK_BODY), content: PACK_BODY },
+    'ko-pro-lex': { id: 'ko-pro-lex', version: '2.0.0', kind: 'lexicon', lang: 'ko', sha256: sha256('lex body'), content: 'lex body' },
+  };
+  return { repoRoot, manifestPacks, contents };
+}
+
+const baseArgs = ['--license', 'k', '--url', 'https://packs.test/api/packs'];
+
+test('pack install writes a pattern pack into custom/patterns and it becomes loadable', async () => {
+  const { repoRoot, manifestPacks, contents } = fixture();
+  try {
+    await runPack(['install', 'ko-structure', ...baseArgs], {
+      fetchImpl: serverFetch({ manifestPacks, contents }),
+      repoRoot,
+    });
+    const dest = join(repoRoot, 'custom', 'patterns', 'ko-structure.md');
+    assert.equal(existsSync(dest), true);
+    assert.equal(readFileSync(dest, 'utf8'), PACK_BODY);
+
+    // and the loader actually discovers it (patterns/ can be absent entirely)
+    mkdirSync(join(repoRoot, 'patterns'), { recursive: true });
+    const packs = loadPatterns(repoRoot, 'ko');
+    assert.deepEqual(packs.map((p) => p.file), ['ko-structure.md']);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('pack install refuses a sha mismatch', async () => {
+  const { repoRoot, manifestPacks, contents } = fixture();
+  contents['ko-structure'] = { ...contents['ko-structure'], content: PACK_BODY + 'tampered' };
+  try {
+    await assert.rejects(
+      runPack(['install', 'ko-structure', ...baseArgs], { fetchImpl: serverFetch({ manifestPacks, contents }), repoRoot }),
+      /integrity/
+    );
+    assert.equal(existsSync(join(repoRoot, 'custom', 'patterns', 'ko-structure.md')), false);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('lexicon install never clobbers an existing custom lexicon without --force', async () => {
+  const { repoRoot, manifestPacks, contents } = fixture();
+  try {
+    mkdirSync(join(repoRoot, 'custom', 'lexicon'), { recursive: true });
+    writeFileSync(join(repoRoot, 'custom', 'lexicon', 'ai-ko.md'), 'hand-maintained');
+    await assert.rejects(
+      runPack(['install', 'ko-pro-lex', ...baseArgs], { fetchImpl: serverFetch({ manifestPacks, contents }), repoRoot }),
+      /overwrite/
+    );
+    assert.equal(readFileSync(join(repoRoot, 'custom', 'lexicon', 'ai-ko.md'), 'utf8'), 'hand-maintained');
+
+    await runPack(['install', 'ko-pro-lex', '--force', ...baseArgs], { fetchImpl: serverFetch({ manifestPacks, contents }), repoRoot });
+    assert.equal(readFileSync(join(repoRoot, 'custom', 'lexicon', 'ai-ko.md'), 'utf8'), 'lex body');
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('missing license is an input error before any network call', async () => {
+  const { repoRoot } = fixture();
+  const prev = process.env.PATINA_LICENSE_KEY;
+  delete process.env.PATINA_LICENSE_KEY;
+  try {
+    await assert.rejects(
+      runPack(['list', '--url', 'https://packs.test/api/packs'], {
+        fetchImpl: async () => { throw new Error('must not fetch'); },
+        repoRoot,
+      }),
+      /license/i
+    );
+  } finally {
+    if (prev !== undefined) process.env.PATINA_LICENSE_KEY = prev;
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('unknown pack id fails before download; --all installs everything', async () => {
+  const { repoRoot, manifestPacks, contents } = fixture();
+  try {
+    await assert.rejects(
+      runPack(['install', 'nope', ...baseArgs], { fetchImpl: serverFetch({ manifestPacks, contents }), repoRoot }),
+      /unknown pack/
+    );
+    await runPack(['install', '--all', ...baseArgs], { fetchImpl: serverFetch({ manifestPacks, contents }), repoRoot });
+    assert.equal(existsSync(join(repoRoot, 'custom', 'patterns', 'ko-structure.md')), true);
+    assert.equal(existsSync(join(repoRoot, 'custom', 'lexicon', 'ai-ko.md')), true);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('custom/patterns shadows a built-in pack with the same filename', () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'patina-shadow-'));
+  try {
+    mkdirSync(join(repoRoot, 'patterns'), { recursive: true });
+    mkdirSync(join(repoRoot, 'custom', 'patterns'), { recursive: true });
+    writeFileSync(join(repoRoot, 'patterns', 'ko-base.md'), '---\nv: 1\n---\nbuiltin');
+    writeFileSync(join(repoRoot, 'custom', 'patterns', 'ko-base.md'), '---\nv: 2\n---\ncustom wins');
+    writeFileSync(join(repoRoot, 'custom', 'patterns', 'ko-extra.md'), '---\nv: 1\n---\nextra');
+    const packs = loadPatterns(repoRoot, 'ko');
+    assert.deepEqual(packs.map((p) => p.file), ['ko-base.md', 'ko-extra.md']);
+    assert.match(packs[0].body, /custom wins/);
+    // skipPatterns applies to custom packs too
+    const skipped = loadPatterns(repoRoot, 'ko', ['ko-extra']);
+    assert.deepEqual(skipped.map((p) => p.file), ['ko-base.md']);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/pack-handler.test.js
+++ b/tests/unit/pack-handler.test.js
@@ -1,0 +1,193 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+
+import { createPackHandler, isValidPackEntry, PACKS_REASONS } from '../../src/pack-handler.js';
+import { createMemoryKv } from '../../src/rate-limit.js';
+import { QUOTA_REASONS } from '../../src/web-rewrite-contract.js';
+
+const sha256 = (s) => createHash('sha256').update(s, 'utf8').digest('hex');
+const FIXED_NOW = 1_700_000_000_000;
+
+const PACK_BODY = '---\nversion: 1.0.0\n---\n\n# pro pack body\n';
+const MANIFEST = {
+  packs: [
+    { id: 'ko-structure', path: 'patterns/ko-structure.md', version: '1.0.0', lang: 'ko', kind: 'pattern', description: 'structural tells', sha256: sha256(PACK_BODY) },
+  ],
+};
+
+function mockRes() {
+  const res = {
+    statusCode: 0,
+    headers: {},
+    body: null,
+    setHeader(k, v) { this.headers[k.toLowerCase()] = v; },
+    end(payload) { this.body = payload ? JSON.parse(payload) : null; },
+  };
+  return res;
+}
+
+function mockReq({ method = 'GET', url = '/api/packs', license = 'good-key' } = {}) {
+  return { method, url, headers: license ? { authorization: `Bearer ${license}` } : {} };
+}
+
+/** GitHub contents API stub keyed by path. */
+function githubFetch(files, calls = []) {
+  return async (url) => {
+    calls.push(String(url));
+    const m = String(url).match(/contents\/([^?]+)\?/);
+    const path = m ? decodeURIComponent(m[1]) : '';
+    if (!(path in files)) return { ok: false, status: 404, text: async () => 'not found' };
+    return { ok: true, status: 200, text: async () => files[path] };
+  };
+}
+
+const allowValidator = { validate: async () => ({ ok: true, subject: 'subj-hmac', tier: 'pro', status: 'active' }) };
+
+function makeHandler({ files = { 'manifest.json': JSON.stringify(MANIFEST), 'patterns/ko-structure.md': PACK_BODY }, validator = allowValidator, env = {}, calls = [], kv = createMemoryKv() } = {}) {
+  return {
+    handler: createPackHandler({
+      env: { PATINA_PACKS_GITHUB_TOKEN: 'tok', ...env },
+      kv,
+      licenseValidator: validator,
+      fetchImpl: githubFetch(files, calls),
+      now: () => FIXED_NOW,
+      logger: { warn: () => {} },
+    }),
+    calls,
+    kv,
+  };
+}
+
+test('manifest listing requires a license and returns validated entries', async () => {
+  const { handler } = makeHandler();
+  const res = mockRes();
+  await handler(mockReq(), res);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.packs.length, 1);
+  assert.equal(res.body.packs[0].id, 'ko-structure');
+  assert.equal(res.body.packs[0].sha256, sha256(PACK_BODY));
+  // listing never includes repo paths or content
+  assert.equal(res.body.packs[0].path, undefined);
+  assert.equal(res.body.packs[0].content, undefined);
+});
+
+test('missing bearer -> 401 LICENSE_REQUIRED, invalid license -> validator status/reason', async () => {
+  const { handler } = makeHandler();
+  const res401 = mockRes();
+  await handler(mockReq({ license: null }), res401);
+  assert.equal(res401.statusCode, 401);
+  assert.equal(res401.body.reason, QUOTA_REASONS.LICENSE_REQUIRED);
+
+  const deny = { validate: async () => ({ ok: false, status: 403, reason: QUOTA_REASONS.LICENSE_INVALID }) };
+  const { handler: denyHandler } = makeHandler({ validator: deny });
+  const res403 = mockRes();
+  await denyHandler(mockReq(), res403);
+  assert.equal(res403.statusCode, 403);
+  assert.equal(res403.body.reason, QUOTA_REASONS.LICENSE_INVALID);
+});
+
+test('pack download verifies manifest sha and returns content', async () => {
+  const { handler } = makeHandler();
+  const res = mockRes();
+  await handler(mockReq({ url: '/api/packs?id=ko-structure' }), res);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.content, PACK_BODY);
+  assert.equal(res.body.kind, 'pattern');
+});
+
+test('sha mismatch between manifest and blob is refused, unknown id -> 404', async () => {
+  const files = { 'manifest.json': JSON.stringify(MANIFEST), 'patterns/ko-structure.md': PACK_BODY + 'tampered' };
+  const { handler } = makeHandler({ files });
+  const res = mockRes();
+  await handler(mockReq({ url: '/api/packs?id=ko-structure' }), res);
+  assert.equal(res.statusCode, 503);
+  assert.equal(res.body.reason, PACKS_REASONS.PACKS_UNAVAILABLE);
+
+  const res404 = mockRes();
+  await handler(mockReq({ url: '/api/packs?id=nope' }), res404);
+  assert.equal(res404.statusCode, 404);
+  assert.equal(res404.body.reason, PACKS_REASONS.PACK_NOT_FOUND);
+});
+
+test('no upstream token -> 503 before any auth work', async () => {
+  const validateCalls = [];
+  const spyValidator = { validate: async () => { validateCalls.push(1); return { ok: true, subject: 's' }; } };
+  const handler = createPackHandler({
+    env: {},
+    kv: createMemoryKv(),
+    licenseValidator: spyValidator,
+    fetchImpl: async () => { throw new Error('must not fetch'); },
+    logger: { warn: () => {} },
+  });
+  const res = mockRes();
+  await handler(mockReq(), res);
+  assert.equal(res.statusCode, 503);
+  assert.equal(res.body.reason, PACKS_REASONS.PACKS_UNAVAILABLE);
+  assert.equal(validateCalls.length, 0);
+});
+
+test('daily download cap meters per subject and returns 429 over the cap', async () => {
+  const { handler } = makeHandler({ env: { PATINA_PACKS_REQ_PER_DAY: '2' } });
+  const ok1 = mockRes(); await handler(mockReq(), ok1);
+  const ok2 = mockRes(); await handler(mockReq(), ok2);
+  const over = mockRes(); await handler(mockReq(), over);
+  assert.equal(ok1.statusCode, 200);
+  assert.equal(ok2.statusCode, 200);
+  assert.equal(over.statusCode, 429);
+  assert.equal(over.body.reason, PACKS_REASONS.DAILY_DOWNLOADS);
+});
+
+test('upstream responses are KV-cached; failures are not cached', async () => {
+  const calls = [];
+  const { handler } = makeHandler({ calls });
+  const r1 = mockRes(); await handler(mockReq(), r1);
+  const r2 = mockRes(); await handler(mockReq(), r2);
+  assert.equal(r2.statusCode, 200);
+  // manifest fetched once, served from KV the second time
+  assert.equal(calls.filter((u) => u.includes('manifest.json')).length, 1);
+
+  const failCalls = [];
+  const { handler: failing } = makeHandler({ files: {}, calls: failCalls });
+  const f1 = mockRes(); await failing(mockReq(), f1);
+  const f2 = mockRes(); await failing(mockReq(), f2);
+  assert.equal(f1.statusCode, 503);
+  assert.equal(f2.statusCode, 503);
+  // 404 upstream must be retried (not pinned into cache)
+  assert.equal(failCalls.filter((u) => u.includes('manifest.json')).length, 2);
+});
+
+test('malformed manifest entries are dropped, not served', async () => {
+  const files = {
+    'manifest.json': JSON.stringify({
+      packs: [
+        MANIFEST.packs[0],
+        { id: '../evil', path: '/etc/passwd', version: 'x', lang: 'ko', kind: 'pattern', sha256: 'zz' },
+        { id: 'no-kind', path: 'a.md', version: '1', lang: 'en', kind: 'binary', sha256: sha256('x') },
+      ],
+    }),
+    'patterns/ko-structure.md': PACK_BODY,
+  };
+  const { handler } = makeHandler({ files });
+  const res = mockRes();
+  await handler(mockReq(), res);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body.packs.map((p) => p.id), ['ko-structure']);
+});
+
+test('non-GET is rejected with 405', async () => {
+  const { handler } = makeHandler();
+  const res = mockRes();
+  await handler(mockReq({ method: 'POST' }), res);
+  assert.equal(res.statusCode, 405);
+});
+
+test('isValidPackEntry enforces id/path/kind/sha shape', () => {
+  const good = MANIFEST.packs[0];
+  assert.equal(isValidPackEntry(good), true);
+  assert.equal(isValidPackEntry({ ...good, id: 'Bad_ID!' }), false);
+  assert.equal(isValidPackEntry({ ...good, path: '../../secrets' }), false);
+  assert.equal(isValidPackEntry({ ...good, path: '/abs/path' }), false);
+  assert.equal(isValidPackEntry({ ...good, kind: 'exe' }), false);
+  assert.equal(isValidPackEntry({ ...good, sha256: 'nothex' }), false);
+});


### PR DESCRIPTION
Open-core deepening (repo-copy protection, option ②): pro packs live in a **private repo** and are served only to valid Pro licenses — never in the public repo, the npm tarball, or any deploy artifact. Binary/obfuscation was rejected: patina's core assets are prose an LLM must read, so *not shipping them* is the only protection that works.

## What's in here

- **`api/packs.js` + `src/pack-handler.js`** — GET-only endpoint reusing the rewrite API's fail-closed Lemon Squeezy validator and KV verbatim. Per-license daily download meter (UTC-day bucket on the HMAC subject), pack ids resolved server-side from the private-repo manifest (no client paths → no traversal), sha256 manifest/content integrity refusal, upstream GitHub reads KV-cached with failures never cached.
- **`patina pack list|install <id…>|--all`** (`src/commands/pack.js`) — license from `--license` > `PATINA_LICENSE_KEY` > `license-key:` in `.patina.yaml`; installs into gitignored `custom/` after re-verifying sha256 client-side; refuses to clobber a hand-maintained `custom/lexicon/ai-<lang>.md` without `--force`.
- **`src/loader.js`** — `loadPatterns` now also discovers `custom/patterns/{lang}-*.md`; custom shadows a built-in on filename collision (personas/lexicon already worked this way).
- **Private repo** `devswha/patina-pro-packs` created (manifest scaffold + publish helper). First real pack (`ko-structure`) lands there once Study 1's structural-tell results are in.
- Docs: `docs/PRO-PACKS.md`, `.env.example` block, CLI help.

## Tests

16 new unit tests (handler: auth/quorum of failure modes, cache semantics, malformed-manifest hardening; CLI: install/integrity/no-clobber/license gating; loader shadowing). Full suite 1363 pass / 0 fail; lint clean. E2E verified against the real private repo (200, empty manifest).

## Deploy checklist (not in this PR)

- Vercel env: `PATINA_PACKS_GITHUB_TOKEN` — fine-grained PAT, **contents: read** on `devswha/patina-pro-packs` only.
- Optional tuning: `PATINA_PACKS_REQ_PER_DAY`, `PATINA_PACKS_CACHE_TTL_MS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)