### PR TITLE
feat(monitor): external aggregate-only log-query service (PATINA_VERCEL_LOG_QUERY_*)

### DIFF
--- a/services/log-query/.gitignore
+++ b/services/log-query/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*

--- a/services/log-query/README.md
+++ b/services/log-query/README.md
@@ -8,16 +8,21 @@ It returns only the four exact closed integer counts from
 
 ## Endpoints
 
-- `POST /api/ingest` — Vercel log-drain receiver. Echoes the `x-vercel-verify`
-  challenge, verifies the drain HMAC-SHA1 signature (`x-vercel-signature`),
-  extracts closed `patina.web.v1` events from delivered log messages, and
-  atomically increments `patina:logq:v1:{channel}:{tier}:{quarter}:{outcome}`
-  counters (TTL 7200s) in the service's own Upstash store. Raw log content is
-  never stored, logged, or echoed.
+- `POST /api/ingest` — Vercel log-drain receiver. Verifies the drain HMAC-SHA1
+  signature (`x-vercel-signature`), extracts only complete nine-field
+  `patina.web.v1` envelopes (canonical field order, closed dimensions) from
+  delivered log messages, and commits every counter increment in ONE atomic
+  EVAL (`patina:logq:v1:{channel}:{tier}:{quarter}:{outcome}`, TTL 7200s) in
+  the service's own Upstash store. Fail-closed: a malformed delivery is `400`
+  and a store failure is `503` (the drain redelivers); a delivery is never
+  acknowledged after a lost or partial write. Raw log content is never
+  stored, logged, or echoed.
 - `GET /api/query?channel=production&tier=pro&window=15m&aggregate_only=true`
   — monitor query endpoint (Bearer auth). `window=15m` answers exactly
   `{numberSafety, entitlementNonOk, entitlementTotal}`; `window=30m` answers
-  exactly `{monitorDrop}`. Counter-store failure returns `503`, never zeroes.
+  exactly `{monitorDrop}`. The whole window is read in one MGET snapshot and
+  every persisted value must be a canonical non-negative safe integer; store
+  failure or a malformed counter returns `503`, never a fabricated zero.
 
 Count semantics: `numberSafety` = `number_safety_failed`; `entitlementNonOk` =
 `entitlement_denied` + `entitlement_unavailable`; `entitlementTotal` = every
@@ -31,6 +36,11 @@ bucket-end rule.
   (never the patina quota/admission KV or the strict observability store).
 - `LOGQ_DRAIN_SECRET` — custom secret configured on the Vercel log drain;
   ingest rejects unsigned or mis-signed deliveries.
+- `LOGQ_VERCEL_VERIFY` — the team endpoint verification code from Vercel's
+  `GET /v1/verify-endpoint`; returned in the `x-vercel-verify` response header
+  so drain-endpoint verification succeeds. Request header values are never
+  echoed, and without this variable there is no pre-authentication response
+  path.
 - `LOGQ_QUERY_TOKEN` — bearer token the monitor sends; mirrors the patina
   production `PATINA_VERCEL_LOG_QUERY_TOKEN` value.
 

--- a/services/log-query/README.md
+++ b/services/log-query/README.md
@@ -1,0 +1,47 @@
+# patina-log-query
+
+External aggregate-only log-query service for the private Pro monitor
+(`api/pro-monitor.js`). Deployed as a **separate Vercel project** so the
+monitored app and its log-derived health signal never share a deployment.
+It returns only the four exact closed integer counts from
+`docs/operations/queries/pro-launch-v1.md` — never raw Vercel logs.
+
+## Endpoints
+
+- `POST /api/ingest` — Vercel log-drain receiver. Echoes the `x-vercel-verify`
+  challenge, verifies the drain HMAC-SHA1 signature (`x-vercel-signature`),
+  extracts closed `patina.web.v1` events from delivered log messages, and
+  atomically increments `patina:logq:v1:{channel}:{tier}:{quarter}:{outcome}`
+  counters (TTL 7200s) in the service's own Upstash store. Raw log content is
+  never stored, logged, or echoed.
+- `GET /api/query?channel=production&tier=pro&window=15m&aggregate_only=true`
+  — monitor query endpoint (Bearer auth). `window=15m` answers exactly
+  `{numberSafety, entitlementNonOk, entitlementTotal}`; `window=30m` answers
+  exactly `{monitorDrop}`. Counter-store failure returns `503`, never zeroes.
+
+Count semantics: `numberSafety` = `number_safety_failed`; `entitlementNonOk` =
+`entitlement_denied` + `entitlement_unavailable`; `entitlementTotal` = every
+terminal request outcome (all outcomes except `monitor_drop`); `monitorDrop` =
+`monitor_drop` only. Window buckets follow the monitor's strictly-after
+bucket-end rule.
+
+## Environment (this service's Vercel project, server-only)
+
+- `LOGQ_REST_API_URL` / `LOGQ_REST_API_TOKEN` — dedicated Upstash REST store
+  (never the patina quota/admission KV or the strict observability store).
+- `LOGQ_DRAIN_SECRET` — custom secret configured on the Vercel log drain;
+  ingest rejects unsigned or mis-signed deliveries.
+- `LOGQ_QUERY_TOKEN` — bearer token the monitor sends; mirrors the patina
+  production `PATINA_VERCEL_LOG_QUERY_TOKEN` value.
+
+## Wiring (patina production)
+
+Set `PATINA_VERCEL_LOG_QUERY_URL` to the exact deployed
+`https://<project>.vercel.app/api/query` URL, pin its lowercase-hex SHA-256 in
+`PATINA_VERCEL_LOG_QUERY_URL_SHA256`, and set
+`PATINA_VERCEL_LOG_QUERY_TOKEN=LOGQ_QUERY_TOKEN`. Create the team log drain
+(sources `lambda`, format `json`, the patina project only) pointing at
+`/api/ingest` with `LOGQ_DRAIN_SECRET` as its custom secret.
+
+Tests live in `tests/unit/log-query-service.test.js` and pin the response
+shapes to the monitor's `parseAggregate` contract.

--- a/services/log-query/api/ingest.js
+++ b/services/log-query/api/ingest.js
@@ -1,7 +1,8 @@
 // @ts-check
 // Vercel log-drain receiver. Counts closed patina.web.v1 outcomes into
 // per-quarter counters and discards everything else. Never stores or echoes
-// raw log content.
+// raw log content. Fail-closed: malformed deliveries and store failures are
+// rejected with non-2xx so the drain redelivers instead of losing evidence.
 
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { LOGQ_TTL_SECONDS, parseDrainDelivery } from '../lib/log-aggregate.js';
@@ -44,20 +45,18 @@ export function createIngestHandler({ env = process.env, kv = createLogqKv(env ?
    */
   return async function ingest(req, res) {
     res.setHeader('Cache-Control', 'no-store, max-age=0');
-    // Vercel verifies drain endpoints by expecting the team's endpoint
-    // verification code (GET /v1/verify-endpoint) in the x-vercel-verify
-    // response header before any drain traffic flows. Sending it on every
-    // response only asserts "this endpoint consents to receive this team's
-    // drain deliveries" — it authorizes nothing else.
+    // Vercel drain-endpoint verification: respond with the operator-configured
+    // team verification code (from GET /v1/verify-endpoint) when the platform
+    // presents its verification request. The request's own header value is a
+    // trigger only and is NEVER echoed; without the configured code there is
+    // no pre-authentication response path at all.
     const verifyCode = env?.LOGQ_VERCEL_VERIFY;
     const hasCode = typeof verifyCode === 'string' && verifyCode.length > 0;
     if (hasCode) res.setHeader('x-vercel-verify', verifyCode);
-    const challenge = req.headers['x-vercel-verify'];
-    if (typeof challenge === 'string' && challenge.length > 0 && challenge.length <= 256 && /^[A-Za-z0-9._-]+$/.test(challenge)) {
-      if (!hasCode) res.setHeader('x-vercel-verify', challenge);
+    if (hasCode && req.headers['x-vercel-verify'] !== undefined) {
       res.setHeader('Content-Type', 'text/plain; charset=utf-8');
       res.statusCode = 200;
-      res.end(typeof verifyCode === 'string' && verifyCode.length > 0 ? verifyCode : challenge);
+      res.end(verifyCode);
       return;
     }
     if (req.method !== 'POST') { res.statusCode = 405; res.end('{"error":"method_not_allowed"}'); return; }
@@ -66,47 +65,26 @@ export function createIngestHandler({ env = process.env, kv = createLogqKv(env ?
     let body;
     try { body = await readBody(req); } catch { res.statusCode = 413; res.end('{"error":"body_too_large"}'); return; }
     if (!signatureValid(secret, body, req.headers['x-vercel-signature'])) { res.statusCode = 403; res.end('{"error":"signature"}'); return; }
-    let stored = 0;
+    const parsed = parseDrainDelivery(body.toString('utf8'), { now: now() });
+    if (parsed.ok !== true) {
+      // Reject the whole malformed delivery before any write; the reason is a
+      // closed enum, never delivery content.
+      res.statusCode = 400;
+      res.end(JSON.stringify({ error: 'malformed_delivery', reason: 'reason' in parsed ? parsed.reason : 'unknown' }));
+      return;
+    }
     try {
-      const text = body.toString('utf8');
-      const increments = parseDrainDelivery(text, { now: now() });
-      for (const { key, count } of increments) {
-        await kv.incrBy(key, count, LOGQ_TTL_SECONDS);
-        stored += 1;
-      }
-      if (env?.LOGQ_DEBUG_SHAPE === 'true') {
-        // Content-free delivery-shape diagnostic (booleans/counts/keys only),
-        // persisted as cumulative counters so no live log tail is needed.
-        let entryKeys = [];
-        let entryCount = -1;
-        let startsWith = text.trimStart().slice(0, 1);
-        try {
-          const parsed = JSON.parse(text);
-          entryCount = Array.isArray(parsed) ? parsed.length : -1;
-          const first = Array.isArray(parsed) ? parsed[0] : parsed;
-          if (first && typeof first === 'object') entryKeys = Object.keys(first).slice(0, 20);
-        } catch { /* NDJSON or malformed; shape fields stay defaults */ }
-        const mentionsSchema = text.includes('patina.web.v1');
-        try {
-          logger?.warn?.({
-            logq: 'shape', startsWith, entryCount, entryKeys,
-            bytes: body.length, mentionsSchema, counters: stored,
-          });
-        } catch { /* diagnostics must not fail ingest */ }
-        try {
-          await kv.incrBy('patina:logq:diag:deliveries', 1, LOGQ_TTL_SECONDS);
-          if (entryCount > 0) await kv.incrBy('patina:logq:diag:entries', entryCount, LOGQ_TTL_SECONDS);
-          if (mentionsSchema) await kv.incrBy('patina:logq:diag:mentions', 1, LOGQ_TTL_SECONDS);
-        } catch { /* diagnostics must not fail ingest */ }
-      }
+      await kv.incrAll(parsed.increments, LOGQ_TTL_SECONDS);
     } catch {
-      // A partial store is acceptable: drains redeliver, counters are coarse,
-      // and the monitor fails closed on unavailability rather than trusting
-      // silence. Never echo delivery content back.
-      try { logger?.warn?.({ logq: 'ingest_partial' }); } catch { /* logging must not fail ingest */ }
+      // All-or-nothing: nothing was committed (single atomic script), so a
+      // non-2xx makes the drain redeliver instead of silently losing counts.
+      try { logger?.warn?.({ logq: 'store_failed' }); } catch { /* logging must not mask the 503 */ }
+      res.statusCode = 503;
+      res.end('{"error":"store_failed"}');
+      return;
     }
     res.statusCode = 200;
-    res.end(JSON.stringify({ ok: true, counters: stored }));
+    res.end(JSON.stringify({ ok: true, counters: parsed.increments.length }));
   };
 }
 

--- a/services/log-query/api/ingest.js
+++ b/services/log-query/api/ingest.js
@@ -68,10 +68,36 @@ export function createIngestHandler({ env = process.env, kv = createLogqKv(env ?
     if (!signatureValid(secret, body, req.headers['x-vercel-signature'])) { res.statusCode = 403; res.end('{"error":"signature"}'); return; }
     let stored = 0;
     try {
-      const increments = parseDrainDelivery(body.toString('utf8'), { now: now() });
+      const text = body.toString('utf8');
+      const increments = parseDrainDelivery(text, { now: now() });
       for (const { key, count } of increments) {
         await kv.incrBy(key, count, LOGQ_TTL_SECONDS);
         stored += 1;
+      }
+      if (env?.LOGQ_DEBUG_SHAPE === 'true') {
+        // Content-free delivery-shape diagnostic (booleans/counts/keys only),
+        // persisted as cumulative counters so no live log tail is needed.
+        let entryKeys = [];
+        let entryCount = -1;
+        let startsWith = text.trimStart().slice(0, 1);
+        try {
+          const parsed = JSON.parse(text);
+          entryCount = Array.isArray(parsed) ? parsed.length : -1;
+          const first = Array.isArray(parsed) ? parsed[0] : parsed;
+          if (first && typeof first === 'object') entryKeys = Object.keys(first).slice(0, 20);
+        } catch { /* NDJSON or malformed; shape fields stay defaults */ }
+        const mentionsSchema = text.includes('patina.web.v1');
+        try {
+          logger?.warn?.({
+            logq: 'shape', startsWith, entryCount, entryKeys,
+            bytes: body.length, mentionsSchema, counters: stored,
+          });
+        } catch { /* diagnostics must not fail ingest */ }
+        try {
+          await kv.incrBy('patina:logq:diag:deliveries', 1, LOGQ_TTL_SECONDS);
+          if (entryCount > 0) await kv.incrBy('patina:logq:diag:entries', entryCount, LOGQ_TTL_SECONDS);
+          if (mentionsSchema) await kv.incrBy('patina:logq:diag:mentions', 1, LOGQ_TTL_SECONDS);
+        } catch { /* diagnostics must not fail ingest */ }
       }
     } catch {
       // A partial store is acceptable: drains redeliver, counters are coarse,

--- a/services/log-query/api/ingest.js
+++ b/services/log-query/api/ingest.js
@@ -44,16 +44,20 @@ export function createIngestHandler({ env = process.env, kv = createLogqKv(env ?
    */
   return async function ingest(req, res) {
     res.setHeader('Cache-Control', 'no-store, max-age=0');
-    // Vercel verifies drain endpoints by expecting the x-vercel-verify value
-    // to be echoed back before any drain traffic flows.
-    const verify = req.headers['x-vercel-verify'];
-    if (typeof verify === 'string' && verify.length > 0 && verify.length <= 256 && /^[A-Za-z0-9._-]+$/.test(verify)) {
-      res.setHeader('x-vercel-verify', verify);
+    // Vercel verifies drain endpoints by expecting the team's endpoint
+    // verification code (GET /v1/verify-endpoint) in the x-vercel-verify
+    // response header before any drain traffic flows. Sending it on every
+    // response only asserts "this endpoint consents to receive this team's
+    // drain deliveries" — it authorizes nothing else.
+    const verifyCode = env?.LOGQ_VERCEL_VERIFY;
+    const hasCode = typeof verifyCode === 'string' && verifyCode.length > 0;
+    if (hasCode) res.setHeader('x-vercel-verify', verifyCode);
+    const challenge = req.headers['x-vercel-verify'];
+    if (typeof challenge === 'string' && challenge.length > 0 && challenge.length <= 256 && /^[A-Za-z0-9._-]+$/.test(challenge)) {
+      if (!hasCode) res.setHeader('x-vercel-verify', challenge);
       res.setHeader('Content-Type', 'text/plain; charset=utf-8');
       res.statusCode = 200;
-      // Header and body both carry the token: Vercel's drain-endpoint
-      // verification accepts either transport.
-      res.end(verify);
+      res.end(typeof verifyCode === 'string' && verifyCode.length > 0 ? verifyCode : challenge);
       return;
     }
     if (req.method !== 'POST') { res.statusCode = 405; res.end('{"error":"method_not_allowed"}'); return; }

--- a/services/log-query/api/ingest.js
+++ b/services/log-query/api/ingest.js
@@ -49,8 +49,11 @@ export function createIngestHandler({ env = process.env, kv = createLogqKv(env ?
     const verify = req.headers['x-vercel-verify'];
     if (typeof verify === 'string' && verify.length > 0 && verify.length <= 256 && /^[A-Za-z0-9._-]+$/.test(verify)) {
       res.setHeader('x-vercel-verify', verify);
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
       res.statusCode = 200;
-      res.end('{}');
+      // Header and body both carry the token: Vercel's drain-endpoint
+      // verification accepts either transport.
+      res.end(verify);
       return;
     }
     if (req.method !== 'POST') { res.statusCode = 405; res.end('{"error":"method_not_allowed"}'); return; }

--- a/services/log-query/api/ingest.js
+++ b/services/log-query/api/ingest.js
@@ -1,0 +1,80 @@
+// @ts-check
+// Vercel log-drain receiver. Counts closed patina.web.v1 outcomes into
+// per-quarter counters and discards everything else. Never stores or echoes
+// raw log content.
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { LOGQ_TTL_SECONDS, parseDrainDelivery } from '../lib/log-aggregate.js';
+import { createLogqKv } from '../lib/rest-kv.js';
+
+const MAX_BODY_BYTES = 1024 * 1024;
+
+/** @param {import('node:http').IncomingMessage} req */
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    /** @type {Buffer[]} */
+    const chunks = [];
+    let size = 0;
+    req.on('data', (chunk) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) { reject(new Error('body_too_large')); req.destroy(); return; }
+      chunks.push(chunk);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+}
+
+/** @param {string} secret @param {Buffer} body @param {unknown} signature */
+function signatureValid(secret, body, signature) {
+  if (typeof signature !== 'string' || signature.length === 0) return false;
+  const expected = createHmac('sha1', secret).update(body).digest('hex');
+  const provided = Buffer.from(signature, 'utf8');
+  const wanted = Buffer.from(expected, 'utf8');
+  return provided.length === wanted.length && timingSafeEqual(provided, wanted);
+}
+
+/**
+ * @param {{env?: Record<string, string|undefined>, kv?: ReturnType<typeof createLogqKv>, now?: () => number, logger?: {warn?: Function}}} [options]
+ */
+export function createIngestHandler({ env = process.env, kv = createLogqKv(env ?? process.env), now = Date.now, logger = console } = {}) {
+  /**
+   * @param {import('node:http').IncomingMessage & {headers: Record<string, string|string[]|undefined>}} req
+   * @param {import('node:http').ServerResponse} res
+   */
+  return async function ingest(req, res) {
+    res.setHeader('Cache-Control', 'no-store, max-age=0');
+    // Vercel verifies drain endpoints by expecting the x-vercel-verify value
+    // to be echoed back before any drain traffic flows.
+    const verify = req.headers['x-vercel-verify'];
+    if (typeof verify === 'string' && verify.length > 0 && verify.length <= 256 && /^[A-Za-z0-9._-]+$/.test(verify)) {
+      res.setHeader('x-vercel-verify', verify);
+      res.statusCode = 200;
+      res.end('{}');
+      return;
+    }
+    if (req.method !== 'POST') { res.statusCode = 405; res.end('{"error":"method_not_allowed"}'); return; }
+    const secret = env?.LOGQ_DRAIN_SECRET;
+    if (typeof secret !== 'string' || secret.length === 0 || !kv) { res.statusCode = 503; res.end('{"error":"ingest_unavailable"}'); return; }
+    let body;
+    try { body = await readBody(req); } catch { res.statusCode = 413; res.end('{"error":"body_too_large"}'); return; }
+    if (!signatureValid(secret, body, req.headers['x-vercel-signature'])) { res.statusCode = 403; res.end('{"error":"signature"}'); return; }
+    let stored = 0;
+    try {
+      const increments = parseDrainDelivery(body.toString('utf8'), { now: now() });
+      for (const { key, count } of increments) {
+        await kv.incrBy(key, count, LOGQ_TTL_SECONDS);
+        stored += 1;
+      }
+    } catch {
+      // A partial store is acceptable: drains redeliver, counters are coarse,
+      // and the monitor fails closed on unavailability rather than trusting
+      // silence. Never echo delivery content back.
+      try { logger?.warn?.({ logq: 'ingest_partial' }); } catch { /* logging must not fail ingest */ }
+    }
+    res.statusCode = 200;
+    res.end(JSON.stringify({ ok: true, counters: stored }));
+  };
+}
+
+export default createIngestHandler();

--- a/services/log-query/api/query.js
+++ b/services/log-query/api/query.js
@@ -1,7 +1,9 @@
 // @ts-check
 // Aggregate-only query endpoint for the private Pro monitor. Returns only the
 // exact closed integer keys for the requested window; anything else is an
-// error. Never proxies or exposes raw Vercel logs.
+// error. Reads the whole window in one snapshot and fails closed (503) on any
+// store or validation failure — never a fabricated zero. Never proxies or
+// exposes raw Vercel logs.
 
 import { timingSafeEqual } from 'node:crypto';
 import { answerQuery } from '../lib/log-aggregate.js';
@@ -46,7 +48,7 @@ export function createQueryHandler({ env = process.env, kv = createLogqKv(env ??
       || params.get('aggregate_only') !== 'true'
     ) { res.statusCode = 400; res.end('{"error":"scope"}'); return; }
     try {
-      const values = await answerQuery({ channel, tier, window, readCounter: (key) => kv.get(key), now: now() });
+      const values = await answerQuery({ channel, tier, window, readCounters: (keys) => kv.getMany(keys), now: now() });
       res.statusCode = 200;
       res.end(JSON.stringify(values));
     } catch {

--- a/services/log-query/api/query.js
+++ b/services/log-query/api/query.js
@@ -1,0 +1,59 @@
+// @ts-check
+// Aggregate-only query endpoint for the private Pro monitor. Returns only the
+// exact closed integer keys for the requested window; anything else is an
+// error. Never proxies or exposes raw Vercel logs.
+
+import { timingSafeEqual } from 'node:crypto';
+import { answerQuery } from '../lib/log-aggregate.js';
+import { createLogqKv } from '../lib/rest-kv.js';
+
+/** @param {string} expected @param {unknown} header */
+function bearerValid(expected, header) {
+  if (typeof header !== 'string') return false;
+  const provided = Buffer.from(header, 'utf8');
+  const wanted = Buffer.from(`Bearer ${expected}`, 'utf8');
+  return provided.length === wanted.length && timingSafeEqual(provided, wanted);
+}
+
+/**
+ * @param {{env?: Record<string, string|undefined>, kv?: ReturnType<typeof createLogqKv>, now?: () => number}} [options]
+ */
+export function createQueryHandler({ env = process.env, kv = createLogqKv(env ?? process.env), now = Date.now } = {}) {
+  /**
+   * @param {import('node:http').IncomingMessage & {headers: Record<string, string|string[]|undefined>, url?: string}} req
+   * @param {import('node:http').ServerResponse} res
+   */
+  return async function query(req, res) {
+    res.setHeader('Cache-Control', 'no-store, max-age=0');
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    if (req.method !== 'GET') { res.statusCode = 405; res.end('{"error":"method_not_allowed"}'); return; }
+    const token = env?.LOGQ_QUERY_TOKEN;
+    if (typeof token !== 'string' || token.length === 0 || !kv) { res.statusCode = 503; res.end('{"error":"query_unavailable"}'); return; }
+    if (Array.isArray(req.headers.authorization) || !bearerValid(token, req.headers.authorization)) {
+      res.statusCode = 401;
+      res.end('{"error":"unauthorized"}');
+      return;
+    }
+    let params;
+    try { params = new URL(req.url ?? '/', 'https://logq.invalid').searchParams; } catch { res.statusCode = 400; res.end('{"error":"bad_request"}'); return; }
+    const channel = params.get('channel');
+    const tier = params.get('tier');
+    const window = params.get('window');
+    if (
+      (channel !== 'production' && channel !== 'staging')
+      || tier !== 'pro'
+      || (window !== '15m' && window !== '30m')
+      || params.get('aggregate_only') !== 'true'
+    ) { res.statusCode = 400; res.end('{"error":"scope"}'); return; }
+    try {
+      const values = await answerQuery({ channel, tier, window, readCounter: (key) => kv.get(key), now: now() });
+      res.statusCode = 200;
+      res.end(JSON.stringify(values));
+    } catch {
+      res.statusCode = 503;
+      res.end('{"error":"aggregate_unavailable"}');
+    }
+  };
+}
+
+export default createQueryHandler();

--- a/services/log-query/lib/log-aggregate.js
+++ b/services/log-query/lib/log-aggregate.js
@@ -1,0 +1,172 @@
+// @ts-check
+// Aggregate-only log-query core for the external Pro monitor service.
+//
+// This module is deliberately dependency-free and side-effect-free. It turns
+// Vercel log-drain deliveries into closed per-quarter outcome counters and
+// answers the monitor's aggregate query with the exact integer shapes that
+// `api/pro-monitor.js#parseAggregate` accepts. Raw log text, identifiers, and
+// any non-closed dimension are dropped at the parsing boundary and never
+// stored or returned.
+
+export const LOGQ_KEY_PREFIX = 'patina:logq:v1';
+export const LOGQ_TTL_SECONDS = 7200;
+
+export const LOGQ_CHANNELS = Object.freeze(['production', 'staging']);
+export const LOGQ_TIERS = Object.freeze(['free', 'byok', 'pro']);
+export const LOGQ_OUTCOMES = Object.freeze([
+  'completed', 'terminal_failed', 'number_safety_failed', 'entitlement_denied',
+  'entitlement_unavailable', 'quota_denied', 'service_disabled', 'monitor_drop',
+]);
+
+const QUARTER_MS = 15 * 60 * 1000;
+const WINDOW_MS = Object.freeze({ '15m': 15 * 60 * 1000, '30m': 30 * 60 * 1000 });
+
+/** Outcomes that mean the entitlement boundary answered non-OK. */
+const ENTITLEMENT_NON_OK = Object.freeze(['entitlement_denied', 'entitlement_unavailable']);
+/**
+ * Outcomes that prove a request reached (or was refused by) the entitlement
+ * boundary. Every terminal request outcome participates; `monitor_drop` is a
+ * telemetry-delivery signal, not a request, and is deliberately excluded.
+ */
+const ENTITLEMENT_TOTAL = Object.freeze([
+  'completed', 'terminal_failed', 'number_safety_failed', 'entitlement_denied',
+  'entitlement_unavailable', 'quota_denied', 'service_disabled',
+]);
+
+/** @param {Date|number} value */
+function asTime(value) {
+  const time = value instanceof Date ? value.getTime() : Number(value);
+  if (!Number.isFinite(time)) throw new TypeError('A valid clock value is required');
+  return time;
+}
+
+/** UTC start of the enclosing 15-minute quarter, compact form (YYYYMMDDTHHmmZ). */
+export function utc15mBucket(value = Date.now()) {
+  const start = Math.floor(asTime(value) / QUARTER_MS) * QUARTER_MS;
+  return new Date(start).toISOString().slice(0, 16).replace(/[-:]/g, '') + 'Z';
+}
+
+/**
+ * Quarter buckets whose end lies strictly after `now - window`, plus the
+ * current quarter — mirrors the monitor's overlapping-quarter selection.
+ * @param {'15m'|'30m'} window
+ * @param {Date|number} [now]
+ */
+export function windowBuckets(window, now = Date.now()) {
+  const windowMs = WINDOW_MS[window];
+  if (!windowMs) throw new TypeError('window must be "15m" or "30m"');
+  const time = asTime(now);
+  const current = Math.floor(time / QUARTER_MS) * QUARTER_MS;
+  const cutoff = time - windowMs;
+  const buckets = [];
+  for (let start = current - Math.ceil(windowMs / QUARTER_MS) * QUARTER_MS; start <= current; start += QUARTER_MS) {
+    if (start + QUARTER_MS > cutoff) buckets.push(utc15mBucket(start));
+  }
+  return buckets;
+}
+
+/** The only counter key shape this service reads or writes. */
+export function logqKey({ channel, tier, bucket, outcome }) {
+  if (!LOGQ_CHANNELS.includes(channel)) throw new TypeError('channel must be a closed drain channel');
+  if (!LOGQ_TIERS.includes(tier)) throw new TypeError('tier must be a closed drain tier');
+  if (!LOGQ_OUTCOMES.includes(outcome)) throw new TypeError('outcome must be a closed drain outcome');
+  if (typeof bucket !== 'string' || !/^\d{8}T\d{4}Z$/.test(bucket)) throw new TypeError('bucket must be a compact UTC quarter');
+  return `${LOGQ_KEY_PREFIX}:${channel}:${tier}:${bucket}:${outcome}`;
+}
+
+/**
+ * Extract closed patina.web.v1 events from one log message. Handles both
+ * JSON-serialized events and Node's `console.info(object)` inspect rendering
+ * (single-quoted keys/values, arbitrary whitespace). Only the closed
+ * channel/tier/outcome dimensions are read; everything else in the message is
+ * ignored and never returned.
+ * @param {unknown} message
+ * @returns {Array<{channel: string, tier: string, outcome: string}>}
+ */
+export function extractWebEvents(message) {
+  if (typeof message !== 'string' || message.length === 0 || message.length > 65536) return [];
+  if (!message.includes('patina.web.v1')) return [];
+  const events = [];
+  const pattern = /schema['"]?\s*:\s*['"]patina\.web\.v1['"][\s\S]{0,600}?sampling['"]?\s*:\s*['"](?:full|sampled_1_of_20)['"]/g;
+  const segments = message.match(pattern) ?? [];
+  for (const segment of segments) {
+    const channel = segment.match(/channel['"]?\s*:\s*['"]([a-z_]+)['"]/)?.[1];
+    const tier = segment.match(/tier['"]?\s*:\s*['"]([a-z_]+)['"]/)?.[1];
+    const outcome = segment.match(/outcome['"]?\s*:\s*['"]([a-z_]+)['"]/)?.[1];
+    const evidenceClass = segment.match(/evidenceClass['"]?\s*:\s*['"]([a-z_]+)['"]/)?.[1];
+    if (evidenceClass !== 'aggregate_only') continue;
+    if (!channel || !tier || !outcome) continue;
+    if (!LOGQ_CHANNELS.includes(channel) || !LOGQ_TIERS.includes(tier) || !LOGQ_OUTCOMES.includes(outcome)) continue;
+    events.push({ channel, tier, outcome });
+  }
+  return events;
+}
+
+/**
+ * Parse one Vercel log-drain delivery body (JSON array or NDJSON) into closed
+ * counter increments keyed by quarter. Entries without a parseable
+ * patina.web.v1 event are dropped. Timestamps outside the retention horizon
+ * (TTL) are dropped rather than resurrecting expired quarters.
+ * @param {string} body
+ * @param {{now?: number}} [options]
+ * @returns {Array<{key: string, count: number}>}
+ */
+export function parseDrainDelivery(body, { now = Date.now() } = {}) {
+  if (typeof body !== 'string' || body.length === 0) return [];
+  /** @type {unknown[]} */
+  let entries = [];
+  const trimmed = body.trim();
+  if (trimmed.startsWith('[')) {
+    try { const parsed = JSON.parse(trimmed); entries = Array.isArray(parsed) ? parsed : []; } catch { entries = []; }
+  } else {
+    for (const line of trimmed.split('\n')) {
+      const candidate = line.trim();
+      if (!candidate) continue;
+      try { entries.push(JSON.parse(candidate)); } catch { /* skip malformed line */ }
+    }
+  }
+  /** @type {Map<string, number>} */
+  const counts = new Map();
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const { message, timestamp } = /** @type {{message?: unknown, timestamp?: unknown}} */ (entry);
+    const time = Number(timestamp);
+    const at = Number.isFinite(time) && time > 0 ? time : now;
+    if (now - at > LOGQ_TTL_SECONDS * 1000 || at - now > QUARTER_MS) continue;
+    for (const event of extractWebEvents(message)) {
+      const key = logqKey({ channel: event.channel, tier: event.tier, bucket: utc15mBucket(at), outcome: event.outcome });
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()].map(([key, count]) => ({ key, count }));
+}
+
+/**
+ * Answer the monitor query with the exact closed shape for the window.
+ * @param {{channel: string, tier: string, window: '15m'|'30m', readCounter: (key: string) => Promise<unknown>, now?: number}} input
+ */
+export async function answerQuery({ channel, tier, window, readCounter, now = Date.now() }) {
+  if (!LOGQ_CHANNELS.includes(channel)) throw new TypeError('channel must be a closed drain channel');
+  if (tier !== 'pro') throw new TypeError('tier must be "pro"');
+  if (window !== '15m' && window !== '30m') throw new TypeError('window must be "15m" or "30m"');
+  if (typeof readCounter !== 'function') throw new TypeError('readCounter is required');
+  const buckets = windowBuckets(window, now);
+  /** @param {readonly string[]} outcomes */
+  const sum = async (outcomes) => {
+    let total = 0;
+    for (const bucket of buckets) {
+      for (const outcome of outcomes) {
+        const value = Number(await readCounter(logqKey({ channel, tier, bucket, outcome })));
+        if (Number.isFinite(value) && value > 0) total += Math.floor(value);
+      }
+    }
+    if (!Number.isSafeInteger(total) || total < 0) throw new Error('counter overflow');
+    return total;
+  };
+  if (window === '30m') return { monitorDrop: await sum(['monitor_drop']) };
+  return {
+    numberSafety: await sum(['number_safety_failed']),
+    entitlementNonOk: await sum(ENTITLEMENT_NON_OK),
+    entitlementTotal: await sum(ENTITLEMENT_TOTAL),
+  };
+}

--- a/services/log-query/lib/log-aggregate.js
+++ b/services/log-query/lib/log-aggregate.js
@@ -6,7 +6,9 @@
 // answers the monitor's aggregate query with the exact integer shapes that
 // `api/pro-monitor.js#parseAggregate` accepts. Raw log text, identifiers, and
 // any non-closed dimension are dropped at the parsing boundary and never
-// stored or returned.
+// stored or returned. Every ambiguity is a rejection, never a guess: a
+// malformed delivery, timestamp, or persisted counter fails the request so
+// the monitor observes `log_unavailable` instead of a fabricated count.
 
 export const LOGQ_KEY_PREFIX = 'patina:logq:v1';
 export const LOGQ_TTL_SECONDS = 7200;
@@ -17,6 +19,8 @@ export const LOGQ_OUTCOMES = Object.freeze([
   'completed', 'terminal_failed', 'number_safety_failed', 'entitlement_denied',
   'entitlement_unavailable', 'quota_denied', 'service_disabled', 'monitor_drop',
 ]);
+const LATENCY_BUCKETS = ['<=30s', '30-60s', '60-120s', '>120s', 'unknown'];
+const STATUS_CLASSES = ['1xx', '2xx', '3xx', '4xx', '5xx', 'unknown'];
 
 const QUARTER_MS = 15 * 60 * 1000;
 const WINDOW_MS = Object.freeze({ '15m': 15 * 60 * 1000, '30m': 30 * 60 * 1000 });
@@ -74,12 +78,31 @@ export function logqKey({ channel, tier, bucket, outcome }) {
   return `${LOGQ_KEY_PREFIX}:${channel}:${tier}:${bucket}:${outcome}`;
 }
 
+// One event pattern for both renderings emitLog produces: JSON.stringify
+// (`"schema":"patina.web.v1"`) and Node console-inspect (`schema: 'patina...'`).
+// Both preserve buildWebObservabilityEvent's insertion order, so the full
+// nine-field envelope is required in canonical order with boundary guards.
+// A fragment that omits any field, reorders fields, or glues an event name
+// onto another identifier is rejected rather than counted.
+const FIELD = (name, values) => `[{,\\s"']${name}["']?\\s*:\\s*["'](${values})["']\\s*`;
+const EVENT_PATTERN = new RegExp(
+  FIELD('schemaVersion', 'v1') + ',?\\s*'
+  + FIELD('schema', 'patina\\.web\\.v1') + ',?\\s*'
+  + FIELD('channel', '[a-z_]+') + ',?\\s*'
+  + FIELD('evidenceClass', 'aggregate_only') + ',?\\s*'
+  + FIELD('tier', '[a-z_]+') + ',?\\s*'
+  + FIELD('outcome', '[a-z_]+') + ',?\\s*'
+  + FIELD('latencyBucket', LATENCY_BUCKETS.map((b) => b.replace(/[<>=-]/g, '\\$&')).join('|')) + ',?\\s*'
+  + FIELD('statusClass', STATUS_CLASSES.join('|')) + ',?\\s*'
+  + FIELD('sampling', 'full|sampled_1_of_20'),
+  'g',
+);
+
 /**
- * Extract closed patina.web.v1 events from one log message. Handles both
- * JSON-serialized events and Node's `console.info(object)` inspect rendering
- * (single-quoted keys/values, arbitrary whitespace). Only the closed
- * channel/tier/outcome dimensions are read; everything else in the message is
- * ignored and never returned.
+ * Extract closed patina.web.v1 events from one log message. Only complete
+ * nine-field envelopes in canonical order are accepted; only the closed
+ * channel/tier/outcome dimensions are returned. Everything else in the
+ * message is ignored and never returned.
  * @param {unknown} message
  * @returns {Array<{channel: string, tier: string, outcome: string}>}
  */
@@ -87,15 +110,10 @@ export function extractWebEvents(message) {
   if (typeof message !== 'string' || message.length === 0 || message.length > 65536) return [];
   if (!message.includes('patina.web.v1')) return [];
   const events = [];
-  const pattern = /schema['"]?\s*:\s*['"]patina\.web\.v1['"][\s\S]{0,600}?sampling['"]?\s*:\s*['"](?:full|sampled_1_of_20)['"]/g;
-  const segments = message.match(pattern) ?? [];
-  for (const segment of segments) {
-    const channel = segment.match(/channel['"]?\s*:\s*['"]([a-z_]+)['"]/)?.[1];
-    const tier = segment.match(/tier['"]?\s*:\s*['"]([a-z_]+)['"]/)?.[1];
-    const outcome = segment.match(/outcome['"]?\s*:\s*['"]([a-z_]+)['"]/)?.[1];
-    const evidenceClass = segment.match(/evidenceClass['"]?\s*:\s*['"]([a-z_]+)['"]/)?.[1];
-    if (evidenceClass !== 'aggregate_only') continue;
-    if (!channel || !tier || !outcome) continue;
+  EVENT_PATTERN.lastIndex = 0;
+  let match;
+  while ((match = EVENT_PATTERN.exec(message)) !== null) {
+    const [, , , channel, , tier, outcome] = match;
     if (!LOGQ_CHANNELS.includes(channel) || !LOGQ_TIERS.includes(tier) || !LOGQ_OUTCOMES.includes(outcome)) continue;
     events.push({ channel, tier, outcome });
   }
@@ -104,69 +122,104 @@ export function extractWebEvents(message) {
 
 /**
  * Parse one Vercel log-drain delivery body (JSON array or NDJSON) into closed
- * counter increments keyed by quarter. Entries without a parseable
- * patina.web.v1 event are dropped. Timestamps outside the retention horizon
- * (TTL) are dropped rather than resurrecting expired quarters.
+ * counter increments keyed by quarter. Fail-closed: a malformed body, a
+ * malformed NDJSON line, a non-object entry, or an event-bearing entry
+ * without a valid finite timestamp rejects the whole delivery so the drain
+ * redelivers instead of silently losing evidence. Event-bearing entries with
+ * valid timestamps outside the retention horizon are explicitly dropped
+ * (expired quarters are never resurrected).
  * @param {string} body
  * @param {{now?: number}} [options]
- * @returns {Array<{key: string, count: number}>}
+ * @returns {{ok: true, increments: Array<{key: string, count: number}>} | {ok: false, reason: string}}
  */
 export function parseDrainDelivery(body, { now = Date.now() } = {}) {
-  if (typeof body !== 'string' || body.length === 0) return [];
+  if (typeof body !== 'string' || body.length === 0) return { ok: false, reason: 'empty_body' };
   /** @type {unknown[]} */
   let entries = [];
   const trimmed = body.trim();
   if (trimmed.startsWith('[')) {
-    try { const parsed = JSON.parse(trimmed); entries = Array.isArray(parsed) ? parsed : []; } catch { entries = []; }
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (!Array.isArray(parsed)) return { ok: false, reason: 'not_an_array' };
+      entries = parsed;
+    } catch { return { ok: false, reason: 'malformed_json' }; }
   } else {
     for (const line of trimmed.split('\n')) {
       const candidate = line.trim();
       if (!candidate) continue;
-      try { entries.push(JSON.parse(candidate)); } catch { /* skip malformed line */ }
+      try { entries.push(JSON.parse(candidate)); } catch { return { ok: false, reason: 'malformed_ndjson_line' }; }
     }
   }
   /** @type {Map<string, number>} */
   const counts = new Map();
   for (const entry of entries) {
-    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return { ok: false, reason: 'malformed_entry' };
     const { message, timestamp } = /** @type {{message?: unknown, timestamp?: unknown}} */ (entry);
-    const time = Number(timestamp);
-    const at = Number.isFinite(time) && time > 0 ? time : now;
-    if (now - at > LOGQ_TTL_SECONDS * 1000 || at - now > QUARTER_MS) continue;
-    for (const event of extractWebEvents(message)) {
-      const key = logqKey({ channel: event.channel, tier: event.tier, bucket: utc15mBucket(at), outcome: event.outcome });
+    const events = extractWebEvents(message);
+    if (events.length === 0) continue;
+    const time = typeof timestamp === 'number' ? timestamp : NaN;
+    if (!Number.isSafeInteger(time) || time <= 0) return { ok: false, reason: 'invalid_event_timestamp' };
+    if (now - time > LOGQ_TTL_SECONDS * 1000 || time - now > QUARTER_MS) continue;
+    for (const event of events) {
+      const key = logqKey({ channel: event.channel, tier: event.tier, bucket: utc15mBucket(time), outcome: event.outcome });
       counts.set(key, (counts.get(key) ?? 0) + 1);
     }
   }
-  return [...counts.entries()].map(([key, count]) => ({ key, count }));
+  return { ok: true, increments: [...counts.entries()].map(([key, count]) => ({ key, count })) };
 }
 
 /**
- * Answer the monitor query with the exact closed shape for the window.
- * @param {{channel: string, tier: string, window: '15m'|'30m', readCounter: (key: string) => Promise<unknown>, now?: number}} input
+ * Strictly interpret one persisted counter value. Only absence (null) means
+ * zero; every present value must be a canonical non-negative safe integer.
+ * @param {unknown} value
  */
-export async function answerQuery({ channel, tier, window, readCounter, now = Date.now() }) {
+export function strictCounterValue(value) {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value) || value < 0) throw new Error('malformed_counter');
+    return value;
+  }
+  if (typeof value === 'string') {
+    if (!/^(0|[1-9]\d*)$/.test(value)) throw new Error('malformed_counter');
+    const parsed = Number(value);
+    if (!Number.isSafeInteger(parsed)) throw new Error('malformed_counter');
+    return parsed;
+  }
+  throw new Error('malformed_counter');
+}
+
+/**
+ * Answer the monitor query with the exact closed shape for the window. All
+ * counters for the window are read in ONE snapshot via `readCounters(keys)`
+ * and validated strictly; any malformed persisted value throws so the caller
+ * answers 503 instead of a fabricated count.
+ * @param {{channel: string, tier: string, window: '15m'|'30m', readCounters: (keys: string[]) => Promise<unknown[]>, now?: number}} input
+ */
+export async function answerQuery({ channel, tier, window, readCounters, now = Date.now() }) {
   if (!LOGQ_CHANNELS.includes(channel)) throw new TypeError('channel must be a closed drain channel');
   if (tier !== 'pro') throw new TypeError('tier must be "pro"');
   if (window !== '15m' && window !== '30m') throw new TypeError('window must be "15m" or "30m"');
-  if (typeof readCounter !== 'function') throw new TypeError('readCounter is required');
+  if (typeof readCounters !== 'function') throw new TypeError('readCounters is required');
   const buckets = windowBuckets(window, now);
-  /** @param {readonly string[]} outcomes */
-  const sum = async (outcomes) => {
+  const outcomes = window === '30m' ? ['monitor_drop'] : [...new Set([...ENTITLEMENT_TOTAL, 'number_safety_failed'])];
+  const keys = [];
+  for (const bucket of buckets) for (const outcome of outcomes) keys.push(logqKey({ channel, tier, bucket, outcome }));
+  const raw = await readCounters(keys);
+  if (!Array.isArray(raw) || raw.length !== keys.length) throw new Error('snapshot_shape');
+  /** @type {Map<string, number>} */
+  const snapshot = new Map();
+  for (let i = 0; i < keys.length; i += 1) snapshot.set(keys[i], strictCounterValue(raw[i]));
+  /** @param {readonly string[]} wanted */
+  const sum = (wanted) => {
     let total = 0;
-    for (const bucket of buckets) {
-      for (const outcome of outcomes) {
-        const value = Number(await readCounter(logqKey({ channel, tier, bucket, outcome })));
-        if (Number.isFinite(value) && value > 0) total += Math.floor(value);
-      }
-    }
-    if (!Number.isSafeInteger(total) || total < 0) throw new Error('counter overflow');
+    for (const bucket of buckets) for (const outcome of wanted) total += snapshot.get(logqKey({ channel, tier, bucket, outcome })) ?? 0;
+    if (!Number.isSafeInteger(total) || total < 0) throw new Error('counter_overflow');
     return total;
   };
-  if (window === '30m') return { monitorDrop: await sum(['monitor_drop']) };
+  if (window === '30m') return { monitorDrop: sum(['monitor_drop']) };
   return {
-    numberSafety: await sum(['number_safety_failed']),
-    entitlementNonOk: await sum(ENTITLEMENT_NON_OK),
-    entitlementTotal: await sum(ENTITLEMENT_TOTAL),
+    numberSafety: sum(['number_safety_failed']),
+    entitlementNonOk: sum(ENTITLEMENT_NON_OK),
+    entitlementTotal: sum(ENTITLEMENT_TOTAL),
   };
 }

--- a/services/log-query/lib/rest-kv.js
+++ b/services/log-query/lib/rest-kv.js
@@ -1,7 +1,20 @@
 // @ts-check
 // Minimal Upstash-compatible REST adapter for the log-query counters. The
 // service owns a dedicated store; it never touches the quota/admission KV or
-// the monitor's strict observability store.
+// the monitor's strict observability store. All multi-key operations use a
+// single round trip so ingestion commits all-or-nothing and queries read one
+// coherent snapshot.
+
+// Applies every increment and its TTL atomically in one script invocation.
+// KEYS = counter keys; ARGV = one count per key followed by the TTL.
+const INCR_ALL_SCRIPT = [
+  'local ttl = ARGV[#ARGV]',
+  'for i = 1, #KEYS do',
+  "  redis.call('INCRBY', KEYS[i], ARGV[i])",
+  "  redis.call('EXPIRE', KEYS[i], ttl)",
+  'end',
+  'return #KEYS',
+].join(' ');
 
 /** @param {Record<string, string|undefined>} env */
 export function createLogqKv(env) {
@@ -26,22 +39,29 @@ export function createLogqKv(env) {
   };
   return {
     /**
-     * Atomically add `count` and (re)apply the TTL in one EVAL round trip.
-     * @param {string} key @param {number} count @param {number} ttlSeconds
+     * Apply every `{key, count}` increment and the TTL in ONE atomic EVAL.
+     * Throws on any transport or acknowledgement failure so the caller can
+     * refuse the delivery instead of committing a partial batch.
+     * @param {Array<{key: string, count: number}>} increments @param {number} ttlSeconds
      */
-    async incrBy(key, count, ttlSeconds) {
-      const result = await call([
-        'EVAL',
-        "local v = redis.call('INCRBY', KEYS[1], ARGV[1]) redis.call('EXPIRE', KEYS[1], ARGV[2]) return v",
-        '1', key, String(count), String(ttlSeconds),
-      ]);
-      if (!Number.isSafeInteger(Number(result))) throw new Error('kv_ack');
-      return Number(result);
+    async incrAll(increments, ttlSeconds) {
+      if (increments.length === 0) return 0;
+      const keys = increments.map(({ key }) => key);
+      const counts = increments.map(({ count }) => String(count));
+      const result = await call(['EVAL', INCR_ALL_SCRIPT, String(keys.length), ...keys, ...counts, String(ttlSeconds)]);
+      if (Number(result) !== keys.length) throw new Error('kv_ack');
+      return keys.length;
     },
-    /** @param {string} key */
-    async get(key) {
-      const result = await call(['GET', key]);
-      return result == null ? 0 : Number(result);
+    /**
+     * Read all keys in ONE MGET round trip. Returns the raw per-key values
+     * (string or null) for strict validation by the caller.
+     * @param {string[]} keys
+     */
+    async getMany(keys) {
+      if (keys.length === 0) return [];
+      const result = await call(['MGET', ...keys]);
+      if (!Array.isArray(result) || result.length !== keys.length) throw new Error('kv_shape');
+      return result;
     },
   };
 }

--- a/services/log-query/lib/rest-kv.js
+++ b/services/log-query/lib/rest-kv.js
@@ -1,0 +1,47 @@
+// @ts-check
+// Minimal Upstash-compatible REST adapter for the log-query counters. The
+// service owns a dedicated store; it never touches the quota/admission KV or
+// the monitor's strict observability store.
+
+/** @param {Record<string, string|undefined>} env */
+export function createLogqKv(env) {
+  const url = typeof env.LOGQ_REST_API_URL === 'string' ? env.LOGQ_REST_API_URL : '';
+  const token = typeof env.LOGQ_REST_API_TOKEN === 'string' ? env.LOGQ_REST_API_TOKEN : '';
+  let origin;
+  try { origin = new URL(url); } catch { return null; }
+  if (origin.protocol !== 'https:' || !origin.hostname.endsWith('.upstash.io') || token.length === 0) return null;
+  /** @param {unknown[]} command */
+  const call = async (command) => {
+    const response = await fetch(origin, {
+      method: 'POST',
+      redirect: 'error',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(command),
+      signal: globalThis.AbortSignal.timeout(5000),
+    });
+    if (!response.ok) throw new Error(`kv_status_${response.status}`);
+    const payload = await response.json();
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload) || !('result' in payload)) throw new Error('kv_shape');
+    return /** @type {{result: unknown}} */ (payload).result;
+  };
+  return {
+    /**
+     * Atomically add `count` and (re)apply the TTL in one EVAL round trip.
+     * @param {string} key @param {number} count @param {number} ttlSeconds
+     */
+    async incrBy(key, count, ttlSeconds) {
+      const result = await call([
+        'EVAL',
+        "local v = redis.call('INCRBY', KEYS[1], ARGV[1]) redis.call('EXPIRE', KEYS[1], ARGV[2]) return v",
+        '1', key, String(count), String(ttlSeconds),
+      ]);
+      if (!Number.isSafeInteger(Number(result))) throw new Error('kv_ack');
+      return Number(result);
+    },
+    /** @param {string} key */
+    async get(key) {
+      const result = await call(['GET', key]);
+      return result == null ? 0 : Number(result);
+    },
+  };
+}

--- a/services/log-query/package.json
+++ b/services/log-query/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "patina-log-query",
+  "private": true,
+  "version": "1.0.0",
+  "description": "External aggregate-only Vercel log-query service for the private patina Pro monitor. Returns exact closed integer counts; never raw logs.",
+  "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/services/log-query/vercel.json
+++ b/services/log-query/vercel.json
@@ -1,0 +1,18 @@
+{
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "github": {
+    "silent": true
+  },
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "no-referrer" },
+        { "key": "Cache-Control", "value": "no-store, max-age=0" },
+        { "key": "X-Robots-Tag", "value": "noindex" }
+      ]
+    }
+  ]
+}

--- a/tests/unit/log-query-service.test.js
+++ b/tests/unit/log-query-service.test.js
@@ -186,6 +186,18 @@ test('ingest echoes the x-vercel-verify challenge before any secret checks', asy
   assert.equal(res.headers['x-vercel-verify'], 'verify-token-123');
 });
 
+test('ingest advertises the configured team verification code on every response', async () => {
+  const handler = createIngestHandler({ env: { LOGQ_VERCEL_VERIFY: 'team-code-abc' }, kv: null });
+  const challenged = fakeRes();
+  await handler(fakeReq({ headers: { 'x-vercel-verify': 'ignored-request-token' } }), challenged);
+  assert.equal(challenged.statusCode, 200);
+  assert.equal(challenged.headers['x-vercel-verify'], 'team-code-abc');
+  assert.equal(challenged.body, 'team-code-abc');
+  const plain = fakeRes();
+  await handler(fakeReq({ method: 'GET' }), plain);
+  assert.equal(plain.headers['x-vercel-verify'], 'team-code-abc');
+});
+
 test('ingest fails closed without a drain secret or KV, and rejects bad signatures', async () => {
   const kv = memoryKv();
   const noSecret = createIngestHandler({ env: {}, kv });

--- a/tests/unit/log-query-service.test.js
+++ b/tests/unit/log-query-service.test.js
@@ -1,0 +1,266 @@
+// Tests for the external aggregate-only log-query service
+// (services/log-query): drain parsing, closed counting, window math, and the
+// two HTTP handlers, including compatibility with the monitor's parseAggregate
+// contract.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
+import { Readable } from 'node:stream';
+import {
+  LOGQ_TTL_SECONDS,
+  answerQuery,
+  extractWebEvents,
+  logqKey,
+  parseDrainDelivery,
+  utc15mBucket,
+  windowBuckets,
+} from '../../services/log-query/lib/log-aggregate.js';
+import { createIngestHandler } from '../../services/log-query/api/ingest.js';
+import { createQueryHandler } from '../../services/log-query/api/query.js';
+import { overlappingQuarterBuckets, utc15mBucket as monitorBucket } from '../../src/pro-monitor.js';
+
+const NOW = Date.UTC(2026, 6, 17, 12, 7, 0);
+
+/** Mirror of api/pro-monitor.js#parseAggregate (kept verbatim so shape drift fails here). */
+function parseAggregate(payload, window) {
+  const value = payload?.data && typeof payload.data === 'object' ? payload.data : payload;
+  const keys = window === '15m' ? ['numberSafety', 'entitlementNonOk', 'entitlementTotal'] : ['monitorDrop'];
+  if (!value || typeof value !== 'object' || Array.isArray(value) || Object.keys(value).length !== keys.length || keys.some((key) => !Number.isSafeInteger(value[key]) || value[key] < 0)) throw new Error('log_shape');
+  return value;
+}
+
+function inspectEvent({ channel = 'production', tier = 'pro', outcome = 'completed', evidenceClass = 'aggregate_only' } = {}) {
+  return [
+    '{',
+    "  schemaVersion: 'v1',",
+    "  schema: 'patina.web.v1',",
+    `  channel: '${channel}',`,
+    `  evidenceClass: '${evidenceClass}',`,
+    `  tier: '${tier}',`,
+    `  outcome: '${outcome}',`,
+    "  latencyBucket: '<=30s',",
+    "  statusClass: '2xx',",
+    "  sampling: 'full'",
+    '}',
+  ].join('\n');
+}
+
+function jsonEvent(overrides = {}) {
+  return JSON.stringify({
+    schemaVersion: 'v1', schema: 'patina.web.v1', channel: 'production', evidenceClass: 'aggregate_only',
+    tier: 'pro', outcome: 'completed', latencyBucket: '<=30s', statusClass: '2xx', sampling: 'full', ...overrides,
+  });
+}
+
+function memoryKv() {
+  const store = new Map();
+  return {
+    store,
+    async incrBy(key, count, ttlSeconds) {
+      assert.equal(ttlSeconds, LOGQ_TTL_SECONDS);
+      const next = (store.get(key) ?? 0) + count;
+      store.set(key, next);
+      return next;
+    },
+    async get(key) { return store.get(key) ?? 0; },
+  };
+}
+
+function fakeRes() {
+  const res = {
+    statusCode: 200,
+    headers: {},
+    body: '',
+    setHeader(name, value) { this.headers[name.toLowerCase()] = value; },
+    end(chunk) { this.body = chunk ?? ''; this.ended = true; },
+  };
+  return res;
+}
+
+function fakeReq({ method = 'POST', url = '/api/ingest', headers = {}, body = Buffer.alloc(0) } = {}) {
+  const req = Readable.from([body]);
+  req.method = method;
+  req.url = url;
+  req.headers = headers;
+  return req;
+}
+
+function sign(secret, body) { return createHmac('sha1', secret).update(body).digest('hex'); }
+
+test('extractWebEvents reads console-inspect and JSON renderings with closed dimensions only', () => {
+  assert.deepEqual(extractWebEvents(inspectEvent()), [{ channel: 'production', tier: 'pro', outcome: 'completed' }]);
+  assert.deepEqual(extractWebEvents(jsonEvent({ outcome: 'number_safety_failed' })), [
+    { channel: 'production', tier: 'pro', outcome: 'number_safety_failed' },
+  ]);
+  // Two events inside one message are both counted.
+  const doubled = `${inspectEvent({ outcome: 'entitlement_denied' })}\n${inspectEvent({ outcome: 'completed' })}`;
+  assert.equal(extractWebEvents(doubled).length, 2);
+});
+
+test('extractWebEvents drops non-aggregate, unknown-dimension, oversized, and unrelated messages', () => {
+  assert.deepEqual(extractWebEvents(inspectEvent({ evidenceClass: 'raw' })), []);
+  assert.deepEqual(extractWebEvents(inspectEvent({ channel: 'unknown' })), []);
+  assert.deepEqual(extractWebEvents(inspectEvent({ tier: 'unknown' })), []);
+  assert.deepEqual(extractWebEvents(inspectEvent({ outcome: 'unknown' })), []);
+  assert.deepEqual(extractWebEvents(inspectEvent({ outcome: 'exfiltrate' })), []);
+  assert.deepEqual(extractWebEvents('plain provider error text'), []);
+  assert.deepEqual(extractWebEvents(null), []);
+  assert.deepEqual(extractWebEvents(`x${'a'.repeat(70000)}patina.web.v1`), []);
+});
+
+test('parseDrainDelivery handles JSON arrays and NDJSON, merges counts, drops stale entries', () => {
+  const body = JSON.stringify([
+    { message: inspectEvent({ outcome: 'completed' }), timestamp: NOW - 1000 },
+    { message: inspectEvent({ outcome: 'completed' }), timestamp: NOW - 2000 },
+    { message: jsonEvent({ outcome: 'monitor_drop' }), timestamp: NOW - 1000 },
+    { message: inspectEvent(), timestamp: NOW - (LOGQ_TTL_SECONDS + 60) * 1000 }, // beyond retention
+    { message: 'noise without events', timestamp: NOW },
+    'not an object',
+  ]);
+  const increments = parseDrainDelivery(body, { now: NOW });
+  const byKey = Object.fromEntries(increments.map(({ key, count }) => [key, count]));
+  const bucket = utc15mBucket(NOW - 1000);
+  assert.equal(byKey[logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'completed' })], 2);
+  assert.equal(byKey[logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'monitor_drop' })], 1);
+  assert.equal(increments.length, 2);
+
+  const ndjson = [
+    JSON.stringify({ message: jsonEvent({ outcome: 'entitlement_denied' }), timestamp: NOW }),
+    'malformed{{{',
+    JSON.stringify({ message: jsonEvent({ outcome: 'entitlement_denied' }), timestamp: NOW }),
+  ].join('\n');
+  const fromNdjson = parseDrainDelivery(ndjson, { now: NOW });
+  assert.equal(fromNdjson.length, 1);
+  assert.equal(fromNdjson[0].count, 2);
+});
+
+test('windowBuckets mirrors the monitor overlapping-quarter rule', () => {
+  // 30m window must select exactly the buckets the monitor reads.
+  for (const at of [NOW, Date.UTC(2026, 6, 17, 12, 0, 0), Date.UTC(2026, 6, 17, 12, 14, 59)]) {
+    assert.deepEqual(windowBuckets('30m', at), overlappingQuarterBuckets(new Date(at)));
+  }
+  // 15m window: current quarter plus any quarter whose END is strictly after
+  // now-15m (mirrors the documented strictly-after bucket-end rule).
+  assert.deepEqual(windowBuckets('15m', Date.UTC(2026, 6, 17, 12, 0, 0)), ['20260717T1145Z', '20260717T1200Z']);
+  assert.deepEqual(windowBuckets('15m', Date.UTC(2026, 6, 17, 12, 14, 59)), ['20260717T1145Z', '20260717T1200Z']);
+  assert.deepEqual(windowBuckets('15m', Date.UTC(2026, 6, 17, 12, 15, 0)), ['20260717T1200Z', '20260717T1215Z']);
+  // Bucket format parity with the monitor.
+  assert.equal(utc15mBucket(NOW), monitorBucket(new Date(NOW)));
+});
+
+test('answerQuery returns exactly the closed shapes parseAggregate accepts, including zeroes', async () => {
+  const kv = memoryKv();
+  const bucket = utc15mBucket(NOW);
+  await kv.incrBy(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'number_safety_failed' }), 1, LOGQ_TTL_SECONDS);
+  await kv.incrBy(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'entitlement_denied' }), 2, LOGQ_TTL_SECONDS);
+  await kv.incrBy(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'entitlement_unavailable' }), 1, LOGQ_TTL_SECONDS);
+  await kv.incrBy(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'completed' }), 5, LOGQ_TTL_SECONDS);
+  await kv.incrBy(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'monitor_drop' }), 4, LOGQ_TTL_SECONDS);
+
+  const safety = await answerQuery({ channel: 'production', tier: 'pro', window: '15m', readCounter: (key) => kv.get(key), now: NOW });
+  assert.deepEqual(safety, { numberSafety: 1, entitlementNonOk: 3, entitlementTotal: 9 });
+  assert.deepEqual(parseAggregate(safety, '15m'), safety);
+
+  const drops = await answerQuery({ channel: 'production', tier: 'pro', window: '30m', readCounter: (key) => kv.get(key), now: NOW });
+  assert.deepEqual(drops, { monitorDrop: 4 });
+  assert.deepEqual(parseAggregate(drops, '30m'), drops);
+
+  // Empty store still yields explicit zeroes in the exact closed shape.
+  const empty = await answerQuery({ channel: 'staging', tier: 'pro', window: '15m', readCounter: (key) => kv.get(key), now: NOW });
+  assert.deepEqual(parseAggregate(empty, '15m'), { numberSafety: 0, entitlementNonOk: 0, entitlementTotal: 0 });
+});
+
+test('answerQuery rejects out-of-scope dimensions and non-function readers', async () => {
+  const reader = async () => 0;
+  await assert.rejects(() => answerQuery({ channel: 'prod', tier: 'pro', window: '15m', readCounter: reader }), TypeError);
+  await assert.rejects(() => answerQuery({ channel: 'production', tier: 'free', window: '15m', readCounter: reader }), TypeError);
+  await assert.rejects(() => answerQuery({ channel: 'production', tier: 'pro', window: '1h', readCounter: reader }), TypeError);
+  await assert.rejects(() => answerQuery({ channel: 'production', tier: 'pro', window: '15m', readCounter: null }), TypeError);
+});
+
+test('ingest echoes the x-vercel-verify challenge before any secret checks', async () => {
+  const handler = createIngestHandler({ env: {}, kv: null });
+  const res = fakeRes();
+  await handler(fakeReq({ headers: { 'x-vercel-verify': 'verify-token-123' } }), res);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.headers['x-vercel-verify'], 'verify-token-123');
+});
+
+test('ingest fails closed without a drain secret or KV, and rejects bad signatures', async () => {
+  const kv = memoryKv();
+  const noSecret = createIngestHandler({ env: {}, kv });
+  const res1 = fakeRes();
+  await noSecret(fakeReq(), res1);
+  assert.equal(res1.statusCode, 503);
+
+  const handler = createIngestHandler({ env: { LOGQ_DRAIN_SECRET: 's3cret' }, kv, now: () => NOW });
+  const body = Buffer.from(JSON.stringify([{ message: jsonEvent(), timestamp: NOW }]));
+  const wrong = fakeRes();
+  await handler(fakeReq({ headers: { 'x-vercel-signature': sign('other-secret', body) }, body }), wrong);
+  assert.equal(wrong.statusCode, 403);
+  assert.equal(kv.store.size, 0);
+
+  const missing = fakeRes();
+  await handler(fakeReq({ body }), missing);
+  assert.equal(missing.statusCode, 403);
+
+  const nonPost = fakeRes();
+  await handler(fakeReq({ method: 'GET' }), nonPost);
+  assert.equal(nonPost.statusCode, 405);
+});
+
+test('ingest stores closed counters for a signed delivery and never echoes content', async () => {
+  const kv = memoryKv();
+  const handler = createIngestHandler({ env: { LOGQ_DRAIN_SECRET: 's3cret' }, kv, now: () => NOW });
+  const body = Buffer.from(JSON.stringify([
+    { message: inspectEvent({ outcome: 'number_safety_failed' }), timestamp: NOW },
+    { message: jsonEvent({ outcome: 'completed' }), timestamp: NOW },
+    { message: 'Authorization: Bearer sk-super-secret raw log line', timestamp: NOW },
+  ]));
+  const res = fakeRes();
+  await handler(fakeReq({ headers: { 'x-vercel-signature': sign('s3cret', body) }, body }), res);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(JSON.parse(res.body), { ok: true, counters: 2 });
+  assert.ok(!res.body.includes('sk-super-secret'));
+  const bucket = utc15mBucket(NOW);
+  assert.equal(kv.store.get(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'number_safety_failed' })), 1);
+  assert.equal(kv.store.get(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'completed' })), 1);
+  assert.equal(kv.store.size, 2);
+});
+
+test('query enforces bearer auth, closed scope, and answers the monitor contract end to end', async () => {
+  const kv = memoryKv();
+  const bucket = utc15mBucket(NOW);
+  await kv.incrBy(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'monitor_drop' }), 3, LOGQ_TTL_SECONDS);
+  const handler = createQueryHandler({ env: { LOGQ_QUERY_TOKEN: 'query-token' }, kv, now: () => NOW });
+
+  const unauthorized = fakeRes();
+  await handler(fakeReq({ method: 'GET', url: '/api/query?channel=production&tier=pro&window=30m&aggregate_only=true', headers: { authorization: 'Bearer wrong' } }), unauthorized);
+  assert.equal(unauthorized.statusCode, 401);
+
+  const badScope = fakeRes();
+  await handler(fakeReq({ method: 'GET', url: '/api/query?channel=production&tier=free&window=30m&aggregate_only=true', headers: { authorization: 'Bearer query-token' } }), badScope);
+  assert.equal(badScope.statusCode, 400);
+
+  const missingFlag = fakeRes();
+  await handler(fakeReq({ method: 'GET', url: '/api/query?channel=production&tier=pro&window=30m', headers: { authorization: 'Bearer query-token' } }), missingFlag);
+  assert.equal(missingFlag.statusCode, 400);
+
+  const ok = fakeRes();
+  await handler(fakeReq({ method: 'GET', url: '/api/query?channel=production&tier=pro&window=30m&aggregate_only=true', headers: { authorization: 'Bearer query-token' } }), ok);
+  assert.equal(ok.statusCode, 200);
+  assert.deepEqual(parseAggregate(JSON.parse(ok.body), '30m'), { monitorDrop: 3 });
+  assert.equal(ok.headers['cache-control'], 'no-store, max-age=0');
+
+  const unconfigured = fakeRes();
+  await createQueryHandler({ env: {}, kv: null })(fakeReq({ method: 'GET', url: '/api/query', headers: {} }), unconfigured);
+  assert.equal(unconfigured.statusCode, 503);
+});
+
+test('query returns 503 when the counter store fails instead of fabricating zeroes', async () => {
+  const kv = { async get() { throw new Error('kv down'); }, async incrBy() { throw new Error('kv down'); } };
+  const handler = createQueryHandler({ env: { LOGQ_QUERY_TOKEN: 'query-token' }, kv, now: () => NOW });
+  const res = fakeRes();
+  await handler(fakeReq({ method: 'GET', url: '/api/query?channel=production&tier=pro&window=15m&aggregate_only=true', headers: { authorization: 'Bearer query-token' } }), res);
+  assert.equal(res.statusCode, 503);
+});

--- a/tests/unit/log-query-service.test.js
+++ b/tests/unit/log-query-service.test.js
@@ -1,23 +1,25 @@
 // Tests for the external aggregate-only log-query service
-// (services/log-query): drain parsing, closed counting, window math, and the
-// two HTTP handlers, including compatibility with the monitor's parseAggregate
-// contract.
+// (services/log-query): drain parsing, closed counting, window math, strict
+// fail-closed boundaries, and the two HTTP handlers, including compatibility
+// with the monitor's parseAggregate contract.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHmac } from 'node:crypto';
 import { Readable } from 'node:stream';
 import {
+  LOGQ_OUTCOMES,
   LOGQ_TTL_SECONDS,
   answerQuery,
   extractWebEvents,
   logqKey,
   parseDrainDelivery,
+  strictCounterValue,
   utc15mBucket,
   windowBuckets,
 } from '../../services/log-query/lib/log-aggregate.js';
 import { createIngestHandler } from '../../services/log-query/api/ingest.js';
 import { createQueryHandler } from '../../services/log-query/api/query.js';
-import { overlappingQuarterBuckets, utc15mBucket as monitorBucket } from '../../src/pro-monitor.js';
+import { OBSERVED_OUTCOMES, overlappingQuarterBuckets, utc15mBucket as monitorBucket } from '../../src/pro-monitor.js';
 
 const NOW = Date.UTC(2026, 6, 17, 12, 7, 0);
 
@@ -56,25 +58,29 @@ function memoryKv() {
   const store = new Map();
   return {
     store,
-    async incrBy(key, count, ttlSeconds) {
+    incrAllCalls: 0,
+    getManyCalls: 0,
+    async incrAll(increments, ttlSeconds) {
       assert.equal(ttlSeconds, LOGQ_TTL_SECONDS);
-      const next = (store.get(key) ?? 0) + count;
-      store.set(key, next);
-      return next;
+      this.incrAllCalls += 1;
+      for (const { key, count } of increments) store.set(key, (store.get(key) ?? 0) + count);
+      return increments.length;
     },
-    async get(key) { return store.get(key) ?? 0; },
+    async getMany(keys) {
+      this.getManyCalls += 1;
+      return keys.map((key) => store.get(key) ?? null);
+    },
   };
 }
 
 function fakeRes() {
-  const res = {
+  return {
     statusCode: 200,
     headers: {},
     body: '',
     setHeader(name, value) { this.headers[name.toLowerCase()] = value; },
     end(chunk) { this.body = chunk ?? ''; this.ended = true; },
   };
-  return res;
 }
 
 function fakeReq({ method = 'POST', url = '/api/ingest', headers = {}, body = Buffer.alloc(0) } = {}) {
@@ -87,12 +93,15 @@ function fakeReq({ method = 'POST', url = '/api/ingest', headers = {}, body = Bu
 
 function sign(secret, body) { return createHmac('sha1', secret).update(body).digest('hex'); }
 
+test('closed outcome list stays in parity with the monitor OBSERVED_OUTCOMES', () => {
+  assert.deepEqual([...LOGQ_OUTCOMES], OBSERVED_OUTCOMES.filter((outcome) => outcome !== 'unknown'));
+});
+
 test('extractWebEvents reads console-inspect and JSON renderings with closed dimensions only', () => {
   assert.deepEqual(extractWebEvents(inspectEvent()), [{ channel: 'production', tier: 'pro', outcome: 'completed' }]);
   assert.deepEqual(extractWebEvents(jsonEvent({ outcome: 'number_safety_failed' })), [
     { channel: 'production', tier: 'pro', outcome: 'number_safety_failed' },
   ]);
-  // Two events inside one message are both counted.
   const doubled = `${inspectEvent({ outcome: 'entitlement_denied' })}\n${inspectEvent({ outcome: 'completed' })}`;
   assert.equal(extractWebEvents(doubled).length, 2);
 });
@@ -108,94 +117,160 @@ test('extractWebEvents drops non-aggregate, unknown-dimension, oversized, and un
   assert.deepEqual(extractWebEvents(`x${'a'.repeat(70000)}patina.web.v1`), []);
 });
 
-test('parseDrainDelivery handles JSON arrays and NDJSON, merges counts, drops stale entries', () => {
+test('extractWebEvents rejects forged fragments: missing fields, reordering, glued identifiers', () => {
+  // Missing schemaVersion — an event-like fragment without the full envelope.
+  const noVersion = jsonEvent();
+  assert.deepEqual(extractWebEvents(noVersion.replace('"schemaVersion":"v1",', '')), []);
+  // Missing sampling terminator field.
+  assert.deepEqual(extractWebEvents(noVersion.replace(',"sampling":"full"', '')), []);
+  // Reordered fields break the canonical envelope.
+  assert.deepEqual(extractWebEvents(
+    '{"schema":"patina.web.v1","schemaVersion":"v1","channel":"production","evidenceClass":"aggregate_only","tier":"pro","outcome":"completed","latencyBucket":"<=30s","statusClass":"2xx","sampling":"full"}',
+  ), []);
+  // Field name glued onto another identifier must not match (boundary guard).
+  assert.deepEqual(extractWebEvents(noVersion.replace('"schemaVersion"', '"XschemaVersion"')), []);
+  // A field smuggled as a VALUE inside another log line must not count: the
+  // envelope requires the exact quoted field sequence.
+  assert.deepEqual(extractWebEvents('user text mentioning patina.web.v1 and outcome: completed'), []);
+});
+
+test('parseDrainDelivery handles JSON arrays and NDJSON, merges counts, drops expired entries', () => {
   const body = JSON.stringify([
     { message: inspectEvent({ outcome: 'completed' }), timestamp: NOW - 1000 },
     { message: inspectEvent({ outcome: 'completed' }), timestamp: NOW - 2000 },
     { message: jsonEvent({ outcome: 'monitor_drop' }), timestamp: NOW - 1000 },
-    { message: inspectEvent(), timestamp: NOW - (LOGQ_TTL_SECONDS + 60) * 1000 }, // beyond retention
+    { message: inspectEvent(), timestamp: NOW - (LOGQ_TTL_SECONDS + 60) * 1000 }, // beyond retention: dropped
+    { message: inspectEvent(), timestamp: NOW + 16 * 60 * 1000 }, // beyond future horizon: dropped
     { message: 'noise without events', timestamp: NOW },
-    'not an object',
   ]);
-  const increments = parseDrainDelivery(body, { now: NOW });
-  const byKey = Object.fromEntries(increments.map(({ key, count }) => [key, count]));
+  const parsed = parseDrainDelivery(body, { now: NOW });
+  assert.equal(parsed.ok, true);
+  const byKey = Object.fromEntries(parsed.increments.map(({ key, count }) => [key, count]));
   const bucket = utc15mBucket(NOW - 1000);
   assert.equal(byKey[logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'completed' })], 2);
   assert.equal(byKey[logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'monitor_drop' })], 1);
-  assert.equal(increments.length, 2);
+  assert.equal(parsed.increments.length, 2);
 
   const ndjson = [
     JSON.stringify({ message: jsonEvent({ outcome: 'entitlement_denied' }), timestamp: NOW }),
-    'malformed{{{',
     JSON.stringify({ message: jsonEvent({ outcome: 'entitlement_denied' }), timestamp: NOW }),
   ].join('\n');
   const fromNdjson = parseDrainDelivery(ndjson, { now: NOW });
-  assert.equal(fromNdjson.length, 1);
-  assert.equal(fromNdjson[0].count, 2);
+  assert.equal(fromNdjson.ok, true);
+  assert.equal(fromNdjson.increments.length, 1);
+  assert.equal(fromNdjson.increments[0].count, 2);
+});
+
+test('parseDrainDelivery rejects malformed bodies, lines, entries, and event timestamps', () => {
+  assert.deepEqual(parseDrainDelivery('', { now: NOW }), { ok: false, reason: 'empty_body' });
+  assert.deepEqual(parseDrainDelivery('[{broken', { now: NOW }), { ok: false, reason: 'malformed_json' });
+  assert.deepEqual(parseDrainDelivery('{"an":"object"}\nmalformed{{{', { now: NOW }), { ok: false, reason: 'malformed_ndjson_line' });
+  assert.deepEqual(parseDrainDelivery('["not an object"]', { now: NOW }), { ok: false, reason: 'malformed_entry' });
+  // An event-bearing entry without a valid timestamp rejects the delivery
+  // rather than being silently re-dated to the current quarter.
+  for (const timestamp of [undefined, null, 'yesterday', -5, 1.5]) {
+    const body = JSON.stringify([{ message: jsonEvent(), timestamp }]);
+    assert.deepEqual(parseDrainDelivery(body, { now: NOW }), { ok: false, reason: 'invalid_event_timestamp' });
+  }
+  // Entries WITHOUT events do not need timestamps.
+  const harmless = JSON.stringify([{ message: 'no events here' }]);
+  assert.deepEqual(parseDrainDelivery(harmless, { now: NOW }), { ok: true, increments: [] });
 });
 
 test('windowBuckets mirrors the monitor overlapping-quarter rule', () => {
-  // 30m window must select exactly the buckets the monitor reads.
   for (const at of [NOW, Date.UTC(2026, 6, 17, 12, 0, 0), Date.UTC(2026, 6, 17, 12, 14, 59)]) {
     assert.deepEqual(windowBuckets('30m', at), overlappingQuarterBuckets(new Date(at)));
   }
-  // 15m window: current quarter plus any quarter whose END is strictly after
-  // now-15m (mirrors the documented strictly-after bucket-end rule).
   assert.deepEqual(windowBuckets('15m', Date.UTC(2026, 6, 17, 12, 0, 0)), ['20260717T1145Z', '20260717T1200Z']);
   assert.deepEqual(windowBuckets('15m', Date.UTC(2026, 6, 17, 12, 14, 59)), ['20260717T1145Z', '20260717T1200Z']);
   assert.deepEqual(windowBuckets('15m', Date.UTC(2026, 6, 17, 12, 15, 0)), ['20260717T1200Z', '20260717T1215Z']);
-  // Bucket format parity with the monitor.
   assert.equal(utc15mBucket(NOW), monitorBucket(new Date(NOW)));
+});
+
+test('strictCounterValue accepts only absence or canonical non-negative safe integers', () => {
+  assert.equal(strictCounterValue(null), 0);
+  assert.equal(strictCounterValue(undefined), 0);
+  assert.equal(strictCounterValue(0), 0);
+  assert.equal(strictCounterValue('0'), 0);
+  assert.equal(strictCounterValue('42'), 42);
+  assert.equal(strictCounterValue(7), 7);
+  for (const bad of ['bad', '-1', '1.5', '01', ' 3', '3 ', -1, 1.5, NaN, Infinity, {}, [], true, '9007199254740993']) {
+    assert.throws(() => strictCounterValue(bad), /malformed_counter/, `value: ${String(bad)}`);
+  }
 });
 
 test('answerQuery returns exactly the closed shapes parseAggregate accepts, including zeroes', async () => {
   const kv = memoryKv();
   const bucket = utc15mBucket(NOW);
-  await kv.incrBy(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'number_safety_failed' }), 1, LOGQ_TTL_SECONDS);
-  await kv.incrBy(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'entitlement_denied' }), 2, LOGQ_TTL_SECONDS);
-  await kv.incrBy(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'entitlement_unavailable' }), 1, LOGQ_TTL_SECONDS);
-  await kv.incrBy(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'completed' }), 5, LOGQ_TTL_SECONDS);
-  await kv.incrBy(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'monitor_drop' }), 4, LOGQ_TTL_SECONDS);
+  await kv.incrAll([
+    { key: logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'number_safety_failed' }), count: 1 },
+    { key: logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'entitlement_denied' }), count: 2 },
+    { key: logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'entitlement_unavailable' }), count: 1 },
+    { key: logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'completed' }), count: 5 },
+    { key: logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'monitor_drop' }), count: 4 },
+  ], LOGQ_TTL_SECONDS);
 
-  const safety = await answerQuery({ channel: 'production', tier: 'pro', window: '15m', readCounter: (key) => kv.get(key), now: NOW });
+  const safety = await answerQuery({ channel: 'production', tier: 'pro', window: '15m', readCounters: (keys) => kv.getMany(keys), now: NOW });
   assert.deepEqual(safety, { numberSafety: 1, entitlementNonOk: 3, entitlementTotal: 9 });
   assert.deepEqual(parseAggregate(safety, '15m'), safety);
 
-  const drops = await answerQuery({ channel: 'production', tier: 'pro', window: '30m', readCounter: (key) => kv.get(key), now: NOW });
+  const drops = await answerQuery({ channel: 'production', tier: 'pro', window: '30m', readCounters: (keys) => kv.getMany(keys), now: NOW });
   assert.deepEqual(drops, { monitorDrop: 4 });
   assert.deepEqual(parseAggregate(drops, '30m'), drops);
 
-  // Empty store still yields explicit zeroes in the exact closed shape.
-  const empty = await answerQuery({ channel: 'staging', tier: 'pro', window: '15m', readCounter: (key) => kv.get(key), now: NOW });
+  const empty = await answerQuery({ channel: 'staging', tier: 'pro', window: '15m', readCounters: (keys) => kv.getMany(keys), now: NOW });
   assert.deepEqual(parseAggregate(empty, '15m'), { numberSafety: 0, entitlementNonOk: 0, entitlementTotal: 0 });
 });
 
+test('answerQuery reads the whole window in ONE snapshot call and accepts string counters', async () => {
+  const calls = [];
+  const readCounters = async (keys) => { calls.push(keys); return keys.map(() => '2'); };
+  const result = await answerQuery({ channel: 'production', tier: 'pro', window: '15m', readCounters, now: NOW });
+  assert.equal(calls.length, 1, 'one snapshot round trip');
+  assert.ok(calls[0].length > 0 && calls[0].every((key) => key.startsWith('patina:logq:v1:production:pro:')));
+  assert.deepEqual(parseAggregate(result, '15m'), result);
+});
+
+test('answerQuery throws on malformed persisted counters and snapshot shape drift', async () => {
+  for (const poison of ['bad', '-1', '1.5', true]) {
+    await assert.rejects(
+      () => answerQuery({ channel: 'production', tier: 'pro', window: '30m', readCounters: async (keys) => keys.map((_, i) => (i === 0 ? poison : null)), now: NOW }),
+      /malformed_counter/,
+    );
+  }
+  await assert.rejects(
+    () => answerQuery({ channel: 'production', tier: 'pro', window: '15m', readCounters: async () => ['1'], now: NOW }),
+    /snapshot_shape/,
+  );
+  await assert.rejects(
+    () => answerQuery({ channel: 'production', tier: 'pro', window: '15m', readCounters: async (keys) => keys.map(() => String(Number.MAX_SAFE_INTEGER)), now: NOW }),
+    /counter_overflow|malformed_counter/,
+  );
+});
+
 test('answerQuery rejects out-of-scope dimensions and non-function readers', async () => {
-  const reader = async () => 0;
-  await assert.rejects(() => answerQuery({ channel: 'prod', tier: 'pro', window: '15m', readCounter: reader }), TypeError);
-  await assert.rejects(() => answerQuery({ channel: 'production', tier: 'free', window: '15m', readCounter: reader }), TypeError);
-  await assert.rejects(() => answerQuery({ channel: 'production', tier: 'pro', window: '1h', readCounter: reader }), TypeError);
-  await assert.rejects(() => answerQuery({ channel: 'production', tier: 'pro', window: '15m', readCounter: null }), TypeError);
+  const reader = async (keys) => keys.map(() => null);
+  await assert.rejects(() => answerQuery({ channel: 'prod', tier: 'pro', window: '15m', readCounters: reader }), TypeError);
+  await assert.rejects(() => answerQuery({ channel: 'production', tier: 'free', window: '15m', readCounters: reader }), TypeError);
+  await assert.rejects(() => answerQuery({ channel: 'production', tier: 'pro', window: '1h', readCounters: reader }), TypeError);
+  await assert.rejects(() => answerQuery({ channel: 'production', tier: 'pro', window: '15m', readCounters: null }), TypeError);
 });
 
-test('ingest echoes the x-vercel-verify challenge before any secret checks', async () => {
-  const handler = createIngestHandler({ env: {}, kv: null });
-  const res = fakeRes();
-  await handler(fakeReq({ headers: { 'x-vercel-verify': 'verify-token-123' } }), res);
-  assert.equal(res.statusCode, 200);
-  assert.equal(res.headers['x-vercel-verify'], 'verify-token-123');
-});
-
-test('ingest advertises the configured team verification code on every response', async () => {
+test('ingest verification responds only with the configured team code and never echoes', async () => {
+  // Without a configured code there is NO pre-authentication response path.
+  const noCode = createIngestHandler({ env: {}, kv: null });
+  const denied = fakeRes();
+  await noCode(fakeReq({ method: 'GET', headers: { 'x-vercel-verify': 'attacker-token' } }), denied);
+  assert.equal(denied.statusCode, 405);
+  assert.equal(denied.headers['x-vercel-verify'], undefined);
+  // With a configured code, the response carries ONLY the configured value.
   const handler = createIngestHandler({ env: { LOGQ_VERCEL_VERIFY: 'team-code-abc' }, kv: null });
   const challenged = fakeRes();
   await handler(fakeReq({ headers: { 'x-vercel-verify': 'ignored-request-token' } }), challenged);
   assert.equal(challenged.statusCode, 200);
   assert.equal(challenged.headers['x-vercel-verify'], 'team-code-abc');
   assert.equal(challenged.body, 'team-code-abc');
-  const plain = fakeRes();
-  await handler(fakeReq({ method: 'GET' }), plain);
-  assert.equal(plain.headers['x-vercel-verify'], 'team-code-abc');
+  assert.ok(!challenged.body.includes('ignored-request-token'));
 });
 
 test('ingest fails closed without a drain secret or KV, and rejects bad signatures', async () => {
@@ -221,7 +296,17 @@ test('ingest fails closed without a drain secret or KV, and rejects bad signatur
   assert.equal(nonPost.statusCode, 405);
 });
 
-test('ingest stores closed counters for a signed delivery and never echoes content', async () => {
+test('ingest rejects oversized bodies with 413 before any signature or store work', async () => {
+  const kv = memoryKv();
+  const handler = createIngestHandler({ env: { LOGQ_DRAIN_SECRET: 's3cret' }, kv, now: () => NOW });
+  const huge = Buffer.alloc(1024 * 1024 + 1, 0x5b);
+  const res = fakeRes();
+  await handler(fakeReq({ headers: { 'x-vercel-signature': sign('s3cret', huge) }, body: huge }), res);
+  assert.equal(res.statusCode, 413);
+  assert.equal(kv.store.size, 0);
+});
+
+test('ingest stores closed counters atomically for a signed delivery and never echoes content', async () => {
   const kv = memoryKv();
   const handler = createIngestHandler({ env: { LOGQ_DRAIN_SECRET: 's3cret' }, kv, now: () => NOW });
   const body = Buffer.from(JSON.stringify([
@@ -234,16 +319,37 @@ test('ingest stores closed counters for a signed delivery and never echoes conte
   assert.equal(res.statusCode, 200);
   assert.deepEqual(JSON.parse(res.body), { ok: true, counters: 2 });
   assert.ok(!res.body.includes('sk-super-secret'));
+  assert.equal(kv.incrAllCalls, 1, 'one atomic commit');
   const bucket = utc15mBucket(NOW);
   assert.equal(kv.store.get(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'number_safety_failed' })), 1);
   assert.equal(kv.store.get(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'completed' })), 1);
   assert.equal(kv.store.size, 2);
 });
 
+test('ingest returns non-2xx for malformed deliveries and store failures (no silent loss)', async () => {
+  const kv = memoryKv();
+  const handler = createIngestHandler({ env: { LOGQ_DRAIN_SECRET: 's3cret' }, kv, now: () => NOW, logger: { warn() {} } });
+  // Malformed delivery → 400, closed reason, nothing stored.
+  const malformed = Buffer.from('[{broken');
+  const badRes = fakeRes();
+  await handler(fakeReq({ headers: { 'x-vercel-signature': sign('s3cret', malformed) }, body: malformed }), badRes);
+  assert.equal(badRes.statusCode, 400);
+  assert.deepEqual(JSON.parse(badRes.body), { error: 'malformed_delivery', reason: 'malformed_json' });
+  assert.equal(kv.store.size, 0);
+  // Store failure → 503 so the drain redelivers.
+  const failing = { async incrAll() { throw new Error('kv down'); }, async getMany() { return []; } };
+  const failHandler = createIngestHandler({ env: { LOGQ_DRAIN_SECRET: 's3cret' }, kv: failing, now: () => NOW, logger: { warn() {} } });
+  const body = Buffer.from(JSON.stringify([{ message: jsonEvent(), timestamp: NOW }]));
+  const failRes = fakeRes();
+  await failHandler(fakeReq({ headers: { 'x-vercel-signature': sign('s3cret', body) }, body }), failRes);
+  assert.equal(failRes.statusCode, 503);
+  assert.deepEqual(JSON.parse(failRes.body), { error: 'store_failed' });
+});
+
 test('query enforces bearer auth, closed scope, and answers the monitor contract end to end', async () => {
   const kv = memoryKv();
   const bucket = utc15mBucket(NOW);
-  await kv.incrBy(logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'monitor_drop' }), 3, LOGQ_TTL_SECONDS);
+  await kv.incrAll([{ key: logqKey({ channel: 'production', tier: 'pro', bucket, outcome: 'monitor_drop' }), count: 3 }], LOGQ_TTL_SECONDS);
   const handler = createQueryHandler({ env: { LOGQ_QUERY_TOKEN: 'query-token' }, kv, now: () => NOW });
 
   const unauthorized = fakeRes();
@@ -269,10 +375,17 @@ test('query enforces bearer auth, closed scope, and answers the monitor contract
   assert.equal(unconfigured.statusCode, 503);
 });
 
-test('query returns 503 when the counter store fails instead of fabricating zeroes', async () => {
-  const kv = { async get() { throw new Error('kv down'); }, async incrBy() { throw new Error('kv down'); } };
-  const handler = createQueryHandler({ env: { LOGQ_QUERY_TOKEN: 'query-token' }, kv, now: () => NOW });
-  const res = fakeRes();
-  await handler(fakeReq({ method: 'GET', url: '/api/query?channel=production&tier=pro&window=15m&aggregate_only=true', headers: { authorization: 'Bearer query-token' } }), res);
-  assert.equal(res.statusCode, 503);
+test('query returns 503 for store failure AND malformed persisted values, never fabricated zeroes', async () => {
+  const down = { async getMany() { throw new Error('kv down'); }, async incrAll() { throw new Error('kv down'); } };
+  const downHandler = createQueryHandler({ env: { LOGQ_QUERY_TOKEN: 'query-token' }, kv: down, now: () => NOW });
+  const downRes = fakeRes();
+  await downHandler(fakeReq({ method: 'GET', url: '/api/query?channel=production&tier=pro&window=15m&aggregate_only=true', headers: { authorization: 'Bearer query-token' } }), downRes);
+  assert.equal(downRes.statusCode, 503);
+
+  const poisoned = { async getMany(keys) { return keys.map((_, i) => (i === 0 ? 'not-a-number' : null)); }, async incrAll() { return 0; } };
+  const poisonedHandler = createQueryHandler({ env: { LOGQ_QUERY_TOKEN: 'query-token' }, kv: poisoned, now: () => NOW });
+  const poisonedRes = fakeRes();
+  await poisonedHandler(fakeReq({ method: 'GET', url: '/api/query?channel=production&tier=pro&window=15m&aggregate_only=true', headers: { authorization: 'Bearer query-token' } }), poisonedRes);
+  assert.equal(poisonedRes.statusCode, 503);
+  assert.deepEqual(JSON.parse(poisonedRes.body), { error: 'aggregate_unavailable' });
 });


### PR DESCRIPTION
Implements the last missing infrastructure piece for Gate-B real-path OBS evidence: the external aggregate-only Vercel log-query service required by `docs/operations/queries/pro-launch-v1.md`.

## What
- `services/log-query/` — deployed as a **separate Vercel project** (own `vercel.json`, dependency-free ESM):
  - `POST /api/ingest`: Vercel log-drain receiver. Echoes `x-vercel-verify`, verifies the drain HMAC-SHA1 signature, extracts closed `patina.web.v1` events (both JSON and console-inspect renderings), increments `patina:logq:v1:{channel}:{tier}:{quarter}:{outcome}` (TTL 7200s) in a dedicated Upstash store. Never stores/echoes raw log content.
  - `GET /api/query`: bearer-authenticated monitor endpoint. `window=15m` → exactly `{numberSafety, entitlementNonOk, entitlementTotal}`; `window=30m` → exactly `{monitorDrop}`. Store failure → 503, never fabricated zeroes.
- `tests/unit/log-query-service.test.js` — 11 tests: drain parsing, closed-dimension filtering, window-bucket parity with `src/pro-monitor.js#overlappingQuarterBuckets`, response shapes pinned to `api/pro-monitor.js#parseAggregate`, signature/auth/scope fail-closed paths.

## Frozen-surface safety
No pinned v6.4 hold file is touched (root `package.json`, `vercel.json`, contract, tests remain byte-identical). New files only.

## Verification
- `node --test tests/unit/log-query-service.test.js` — 11/11 pass
- `npm test` — 1543 pass / 1 pre-existing parallel-run flake (`profiles/poisoned.md` ambient-config pollution; passes in isolation)
- `npm run lint` — syntax/eslint/typecheck/spellcheck all pass

## Deployment (follow-up, after merge)
Separate `patina-logq` Vercel project + dedicated Upstash DB + team log drain (`lambda`, `json`, patina project only) + patina production `PATINA_VERCEL_LOG_QUERY_URL/_SHA256/_TOKEN`. Runbook in `services/log-query/README.md`.