### PR TITLE
fix(api): pro tier broken in production — claude-sonnet-5 rejects temperature

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -26,6 +26,43 @@ const MAX_SSE_BUFFER_BYTES = 1024 * 1024;
  */
 export const DEFAULT_TEMPERATURE = 0.7;
 
+// Models that rejected the `temperature` field outright (HTTP 400
+// "deprecated" / "not supported" — Anthropic's OpenAI-compat endpoint started
+// this with claude-sonnet-5; some OpenAI reasoning models do the same).
+// Learned at runtime and shared with the streaming client so a warm process
+// skips the doomed first attempt on subsequent calls.
+const temperatureRejectedModels = new Set();
+
+/**
+ * True when the provider rejected a request solely because `temperature` is
+ * unsupported/deprecated for the requested model. Callers retry exactly once
+ * with the field omitted (and remember the model for this process).
+ *
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+export function isTemperatureRejectedError(err) {
+  if (!(err instanceof HttpError) || err.status !== 400) return false;
+  const text = `${err.message} ${err.body}`;
+  return /temperature/i.test(text) && /deprecat|unsupported|not (?:be )?support/i.test(text);
+}
+
+/**
+ * @param {string} model
+ * @returns {boolean} Whether this process already saw the model reject `temperature`.
+ */
+export function modelRejectsTemperature(model) {
+  return temperatureRejectedModels.has(model);
+}
+
+/**
+ * @param {string} model
+ * @returns {void}
+ */
+export function markTemperatureRejected(model) {
+  temperatureRejectedModels.add(model);
+}
+
 // Status codes that warrant a retry. Network errors (no status, AbortError)
 // are also retryable; auth / validation 4xxs are not.
 const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
@@ -324,8 +361,10 @@ export async function callLLM({
   const body = {
     model,
     messages: [{ role: 'user', content: prompt }],
-    temperature,
   };
+  // Skip `temperature` up front when this process already saw the model
+  // reject it (e.g. claude-sonnet-5) — avoids a guaranteed 400 round trip.
+  if (!modelRejectsTemperature(model)) body.temperature = temperature;
   if (seed !== undefined && seed !== null) body.seed = seed;
   if (responseFormat) body.response_format = responseFormat;
 
@@ -397,7 +436,7 @@ export async function callLLM({
         provider: 'openai-http',
         model: data.model ?? model,
         requestedModel: model,
-        temperature,
+        temperature: 'temperature' in body ? temperature : null,
         seed: seed ?? null,
         usage: data.usage ?? null,
         cacheTokens: extractCacheTokens(data.usage),
@@ -416,6 +455,15 @@ export async function callLLM({
       if (remainingAfterAttempt <= 0) {
         lastError = new Error(`LLM API deadline exceeded after attempt ${attempt + 1}: ${err.message}`);
         break;
+      }
+      // `temperature` rejected for this model: drop the field and re-issue
+      // immediately. Does not consume a backoff attempt; cannot loop because
+      // the field is gone from `body` after the first hit.
+      if (isTemperatureRejectedError(err) && 'temperature' in body) {
+        markTemperatureRejected(model);
+        delete body.temperature;
+        attempt--;
+        continue;
       }
       if (attempt < maxRetries && isRetryable(err)) {
         const delay = computeBackoffMs(attempt, err.retryAfter, {

--- a/src/streaming-api.js
+++ b/src/streaming-api.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { HttpError, redactErrorText } from './api.js';
+import { HttpError, redactErrorText, isTemperatureRejectedError, markTemperatureRejected, modelRejectsTemperature } from './api.js';
 
 const DEFAULT_TIMEOUT = 120000;
 // Cap a single un-terminated SSE line so a malformed provider cannot grow the
@@ -97,23 +97,43 @@ export async function callLLMStream({
     cleanupSignal = () => signal.removeEventListener('abort', onAbort);
   }
 
+  // Skip `temperature` up front when this process already saw the model
+  // reject it (e.g. claude-sonnet-5) — avoids a guaranteed 400 round trip.
+  const payload = {
+    model,
+    messages: [{ role: 'user', content: prompt }],
+    stream: true,
+  };
+  if (!modelRejectsTemperature(model)) payload.temperature = temperature;
+
   try {
-    const response = await fetchImpl(`${baseURL}/chat/completions`, {
+    const issue = () => fetchImpl(`${baseURL}/chat/completions`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        model,
-        messages: [{ role: 'user', content: prompt }],
-        temperature,
-        stream: true,
-      }),
+      body: JSON.stringify(payload),
       signal: controller.signal,
     });
 
+    let response = await issue();
+
     throwIfAborted(signal);
+    if (!response.ok) {
+      const body = typeof response.text === 'function' ? await response.text() : '';
+      const err = new HttpError(response.status, redact(body), response.headers?.get?.('retry-after'));
+      // `temperature` rejected for this model: drop the field and re-issue
+      // once. Cannot loop — the field is gone from `payload` after this hit.
+      if (isTemperatureRejectedError(err) && 'temperature' in payload) {
+        markTemperatureRejected(model);
+        delete payload.temperature;
+        response = await issue();
+        throwIfAborted(signal);
+      } else {
+        throw err;
+      }
+    }
     if (!response.ok) {
       const body = typeof response.text === 'function' ? await response.text() : '';
       throw new HttpError(response.status, redact(body), response.headers?.get?.('retry-after'));

--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -450,3 +450,59 @@ test('callLLM falls back to buffered JSON when a server ignores stream:true (#57
     globalThis.fetch = originalFetch;
   }
 });
+
+test('callLLM drops temperature and retries once when the model rejects it (claude-sonnet-5)', async () => {
+  const originalFetch = globalThis.fetch;
+  const bodies = [];
+  globalThis.fetch = async (_url, opts) => {
+    const body = JSON.parse(opts.body);
+    bodies.push(body);
+    if ('temperature' in body) {
+      return {
+        ok: false,
+        status: 400,
+        headers: { get: () => null },
+        text: async () => '{"error":{"code":"invalid_request_error","message":"`temperature` is deprecated for this model."}}',
+      };
+    }
+    return { ok: true, json: async () => ({ model: body.model, choices: [{ message: { content: 'ok' } }] }) };
+  };
+  try {
+    let meta;
+    const out = await callLLM({
+      prompt: 'p', apiKey: 'k', model: 'temp-reject-buffered', maxRetries: 0,
+      onResponse: (m) => { meta = m; },
+    });
+    assert.equal(out, 'ok');
+    assert.equal(bodies.length, 2, 'exactly one drop-and-retry');
+    assert.ok('temperature' in bodies[0], 'first attempt sends temperature');
+    assert.ok(!('temperature' in bodies[1]), 'retry omits temperature');
+    assert.equal(meta.temperature, null, 'metadata reflects the dropped field');
+
+    // The model is remembered: the next call skips temperature up front.
+    bodies.length = 0;
+    await callLLM({ prompt: 'p', apiKey: 'k', model: 'temp-reject-buffered', maxRetries: 0 });
+    assert.equal(bodies.length, 1);
+    assert.ok(!('temperature' in bodies[0]), 'learned model skips temperature on the first attempt');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('callLLM does not strip temperature for unrelated 400s', async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls++;
+    return { ok: false, status: 400, headers: { get: () => null }, text: async () => 'bad request: missing field' };
+  };
+  try {
+    await assert.rejects(
+      callLLM({ prompt: 'p', apiKey: 'k', model: 'temp-keep-model', maxRetries: 0 }),
+      /400/
+    );
+    assert.equal(calls, 1, 'a generic 400 is not retried');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/unit/streaming-api.test.js
+++ b/tests/unit/streaming-api.test.js
@@ -84,3 +84,52 @@ test('callLLMStream skips malformed JSON data lines without crashing', async () 
   assert.deepEqual(deltas, ['ok']);
   assert.equal(result.text, 'ok');
 });
+
+test('callLLMStream drops temperature and retries once when the model rejects it (claude-sonnet-5)', async () => {
+  const bodies = [];
+  const fetchImpl = async (_url, init) => {
+    const body = JSON.parse(String(/** @type {any} */ (init).body));
+    bodies.push(body);
+    if ('temperature' in body) {
+      return new Response('{"error":{"code":"invalid_request_error","message":"`temperature` is deprecated for this model."}}', {
+        status: 400,
+        headers: new globalThis.Headers(),
+      });
+    }
+    return okResponse([
+      'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":null}]}\n\n',
+      'data: [DONE]\n\n',
+    ]);
+  };
+
+  const result = await callLLMStream({ prompt: 'p', apiKey: 'sk-test', model: 'temp-reject-stream', fetchImpl });
+  assert.equal(result.text, 'ok');
+  assert.equal(bodies.length, 2, 'exactly one drop-and-retry');
+  assert.ok('temperature' in bodies[0], 'first attempt sends temperature');
+  assert.ok(!('temperature' in bodies[1]), 'retry omits temperature');
+
+  // The model is remembered: the next stream skips temperature up front.
+  bodies.length = 0;
+  const again = await callLLMStream({ prompt: 'p', apiKey: 'sk-test', model: 'temp-reject-stream', fetchImpl });
+  assert.equal(again.text, 'ok');
+  assert.equal(bodies.length, 1);
+  assert.ok(!('temperature' in bodies[0]), 'learned model skips temperature on the first attempt');
+});
+
+test('callLLMStream still throws for unrelated 400s', async () => {
+  let calls = 0;
+  const fetchImpl = async () => {
+    calls++;
+    return new Response('bad request: missing field', { status: 400, headers: new globalThis.Headers() });
+  };
+  await assert.rejects(
+    callLLMStream({ prompt: 'p', apiKey: 'sk-test', model: 'temp-keep-stream', fetchImpl }),
+    (err) => {
+      const error = /** @type {any} */ (err);
+      assert.equal(error.name, 'HttpError');
+      assert.equal(error.status, 400);
+      return true;
+    }
+  );
+  assert.equal(calls, 1, 'a generic 400 is not retried');
+});


### PR DESCRIPTION
## What
Launch zero-hour rehearsal (LS test-mode license, full payment→key→apply E2E against production) found the Pro tier hard-broken: entitlement passes, then every rewrite dies with `HTTP 400: temperature is deprecated for this model` from Anthropic's OpenAI-compat endpoint for claude-sonnet-5.

Repro (prod, before fix): pro request with a valid test-mode license → `{"type":"start","provider":"claude","model":"claude-sonnet-5"}` then `{"type":"error","code":"stream_failed",...temperature is deprecated...}`.

Why it was never caught: the runbook deferred the pro real-license 200 check to the first real purchase; unit/redteam QA mocks the provider.

## Fix
- `callLLM` + `callLLMStream`: detect the temperature-rejected 400, drop the field, re-issue once. Rejecting model remembered per process (shared) so warm instances/score calls skip the bad first attempt.
- Unrelated 400s unchanged (fail fast, no retry).

## Verification
- 4 new unit tests (drop-and-retry, learned skip, unrelated-400 fail-fast, both clients).
- `npm test` 1376 pass / `npm run lint` clean.
- Post-deploy: will re-run the prod E2E with the test-mode license key (this is the rehearsal's remaining gate).