### PR TITLE
research: adopt deterministic panel v2 judge

### DIFF
--- a/docs/research/2026-panel-v2-design.md
+++ b/docs/research/2026-panel-v2-design.md
@@ -1,11 +1,12 @@
 # Panel v2 design — judge panel reconstitution after kimi's exit
 
-Drafted 2026-07-13, before any study uses it. Trigger: the kimi subscription
-ends 2026-07-17 (operator-confirmed), removing `judge-kimi` from the fixed
-3-judge panel used by Studies 0–3. This document is the registered design for
-every judging run in studies registered after this date; each future
-pre-registration binds itself to this design by citing it. Study 3 (running
-under its own 2026-07-12 registration) is unaffected.
+Adopted 2026-07-15, before any v2 study uses it. Trigger: the kimi
+subscription ends 2026-07-17 (operator-confirmed), removing `judge-kimi` from
+the fixed 3-judge panel used by Studies 0–3. The deterministic document scorer
+is promoted to chief judge under the 2026-07-14 calibration; gpt and grok remain
+the perceptual panel. Every judging run in studies registered after this date
+MUST import the executable policy in `scripts/research/panel-v2.mjs`. Study 3,
+registered on 2026-07-12, is unaffected.
 
 Grounding: the judge-calibration side study
 (`2026-judge-calibration.md`, registered design, 192/192 judgments) plus a
@@ -15,24 +16,30 @@ bridge analysis computed from its existing data — no new calls.
 
 | seat | scorer | role |
 |---|---|---|
-| judge-gpt | codex CLI, gpt-5.5 | LLM judge (calibrated AUC 1.00 [1.00, 1.00]) |
-| judge-grok | xai API, grok-4.5 | LLM judge (calibrated AUC 0.93 [0.83, 1.00]) |
-| judge-det | patina deterministic prose-score (lang-scoped) | always-on free baseline lane (calibrated AUC 0.98 [0.93, 1.00]) |
+| **chief: judge-det** | patina deterministic prose-score (lang-scoped) | primary document verdict (`score >= 35`) and continuous score |
+| judge-gpt | codex CLI, gpt-5.5 | perceptual corroboration (calibrated AUC 1.00 [1.00, 1.00]) |
+| judge-grok | xai API, grok-4.5 | perceptual corroboration (calibrated AUC 0.93 [0.83, 1.00]) |
 
-- **Primary perceptual metric:** LLM panel mean over gpt + grok, both
-  required per passage-condition; a missing/unparseable judge is data loss,
-  reported (no silent 1-of-2 scoring).
-- **judge-det is a co-primary corroboration lane, not pooled** into the LLM
-  mean: every study reports Δ_det beside Δ_panel. Pooling raw det scores
-  measured AUC 0.996 on the calibration corpus, but mixing scales (det human
-  mean 17.7 vs judges ~35) breaks absolute comparability with the archived
-  series; pooling stays deferred together with the operator-deferred panel-
-  shrink decision (#153 ③) until a middle-ground (edited/humanized text)
-  validation exists.
-- **Authorship-call metrics** (AI-call rate) come from the LLM judges only;
-  det's document-level binary verdict is miscalibrated (0.55 accuracy at
-  document length — see calibration results) and MUST NOT be used until the
-  approved recalibration task lands.
+- **Primary document metric:** judge-det's deterministic verdict and continuous
+  score. The chief lane is auditable, free, and independent of expiring model
+  subscriptions. Its threshold is fixed at 35; no study may tune it on outcome
+  data.
+- **Binding fresh-corpus gate:** before reporting det binary outcomes, each study
+  MUST pass its own labeled fresh corpus to
+  `requireFreshCorpusValidation()` in `scripts/research/panel-v2.mjs`.
+  Accuracy below 0.85 throws and disables the binary verdict column. Continuous
+  deterministic scores remain reportable. This preserves the 2026-07-14
+  calibration's anti-overfit condition in executable form.
+- **Perceptual corroboration:** report the gpt+grok mean and both individual
+  scores beside the chief result. Both are required for claude-generated
+  passages; a missing/unparseable required judge is data loss, never silently
+  reduced to one judge.
+- **No pooled score:** deterministic and LLM scales remain separate. The det
+  human mean was 17.7 versus roughly 35 for the LLM judges, so averaging them
+  would create a number with no stable interpretation.
+- **Authorship-call metrics:** the reported primary call comes from judge-det
+  after the fresh-corpus gate. LLM calls are labeled perceptual corroboration,
+  not quorum votes.
 
 ## Bridge to the old panel (computed from calibration data, n=44 docs)
 
@@ -74,10 +81,13 @@ with the LLM panel is reported separately (Spearman ρ) as a drift monitor.
 
 ## Effective date & audit trail
 
-- Binding for studies registered on/after the first registration that cites
-  this document; at the latest, any run after 2026-07-17 (kimi unavailable).
+- Adopted by the operator's 2026-07-15 autonomous reconstitution order and
+  binding for studies registered from that date; Study 3 remains archived under
+  its original panel.
 - The judge prompt, parser, retry policy, and invocation shapes remain
   byte-identical to the S2/S3 runners for the two LLM seats.
-- This design was approved as a proposal lane by tower decision #153 follow-up
-  (panel reconstitution requested by the operator); adoption of THIS concrete
-  design is a separate operator decision.
+- Calibration evidence: document threshold 35 reached 0.955 accuracy on 44
+  leakage-free KO documents. The same-corpus selection caveat is enforced by
+  the per-study fresh-corpus accuracy floor of 0.85.
+- Kimi's archived scores and old runners remain untouched for reproducibility;
+  no new runner may import `judge-kimi`.

--- a/scripts/research/panel-v2.mjs
+++ b/scripts/research/panel-v2.mjs
@@ -1,0 +1,64 @@
+import { scoreText } from '../prose-score.mjs';
+
+export const DET_DOCUMENT_THRESHOLD = 35;
+export const MIN_FRESH_CORPUS_ACCURACY = 0.85;
+
+export const PANEL_V2 = Object.freeze({
+  chief: Object.freeze({
+    id: 'judge-det',
+    role: 'deterministic-document-verdict',
+    threshold: DET_DOCUMENT_THRESHOLD,
+  }),
+  perceptual: Object.freeze([
+    Object.freeze({ id: 'judge-gpt', family: 'gpt-family' }),
+    Object.freeze({ id: 'judge-grok', family: 'xai-family' }),
+  ]),
+});
+
+export function deterministicDocumentVerdict(text, { lang = 'ko', file = '' } = {}) {
+  const result = scoreText(text, { file, lang });
+  return {
+    judge: PANEL_V2.chief.id,
+    score: result.score,
+    verdict: result.score >= DET_DOCUMENT_THRESHOLD ? 'ai' : 'human',
+    threshold: DET_DOCUMENT_THRESHOLD,
+    lang: result.lang,
+    paragraphCount: result.paragraphCount,
+    analysisSkipped: result.analysisSkipped,
+  };
+}
+
+export function validateFreshCorpus(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    throw new TypeError('fresh-corpus validation requires at least one labeled row');
+  }
+
+  let correct = 0;
+  for (const [index, row] of rows.entries()) {
+    if (!row || !['ai', 'human'].includes(row.label) || !Number.isFinite(row.score)) {
+      throw new TypeError(`fresh-corpus row ${index} requires label=ai|human and a finite score`);
+    }
+    const verdict = row.score >= DET_DOCUMENT_THRESHOLD ? 'ai' : 'human';
+    if (verdict === row.label) correct += 1;
+  }
+
+  const accuracy = correct / rows.length;
+  return {
+    threshold: DET_DOCUMENT_THRESHOLD,
+    minimumAccuracy: MIN_FRESH_CORPUS_ACCURACY,
+    accuracy,
+    correct,
+    total: rows.length,
+    binaryVerdictsAllowed: accuracy >= MIN_FRESH_CORPUS_ACCURACY,
+  };
+}
+
+export function requireFreshCorpusValidation(rows) {
+  const validation = validateFreshCorpus(rows);
+  if (!validation.binaryVerdictsAllowed) {
+    throw new Error(
+      `judge-det binary verdict disabled: fresh-corpus accuracy ${validation.accuracy.toFixed(3)} < ${MIN_FRESH_CORPUS_ACCURACY.toFixed(2)}`,
+    );
+  }
+  return validation;
+}

--- a/tests/unit/panel-v2.test.js
+++ b/tests/unit/panel-v2.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  DET_DOCUMENT_THRESHOLD,
+  PANEL_V2,
+  requireFreshCorpusValidation,
+  validateFreshCorpus,
+} from '../../scripts/research/panel-v2.mjs';
+
+describe('panel v2 judge policy', () => {
+  it('promotes the deterministic document verdict to chief judge', () => {
+    assert.equal(PANEL_V2.chief.id, 'judge-det');
+    assert.equal(PANEL_V2.chief.threshold, 35);
+    assert.equal(DET_DOCUMENT_THRESHOLD, 35);
+    assert.deepEqual(PANEL_V2.perceptual.map(({ id }) => id), ['judge-gpt', 'judge-grok']);
+  });
+
+  it('uses score >= 35 for the document verdict', () => {
+    const validation = validateFreshCorpus([
+      { label: 'human', score: 34.999 },
+      { label: 'ai', score: 35 },
+    ]);
+    assert.equal(validation.accuracy, 1);
+    assert.equal(validation.binaryVerdictsAllowed, true);
+  });
+
+  it('enforces fresh-corpus accuracy of at least 0.85', () => {
+    const passing = Array.from({ length: 20 }, (_, index) => ({
+      label: index < 17 ? 'ai' : 'human',
+      score: index < 17 ? 35 : 0,
+    }));
+    assert.equal(requireFreshCorpusValidation(passing).accuracy, 1);
+
+    const failing = Array.from({ length: 20 }, (_, index) => ({
+      label: 'ai',
+      score: index < 16 ? 35 : 0,
+    }));
+    assert.throws(
+      () => requireFreshCorpusValidation(failing),
+      /binary verdict disabled: fresh-corpus accuracy 0\.800 < 0\.85/,
+    );
+  });
+
+  it('rejects missing or malformed validation evidence', () => {
+    assert.throws(() => validateFreshCorpus([]), /at least one labeled row/);
+    assert.throws(
+      () => validateFreshCorpus([{ label: 'unknown', score: 35 }]),
+      /label=ai\|human and a finite score/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- promote deterministic `judge-det` to the panel-v2 chief document judge at `score >= 35`
- retain gpt-5.5 and grok-4.5 as separate perceptual corroboration lanes
- enforce the binding per-study fresh-corpus accuracy floor (`>= 0.85`) before binary verdicts are reportable
- preserve archived kimi scores and old runners for reproducibility after the 2026-07-17 subscription exit

## Evidence
- `node --test tests/unit/panel-v2.test.js` — 4/4 pass
- leakage-free calibration corpus — 42/44 correct, accuracy `0.954545` at threshold 35
- `npx eslint scripts/research/panel-v2.mjs tests/unit/panel-v2.test.js` — pass

## Scope
Research lane only: this does not change `analyzeText`, public benchmark behavior, CLI scoring output, playground behavior, or any product surface.