### PR TITLE
docs(env): document LS lock-poll tunables (#612 follow-up)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,8 @@ PATINA_RUNTIME_CLI=your-runtime-cli-binary
 # PATINA_LS_NEGATIVE_CACHE_TTL_MS=60000  # negative (denied) result cache
 # PATINA_LS_TIMEOUT_MS=2500              # LS validate fetch abort deadline
 # PATINA_LS_VALIDATE_RPM=50              # outbound cap (LS hard limit is 60/min)
+# PATINA_LS_LOCK_POLL_INTERVAL_MS=150    # follower cache-poll cadence while the winner validates
+# PATINA_LS_LOCK_WAIT_MS=3500            # follower poll budget (default min(lock TTL, timeout+1s))
 
 # Escape hatch: let Pro fall back to PATINA_FREE_API_KEY when PATINA_PRO_API_KEY
 # is unset. Honored in ALL postures when 'true' (including production) — so leave


### PR DESCRIPTION
Adds the two knobs #612 introduced (PATINA_LS_LOCK_POLL_INTERVAL_MS / PATINA_LS_LOCK_WAIT_MS) to the LS tunables block in .env.example — they were review-noted as missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)