### PR TITLE
Hotfix deploy: numeric-safety v2 (live KO/EN 422 regression)

### DIFF
--- a/src/features/meaning-proxy.js
+++ b/src/features/meaning-proxy.js
@@ -18,7 +18,7 @@ const NUMBER_RE = /\d[\d.,]*/g;
 // grouping like 1,2 or 3,14 is intentionally NOT stripped so it never collapses
 // onto 12 / 314 and masks a genuinely dropped number.
 const GROUPED_THOUSANDS_RE = /^\d{1,3}(,\d{3})+(\.\d+)?$/;
-const NUMERIC_SAFETY_VERSION = 'numeric-safety-v1';
+const NUMERIC_SAFETY_VERSION = 'numeric-safety-v2';
 const NUMBER_TOKEN_RE = /[-+−]?\d[\d,.]*/g;
 const ISO_DATE_RE = /\b(\d{4})-(\d{2})-(\d{2})\b/g;
 const EN_DATE_RE = /\b(?:January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),\s*(\d{4})\b|\b(\d{1,2})\s+(?:January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{4})\b/gi;
@@ -40,19 +40,42 @@ const UNIT_FACTORS_V1 = Object.freeze({
   mL: ['volume-ml', 1],
   L: ['volume-ml', 1000],
 });
+const KO_MAGNITUDE_FACTORS = Object.freeze({
+  백: 100,
+  천: 1000,
+  만: 10000,
+  억: 100000000,
+  조: 1000000000000,
+  경: 10000000000000000,
+  해: 100000000000000000000,
+});
 const WORD_NUMBERS = Object.freeze({
   en: Object.freeze({ zero: 0, one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7, eight: 8, nine: 9, ten: 10, eleven: 11, twelve: 12 }),
   ko: Object.freeze({ 영: 0, 하나: 1, 둘: 2, 셋: 3, 넷: 4, 다섯: 5, 여섯: 6, 일곱: 7, 여덟: 8, 아홉: 9, 열: 10 }),
   zh: Object.freeze({ 零: 0, 〇: 0, 一: 1, 二: 2, 三: 3, 四: 4, 五: 5, 六: 6, 七: 7, 八: 8, 九: 9, 十: 10 }),
   ja: Object.freeze({ 零: 0, 〇: 0, 一: 1, 二: 2, 三: 3, 四: 4, 五: 5, 六: 6, 七: 7, 八: 8, 九: 9, 十: 10 }),
 });
+// v2 precision pass (2026-07-23): word-number detection is scoped to contexts
+// that are actually numeric. v1 flagged bare ordinals/fractions (en: first,
+// half, quarter, score) and any Hangul containing a Sino-Korean numeral
+// morpheme (이해, 오해, 구조, 조건, 환경이 all matched 이+해 / 구+조 / 조+건 /
+// 경+이), which 422-rejected most real KO/EN prose on the live web tier.
+// Digit-anchored protection is untouched; word-only numeral drift (e.g.
+// "이백" -> "삼백", "first" -> "second") is delegated to the LLM MPS/fidelity
+// floors, which remain the enforcement line for non-digit claims.
 const UNSUPPORTED_WORD_NUMBER_RE = Object.freeze({
-  en: /\b(?:first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth|eleventh|twelfth|thirteenth|fourteenth|fifteenth|sixteenth|seventeenth|eighteenth|nineteenth|twentieth|thirtieth|fortieth|fiftieth|sixtieth|seventieth|eightieth|ninetieth|hundredth|thousandth|millionth|billionth|trillionth|quadrillionth|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety|hundred|thousand|million|billion|trillion|quadrillion|half|halves|quarter|quarters|third|thirds|fourth|fourths|fifth|fifths|dozen|score)\b/i,
-  ko: /(?:열(?:한|두)|스물|서른|마흔|쉰|예순|일흔|여든|아흔|(?:첫|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)째|절반|분의|[공령일이삼사오육칠팔구십한두세네]+[백천만억조경해]|[백천만억조경해](?:[공령일이삼사오육칠팔구십한두세네]|[백천만억조경해]))/u,
+  en: /\b(?:thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety|hundred|thousand|million|billion|trillion|quadrillion|dozen)\b/i,
+  ko: /(?:열(?:한|두)|스물|서른|마흔|쉰|예순|일흔|여든|아흔|절반|분의)/u,
   zh: /(?:两|兩|壹|贰|貳|叁|參|肆|伍|陆|陸|柒|捌|玖|拾|廿|卅|卌|半|第|分之|百|千|萬|万|億|亿|兆|京|垓)/,
   ja: /(?:壱|弐|参|肆|伍|陸|漆|捌|玖|拾|半|第|分の|百|千|万|億|兆|京|垓)/,
 });
-const KO_SINGLE_MAGNITUDE_CONTEXT_RE = /(?:\d\s*[백천만억조경해]|[백천만억조경해](?:\s+(?:개|건|권|그릇|대|마리|명|번|병|살|세|송이|장|채|층|통|편|회|년|월|일)|(?:개|건|권|그릇|대|달러|마리|명|번|병|살|세|송이|원|엔|위안|장|채|층|통|퍼센트|편|회)))/u;
+// Bare-magnitude context: digits next to a magnitude are always claimable-
+// adjacent ("3백"), and a magnitude char is treated as numeric only when it is
+// a standalone eojeol head — `(?<![가-힣])` — so 환경/배경/골백 never fire. The
+// spaced/attached counter branches carry only 백천만억: 조/경/해 as bare word
+// numerals do not occur without digits, while their morpheme collisions are
+// everywhere (조건, 조회, 경우, "그 해 명절").
+const KO_SINGLE_MAGNITUDE_CONTEXT_RE = /(?:\d\s*[백천만억조경해]|(?<![가-힣])[백천만억](?:\s+(?:개|건|권|그릇|대|마리|명|번|병|살|세|송이|장|채|층|통|편|회|년|월|일)|(?:달러|원|엔|위안|퍼센트)))/u;
 const NUMERIC_OPERATOR_RE = /\p{Nd}\s*(?:[-+−–—:\x2F÷×*]\s*)+\p{Nd}/u;
 const NUMERIC_COMPARATOR_RE = /(?:[-+−]?\p{Nd}[\p{Nd}.,]*\s*(?:<=|>=|<|>|≤|≥)|(?:<=|>=|<|>|≤|≥)\s*[-+−]?\p{Nd})/u;
 const DECIMAL_DIGIT_RE = /\p{Nd}/u;
@@ -124,7 +147,22 @@ function hasUnsupportedWordNumberExpression(source, lang, occupied = []) {
     return compoundNumerals.test(uncoveredSource);
   }
   if (UNSUPPORTED_WORD_NUMBER_RE[lang]?.test(uncoveredSource)) return true;
-  if (lang === 'ko' && KO_SINGLE_MAGNITUDE_CONTEXT_RE.test(source)) return true;
+  if (lang === 'ko' && KO_SINGLE_MAGNITUDE_CONTEXT_RE.test(uncoveredSource)) return true;
+  if (lang === 'ko') {
+    // Chained magnitude terms ("1억 2천만", "3만5천") leave residual magnitude
+    // chars next to claimed spans or digits after the single-term scaled pass.
+    // Partial claims would compare wrong values (천만 -> 천억 undetected), so
+    // any leftover magnitude adjacent (space-skipped) to an occupied position
+    // or digit fails closed instead.
+    for (const match of uncoveredSource.matchAll(/[백천만억조경해]/gu)) {
+      let left = match.index - 1;
+      while (left >= 0 && /\s/.test(source[left])) left -= 1;
+      if (left >= 0 && (occupied[left] || /\d/.test(source[left]))) return true;
+      let right = match.index + 1;
+      while (right < source.length && /\s/.test(source[right])) right += 1;
+      if (right < source.length && (occupied[right] || /\d/.test(source[right]))) return true;
+    }
+  }
   const words = WORD_NUMBERS[lang] ?? WORD_NUMBERS.en;
   const matches = [];
   const re = lang === 'en'
@@ -242,6 +280,17 @@ function addClaims(text, lang) {
     const [dimension, factor] = UNIT_FACTORS_V1[m[2]];
     add(m.index, m[0].length, `unit:${dimension}:${scaledRational(normalizedNumber(m[1]), factor)}`);
   });
+
+  // KO digit+magnitude ("3만", "1,200만", "1.5억") is the dominant Korean way
+  // to write large numbers; v1 rejected it wholesale as unsupported, which
+  // 422-blocked most business/news prose. A single digit-anchored magnitude is
+  // deterministically convertible, so claim it as a scaled rational. Chained
+  // magnitude terms ("1억2천만", "3만5천") stay unclaimed and fall through to
+  // the fail-closed magnitude-context check on the uncovered residue.
+  if (lang === 'ko') {
+    const koScaled = new RegExp(String.raw`(?<![\w.])(${number})\s*([백천만억조경해])(?![\d백천만억조경해])`, 'g');
+    matchAll(koScaled, (m) => add(m.index, m[0].length, `number:${scaledRational(normalizedNumber(m[1]), KO_MAGNITUDE_FACTORS[m[2]])}`));
+  }
   if (hasUnsupportedNumericSyntax(source, occupied)) {
     return { ok: false, reason: 'unsupported_numeric_syntax', claims: [] };
   }

--- a/tests/unit/meaning-proxy.test.js
+++ b/tests/unit/meaning-proxy.test.js
@@ -134,7 +134,7 @@ test('number safety accepts only deterministic equivalent claims across locales'
   for (const [name, lang, original, rewrite] of cases) {
     const result = evaluateNumberSafety(original, rewrite, lang);
     assert.equal(result.ok, true, `${name}: ${result.reason}`);
-    assert.equal(result.version, 'numeric-safety-v1');
+    assert.equal(result.version, 'numeric-safety-v2');
   }
 });
 
@@ -255,8 +255,7 @@ test('number safety handles CJK numeric context and Han numeral compounds', () =
 
 test('number safety rejects unsupported or partial word-number expressions', () => {
   const cases = [
-    ['en ordinal replacement', 'en', 'Choose the first option.', 'Choose the second option.'],
-    ['en fraction', 'en', 'Use half the amount.', 'Use half the amount.'],
+    ['en unsupported teen word number', 'en', 'Choose thirteen options.', 'Choose one option.'],
     ['en unsupported magnitude must not collapse', 'en', 'Choose one quadrillion options.', 'Choose one option.'],
     ['en partial word number', 'en', 'Choose one hundred options.', 'Choose one option.'],
     ['en unsupported word-number insertion', 'en', 'Choose one option.', 'Choose one hundred options.'],
@@ -271,6 +270,60 @@ test('number safety rejects unsupported or partial word-number expressions', () 
     const result = evaluateNumberSafety(original, rewrite, lang);
     assert.equal(result.ok, false, name);
     assert.equal(result.reason, 'unsupported_word_number', name);
+  }
+});
+test('number safety v2 leaves everyday KO/EN words claim-free (precision regression)', () => {
+  // v1 regressions: Sino-Korean numeral morphemes inside ordinary words
+  // (이+해, 오+해, 구+조, 조+건, 경+이, 만+일) and bare EN ordinals/fractions
+  // 422-rejected most real prose on the live web tier. These must all pass.
+  const cases = [
+    ['ko 이해', 'ko', '이 문제를 이해하고 있다.'],
+    ['ko 오해', 'ko', '오해를 풀고 싶다.'],
+    ['ko 구조', 'ko', '시스템 구조를 바꿨다.'],
+    ['ko 조건', 'ko', '조건이 좋아진다.'],
+    ['ko 조회', 'ko', '조회수가 늘었다.'],
+    ['ko 만일', 'ko', '만일의 사태에 대비한다.'],
+    ['ko 환경+조사', 'ko', '디지털 환경이 빠르게 바뀌고 있다.'],
+    ['ko 천장', 'ko', '천장이 높다.'],
+    ['ko 만장일치', 'ko', '만장일치로 통과했다.'],
+    ['ko 해+명절', 'ko', '그 해 명절에 모였다.'],
+    ['ko 환경 개선', 'ko', '환경 개선이 필요하다.'],
+    ['en ordinal prose', 'en', 'The first thing to check is the score.'],
+    ['en fraction prose', 'en', 'Half of our users prefer the second option.'],
+    ['en quarter prose', 'en', 'Revenue grew this quarter.'],
+  ];
+  for (const [name, lang, text] of cases) {
+    const result = evaluateNumberSafety(text, text, lang);
+    assert.equal(result.ok, true, `${name}: ${result.reason}`);
+  }
+  // Ordinal/fraction word drift is delegated to the LLM MPS/fidelity floors in
+  // v2 — the deterministic gate no longer rejects it.
+  assert.equal(evaluateNumberSafety('Choose the first option.', 'Choose the second option.', 'en').ok, true);
+});
+test('number safety claims KO digit+magnitude and fail-closes chained magnitudes', () => {
+  const passing = [
+    ['single magnitude with counter', '참석자가 3만 명이다.', '참석자가 3만 명이다.', ['number:30000/1']],
+    ['grouped digits + magnitude', '매출이 1,200만 원 늘었다.', '매출이 1,200만 원 늘었다.', ['number:12000000/1']],
+    ['decimal magnitude', '예산은 1.5억이다.', '예산은 1.5억이다.', ['number:150000000/1']],
+    ['notation equivalence 3만 == 30000', '참석자가 3만 명이다.', '참석자가 30000명이다.', ['number:30000/1']],
+    ['만 as 滿 stays lexical (5점 만점)', '별점 5점 만점에 4점이다.', '별점 5점 만점에 4점이다.', ['number:5/1', 'number:4/1']],
+  ];
+  for (const [name, original, rewrite, claims] of passing) {
+    const result = evaluateNumberSafety(original, rewrite, 'ko');
+    assert.equal(result.ok, true, `${name}: ${result.reason}`);
+    assert.deepEqual(result.originalClaims, claims, name);
+  }
+  const failing = [
+    ['dropped magnitude value', '매출이 1,200만 원 늘었다.', '매출이 늘었다.', 'numeric_claim_changed'],
+    ['changed magnitude value', '참석자가 3만 명이다.', '참석자가 5만 명이다.', 'numeric_claim_changed'],
+    ['spaced chain fails closed', '예산은 1억 2천만 원이다.', '예산은 1억 2천만 원이다.', 'unsupported_word_number'],
+    ['chain drift never compares partial claims', '예산은 1억 2천만 원이다.', '예산은 1억 2천억 원이다.', 'unsupported_word_number'],
+    ['attached chain fails closed', '가격은 3만5천 원이다.', '가격은 3만5천 원이다.', 'unsupported_word_number'],
+  ];
+  for (const [name, original, rewrite, reason] of failing) {
+    const result = evaluateNumberSafety(original, rewrite, 'ko');
+    assert.equal(result.ok, false, name);
+    assert.equal(result.reason, reason, name);
   }
 });
 test('number safety fails closed for ambiguous or changed numeric claims', () => {


### PR DESCRIPTION
The #644 deploy shipped numeric-safety v1, whose word-number heuristics reject most everyday KO/EN prose on the live free tier (number_safety_failed 422) — caught by a post-deploy KO smoke where the site's own sample text was rejected (환경이 parsed as 경+이).

v2 (details in the feature commit):
- KO digit+magnitude (3만 / 1,200만 / 1.5억) becomes a real scaled numeric claim; drops and changes still fail closed; chained magnitudes stay rejected via residue adjacency.
- KO/EN lexical collisions (이해, 오해, 구조, 조건, 조회, 만일, 환경이, 천장 / first, second, half, quarter, score) no longer fire; digit-anchored protection is untouched.
- NUMERIC_SAFETY_VERSION -> numeric-safety-v2 with regression suites.

Verified: full lint + node --test 1572 pass / 0 fail; deterministic repro of the live failure now passes locally.