### PR TITLE
fix(web): pre-spike hardening — KV TTL atomicity, follower cache-poll, client-IP trust order (#605–#607)

### DIFF
--- a/api/rewrite.js
+++ b/api/rewrite.js
@@ -56,6 +56,24 @@ export function createRestKv(env = {}) {
     return response.json();
   }
 
+  // Atomic counter bump + TTL in ONE round trip (EVAL): the GET-path
+  // /incr → /expire pair had the same crash window as SET+EXPIRE above. For
+  // time-bucketed quota keys a lost expire merely leaks storage, but the
+  // CONCURRENCY key is stable per IP/subject — a TTL-less counter there pins
+  // that identity near its cap until manual cleanup, so the self-heal TTL must
+  // be applied atomically with the increment.
+  const INCRBY_PEXPIRE_SCRIPT = "local v = redis.call('INCRBY', KEYS[1], ARGV[1]) redis.call('PEXPIRE', KEYS[1], ARGV[2]) return v";
+
+  async function incrByAtomic(key, amount, ttlMs) {
+    const data = await command([
+      'EVAL', INCRBY_PEXPIRE_SCRIPT, '1', key,
+      String(amount), String(Math.max(1, Math.ceil(ttlMs))),
+    ]);
+    const value = parseKvNumber(data);
+    if (value == null) throw new Error('kv incr returned invalid counter');
+    return value;
+  }
+
   return {
     async get(key) {
       const data = await read(`/get/${encodeURIComponent(key)}`);
@@ -87,27 +105,19 @@ export function createRestKv(env = {}) {
       }
     },
     async incr(key, { ttlMs } = {}) {
-      const encoded = encodeURIComponent(key);
-      const data = await read(`/incr/${encoded}`);
+      if (typeof ttlMs === 'number' && ttlMs > 0) return incrByAtomic(key, 1, ttlMs);
+      const data = await read(`/incr/${encodeURIComponent(key)}`);
       const value = parseKvNumber(data);
       if (value == null) throw new Error('kv incr returned invalid counter');
-      if (typeof ttlMs === 'number' && ttlMs > 0) {
-        const seconds = Math.max(1, Math.ceil(ttlMs / 1000));
-        await read(`/expire/${encoded}/${seconds}`);
-      }
       return value;
     },
     async incrBy(key, amount, { ttlMs } = {}) {
-      const encoded = encodeURIComponent(key);
       // Upstash/Vercel KV INCRBY: atomic add-N, returned as the new total. Used
       // for the pro monthly character counter (add textLength per request).
-      const data = await read(`/incrby/${encoded}/${encodeURIComponent(String(amount))}`);
+      if (typeof ttlMs === 'number' && ttlMs > 0) return incrByAtomic(key, amount, ttlMs);
+      const data = await read(`/incrby/${encodeURIComponent(key)}/${encodeURIComponent(String(amount))}`);
       const value = parseKvNumber(data);
       if (value == null) throw new Error('kv incrby returned invalid counter');
-      if (typeof ttlMs === 'number' && ttlMs > 0) {
-        const seconds = Math.max(1, Math.ceil(ttlMs / 1000));
-        await read(`/expire/${encoded}/${seconds}`);
-      }
       return value;
     },
     async decr(key) {

--- a/src/entitlement.js
+++ b/src/entitlement.js
@@ -37,6 +37,7 @@ const DEFAULT_NEGATIVE_CACHE_TTL_MS = 60_000; // negative-result cache
 const DEFAULT_TIMEOUT_MS = 2_500; // LS fetch abort deadline
 const DEFAULT_VALIDATE_RPM = 50; // stays below LS's hard 60 rpm ceiling
 const LOCK_TTL_MS = 10_000; // single-flight lock self-heal window
+const DEFAULT_LOCK_POLL_INTERVAL_MS = 150; // follower cache-poll cadence while the winner validates
 /** Dev-only HMAC fallback; only ever reached OUTSIDE production (prod requires a real secret). */
 const DEV_FALLBACK_SECRET = 'patina-local-license-secret';
 
@@ -291,6 +292,31 @@ export function createLemonSqueezyLicenseValidator({
     }
     if (!Number.isSafeInteger(lockCount) || lockCount < 1) return unavailable();
     if (lockCount > 1) {
+      // Follower path: the winner is validating this SAME license right now and
+      // writes the cache when it finishes (typically well under timeoutMs). An
+      // instant 503 here would break the advertised concurrency for a license's
+      // first burst — right after purchase, or whenever the positive cache TTL
+      // lapses — so followers briefly poll the cache instead (#606). The loop
+      // is bounded by ITERATION COUNT, never the wall clock, so an injected or
+      // frozen `now` cannot spin it forever; when the winner crashed or LS is
+      // down, nothing gets cached and this stays fail-closed 503.
+      const pollIntervalMs = readPositiveInt(env.PATINA_LS_LOCK_POLL_INTERVAL_MS, DEFAULT_LOCK_POLL_INTERVAL_MS);
+      const lockWaitMs = readPositiveInt(env.PATINA_LS_LOCK_WAIT_MS, Math.min(lockTtlMs, timeoutMs + 1_000));
+      const attempts = Math.max(1, Math.ceil(lockWaitMs / pollIntervalMs));
+      for (let i = 0; i < attempts; i += 1) {
+        await sleep(pollIntervalMs);
+        try {
+          const hit = readCacheEntry(await store.get(cacheKey), now());
+          if (hit) {
+            if (hit.decision === 'allow') {
+              return { ok: true, subject, tier: 'pro', status: hit.status, cache: 'hit' };
+            }
+            return /** @type {EntitlementDeny} */ ({ ok: false, status: hit.status, reason: hit.reason });
+          }
+        } catch {
+          /* a broken cache read never fails open; keep polling */
+        }
+      }
       warnSafe('entitlement: LS validate single-flight lock held', { subject, lockCount });
       return unavailable();
     }
@@ -459,6 +485,11 @@ function scrubLicense(value, license) {
     return v;
   };
   return walk(value);
+}
+
+/** @param {number} ms @returns {Promise<void>} */
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /** @param {unknown} err @returns {string} */

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -21,11 +21,19 @@ export function quotaKeyHmac(secret, ...parts) {
 /**
  * Extract a client IP only from trusted platform headers.
  *
+ * Order matters: `x-vercel-forwarded-for` is consulted FIRST because the
+ * `x-vercel-*` prefix is platform-controlled under every topology (Vercel
+ * always strips/sets it at its own proxy). `x-real-ip` is equally
+ * platform-set on a direct Vercel deployment, but its trustworthiness depends
+ * on that topology staying true — behind a future fronting proxy/CDN or a
+ * verified-proxy setup a client-supplied value could survive, which on this
+ * boundary would mint fresh per-IP free-tier quota per spoofed header (#607).
+ *
  * @param {Record<string, string|string[]|undefined>} headers
  * @param {{trustedHeaders?: string[]}} [options]
  * @returns {string|null}
  */
-export function extractClientIp(headers, { trustedHeaders = ['x-real-ip', 'x-vercel-forwarded-for'] } = {}) {
+export function extractClientIp(headers, { trustedHeaders = ['x-vercel-forwarded-for', 'x-real-ip'] } = {}) {
   for (const name of trustedHeaders) {
     const value = getHeader(headers, name);
     if (!value) continue;

--- a/tests/unit/entitlement.redteam.test.js
+++ b/tests/unit/entitlement.redteam.test.js
@@ -332,18 +332,37 @@ function lockKeyFor(license) {
   return quotaKeyHmac(SECRET, 'ls-lock', license);
 }
 
-check('C3-a', 'single-flight: N concurrent misses call LS exactly once', 'LS called once; 1 winner (miss); N-1 losers fail closed 503', async () => {
+check('C3-a', 'single-flight: N concurrent misses call LS exactly once', 'LS called once; 1 winner (miss); N-1 followers poll into the cache (hit)', async () => {
   const N = 8;
-  // The winner's fetch resolves on a macrotask so every loser returns 503 first.
+  // The winner's fetch resolves on a macrotask, so every follower enters the
+  // bounded cache poll (#606) before the winner writes the cache.
   const fetchImpl = spyFetch(async () => { await new Promise((r) => setTimeout(r, 15)); return lsResponse(okBody()); });
-  const validator = makeValidator({ fetchImpl });
+  const validator = makeValidator({ fetchImpl, env: baseEnv({ PATINA_LS_LOCK_POLL_INTERVAL_MS: '5' }) });
   const license = 'LK-c3-concurrent';
   const results = await Promise.all(Array.from({ length: N }, () => validator.validate({ licenseKey: license })));
   assert.equal(fetchImpl.calls.length, 1, 'exactly one instance may call LS');
-  const winners = results.filter((r) => r.ok);
-  assert.equal(winners.length, 1, 'exactly one winner');
-  assert.equal(winners[0].cache, 'miss');
-  assert.equal(results.filter((r) => !r.ok && r.status === 503).length, N - 1, 'losers fail closed');
+  assert.equal(results.filter((r) => r.ok).length, N, 'the whole first burst succeeds — no follower 503s (#606)');
+  assert.equal(results.filter((r) => r.ok && r.cache === 'miss').length, 1, 'exactly one winner validated against LS');
+  assert.equal(results.filter((r) => r.ok && r.cache === 'hit').length, N - 1, 'followers are served from the winner-written cache');
+});
+
+check('C3-a2', 'single-flight: a follower with a crashed winner exhausts its bounded poll', 'no cache ever appears -> follower stays fail-closed 503 without calling LS', async () => {
+  const kv = createMemoryKv();
+  const license = 'LK-c3-crashed-winner';
+  const fetchImpl = spyFetch(() => { throw new Error('a follower must never reach LS'); });
+  const validator = makeValidator({
+    kv,
+    fetchImpl,
+    env: baseEnv({ PATINA_LS_LOCK_POLL_INTERVAL_MS: '2', PATINA_LS_LOCK_WAIT_MS: '10' }),
+  });
+  // A "winner" that took the lock and died: the lock is held, no cache is ever
+  // written, and only the lock TTL will eventually self-heal it.
+  await kv.incr(lockKeyFor(license), { ttlMs: 10_000 });
+  const res = await validator.validate({ licenseKey: license });
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 503, 'poll exhaustion stays fail-closed');
+  assert.equal(res.reason, QUOTA_REASONS.LICENSE_UNAVAILABLE);
+  assert.equal(fetchImpl.calls.length, 0);
 });
 
 check('C3-b', 'single-flight: a failed winner (non-2xx) releases the lock for retry', 'lock reset to 0; retry re-validates against LS and succeeds', async () => {

--- a/tests/unit/entitlement.test.js
+++ b/tests/unit/entitlement.test.js
@@ -457,13 +457,20 @@ test('admission: the RPM bucket resets in a new minute', async () => {
   assert.equal(fetchImpl.calls.length, 2);
 });
 
-test('admission: a held single-flight lock denies without calling LS', async () => {
+test('admission: a held single-flight lock polls the cache, then denies without calling LS', async () => {
   const kv = createMemoryKv();
   const license = 'LK-lock-0001';
   const fetchImpl = spyFetch(() => lsResponse(okBody()));
-  const validator = makeValidator({ kv, fetchImpl });
+  // Small poll budget so the bounded follower wait doesn't slow the suite.
+  const validator = makeValidator({
+    kv,
+    fetchImpl,
+    env: baseEnv({ PATINA_LS_LOCK_POLL_INTERVAL_MS: '2', PATINA_LS_LOCK_WAIT_MS: '10' }),
+  });
 
-  // Simulate another instance mid-validation by pre-incrementing the shared lock key.
+  // Simulate another instance mid-validation by pre-incrementing the shared lock
+  // key — and never writing the cache (a crashed/stuck winner). The follower
+  // polls its bounded budget, then still fails CLOSED without touching LS.
   const lockKey = quotaKeyHmac(SECRET, 'ls-lock', license);
   await kv.incr(lockKey, { ttlMs: 10_000 }); // -> 1; the validator's incr then returns 2 (>1)
 
@@ -474,9 +481,37 @@ test('admission: a held single-flight lock denies without calling LS', async () 
   assert.equal(fetchImpl.calls.length, 0);
 });
 
+test('admission: a follower is served from the cache the winner writes mid-poll (no 503, no LS re-call)', async () => {
+  const kv = createMemoryKv();
+  const license = 'LK-lock-0002';
+  const fetchImpl = spyFetch(() => lsResponse(okBody()));
+  const validator = makeValidator({
+    kv,
+    fetchImpl,
+    env: baseEnv({ PATINA_LS_LOCK_POLL_INTERVAL_MS: '2' }),
+  });
+
+  // Another instance holds the lock…
+  const lockKey = quotaKeyHmac(SECRET, 'ls-lock', license);
+  await kv.incr(lockKey, { ttlMs: 10_000 });
+  // …and finishes validating while the follower is polling.
+  const cacheKey = quotaKeyHmac(SECRET, 'ls-license-cache', license);
+  setTimeout(() => {
+    void kv.set(cacheKey, { decision: 'allow', tier: 'pro', status: 'active', expiresAt: FIXED_NOW + 60_000 }, { ttlMs: 60_000 });
+  }, 4);
+
+  const res = await validator.validate({ licenseKey: license });
+  assert.equal(res.ok, true, 'the follower must pick up the winner-written cache');
+  assert.equal(res.cache, 'hit');
+  assert.equal(fetchImpl.calls.length, 0, 'the follower must never call LS itself');
+});
+
 test('admission: concurrent misses for one license call LS exactly once (single-flight)', async () => {
   const fetchImpl = spyFetch(() => lsResponse(okBody()));
-  const validator = makeValidator({ fetchImpl });
+  const validator = makeValidator({
+    fetchImpl,
+    env: baseEnv({ PATINA_LS_LOCK_POLL_INTERVAL_MS: '2' }),
+  });
   const license = 'LK-concurrent-0001';
 
   const results = await Promise.all([
@@ -487,9 +522,12 @@ test('admission: concurrent misses for one license call LS exactly once (single-
     validator.validate({ licenseKey: license }),
   ]);
 
+  // #606: the first concurrent burst for an uncached license must NOT 503 the
+  // followers — they poll into the cache the winner writes.
   assert.equal(fetchImpl.calls.length, 1, 'exactly one instance may call LS');
-  assert.equal(results.filter((r) => r.ok).length, 1, 'exactly one winner');
-  assert.equal(results.filter((r) => !r.ok && r.status === 503).length, 4, 'losers fail closed and retry into cache');
+  assert.equal(results.filter((r) => r.ok).length, 5, 'winner and followers all succeed');
+  assert.equal(results.filter((r) => r.ok && r.cache === 'miss').length, 1, 'exactly one winner validated against LS');
+  assert.equal(results.filter((r) => r.ok && r.cache === 'hit').length, 4, 'followers are served from the winner-written cache');
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/rate-limit.redteam.test.js
+++ b/tests/unit/rate-limit.redteam.test.js
@@ -586,25 +586,37 @@ test('category 15 createRestKv set/get: atomic single-command SET(+PX) round-tri
 });
 
 test('category 16 createRestKv incr/decr: numeric REST path is parsed independently of get and fails closed on an invalid counter', async () => {
-  // incr parses number|numeric-string|nested {result} via parseKvNumber and
-  // issues a SEPARATE /expire only when a positive ttl is supplied (counter path
-  // is unaffected by get()'s JSON-parsing round-trip).
+  // A TTL'd incr is ONE atomic root-POST EVAL(INCRBY+PEXPIRE) — never an /incr
+  // followed by a separate /expire the process could die before issuing (#605:
+  // a lost expire on the stable concurrency key would pin that identity near
+  // its cap until manual cleanup). No-ttl incr keeps the plain GET path. Both
+  // parse number|numeric-string|nested {result} via parseKvNumber.
   {
     const calls = [];
-    await withMockFetch(async (url) => {
+    const posts = [];
+    await withMockFetch(async (url, init) => {
+      if (init && init.method === 'POST') {
+        posts.push(JSON.parse(String(init.body)));
+        return { ok: true, async json() { return { result: '7' }; } };
+      }
       const u = String(url);
       calls.push(u);
       if (u.includes('/incr/')) return { ok: true, async json() { return { result: '7' }; } };
-      if (u.includes('/expire/')) return { ok: true, async json() { return { result: 1 }; } };
       if (u.includes('/decr/')) return { ok: true, async json() { return { result: { result: 3 } }; } };
       return { ok: true, async json() { return { result: null }; } };
     }, async () => {
       const kv = createRestKv({ KV_REST_API_URL: 'https://kv.example.test', KV_REST_API_TOKEN: 'token' });
-      assert.equal(await kv.incr('c', { ttlMs: 60_000 }), 7, 'numeric-string incr result parses to a number');
-      assert.deepEqual(calls, ['https://kv.example.test/incr/c', 'https://kv.example.test/expire/c/60'], 'incr + expire, 60s = ceil(60000/1000)');
-      calls.length = 0;
+      assert.equal(await kv.incr('c', { ttlMs: 60_000 }), 7, 'numeric-string EVAL result parses to a number');
+      assert.equal(posts.length, 1, 'ttl incr is a single atomic command');
+      assert.deepEqual(calls, [], 'ttl incr never touches the GET path');
+      assert.equal(posts[0][0], 'EVAL');
+      assert.match(posts[0][1], /INCRBY/);
+      assert.match(posts[0][1], /PEXPIRE/);
+      assert.deepEqual(posts[0].slice(2), ['1', 'c', '1', '60000'], 'one key; amount 1; ttl in ms');
+      posts.length = 0;
       assert.equal(await kv.incr('c'), 7, 'incr without a ttl issues no expire');
       assert.deepEqual(calls, ['https://kv.example.test/incr/c']);
+      assert.equal(posts.length, 0, 'no-ttl incr stays on the GET path');
       assert.equal(await kv.decr('c'), 3, 'nested {result} decr result parses to a number');
     });
   }
@@ -612,10 +624,13 @@ test('category 16 createRestKv incr/decr: numeric REST path is parsed independen
   // A malformed counter (non-numeric, null, non-integer, object) fails closed by
   // THROWING -- never silently returns a bogus count the limiter would trust
   // (the limiter converts that throw into a 503, verified in category 12).
+  // Checked on the GET path (no ttl) AND the atomic EVAL path (ttl).
   for (const bad of [{ result: 'not-a-number' }, { result: null }, { result: 1.5 }, { result: {} }, {}]) {
     await withMockFetch(async () => ({ ok: true, async json() { return bad; } }), async () => {
       const kv = createRestKv({ KV_REST_API_URL: 'https://kv.example.test', KV_REST_API_TOKEN: 'token' });
       await assert.rejects(() => kv.incr('c'), /kv incr returned invalid counter/, `incr rejects ${JSON.stringify(bad)}`);
+      await assert.rejects(() => kv.incr('c', { ttlMs: 1_000 }), /kv incr returned invalid counter/, `ttl incr rejects ${JSON.stringify(bad)}`);
+      await assert.rejects(() => kv.incrBy('c', 5, { ttlMs: 1_000 }), /kv incr returned invalid counter/, `ttl incrBy rejects ${JSON.stringify(bad)}`);
       await assert.rejects(() => kv.decr('c'), /kv decr returned invalid counter/, `decr rejects ${JSON.stringify(bad)}`);
     });
   }

--- a/tests/unit/rate-limit.test.js
+++ b/tests/unit/rate-limit.test.js
@@ -19,10 +19,13 @@ test('quotaKeyHmac is deterministic, part-sensitive, and never exposes the raw I
 });
 
 test('extractClientIp honors trusted-header precedence and comma splitting', () => {
+  // The platform-controlled x-vercel-* header outranks x-real-ip: only the
+  // former is guaranteed proxy-set under every deploy topology (#607).
   assert.equal(
     extractClientIp({ 'x-real-ip': '198.51.100.1', 'x-vercel-forwarded-for': '203.0.113.1' }),
-    '198.51.100.1',
+    '203.0.113.1',
   );
+  assert.equal(extractClientIp({ 'x-real-ip': '198.51.100.1' }), '198.51.100.1');
   assert.equal(extractClientIp({ 'x-vercel-forwarded-for': '203.0.113.2, 10.0.0.1' }), '203.0.113.2');
   assert.equal(extractClientIp({ 'x-forwarded-for': '198.51.100.9' }), null);
   assert.equal(extractClientIp({}), null);

--- a/tests/unit/rewrite-api.test.js
+++ b/tests/unit/rewrite-api.test.js
@@ -325,11 +325,16 @@ test('REST KV set without a TTL omits PX; get is undefined for null and verbatim
   }
 });
 
-test('REST KV incrBy adds N atomically via /incrby and sets a whole-second PEXPIRE', async () => {
+test('REST KV incrBy with a TTL adds N and applies the expiry in ONE atomic EVAL command', async () => {
   const gets = [];
+  const posts = [];
   const results = [];
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = /** @type {any} */ (async (url) => {
+  globalThis.fetch = /** @type {any} */ (async (url, init) => {
+    if (init && init.method === 'POST') {
+      posts.push(JSON.parse(String(init.body)));
+      return { ok: true, async json() { return { result: 1200 }; } };
+    }
     gets.push(String(url));
     return { ok: true, async json() { return results.shift(); } };
   });
@@ -337,13 +342,21 @@ test('REST KV incrBy adds N atomically via /incrby and sets a whole-second PEXPI
     const kv = createRestKv({ KV_REST_API_URL: 'https://kv.example.test', KV_REST_API_TOKEN: 'token' });
     assert.ok(kv);
 
-    // incrby returns the new running total; ttlMs -> /expire with ceil(ms/1000) seconds.
-    results.push({ result: 1200 }); // incrby result
-    results.push({ result: 1 }); // expire ack
+    // #605: increment + TTL is a single EVAL(INCRBY+PEXPIRE) round trip — never
+    // an /incrby followed by a separate /expire the process could die before.
     const total = await kv.incrBy('month key', 400, { ttlMs: 2_500 });
     assert.equal(total, 1200);
+    assert.equal(posts.length, 1, 'one atomic command, no separate expire call');
+    assert.equal(gets.length, 0, 'the GET path is never used when a TTL is supplied');
+    assert.equal(posts[0][0], 'EVAL');
+    assert.match(posts[0][1], /INCRBY/);
+    assert.match(posts[0][1], /PEXPIRE/);
+    assert.deepEqual(posts[0].slice(2), ['1', 'month key', '400', '2500'], 'one key; amount; ttl in ms');
+
+    // Without a TTL the plain GET-path INCRBY is kept.
+    results.push({ result: 800 });
+    assert.equal(await kv.incrBy('month key', 400), 800);
     assert.equal(gets[0], 'https://kv.example.test/incrby/month%20key/400');
-    assert.equal(gets[1], 'https://kv.example.test/expire/month%20key/3');
 
     // A malformed counter (non-numeric) fails closed by throwing.
     results.push({ result: 'not-a-number' });
@@ -496,10 +509,16 @@ test('pro tier: in production, no pro key + present free key + no allow-flag ret
   // One mock serves both the LS validate call and the Upstash KV REST adapter so
   // entitlement + rate limiting pass in production and the flow reaches the
   // server-key resolution (where the policy denial happens).
-  globalThis.fetch = /** @type {any} */ (async (url) => {
+  globalThis.fetch = /** @type {any} */ (async (url, init) => {
     const u = String(url);
     if (u.includes('api.lemonsqueezy.com')) {
       return { ok: true, status: 200, async json() { return { valid: true, license_key: { status: 'active' }, meta: { store_id: '42', variant_id: '99' } }; } };
+    }
+    if (init && init.method === 'POST') {
+      // Root-POST commands: atomic EVAL(INCRBY+PEXPIRE) counters return 1; SET returns OK.
+      const args = JSON.parse(String(init.body));
+      if (args[0] === 'EVAL') return { ok: true, async json() { return { result: 1 }; } };
+      return { ok: true, async json() { return { result: 'OK' }; } };
     }
     if (u.includes('/incr/')) return { ok: true, async json() { return { result: 1 }; } };
     if (u.includes('/decr/')) return { ok: true, async json() { return { result: 0 }; } };


### PR DESCRIPTION
Pre-traffic-spike hardening for the three findings from the 2026-07-10 Pro-path audit, ahead of the planned launch push.

## #605 — atomic EVAL incr+expire (api/rewrite.js)
`createRestKv` incr/incrBy did the increment and then a **separate** `/expire`; a crash in that window leaves a TTL-less counter. Bucketed quota keys only leak storage, but the **concurrency key is stable per IP/subject** — a lost expire pins that identity near its cap until manual cleanup. TTL'd bumps now go through one atomic `EVAL(INCRBY+PEXPIRE)` root-POST (same shape as the existing atomic `SET … PX`); no-TTL paths keep the GET route.

## #606 — follower cache-poll on a held single-flight lock (src/entitlement.js)
Losers of the single-flight lock used to 503 instantly, so `maxConcurrent: 3` didn't hold for a license's *first* burst (right after purchase / positive-cache lapse). Followers now poll the cache the winner writes — bounded by **iteration count**, never the wall clock (`PATINA_LS_LOCK_POLL_INTERVAL_MS` default 150ms, `PATINA_LS_LOCK_WAIT_MS` default `min(lockTtl, timeout+1s)`). Winner crashed / LS down ⇒ nothing cached ⇒ still fail-closed 503, LS never called by a follower.

## #607 — client-IP trust order (src/rate-limit.js)
Ops verification done: the deployment is **direct Vercel** (`server: Vercel`, apex A `76.76.21.21`, no fronting CDN), and Vercel overwrites client-supplied IP headers, so today's behavior was safe. Defense-in-depth anyway: only the `x-vercel-*` prefix is platform-controlled under every topology, so `x-vercel-forwarded-for` is now consulted before `x-real-ip` (which stays as fallback).

## Tests
- New/updated: atomic-EVAL contract (single POST, no GET-path leak, malformed-counter fail-closed on both paths), follower-poll contract (first-burst all-succeed with exactly 1 LS call; crashed-winner poll exhaustion stays 503; mid-poll cache pickup), header-precedence flip.
- Full suite: **1349 pass / 0 fail / 1 skipped**; `npm run lint` clean.

Closes #605. Closes #606. Closes #607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)