### PR TITLE
Hotfix deploy: brand SVGs 404 (top-left mark + favicon)

### DIFF
--- a/playground/assets/brand/patina-icon.svg
+++ b/playground/assets/brand/patina-icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">patina icon</title>
+  <desc id="desc">A flat dark icon: copper transforms into patina teal around a warm preserved-meaning core.</desc>
+
+  <rect width="512" height="512" rx="112" fill="#020617"/>
+  <path d="M92 196C160 86 320 74 420 164L346 238C288 190 218 198 174 258Z" fill="#c46a2a"/>
+  <path d="M420 316C352 426 192 438 92 348L160 270C224 322 294 314 338 254Z" fill="#2dd4bf"/>
+  <circle cx="252" cy="248" r="54" fill="#ffe6a8" stroke="#020617" stroke-width="10"/>
+</svg>

--- a/playground/assets/brand/patina-mark.svg
+++ b/playground/assets/brand/patina-mark.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">patina mark</title>
+  <desc id="desc">A transparent copper-to-teal mark around a warm preserved-meaning core.</desc>
+
+  <path d="M92 196C160 86 320 74 420 164L346 238C288 190 218 198 174 258Z" fill="#c46a2a"/>
+  <path d="M420 316C352 426 192 438 92 348L160 270C224 322 294 314 338 254Z" fill="#2dd4bf"/>
+  <circle cx="252" cy="248" r="54" fill="#ffe6a8" stroke="#020617" stroke-width="10"/>
+</svg>

--- a/tests/unit/playground-a11y.test.js
+++ b/tests/unit/playground-a11y.test.js
@@ -5,7 +5,7 @@
 // and a closed mobile sidebar that leaves the tab order.
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -113,5 +113,23 @@ test('localized copy never flows through innerHTML (clear-only usage allowed)', 
   const assignments = js.match(/\.innerHTML\s*=\s*[^;]+/g) || [];
   for (const a of assignments) {
     assert.match(a, /\.innerHTML\s*=\s*''/, `unexpected non-empty innerHTML assignment: ${a}`);
+  }
+});
+
+test('every root-absolute asset reference resolves inside the served static root (playground/)', () => {
+  // vercel.json serves ONLY playground/ as the static output, so a reference
+  // like /assets/brand/patina-mark.svg 404s in production unless the file
+  // exists under playground/. The top-left brand mark and the favicon shipped
+  // broken exactly this way (repo-root assets/ is not deployed).
+  const refs = new Set();
+  for (const source of [html, js]) {
+    for (const m of source.matchAll(/["'`(](\/assets\/[A-Za-z0-9_./-]+)["'`)]/g)) refs.add(m[1]);
+  }
+  assert.ok(refs.size > 0, 'expected at least one /assets/ reference to guard');
+  for (const ref of refs) {
+    assert.ok(
+      existsSync(join(root, 'playground', ...ref.split('/').filter(Boolean))),
+      `${ref} is referenced by the playground but missing under playground/ (would 404 on the live deploy)`,
+    );
   }
 });


### PR DESCRIPTION
The playground references /assets/brand/patina-{mark,icon}.svg but those files live at the repo root, outside the vercel.json playground/ static output — so the nav brand mark, sidebar/footer marks, chat avatar, and favicon 404 in production. Ships the two SVGs under playground/assets/brand/ plus a regression test that every root-absolute /assets/ reference resolves inside the static root.