### PR TITLE
Deploy: web version badge (release-gate synced)

### DIFF
--- a/playground/chatgpt.css
+++ b/playground/chatgpt.css
@@ -415,6 +415,7 @@ details.foldout[open] > summary::before { content: "▾ "; }
 .output-action { border-radius: 9999px; padding: 5px 12px; }
 .report-fp { display: inline-block; margin-top: 8px; font-size: 13px; color: var(--text-dim); text-decoration: underline; text-underline-offset: 3px; }
 .report-fp:hover { color: var(--text); }
+.ver-badge { font-size: 11px; color: var(--text-faint); font-family: var(--mono); align-self: center; }
 
 /* ───────── keyboard focus (a11y) ─────────
    Hover-only affordances are invisible to keyboard users; every interactive

--- a/playground/index.html
+++ b/playground/index.html
@@ -219,7 +219,7 @@
       </section>
 
       <footer class="foot">
-        <div class="foot__brand"><img class="foot__icon" src="/assets/brand/patina-mark.svg" alt="" width="20" height="20" /> patina</div>
+        <div class="foot__brand"><img class="foot__icon" src="/assets/brand/patina-mark.svg" alt="" width="20" height="20" /> patina <span class="ver-badge">v6.3.1</span></div>
         <nav class="foot__links" aria-label="Footer">
           <a href="https://github.com/devswha/patina">GitHub</a>
           <a href="#pricing">Pricing</a>
@@ -242,7 +242,7 @@
         </div>
         <nav class="sidebar__history" id="history" aria-label="Conversations"></nav>
         <div class="sidebar__foot">
-          <div class="brandmark"><img class="brandmark__icon" src="/assets/brand/patina-mark.svg" alt="" width="22" height="22" /> patina</div>
+          <div class="brandmark"><img class="brandmark__icon" src="/assets/brand/patina-mark.svg" alt="" width="22" height="22" /> patina <span class="ver-badge">v6.3.1</span></div>
           <div class="sidebar__note">Deterministic humanizer —<br />same claim, numbers, tone.</div>
         </div>
       </aside>

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -48,6 +48,12 @@ export function collectReleaseMetadataErrors({ repoRoot = REPO_ROOT, env = proce
     expect(readme.includes(README_CATALOGS[path]), `${path} catalog must match the canonical 184-pattern breakdown`);
   }
 
+  const playgroundHtml = readFileSync(repoPath('playground/index.html'), 'utf8');
+  expect(
+    playgroundHtml.includes(`<span class="ver-badge">v${version}</span>`),
+    'playground/index.html ver-badge must match package.json'
+  );
+
   expect(new RegExp(`^## ${escapeRegex(version)} — \\d{4}-\\d{2}-\\d{2}`, 'm').test(readFileSync(repoPath('CHANGELOG.md'), 'utf8')), 'CHANGELOG.md must contain a release heading for package.json version');
   const githubRef = env.GITHUB_REF;
   if (githubRef?.startsWith('refs/tags/')) {

--- a/tests/unit/check-release-metadata.test.js
+++ b/tests/unit/check-release-metadata.test.js
@@ -45,6 +45,7 @@ function createFixture() {
   writeFixtureFile(root, 'SKILL.md', `version: ${VERSION}\n`);
   writeFixtureFile(root, '.patina.default.yaml', `version: ${VERSION}\n`);
   writeFixtureFile(root, 'CHANGELOG.md', `## ${VERSION} — 2026-07-15\n`);
+  writeFixtureFile(root, 'playground/index.html', `<footer><span class="ver-badge">v${VERSION}</span></footer>\n`);
   for (const path of README_FILES) {
     writeFixtureFile(root, path, `![Version](https://img.shields.io/badge/version-${VERSION}-blue)\nversion: "${VERSION}"\n${README_CATALOGS[path]}\n`);
   }
@@ -149,6 +150,15 @@ for (const path of README_FILES) {
     });
   });
 }
+
+test('collector rejects playground ver-badge drift', () => {
+  withFixture((root) => {
+    writeFixtureFile(root, 'playground/index.html', '<footer><span class="ver-badge">v0.0.0</span></footer>\n');
+    assert.deepEqual(collectReleaseMetadataErrors({ repoRoot: root }).errors, [
+      'playground/index.html ver-badge must match package.json',
+    ]);
+  });
+});
 
 test('collector rejects a mismatched release tag', () => {
   withFixture((root) => {


### PR DESCRIPTION
Shows v6.3.1 (from package.json) in the landing footer and chat sidebar so the live build is identifiable at a glance. playground/index.html joins the version-bearing surfaces: release:check now fails if the web badge does not match package.json, keeping the web version locked to every release bump. Gate: release:check OK, full lint, 1577 pass / 0 fail.