### PR TITLE
feat(playground): Pro upsell CTA at free-quota exhaustion

### DIFF
--- a/playground/chatgpt.css
+++ b/playground/chatgpt.css
@@ -397,6 +397,10 @@ details.foldout[open] > summary::before { content: "▾ "; }
 .retrybtn { display: inline-flex; align-items: center; margin-top: 10px; font-family: inherit; font-size: 13px; border-radius: 9999px; padding: 6px 16px; cursor: pointer; background: transparent; border: 1px solid var(--border-strong); color: var(--text); transition: background .15s; }
 .retrybtn:hover { background: var(--bg-hover); }
 
+/* Pro upsell link shown on free-tier quota exhaustion */
+.pro-upsell { display: inline-flex; align-items: center; margin: 10px 8px 0 0; font-size: 13px; font-weight: 600; border-radius: 9999px; padding: 6px 16px; text-decoration: none; background: var(--accent); color: var(--on-accent); box-shadow: var(--inset); transition: background .15s; }
+.pro-upsell:hover { background: var(--accent-press); }
+
 /* ───────── keyboard focus (a11y) ─────────
    Hover-only affordances are invisible to keyboard users; every interactive
    control gets one consistent focus ring. :focus-visible keeps mouse clicks
@@ -419,6 +423,7 @@ details.foldout[open] > summary::before { content: "▾ "; }
 .foot__links a:focus-visible,
 details.foldout > summary:focus-visible,
 .retrybtn:focus-visible,
+.pro-upsell:focus-visible,
 .ctl__select:focus-visible,
 .ctl__input:focus-visible {
   outline: 2px solid var(--accent);

--- a/playground/chatgpt.js
+++ b/playground/chatgpt.js
@@ -80,6 +80,7 @@ const I18N = {
     failNote: 'Rewrite failed. Try again, or check the mode/key.',
     quotaDaily: 'You’ve used today’s free quota. Try again tomorrow, or switch to BYOK mode with your own API key for unlimited use.',
     quotaHourly: 'Free quota is full for now. Try again shortly, or use BYOK mode with your own API key.',
+    proUpsell: 'Upgrade to Pro — $9.99/mo',
     quotaConcurrent: 'A rewrite is already running for your connection. Wait for it to finish, then try again.',
     serviceDown: 'The rewrite service is temporarily unavailable. Please try again later.',
     tooLong: 'Text is over the {tier} limit of {cap} characters. Shorten it and try again.',
@@ -118,6 +119,7 @@ const I18N = {
     failNote: '리라이트 실패. 다시 시도하거나 모드·키를 확인해 주세요.',
     quotaDaily: '오늘 무료 사용량을 다 쓰셨어요. 내일 다시 시도하거나, 본인 API 키로 BYOK 모드를 쓰면 제한 없이 이용할 수 있어요.',
     quotaHourly: '무료 사용량이 잠시 가득 찼어요. 잠시 후 다시 시도하거나, 본인 API 키로 BYOK 모드를 쓰면 바로 이용할 수 있어요.',
+    proUpsell: 'Pro로 업그레이드 — $9.99/월',
     quotaConcurrent: '이미 진행 중인 리라이트가 있어요. 끝난 뒤 다시 시도해 주세요.',
     serviceDown: '리라이트 서비스를 잠시 사용할 수 없어요. 나중에 다시 시도해 주세요.',
     tooLong: '{tier} 모드 한도({cap}자)를 넘었어요. 줄여서 다시 시도해 주세요.',
@@ -156,6 +158,7 @@ const I18N = {
     failNote: '改写失败。请重试，或检查模式 / 密钥。',
     quotaDaily: '今天的免费额度已用完。请明天再试，或切换到 BYOK 模式使用自己的 API 密钥，即可无限制使用。',
     quotaHourly: '免费额度暂时已满。请稍后再试，或使用 BYOK 模式和自己的 API 密钥。',
+    proUpsell: '升级到 Pro — 每月 $9.99',
     quotaConcurrent: '已有一个改写正在进行。请等它完成后再试。',
     serviceDown: '改写服务暂时不可用，请稍后再试。',
     tooLong: '文字超过 {tier} 模式的 {cap} 字上限。请缩短后重试。',
@@ -194,6 +197,7 @@ const I18N = {
     failNote: '書き換えに失敗しました。再試行するか、モード・キーを確認してください。',
     quotaDaily: '本日の無料利用枠を使い切りました。明日また試すか、ご自身のAPIキーでBYOKモードに切り替えると無制限で使えます。',
     quotaHourly: '無料利用枠が一時的にいっぱいです。しばらくして再試行するか、ご自身のAPIキーでBYOKモードをお使いください。',
+    proUpsell: 'Proにアップグレード — 月額$9.99',
     quotaConcurrent: 'すでに実行中の書き換えがあります。完了後にもう一度お試しください。',
     serviceDown: '書き換えサービスは一時的に利用できません。しばらくしてからお試しください。',
     tooLong: '{tier}モードの上限（{cap}文字）を超えています。短くしてからお試しください。',
@@ -319,6 +323,27 @@ function wireProCta() {
     btn.classList.add('is-soon');
     btn.textContent = 'Pro — coming soon';
   }
+}
+
+// Pro upsell link for quota-exhausted errors — the roadmap's "optimal exposure
+// point". Before payments open (no PRO_CHECKOUT_URL) it routes to the landing
+// pricing section; once live it deep-links the UTM-attributed checkout.
+function quotaUpsell() {
+  const a = el('a', 'pro-upsell', i18n().proUpsell);
+  const href = proCheckoutHref();
+  if (href) {
+    a.href = href;
+    a.target = '_blank';
+    a.rel = 'noreferrer';
+  } else {
+    a.href = '#pricing';
+    a.addEventListener('click', (e) => {
+      e.preventDefault();
+      showLanding();
+      document.getElementById('pricing')?.scrollIntoView({ behavior: 'smooth' });
+    });
+  }
+  return a;
 }
 
 function wirePricingCtas() {
@@ -835,7 +860,13 @@ async function runAttempt(attempt) {
         body.appendChild(errorNote(t.floorWarn));
       } else {
         textEl.style.display = 'none';
-        body.appendChild(errorNote(failureMessage(classifyRewriteError(ff), ff, t)));
+        const kind = classifyRewriteError(ff);
+        body.appendChild(errorNote(failureMessage(kind, ff, t)));
+        // Free-tier quota exhaustion is the optimal Pro exposure point.
+        const K = REWRITE_ERROR_KINDS;
+        if (els.tier.value === WEB_TIERS.FREE && (kind === K.QUOTA_DAILY || kind === K.QUOTA_HOURLY)) {
+          body.appendChild(quotaUpsell());
+        }
         addRetry(body, attempt);
       }
     }
@@ -884,7 +915,7 @@ function addRetry(body, attempt) {
   btn.type = 'button';
   btn.addEventListener('click', () => {
     if (state.busy) return; // another attempt is streaming; keep the button for later
-    body.querySelectorAll('.error-note, .retrybtn').forEach((n) => n.remove());
+    body.querySelectorAll('.error-note, .retrybtn, .pro-upsell').forEach((n) => n.remove());
     runAttempt(attempt);
   });
   body.appendChild(btn);


### PR DESCRIPTION
Launch-funnel check deliverable. Free-tier quota exhaustion (the roadmap's 'optimal exposure point') previously pointed users to BYOK only. This adds a localized Pro upsell pill on QUOTA_DAILY/QUOTA_HOURLY for the free tier: pre-launch it routes to #pricing; post-launch it deep-links the UTM-attributed checkout. Headless-browser verified against the dev server (429 stub → upsell renders → click lands on pricing; UTM survives into the checkout URL). Lint/typecheck clean.