### PR TITLE
research: Study 2 — structure pack fails its efficacy study; retired from manifest; over-editing guard ships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ artifacts/ai-test-sources.md
 # Rewrite-efficacy study raw outputs (regenerated; text bodies stay private)
 artifacts/rewrite-efficacy-pilot/
 artifacts/rewrite-efficacy-study1/
+artifacts/rewrite-efficacy-study2/

--- a/.patina.default.yaml
+++ b/.patina.default.yaml
@@ -90,6 +90,13 @@ allowlist: []              # additive merge: 감지에서 제외할 어휘
 # Other arrays are replaced by the higher-precedence config so users can choose
 # an exact value instead of merging by accident.
 
+# Over-editing guard: before a rewrite, if the deterministic layer finds
+# nothing to fix (0 hot paragraphs, near-zero signal, 3+ paragraphs), warn that
+# rewriting already-human text can ADD AI-likeness (measured on human documents
+# in docs/research/2026-rewrite-efficacy-study1.md). Advisory only — never
+# blocks. Set to false to silence.
+over-editing-guard: true
+
 # Scoring: LLM score remains canonical, with a deterministic shadow score
 # from src/features/* for reproducible drift checks.
 scoring:

--- a/docs/PRO-PACKS.md
+++ b/docs/PRO-PACKS.md
@@ -41,6 +41,14 @@ same precedence the loaders already give user files:
 Every download is integrity-checked: the CLI recomputes the file's sha256 and
 compares it against the server manifest before writing anything.
 
+## Efficacy policy
+
+Packs only carry efficacy claims that a pre-registered study measured. The
+first structure pack (ko-doc-structure 1.0.0) was **retired from the manifest
+on 2026-07-12** after its intervention study found no perceptual improvement
+and two guard-rail violations (docs/research/2026-rewrite-efficacy-study2.md)
+— the honest baseline this catalog is built on.
+
 ## Operating it (maintainer)
 
 - Content lives in the private repo (`PATINA_PACKS_REPO`, default

--- a/docs/research/2026-rewrite-efficacy-prereg.md
+++ b/docs/research/2026-rewrite-efficacy-prereg.md
@@ -372,6 +372,54 @@ rather than re-run underpowered.
   absolute score levels are not comparable across studies; only within-study
   paired deltas are interpreted.
 
+## Study 2 (intervention study) — registered 2026-07-12, before any Study 2 data
+
+Study 1's headline was that Korean document rewrites barely move perception
+(Δ −6.0) and that 75–81% of surviving cues are structural. The
+`ko-doc-structure` pack (6 document-architecture patterns, private pro pack,
+authored 2026-07-10 from Study 1's cue evidence) is the designed response.
+Study 2 measures whether it actually works — before any efficacy claim ships
+in marketing or pack docs.
+
+### Design
+
+- **Intervention:** the `ko-doc-structure` pack installed into
+  `custom/patterns/` (via the shipping `patina pack` path), which places its 6
+  patterns into the live rewrite prompt. Everything else — corpus, rewriter
+  (claude-cli), judge panel, prompts, analyzer stats — is identical to
+  Study 1's Arm D.
+- **Arm D2:** re-rewrite the SAME 54 Study 1 ko documents (27 AI + 27 human,
+  by stored original text) with the pack active; judge each new rewrite with
+  the same fixed 3-judge panel (kimi / gpt-5.5 / grok-4.5, 2-of-3 quorum).
+  Originals are NOT re-judged: Study 1's original-condition ratings are reused
+  as the shared baseline, so the paired comparison is
+  Δ2(doc) = panel(rewrite₂) − panel(original₁) vs Δ1(doc) from Study 1.
+- **Primary outcome (H-S2a):** paired per-document improvement
+  d(doc) = Δ2 − Δ1 on AI documents; hypothesis mean d < 0 (the pack helps),
+  95% bootstrap CI excluding 0.
+- **Secondary (H-S2b):** among still-called-"ai" judgments on D2 rewrites, the
+  structural share of strongest-cues (same fixed rubric) falls below 60%
+  (Study 1: 81%).
+- **Guard rails:** RQ5a gate pass-rate ≥ 95% must hold (structure edits are
+  the riskiest for meaning); human-control Δ2 must not worsen beyond Study 1's
+  band (over-editing check); rewrite length ratio reported.
+- **Confound noted up front:** rewriter and judges are stochastic and two days
+  have passed; the comparison is same-original paired but not same-run
+  randomized. If d is small relative to rewrite-rerun noise, the honest read
+  is "cannot distinguish from rerun variance" — a no-effect verdict, not a
+  spin. (A same-run A/B was rejected for cost; this is a pilot-grade
+  intervention estimate.)
+- Quota headroom probed on all four backends immediately before the run
+  (done 2026-07-12: codex, kimi, grok, claude all answered).
+
+### What ships on the result
+
+- d meaningfully negative → the pack's efficacy line in PRO-PACKS/marketing
+  may cite it, with CIs and this registration.
+- d ≈ 0 or positive → published as-is in the results doc; the pack docs must
+  NOT claim measured efficacy, and the next iteration targets whatever the
+  surviving cues say.
+
 ## Sources
 - Self-Preference Bias in LLM-as-a-Judge — arXiv:2410.21819
 - TH-Bench (humanizing attacks vs detectors) — arXiv:2503.08708

--- a/docs/research/2026-rewrite-efficacy-study2.md
+++ b/docs/research/2026-rewrite-efficacy-study2.md
@@ -1,0 +1,102 @@
+# Does the ko-doc-structure pack fix the Korean gap? — Study 2 results
+
+Companion to `2026-rewrite-efficacy-prereg.md` ("Study 2" section, registered
+2026-07-12 before any data) and to Study 1 (`2026-rewrite-efficacy-study1.md`).
+Study 1 found Korean document rewrites barely move perceived AI-likeness
+(Δ −6.0) and that 75–81% of surviving cues are structural. The
+`ko-doc-structure` pack (6 document-architecture patterns, authored from that
+cue evidence) was the designed response. This study measured it.
+
+**Verdict up front: the pack does not work in its current form, and it harms
+two guard rails. It must not ship with any efficacy claim, and we have pulled
+it from the pro-pack manifest until a redesigned intervention passes.**
+
+- Run: 2026-07-12. Same corpus (54 Study 1 Arm-D documents), same rewriter
+  (claude-cli), same fixed 3-judge panel (kimi / gpt-5.5 / grok-4.5, 2-of-3
+  quorum). Intervention: the pack installed via the shipping `patina pack`
+  path (sha `36f5491f…` recorded per row); its 6 patterns entered the live
+  rewrite prompt (verified in Study-1-era e2e).
+- Final matrix: 54/54 rewrites, 0 unparseable judge cells.
+
+## H-S2a (primary) — paired improvement on AI documents: **REJECTED**
+
+Baseline = each document's own Study 1 panel scores (original + rewrite).
+
+| | orig | rewrite (S1, no pack) | rewrite (S2, pack) | paired d = rw2−rw1 (95% CI) |
+|---|---:|---:|---:|---|
+| AI docs (n=27) | 83.6 | 77.6 | 76.9 | **−0.7 [−3.4, +1.8]** |
+
+The CI includes 0. Adding the pack's pattern descriptions to the rewrite
+prompt produced no detectable perceptual improvement over the pack-less
+rewrite. AI-call rate: 93% (S1) → 88% (S2) — marginal.
+
+## H-S2b — structural-cue share: **REJECTED**
+
+Among judgments that still called the S2 rewrite "ai": **82% structural cues**
+(Study 1: 81%; pre-registered target: <60%). The judges' complaints are the
+same complaints — uniform report-style paragraphs, checklist coverage, tidy
+arcs. The pack described these shapes to the rewriter; the rewriter did not
+dismantle them.
+
+## Guard rails — **both violated**
+
+1. **Meaning-safety gate (target ≥95% pass):** 87.0% (47/54), down from 92.6%
+   on the same 54 documents in Study 1. All 7 failures are dropped-numbers.
+   Structure-level editing drops facts: when the rewriter merges sections or
+   compresses checklists, numbers fall out. This is exactly why the gate
+   exists.
+2. **Human-control over-editing:** paired d = **+5.1 [+0.3, +9.6]** — the
+   pack-on rewrite made human documents read MORE AI-like than the pack-less
+   rewrite did (41.9 → 47.0 vs original 45.4), and the CI excludes 0. AI-call
+   on human docs rose 22% → 32%. The over-editing failure mode Study 1 flagged
+   as borderline on English is now measured and significant on Korean, caused
+   by the intervention itself.
+
+Mean rewrite/original length ratio 0.91 (the pack's compression pressure is
+visible but mild).
+
+## Why it failed (diagnosis, not spin)
+
+The intervention was **pattern descriptions in the prompt** — the same
+mechanism that works for lexical patterns. Document architecture apparently
+does not yield to that mechanism: the rewriter edits sentence-by-sentence and
+paragraph-by-paragraph, so "break the parallel sections, make coverage
+asymmetric" degrades into local paraphrase plus occasional deletion (hence the
+dropped numbers) rather than actual reorganization. The one thing the pack
+reliably did — push toward compression — cost meaning without buying
+perception.
+
+Design implication, carried to the next iteration: structural humanization
+needs a **structural mechanism**, not more prompt text. The candidate designs,
+in order of likely cost-effectiveness:
+1. a pre-rewrite **structure plan step** (LLM produces a reorganization plan —
+   merge/split/reorder decisions with number-preservation constraints — then
+   the rewrite executes it);
+2. deterministic structure transforms (section merge/split scaffolding) with
+   LLM infill;
+3. persona-conditioned document templates per register.
+
+## Execution notes
+
+- Two infrastructure failures interrupted the run (a duplicated config key
+  from the over-editing-guard commit; a claude CLI login expiry). Both
+  produced fail-soft recorded rows, were pruned, and re-ran cleanly; the
+  resume path (skip-by-original_sha) worked as designed. Neither affects
+  judged data: every kept row has a real rewrite and full panel coverage.
+- The new over-editing guard fired on exactly the human controls whose
+  deterministic signal was already clean (7 warnings, 0 on AI docs) — its
+  first live validation, consistent with its design.
+- One S2-specific confound stands as registered: rewriter/judges are
+  stochastic and S1 ran two days earlier. The paired design absorbs
+  document-level variance but not run-level drift; given d ≈ 0 with a tight
+  CI, the conclusion "no effect distinguishable from rerun variance" is the
+  honest reading — and the guard-rail violations are same-run internal
+  comparisons (gate) or CI-excluding-zero (human d), so they do not hinge on
+  the confound.
+
+## What ships
+
+Per the pre-registered decision rule: the results are published as-is; the
+pack carries **no efficacy claim**; `ko-doc-structure` is **removed from the
+pro-pack manifest** (unpublished, kept in the repo history for iteration 2);
+the next intervention targets the structural mechanism, not the pattern prose.

--- a/scripts/research/rewrite-efficacy-study2.mjs
+++ b/scripts/research/rewrite-efficacy-study2.mjs
@@ -1,0 +1,242 @@
+// Study 2 runner — ko-doc-structure pack intervention (pre-registration:
+// docs/research/2026-rewrite-efficacy-prereg.md, "Study 2" section).
+//
+// Re-rewrites the SAME Study 1 Arm-D documents with the ko-doc-structure pro
+// pack installed (custom/patterns/ — the shipping `patina pack` destination),
+// then judges only the NEW rewrites with the same fixed 3-judge panel.
+// Study 1's original-condition ratings are reused as the shared baseline at
+// analysis time, so this run never re-judges originals.
+//
+// Fails fast unless the intervention is actually present, and records the
+// pack's sha256 in every row for provenance.
+//
+// Usage: node scripts/research/rewrite-efficacy-study2.mjs
+
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { scoreText } from '../prose-score.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const S1_DIR = join(ROOT, 'artifacts', 'rewrite-efficacy-study1');
+const OUT_DIR = join(ROOT, 'artifacts', 'rewrite-efficacy-study2');
+const OUT_JSONL = join(OUT_DIR, 's2-rows-D2.jsonl');
+const TEXTS_JSONL = join(OUT_DIR, 's2-texts-D2.private.jsonl');
+const LOG = join(OUT_DIR, 's2-run.log');
+const PACK_PATH = join(ROOT, 'custom', 'patterns', 'ko-doc-structure.md');
+
+const REWRITER = { backend: 'claude-cli', family: 'claude' };
+const KIMI_ARGS = ['--print', '--input-format', 'text', '--output-format', 'text',
+  '--final-message-only', '--no-thinking', '--max-steps-per-turn', '20'];
+const CODEX_ARGS = ['exec', '--skip-git-repo-check', '--sandbox', 'read-only'];
+const JUDGES = [
+  { id: 'judge-kimi', family: 'moonshot', cmd: 'kimi', args: KIMI_ARGS },
+  { id: 'judge-gpt', family: 'gpt', cmd: 'codex', args: CODEX_ARGS },
+  { id: 'judge-grok', family: 'xai', cmd: 'node', args: [join('scripts', 'research', 'xai-cli.mjs')] },
+];
+
+// Study 1 learned 300s times out on 13/54 ko docs; start at the top-up value.
+const REWRITE_TIMEOUT_MS = 600_000;
+const JUDGE_TIMEOUT_MS = 120_000;
+const JUDGE_ATTEMPTS = 3;
+
+const sha = (s) => createHash('sha256').update(s, 'utf8').digest('hex').slice(0, 16);
+const log = (m) => {
+  const line = `[${new Date().toISOString()}] ${m}`;
+  console.log(line);
+  appendFileSync(LOG, line + '\n');
+};
+
+function run(cmd, args, { input = '', timeout = 120_000, cwd = ROOT } = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { cwd, stdio: ['pipe', 'pipe', 'pipe'], detached: true });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const finish = (v) => { if (!settled) { settled = true; clearTimeout(timer); resolve(v); } };
+    const timer = setTimeout(() => {
+      try { process.kill(-child.pid, 'SIGKILL'); } catch { try { child.kill('SIGKILL'); } catch { /* noop */ } }
+      finish({ ok: false, stdout, stderr, error: `timeout after ${timeout}ms` });
+    }, timeout);
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.stderr.on('data', (d) => { stderr += d; });
+    child.on('error', (e) => finish({ ok: false, stdout, stderr, error: String(e?.message ?? e) }));
+    child.on('close', (code) => finish({ ok: code === 0, code, stdout, stderr }));
+    if (input) child.stdin.write(input);
+    child.stdin.end();
+  });
+}
+
+function readJsonl(path) {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf8').split('\n').filter((l) => l.trim())
+    .map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+}
+
+/** S1 D-arm text store, TOPUP-deduped by original_sha (last write wins). */
+function loadS1Texts() {
+  const byKey = new Map();
+  for (const f of readdirSync(S1_DIR).filter((x) => /^s1-texts(-.*)?\.private\.jsonl$/.test(x))) {
+    for (const t of readJsonl(join(S1_DIR, f))) if (t.arm === 'D') byKey.set(t.original_sha, t);
+  }
+  return byKey;
+}
+
+async function patinaRewrite(text, lang) {
+  const res = await run('node', [
+    'bin/patina.js', '--lang', lang, '--backend', REWRITER.backend,
+    '--format', 'text', '--no-interactive',
+  ], { input: text, timeout: REWRITE_TIMEOUT_MS });
+  const gateFailed = res.code === 4;
+  if (!res.ok && !gateFailed) return { text: null, error: res.error || res.stderr.slice(0, 300) || `exit ${res.code}`, gate_failed: null, gate_reason: null };
+  const body = String(res.stdout).split(/\n---\n/)[0].trim();
+  if (!body) return { text: null, error: 'empty rewrite', gate_failed: null, gate_reason: null };
+  let gateReason = null;
+  if (gateFailed) {
+    const m = String(res.stderr).match(/persona safety gate failed:\s*([^\n]*)/);
+    gateReason = m ? m[1].trim().slice(0, 200) : 'unspecified';
+  }
+  return { text: body, error: null, gate_failed: gateFailed, gate_reason: gateReason };
+}
+
+function judgePrompt(text) {
+  return [
+    'You are evaluating a single passage of writing. You do not know its origin.',
+    '',
+    'Answer BOTH questions independently. Do not let one answer drive the other.',
+    '',
+    'Q1 (authorship): Was this passage most likely written by a human, or generated by an AI language model?',
+    'Q2 (AI-likeness): On a 0-100 scale, how AI-like does the PROSE read?',
+    '   0 = reads unmistakably like an individual human wrote it',
+    '   100 = reads unmistakably like generic AI output',
+    '   Judge the writing itself (rhythm, word choice, structure, specificity), not the topic.',
+    '',
+    'Then name the single strongest cue that drove your judgement.',
+    '',
+    'The passage is in Korean.',
+    '',
+    'Respond with ONLY a JSON object, no code fence, no prose:',
+    '{"authorship":"human"|"ai","ai_likeness":<0-100 integer>,"strongest_cue":"<short phrase>"}',
+    '',
+    '--- PASSAGE START ---',
+    text,
+    '--- PASSAGE END ---',
+  ].join('\n');
+}
+
+const SCORE_KEYS = ['ai_likeness', 'ai_status', 'ai_score', 'score', 'aiLikeness'];
+
+function parseJudge(raw) {
+  if (!raw) return null;
+  const matches = String(raw).match(/\{[^{}]*"authorship"[^{}]*\}/g);
+  if (!matches) return null;
+  for (const candidate of [...matches].reverse()) {
+    try {
+      const o = JSON.parse(candidate);
+      const authorship = String(o.authorship || '').toLowerCase();
+      if (authorship !== 'human' && authorship !== 'ai') continue;
+      const key = SCORE_KEYS.find((k) => Number.isFinite(Number(o[k])));
+      if (!key) continue;
+      return {
+        authorship,
+        ai_likeness: Math.max(0, Math.min(100, Math.round(Number(o[key])))),
+        strongest_cue: String(o.strongest_cue || '').slice(0, 200),
+        score_key: key === 'ai_likeness' ? undefined : key,
+      };
+    } catch { /* next */ }
+  }
+  return null;
+}
+
+async function judgeOnce(judge, text) {
+  const attempts = [];
+  let lastOut = '';
+  let lastErr = '';
+  for (let attempt = 1; attempt <= JUDGE_ATTEMPTS; attempt += 1) {
+    const res = await run(judge.cmd, judge.args, { input: judgePrompt(text), timeout: JUDGE_TIMEOUT_MS });
+    const parsed = parseJudge(res.stdout);
+    if (parsed) return attempt === 1 ? parsed : { ...parsed, retried: true };
+    attempts.push(res.error || 'unparseable');
+    lastOut = String(res.stdout);
+    lastErr = String(res.stderr);
+  }
+  return { error: attempts.join(' | '), raw_head: (lastOut || lastErr).slice(-240), retries_exhausted: true };
+}
+
+function internalScore(text) {
+  try {
+    const r = scoreText(text, { lang: 'ko', repoRoot: ROOT });
+    return { signal_score: r.signalScore ?? null, score: r.score ?? null, pattern_hits: r.patternHits ?? null };
+  } catch (e) {
+    return { error: String(e?.message ?? e).slice(0, 200) };
+  }
+}
+
+async function main() {
+  // Intervention gate: refuse to record anything unless the pack is present.
+  if (!existsSync(PACK_PATH)) {
+    console.error(`FATAL: intervention missing — ${PACK_PATH} not installed. Run patina pack install ko-doc-structure first.`);
+    process.exit(1);
+  }
+  const packSha = sha(readFileSync(PACK_PATH, 'utf8'));
+  mkdirSync(OUT_DIR, { recursive: true });
+  if (!existsSync(LOG)) writeFileSync(LOG, '');
+
+  const s1Rows = readJsonl(join(S1_DIR, 's1-rows-D.jsonl'));
+  const texts = loadS1Texts();
+  log(`study2 start — intervention pack sha ${packSha}; ${s1Rows.length} S1 D-arm rows; rewriter=${REWRITER.backend}`);
+
+  const done = new Set(readJsonl(OUT_JSONL).map((r) => r.original_sha));
+
+  for (const [idx, s1] of s1Rows.entries()) {
+    if (done.has(s1.original_sha)) continue; // resume
+    const stored = texts.get(s1.original_sha);
+    if (!stored?.original) { log(`WARN no stored original for ${s1.original_sha}`); continue; }
+    const label = `D2/${s1.source_class}/${idx + 1}`;
+
+    log(`${label}: rewriting with pack (${stored.original.length} chars)…`);
+    const rw = await patinaRewrite(stored.original, 'ko');
+    if (rw.error) log(`${label}: REWRITE FAILED — ${rw.error}`);
+    if (rw.gate_failed) log(`${label}: SAFETY GATE FAILED (text kept) — ${rw.gate_reason}`);
+
+    let judged = null;
+    if (rw.text) {
+      log(`${label}: judging rewrite…`);
+      judged = {};
+      for (const judge of JUDGES) judged[judge.id] = await judgeOnce(judge, rw.text);
+    }
+
+    const row = {
+      arm: 'D2',
+      pack_sha: packSha,
+      source_class: s1.source_class,
+      pair_id: s1.pair_id,
+      model_family: s1.model_family,
+      register: s1.register,
+      rewriter: REWRITER.backend,
+      original_sha: s1.original_sha,
+      rewrite2_sha: rw.text ? sha(rw.text) : null,
+      original_chars: stored.original.length,
+      rewrite2_chars: rw.text ? rw.text.length : null,
+      rewrite_error: rw.error,
+      gate_failed: rw.gate_failed ?? null,
+      gate_reason: rw.gate_reason ?? null,
+      internal_rewrite2: rw.text ? internalScore(rw.text) : null,
+      judges_rewrite2: judged,
+    };
+    appendFileSync(OUT_JSONL, JSON.stringify(row) + '\n');
+    appendFileSync(TEXTS_JSONL, JSON.stringify({
+      original_sha: s1.original_sha, rewrite2_sha: row.rewrite2_sha,
+      source_class: s1.source_class, original: stored.original, rewritten2: rw.text,
+    }) + '\n');
+
+    const summary = JUDGES.map((j) => `${j.id.replace('judge-', '')} ${judged?.[j.id]?.ai_likeness ?? '?'}`).join(' ');
+    log(`${label}: done (${summary})`);
+  }
+  log('study2 complete');
+}
+
+main().catch((e) => { log(`FATAL ${e?.stack ?? e}`); process.exit(1); });

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -235,6 +235,7 @@ export async function runDefault(parsed, logger) {
         // Route a deferred batch read failure (#503) into the per-file catch so
         // it counts against the circuit breaker (batch) or rethrows (single).
         if (readError) throw readError;
+        if (mode === 'rewrite') warnIfAlreadyHuman({ text, config, repoRoot, logger });
         let result;
 
         result = await invokeBackendChain({
@@ -1150,6 +1151,38 @@ function buildDocumentSignals({ text, lang }) {
     ? [`어미 분포: ${distribution} — 지배 어투 없음(혼합). 문서 성격에 맞는 어투 하나를 골라 전체를 통일할 것`]
     : [`지배 어투: ${register.label} — ${distribution}. 재작성 문장 전체를 이 어투로 통일할 것`];
   return { signals, register };
+}
+
+/**
+ * Over-editing guard (Study 1 RQ5b): rewriting text that already reads human
+ * measurably nudged it TOWARD AI-likeness (+3.3 judged points on human English
+ * documents, docs/research/2026-rewrite-efficacy-study1.md). When the
+ * deterministic layer finds nothing to fix, say so before spending a rewrite —
+ * advisory only, never blocks, and silent wherever the deterministic score is
+ * unavailable or the text is too short to judge (Study 0 Deviation 1).
+ * Opt out with `over-editing-guard: false` in config.
+ */
+export function warnIfAlreadyHuman({ text, config = {}, repoRoot, logger, scorer = scoreDeterministicSignals }) {
+  if (config['over-editing-guard'] === false) return null;
+  let score = null;
+  try {
+    score = scorer({ text, config, repoRoot, logger: { warn() {} } });
+  } catch {
+    return null; // the guard must never break a rewrite
+  }
+  if (!score || score.skipped) return null;
+  if (typeof score.paragraphCount !== 'number' || score.paragraphCount < 3) return null;
+  const clean = score.hotParagraphs === 0
+    && typeof score.signalScore === 'number' && score.signalScore <= 10
+    && (score.overall === 0 || score.overall === null);
+  if (!clean) return null;
+  logger?.warn?.('rewrite.over_editing_guard', {
+    message: '[patina] over-editing guard: this text already reads human on the deterministic layer '
+      + `(0 hot paragraphs, signal ${Math.round(score.signalScore * 10) / 10}). Rewriting anyway can ADD AI-likeness `
+      + '(measured on human documents in the rewrite-efficacy study). Consider --audit or --score first. '
+      + 'Proceeding; disable this note with `over-editing-guard: false`.',
+  });
+  return score;
 }
 
 function withDeterministicScore(rawResult, { text, config, repoRoot, logger }) {

--- a/tests/unit/over-editing-guard.test.js
+++ b/tests/unit/over-editing-guard.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { warnIfAlreadyHuman } from '../../src/cli/run.js';
+
+function collectLogger() {
+  const events = [];
+  return {
+    events,
+    warn(event, fields) { events.push({ event, message: fields?.message }); },
+  };
+}
+
+const cleanScore = { skipped: false, paragraphCount: 5, hotParagraphs: 0, signalScore: 3.2, overall: 0 };
+
+test('warns when the deterministic layer finds nothing to fix', () => {
+  const logger = collectLogger();
+  const result = warnIfAlreadyHuman({ text: 'x', logger, scorer: () => cleanScore });
+  assert.ok(result, 'returns the score when the guard fires');
+  assert.equal(logger.events.length, 1);
+  assert.equal(logger.events[0].event, 'rewrite.over_editing_guard');
+  assert.match(logger.events[0].message, /already reads human/);
+  assert.match(logger.events[0].message, /Proceeding/, 'guard is advisory, never blocking');
+});
+
+test('stays silent when there is anything to fix or the score is unusable', () => {
+  const cases = [
+    { ...cleanScore, hotParagraphs: 1 },
+    { ...cleanScore, signalScore: 25 },
+    { ...cleanScore, overall: 12 },
+    { ...cleanScore, paragraphCount: 2 }, // too short to judge (Study 0 Dev 1)
+    { ...cleanScore, skipped: true },
+    null,
+  ];
+  for (const score of cases) {
+    const logger = collectLogger();
+    const result = warnIfAlreadyHuman({ text: 'x', logger, scorer: () => score });
+    assert.equal(result, null, `no guard for ${JSON.stringify(score)}`);
+    assert.equal(logger.events.length, 0);
+  }
+});
+
+test('config over-editing-guard: false disables it; scorer throw never escapes', () => {
+  const logger = collectLogger();
+  assert.equal(
+    warnIfAlreadyHuman({ text: 'x', config: { 'over-editing-guard': false }, logger, scorer: () => cleanScore }),
+    null,
+  );
+  assert.equal(logger.events.length, 0);
+
+  assert.equal(
+    warnIfAlreadyHuman({ text: 'x', logger, scorer: () => { throw new Error('boom'); } }),
+    null,
+    'a scorer failure must never break the rewrite path',
+  );
+});


### PR DESCRIPTION
Second intervention cycle of the pre-registered rewrite-efficacy program. Honest headline: **the designed fix didn't work, the study caught it before any customer saw an efficacy claim, and the measurement rig produced a shippable safety feature along the way.**

## Study 2 (pre-registered before data, same corpus/panel as Study 1)

The ko-doc-structure pack's 6 document-architecture patterns entered the live rewrite prompt (shipping `patina pack` path, sha-verified per row). Against each document's own Study 1 baseline:

- **H-S2a REJECTED** — AI docs paired d = −0.7 [−3.4, +1.8]: no perceptual improvement over the pack-less rewrite
- **H-S2b REJECTED** — structural-cue share 82% vs 81%: judges' complaints unchanged
- **Both guard rails violated** — meaning-gate pass 87% (< 95% target, all dropped-numbers: structure edits drop facts) and human-control over-editing now significant (d +5.1 [+0.3, +9.6], AI-call on humans 22%→32%)

**Diagnosis:** pattern *descriptions* work for lexical tells but not architecture — the rewriter edits locally and never reorganizes, so the pack bought compression (0.91 length ratio) that cost meaning without buying perception. Next iteration targets a structural *mechanism* (pre-rewrite reorganization plan step) instead of more prompt prose.

**Actions taken per the registered decision rule:** results published as-is; pack retired from the pro-pack manifest (private repo updated with a retirement note); PRO-PACKS.md now states the efficacy policy.

## Over-editing guard (Study 1 RQ5b follow-through)

`warnIfAlreadyHuman` in the rewrite path: when the deterministic layer finds nothing to fix (0 hot paragraphs, near-zero signal, 3+ paragraphs), warn on stderr that rewriting can ADD AI-likeness — advisory, never blocks, `over-editing-guard: false` to silence, silent on any scorer failure. **Live-validated in this very study**: fired on exactly the clean human controls (7×), never on AI documents. Unit tests cover fire/silence/opt-out/scorer-throw.

## Execution transparency

Two infra failures mid-run (duplicated YAML key from the guard's config docs — caught by patina's own config parser; a claude CLI login expiry). Both fail-soft-recorded, pruned, resumed cleanly by original_sha; final matrix 54/54 rewrites, 0 unparseable judge cells. Gates: 1373 tests pass, lint clean, results doc scores 11.1%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)