### PR TITLE
Docs: go-live step-1 clearance + owner runbook

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -302,6 +302,14 @@ Campaign state:
 - Closed or verified during the campaign: #99, #104, #155, #156, #157, #160, #303, #165, #186, #191, #199, #209, #210, #286, #304, #305, #306, #308.
 - Kept open with explicit blocker comments or pending external action: #158, #159, #206, #207, #211, #212, #284, #307, #324.
 - Legacy bot/harness notes were removed from the public repo; restart autonomous bot work only from a fresh, tracked design if it becomes necessary.
+- Payment processor decision (2026-07-23, owner-agreed): ship Pro on Lemon
+  Squeezy — the store is active and the go-live path is mechanical. A Polar
+  migration (lower fees: 4%+$0.40 vs 5%+$0.50; stronger support reputation) is
+  deliberately deferred and becomes an agenda item only when either trigger
+  fires: (a) MRR exceeds $500, or (b) a concrete LS support/payout failure.
+  The entitlement layer stays provider-agnostic (injected license validator,
+  env-driven checkout URL) so an adapter remains bounded work; do not build it
+  speculatively before a trigger fires.
 
 Next recommended order:
 

--- a/docs/operations/owner-actions-go-live.md
+++ b/docs/operations/owner-actions-go-live.md
@@ -1,0 +1,74 @@
+# Owner actions to open Pro sales (two items, ~15 minutes)
+
+> Companion to [`production-go-live-checklist.md`](production-go-live-checklist.md).
+> Step 1 (LS tax review) was observed CLEARED on 2026-07-23 — the live checkout
+> renders at 200. These are the only two human actions between here and the
+> agent-run binding/deploy steps. **No secret values in this file — names only.**
+
+## Action 1 — provision live secrets in Vercel (Production env)
+
+Vercel → patina project → Settings → Environment Variables → scope **Production**.
+
+### Identity (non-secret, copy verbatim)
+
+| Name | Value |
+|---|---|
+| `LS_STORE_ID` | `425473` |
+| `LS_PRO_PRODUCT_ID` | `1236551` |
+| `LS_PRO_VARIANT_ID` | `1932893` |
+| `PATINA_PRO_PROVIDER` | `claude` |
+| `PATINA_PRO_MODEL` | `claude-sonnet-5` |
+| `PATINA_DEPLOYMENT_CHANNEL` | `production` |
+| `PATINA_PRO_CHECKOUT_ENABLED` | `false` (stays false until the Live-open step) |
+| `PATINA_PRO_CHECKOUT_URL` | `https://vibetip.lemonsqueezy.com/checkout/buy/8ab3a49b-cc55-49e8-bd94-9cbdff5e6a7d` |
+| `PATINA_PUBLIC_BASE_URL` | `https://patina.vibetip.help` |
+
+### Secrets (owner sources)
+
+| Name | Where to get it |
+|---|---|
+| `PATINA_PRO_API_KEY` | Anthropic console — create a dedicated production key (do NOT reuse the free-tier key) |
+| `PATINA_FREE_API_KEY` / `PATINA_FREE_PROVIDER` / `PATINA_FREE_MODEL` | already live — verify they exist in Production scope |
+| `KV_REST_API_URL` / `KV_REST_API_TOKEN` | Upstash console → the quota/admission KV database → REST API tab |
+| `PATINA_LICENSE_HMAC_SECRET` | generate: `openssl rand -hex 32` |
+| `PATINA_QUOTA_HMAC_SECRET` | already live — verify it exists |
+| `PATINA_OBSERVABILITY_REST_API_URL` / `_TOKEN` | Upstash — the **dedicated monitor** KV (NOT the quota KV) |
+| `CRON_SECRET` | generate: `openssl rand -hex 32` |
+| `PATINA_ALERT_DISCORD_WEBHOOK` | Discord → server settings → integrations → webhook URL |
+| `PATINA_SYNTHETIC_PRO_LICENSE` / `PATINA_SYNTHETIC_OBSERVER_SECRET` | issue one synthetic license in LS (test customer) / `openssl rand -hex 32` |
+| `PATINA_PUBLIC_BASE_URL_SHA256` | `printf %s 'https://patina.vibetip.help' \| sha256sum` |
+
+Leave **unset**: `PATINA_PRO_ALLOW_FREE_KEY` (its absence keeps the fail-closed 503).
+Optional caps (`PATINA_PRO_MAX_CHARS`, `PATINA_PRO_REQ_PER_DAY`, `PATINA_PRO_MAX_CONCURRENT`,
+`PATINA_PRO_CHARS_PER_MONTH`) — defaults are fine, skip them.
+
+When done: tell the agent "secrets provisioned" — no values, just the fact.
+
+## Action 2 — PAY-B production binding approval (one immutable record)
+
+Copy the block below, fill the date, and post it somewhere immutable that you
+control (a dated commit in your private ops repo, or a signed dated note). Then
+give the agent the evidence ID.
+
+```
+PAY-B-<YYYYMMDD>-1236551-1932893
+I approve the production checkout source binding for patina Pro.
+Store: 425473 (vibetip) · Product: 1236551 · Variant: 1932893 ($9.99/mo, license keys, activation 3)
+Production checkout URL (exact):
+https://vibetip.lemonsqueezy.com/checkout/buy/8ab3a49b-cc55-49e8-bd94-9cbdff5e6a7d
+Reviewed against staging evidence PAY-STG-20260716-1199625-1875389.
+Approved by: <name>, <date, UTC>
+```
+
+## What happens next (agent-run, in order)
+
+1. Agent commits the production `{channel, evidence, origin, path}` tuple to
+   `scripts/checkout-evidence-bindings.mjs` (deferred action
+   `SOURCE_BINDING_PRODUCTION_INTEGRATION`).
+2. Owner Gate B sign-off → deploy with checkout **disabled**, verify fail-closed
+   paths + monitor cron.
+3. Owner Gate D + rollback drills sign-off → Live open
+   (`PATINA_PRO_CHECKOUT_ENABLED=true`), CTA flips from "coming soon" to the
+   real checkout.
+4. First bounded real payment/refund/revoke evidence (PAY_LIVE) → v6.4 tag +
+   npm publish (REL_PUBLISH) once the Release Authority approves.

--- a/docs/operations/production-go-live-checklist.md
+++ b/docs/operations/production-go-live-checklist.md
@@ -13,11 +13,16 @@
   fixes (locale default, FP-report link, dead-UI contract artifact, version
   badge), numeric-safety v2/v2.1, the 184-pattern catalog, the free-quota
   raise (20/day, 10/hour), and the BYOK model refresh (+Gemini provider).
-- Payment: **step 1 (LS tax review) is CLEARED — observed 2026-07-23.** The
-  live checkout URL now resolves `302 → 200` at "Patina Pro - Checkout" with
-  the $9.99 price rendered (it returned 404 through 07-22). Store is active.
-  Owner should eyeball `Settings → Payouts → Tax information: Approved` in the
-  LS dashboard as final confirmation.
+- Payment: **step 1 (LS tax review) is still PENDING** — the dashboard shows
+  `Settings → Payouts → Tax information: Submitted` (owner-checked
+  2026-07-23). Progress signal, not clearance: the live checkout URL now
+  resolves `302 → 200` at "Patina Pro - Checkout" with the $9.99 price
+  rendered (it returned 404 through 07-22), which likely reflects the variant
+  publishing — LS can render checkout pages before the store is cleared to
+  take payments. **The dashboard status is authoritative**; a rendering
+  checkout page must never be recorded as review clearance again.
+  Owner steps that do NOT depend on the review (Vercel secret provisioning,
+  the PAY-B binding approval record) can proceed now; only Live-open waits.
 - Still not sellable by design: the deployed launch config remains the
   fail-closed disabled artifact and the site CTA stays "Pro — coming soon"
   until steps 2–8 below complete. Nothing opens payment automatically.

--- a/docs/operations/production-go-live-checklist.md
+++ b/docs/operations/production-go-live-checklist.md
@@ -7,16 +7,20 @@
 > flip from HOLD → live is mechanical once approvals land. **No secret values
 > live here or anywhere in the repo** — only names and non-secret identifiers.
 
-## Current state (2026-07-21)
+## Current state (2026-07-23)
 
-- Engine/quality: clean (P0 evidence-floor fix, scorer benchmark leg, P1
-  short-form em-dash, non-skipped floor fix — all on `dev`).
-- Payment: `HOLD_NO_PROMOTION`. Store activation is blocked only by the
-  Lemon Squeezy **tax review** (`Settings → Payouts → Tax information:
-  Submitted / Pending`). Identity verification is `Active`; bank payout (KRW)
-  is set; the live product is `Published`.
-- Not sellable yet: live variant is `pending`, the checkout returns 404 until
-  the tax review clears and the store activates.
+- Engine/quality: clean. Since 07-21, `dev`→`main` also shipped the playground
+  fixes (locale default, FP-report link, dead-UI contract artifact, version
+  badge), numeric-safety v2/v2.1, the 184-pattern catalog, the free-quota
+  raise (20/day, 10/hour), and the BYOK model refresh (+Gemini provider).
+- Payment: **step 1 (LS tax review) is CLEARED — observed 2026-07-23.** The
+  live checkout URL now resolves `302 → 200` at "Patina Pro - Checkout" with
+  the $9.99 price rendered (it returned 404 through 07-22). Store is active.
+  Owner should eyeball `Settings → Payouts → Tax information: Approved` in the
+  LS dashboard as final confirmation.
+- Still not sellable by design: the deployed launch config remains the
+  fail-closed disabled artifact and the site CTA stays "Pro — coming soon"
+  until steps 2–8 below complete. Nothing opens payment automatically.
 
 ## Verified live Lemon Squeezy identity (non-secret)
 


### PR DESCRIPTION
Records the observed 404 -> 200 flip of the live LS checkout (tax review cleared, store active) in the go-live checklist, and adds owner-actions-go-live.md: the exact Vercel Production secret punch list (names only) plus the PAY-B approval fill-in template. Docs only.