### PR TITLE
Hotfix deploy: bare KO discourse counters no longer 422 pattern rewrites

### DIFF
--- a/src/features/meaning-proxy.js
+++ b/src/features/meaning-proxy.js
@@ -183,7 +183,13 @@ function isClaimableWordNumber(source, index, word, lang) {
     const suffix = source.slice(index + word.length);
     const hangul = /\p{Script=Hangul}/u;
     if (hangul.test(previous)) return false;
-    if (!hangul.test(suffix[0] ?? '')) return true;
+    // Bare numeral with nothing attached (space, dash, punctuation, or EOF
+    // next): in Korean prose this position is dominated by discourse counters
+    // ("사실 하나 —", "팁 하나 공유합니다", "질문 하나.") that filler/hook
+    // rewrites legitimately delete; claiming them 422s meaning-preserving
+    // rewrites. Genuine quantity claims carry a particle or counter and are
+    // claimed below; bare-numeral drift is left to the LLM MPS/fidelity floors.
+    if (!hangul.test(suffix[0] ?? '')) return false;
     return /^(?:은|는|이|가|을|를|의|도|만|와|과|에|에서|에게|한테|으로|로|부터|까지|보다|처럼|마저|조차|이라도|라도|(?:개|건|권|그릇|대|마리|명|번|병|살|세|송이|장|채|층|통|편|회|년|월|일|시간|분|초))/.test(suffix);
   }
   if (lang !== 'zh' && lang !== 'ja') return true;

--- a/tests/unit/meaning-proxy.test.js
+++ b/tests/unit/meaning-proxy.test.js
@@ -300,6 +300,27 @@ test('number safety v2 leaves everyday KO/EN words claim-free (precision regress
   // v2 — the deterministic gate no longer rejects it.
   assert.equal(evaluateNumberSafety('Choose the first option.', 'Choose the second option.', 'en').ok, true);
 });
+test('number safety leaves bare KO discourse counters claim-free (v2.1 regression)', () => {
+  // Live 422: "아무도 말해주지 않는 사실 하나 —" claimed number:1, so the
+  // faux-insight rewrite that deletes the frame (with its counter) failed
+  // numeric equivalence. Bare numerals without a particle/counter are
+  // discourse counters, not quantity claims.
+  const original = '솔직히 말하면, 반전: 개발 기간은 겨우 두 달이었습니다. 아무도 말해주지 않는 사실 하나 — 좋은 도구는 홍보가 필요 없습니다.';
+  const rewrite = '개발 기간은 겨우 두 달이었다. 좋은 도구는 홍보가 필요 없다.';
+  const result = evaluateNumberSafety(original, rewrite, 'ko');
+  assert.equal(result.ok, true, result.reason);
+  assert.deepEqual(result.originalClaims, []);
+  const bare = [
+    ['sentence-final bare numeral', '팁 하나 공유합니다.', '팁을 공유합니다.'],
+    ['dash-separated bare numeral', '질문 하나. 왜 지금인가?', '왜 지금인가?'],
+  ];
+  for (const [name, o, r] of bare) {
+    assert.equal(evaluateNumberSafety(o, r, 'ko').ok, true, name);
+  }
+  // Particled/countered numerals stay claimed: dropping one still fails.
+  assert.equal(evaluateNumberSafety('하나를 선택한다.', '선택한다.', 'ko').ok, false);
+  assert.equal(evaluateNumberSafety('하나만 남았다.', '남았다.', 'ko').ok, false);
+});
 test('number safety claims KO digit+magnitude and fail-closes chained magnitudes', () => {
   const passing = [
     ['single magnitude with counter', '참석자가 3만 명이다.', '참석자가 3만 명이다.', ['number:30000/1']],


### PR DESCRIPTION
Post-#648 live smoke: the new faux-insight pattern (#36) correctly deletes '아무도 말해주지 않는 사실 하나 —' frames, but numeric-safety claimed the bare '하나' as number:1 and 422'd the rewrite. v2.1 claims ko word numerals only with an attached particle/counter; bare discourse counters are left to the MPS/fidelity floors. Regression suite pins the live pair. Gate: 1574 pass / 0 fail.