### PR TITLE
feat(doctor): npm update check + document plugin auto-update toggle

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -19,6 +19,14 @@ If the user is in an **interactive Claude Code session**, the simplest install i
 /plugin install patina@patina
 ```
 
+After installing, turn on automatic updates — third-party marketplaces ship with auto-update **disabled** by default, so without this step the plugin silently stays on the installed version:
+
+```text
+/plugin   ->  Marketplaces tab  ->  patina  ->  Enable auto-update
+```
+
+(Manual alternative: `/plugin marketplace update patina` then `/reload-plugins`.)
+
 Uninstall with `/plugin uninstall patina@patina`. This path loads the repo-root `SKILL.md` as the `/patina` skill. The git/symlink paths below (A/B/C) are for non-interactive installs or multi-host setups; to remove a script install, run `uninstall.sh` (or `curl -fsSL https://raw.githubusercontent.com/devswha/patina/main/uninstall.sh | bash`).
 
 ---

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../patina/node_modules

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -6,7 +6,7 @@ import { inputError } from '../errors.js';
 
 const MIN_NODE_MAJOR = 18;
 
-export function runDoctor(args = [], { version } = {}) {
+export async function runDoctor(args = [], { version, fetchImpl } = {}) {
   const parsed = parseDoctorArgs(args);
   if (parsed.help) {
     printDoctorHelp();
@@ -14,6 +14,9 @@ export function runDoctor(args = [], { version } = {}) {
   }
 
   const report = buildDoctorReport({ version });
+  if (parsed.updateCheck) {
+    await appendUpdateCheck(report, { version, fetchImpl });
+  }
   if (parsed.format === 'json') {
     console.log(JSON.stringify(report, null, 2));
   } else {
@@ -23,6 +26,66 @@ export function runDoctor(args = [], { version } = {}) {
   if (!report.ok) {
     process.exitCode = Math.max(Number(process.exitCode) || 0, 1);
   }
+}
+
+export const NPM_LATEST_URL = 'https://registry.npmjs.org/patina-cli/latest';
+const UPDATE_CHECK_TIMEOUT_MS = 3000;
+
+/** Numeric x.y.z compare; returns 1/0/-1, or null when either side is unparseable. */
+export function compareSemver(a, b) {
+  const parse = (v) => {
+    const m = String(v || '').match(/^(\d+)\.(\d+)\.(\d+)/);
+    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  if (!pa || !pb) return null;
+  for (let i = 0; i < 3; i += 1) {
+    if (pa[i] !== pb[i]) return pa[i] > pb[i] ? 1 : -1;
+  }
+  return 0;
+}
+
+/**
+ * Ask the npm registry for the latest published patina-cli version and append
+ * the verdict to the report. Diagnostics must degrade gracefully offline: any
+ * failure (timeout, DNS, 404, bad JSON) becomes an informational "could not
+ * check" line, never a warning or blocker, and never throws.
+ */
+export async function appendUpdateCheck(report, { version, fetchImpl = globalThis.fetch, timeoutMs = UPDATE_CHECK_TIMEOUT_MS } = {}) {
+  let latest = null;
+  let error = null;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(NPM_LATEST_URL, {
+      signal: controller.signal,
+      headers: { accept: 'application/json' },
+    });
+    if (!response.ok) error = `registry answered ${response.status}`;
+    else latest = String((await response.json())?.version || '') || null;
+  } catch (err) {
+    error = err?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : String(err?.message ?? err);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const cmp = latest ? compareSemver(latest, version) : null;
+  const updateAvailable = cmp === 1;
+  report.update = { latest, current: version || null, updateAvailable, error };
+  report.checks.push({
+    name: 'update',
+    // An available update is worth a visible `!`, but never a blocker — and an
+    // unreachable registry (air-gapped CI) stays a quiet informational line.
+    status: updateAvailable ? 'warning' : 'ok',
+    summary: updateAvailable
+      ? `update available: ${version} -> ${latest}`
+      : (latest ? `up to date (latest ${latest})` : 'update check skipped'),
+    detail: updateAvailable
+      ? 'npm: `npm update -g patina-cli` · plugin: `/plugin` -> Marketplaces -> patina -> update (or enable auto-update) · git: `git pull --ff-only`'
+      : (error ? `could not reach the npm registry (${error})` : 'patina-cli on the npm registry'),
+  });
+  return report;
 }
 
 export function buildDoctorReport({ version } = {}) {
@@ -120,7 +183,7 @@ export function buildDoctorReport({ version } = {}) {
 }
 
 function parseDoctorArgs(args) {
-  const parsed = { format: 'text' };
+  const parsed = { format: 'text', updateCheck: true };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     switch (arg) {
@@ -130,6 +193,9 @@ function parseDoctorArgs(args) {
         break;
       case '--json':
         parsed.format = 'json';
+        break;
+      case '--no-update-check':
+        parsed.updateCheck = false;
         break;
       case '--format': {
         const value = args[++i];
@@ -146,7 +212,7 @@ function parseDoctorArgs(args) {
       default:
         throw inputError(
           `unknown doctor option ${arg}`,
-          'The doctor command only accepts --json, --format, and --help.',
+          'The doctor command only accepts --json, --format, --no-update-check, and --help.',
           'Run `patina doctor --help` for usage.'
         );
     }
@@ -223,10 +289,12 @@ function yesNo(value) {
 function printDoctorHelp() {
   console.log(`patina doctor — check local CLI readiness
 
-Usage: patina doctor [--json]
+Usage: patina doctor [--json] [--no-update-check]
 
 Checks Node version, patina CLI version, backend availability/authentication,
-tmux, and PATINA/provider API key environment variables. Exits 0 when no
-blockers are found, or 1 when a blocking setup issue is detected.
+tmux, PATINA/provider API key environment variables, and whether a newer
+patina-cli is on npm (skip with --no-update-check; offline failures are
+informational, never blockers). Exits 0 when no blockers are found, or 1 when
+a blocking setup issue is detected.
 `);
 }

--- a/tests/unit/doctor-update-check.test.js
+++ b/tests/unit/doctor-update-check.test.js
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { appendUpdateCheck, compareSemver, NPM_LATEST_URL } from '../../src/commands/doctor.js';
+
+const baseReport = () => ({ ok: true, checks: [] });
+
+const registry = (body, { ok = true, status = 200 } = {}) => async (url) => {
+  assert.equal(url, NPM_LATEST_URL);
+  return { ok, status, json: async () => body };
+};
+
+test('newer registry version -> warning check with update instructions', async () => {
+  const report = baseReport();
+  await appendUpdateCheck(report, { version: '6.3.1', fetchImpl: registry({ version: '6.4.0' }) });
+  assert.equal(report.update.updateAvailable, true);
+  assert.equal(report.update.latest, '6.4.0');
+  const check = report.checks.find((c) => c.name === 'update');
+  assert.equal(check.status, 'warning');
+  assert.match(check.summary, /6\.3\.1 -> 6\.4\.0/);
+  assert.match(check.detail, /npm update -g patina-cli/);
+});
+
+test('same or older registry version -> ok, no update flag', async () => {
+  for (const latest of ['6.3.1', '6.2.0']) {
+    const report = baseReport();
+    await appendUpdateCheck(report, { version: '6.3.1', fetchImpl: registry({ version: latest }) });
+    assert.equal(report.update.updateAvailable, false);
+    assert.equal(report.checks.find((c) => c.name === 'update').status, 'ok');
+  }
+});
+
+test('registry failure degrades to informational ok, never throws', async () => {
+  const cases = [
+    registry({}, { ok: false, status: 404 }),
+    async () => { throw new Error('getaddrinfo ENOTFOUND'); },
+    registry({ version: null }),
+  ];
+  for (const fetchImpl of cases) {
+    const report = baseReport();
+    await appendUpdateCheck(report, { version: '6.3.1', fetchImpl });
+    const check = report.checks.find((c) => c.name === 'update');
+    assert.equal(check.status, 'ok');
+    assert.equal(report.update.updateAvailable, false);
+    assert.equal(report.ok, true);
+  }
+});
+
+test('timeout aborts the request and degrades gracefully', async () => {
+  const report = baseReport();
+  const hang = (_url, { signal }) => new Promise((_, reject) => {
+    signal.addEventListener('abort', () => reject(Object.assign(new Error('aborted'), { name: 'AbortError' })));
+  });
+  await appendUpdateCheck(report, { version: '6.3.1', fetchImpl: hang, timeoutMs: 20 });
+  const check = report.checks.find((c) => c.name === 'update');
+  assert.equal(check.status, 'ok');
+  assert.match(check.detail, /timed out/);
+});
+
+test('compareSemver handles ordering and unparseable input', () => {
+  assert.equal(compareSemver('6.4.0', '6.3.9'), 1);
+  assert.equal(compareSemver('6.3.1', '6.3.1'), 0);
+  assert.equal(compareSemver('6.3.1', '10.0.0'), -1);
+  assert.equal(compareSemver('2.10.0', '2.9.9'), 1);
+  assert.equal(compareSemver('not-a-version', '1.0.0'), null);
+  assert.equal(compareSemver('1.0.0', undefined), null);
+});


### PR DESCRIPTION
patina has no auto-update of its own, and Claude Code's plugin auto-update is **off by default for third-party marketplaces** — so users on every install path (plugin / git skill / npm CLI) silently stay stale. Two smallest-possible fixes:

1. **`patina doctor` update check** — one GET to `registry.npmjs.org/patina-cli/latest` (3s abort), compared with a dependency-free semver compare. An available update is a visible `!` with per-path instructions (npm / `/plugin` toggle / `git pull --ff-only`); an unreachable registry degrades to an informational line and never affects the exit code. `--no-update-check` opts out for air-gapped CI.
2. **INSTALLATION.md Path 0** now tells users to enable the marketplace auto-update toggle right after `/plugin install` (with the manual `/plugin marketplace update` + `/reload-plugins` alternative).

5 new unit tests (newer/same/older, 404/DNS/bad-JSON degradation, abort timeout, semver edge cases). Full suite green, lint clean. Live-verified: local 6.3.1 vs npm latest 6.2.0 (held release) correctly reads "up to date"; `--no-update-check` suppresses the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)