### PR TITLE
Monitor: paid-probe guard (blind-skip + hourly budget)

### DIFF
--- a/docs/operations/owner-actions-go-live.md
+++ b/docs/operations/owner-actions-go-live.md
@@ -72,3 +72,36 @@ Approved by: <name>, <date, UTC>
    real checkout.
 4. First bounded real payment/refund/revoke evidence (PAY_LIVE) → v6.4 tag +
    npm publish (REL_PUBLISH) once the Release Authority approves.
+
+## Monitor env self-check (run locally, values never leave your shell)
+
+The pro-monitor returns 503 `monitor_unavailable` while any of its adapter
+env values fails its shape rule. Sensitive values cannot be read back from
+Vercel, so validate the value you are ABOUT to paste, locally:
+
+```bash
+node -e '
+const v = process.env.V; const { createHash } = require("crypto");
+const h = (x) => createHash("sha256").update(x).digest("hex");
+const u = new URL(v);
+console.log("normalized:", u.toString());
+console.log("obs-kv ok:", u.protocol === "https:" && u.hostname.endsWith(".upstash.io"));
+console.log("logq/base shape ok:", u.protocol === "https:" && !u.port && !u.search && !u.hash);
+console.log("discord ok:", ["discord.com","discordapp.com"].includes(u.hostname) && /^\/api\/webhooks\/\d+\/[A-Za-z0-9._-]+$/.test(u.pathname));
+console.log("sha256 of normalized:", h(u.toString()));
+' 2>/dev/null || echo "not a valid URL"
+```
+
+Run it as `V='<value>' node -e ...` per candidate. Rules that bite:
+
+- `PATINA_OBSERVABILITY_REST_API_URL`: https and the hostname must end in
+  `.upstash.io` (paste the Upstash REST URL untouched).
+- `PATINA_VERCEL_LOG_QUERY_URL_SHA256` and `PATINA_PUBLIC_BASE_URL_SHA256`:
+  always hash the **normalized** form the command prints (bare origins gain a
+  trailing slash).
+- `PATINA_ALERT_DISCORD_WEBHOOK`: exact `/api/webhooks/<id>/<token>` path on a
+  Discord host; no query string.
+
+After re-entering values, env changes only apply to NEW deployments: merge any
+dev commit to main (git deploy) rather than `vercel redeploy` so the monitor
+keeps its deployment identity.

--- a/src/pro-monitor.js
+++ b/src/pro-monitor.js
@@ -196,8 +196,21 @@ export async function evaluateProMonitor(deps) {
   const safetyLogs = await queryLogs(logQuery, channel, tier, '15m'); const dropLogs = await queryLogs(logQuery, channel, tier, '30m');
   const safety = safetyLogs.values; const drops = dropLogs.values;
   const numberSafety = number(safety.numberSafety); const entitlementNonOk = number(safety.entitlementNonOk); const entitlementTotal = number(safety.entitlementTotal); const monitorDrop = number(drops.monitorDrop);
-  let syntheticTerminal = 'failed'; try { const response = await syntheticRequest({ channel, tier, text: SYNTHETIC_TEXT, timeoutMs: 60_000 }); syntheticTerminal = response?.terminal === 'done' && response?.ok === true ? 'done' : 'failed'; } catch {}
-  const streakKey = controlKey(channel, tier, 'synthetic-streak'); const storedStreak = persistedStreak(await requiredControl(controlStore, 'get')(streakKey)); if (storedStreak === null) throw new Error('invalid synthetic streak state'); const previousStreak = storedStreak; if (syntheticTerminal !== 'done' && previousStreak === Number.MAX_SAFE_INTEGER) throw new Error('synthetic streak overflow'); const syntheticStreak = syntheticTerminal === 'done' ? 0 : previousStreak + 1; if (await requiredControl(controlStore, 'set')(streakKey, syntheticStreak, THIRTY_MINUTES_MS) !== true) throw new Error('synthetic streak persistence failed');
+  // Paid-probe guard (2026-07-23 incident): the synthetic probe is a real pro
+  // rewrite (three provider calls with the full catalog prompt). A run whose
+  // cheap adapters are already blind can only terminate as monitor_blind +
+  // 503, so its probe outcome would be discarded while the provider bill is
+  // real — an overnight cron burned ~82 probes exactly this way. Skip the
+  // probe when blind, and budget it to one per hour otherwise. A skipped
+  // probe reports 'failed' (conservative) but neither grows nor resets the
+  // persisted streak, so it can never fabricate a synthetic_failure alert.
+  const adaptersBlind = !aggregate.available || !safetyLogs.available || !dropLogs.available;
+  let syntheticTerminal = 'failed'; let syntheticRan = false;
+  if (!adaptersBlind && await acquire(controlStore, controlKey(channel, tier, 'synthetic-probe-budget'), `${now.getTime()}`, ONE_HOUR_MS)) {
+    syntheticRan = true;
+    try { const response = await syntheticRequest({ channel, tier, text: SYNTHETIC_TEXT, timeoutMs: 60_000 }); syntheticTerminal = response?.terminal === 'done' && response?.ok === true ? 'done' : 'failed'; } catch {}
+  }
+  const streakKey = controlKey(channel, tier, 'synthetic-streak'); const storedStreak = persistedStreak(await requiredControl(controlStore, 'get')(streakKey)); if (storedStreak === null) throw new Error('invalid synthetic streak state'); const previousStreak = storedStreak; if (syntheticRan && syntheticTerminal !== 'done' && previousStreak === Number.MAX_SAFE_INTEGER) throw new Error('synthetic streak overflow'); const syntheticStreak = syntheticRan ? (syntheticTerminal === 'done' ? 0 : previousStreak + 1) : previousStreak; if (await requiredControl(controlStore, 'set')(streakKey, syntheticStreak, THIRTY_MINUTES_MS) !== true) throw new Error('synthetic streak persistence failed');
   const triggers = [];
   if (numberSafety >= 1) triggers.push({ trigger: 'number_safety', count: numberSafety, window: '15m' });
   if (entitlementTotal >= 20 && entitlementNonOk >= 5) triggers.push({ trigger: 'entitlement_pro', count: entitlementNonOk, window: '15m' });

--- a/tests/unit/pro-monitor.test.js
+++ b/tests/unit/pro-monitor.test.js
@@ -103,8 +103,36 @@ test('new ACKs retain safe active receipts for complete recovery linkage', async
 
 test('synthetic completion requires explicit terminal done', async () => {
   const control = store(); const common = deps({ controlStore: control, syntheticRequest: async () => ({ status: 204, ok: true, terminal: 'queued' }) });
-  await evaluateProMonitor(common); await evaluateProMonitor(common); const third = await evaluateProMonitor(common);
+  const budgetKey = 'patina:monctl:v1:production:pro:synthetic-probe-budget';
+  await evaluateProMonitor(common); control.values.delete(budgetKey);
+  await evaluateProMonitor(common); control.values.delete(budgetKey);
+  const third = await evaluateProMonitor(common);
   assert.equal(third.syntheticTerminal, 'failed'); assert.ok(third.triggers.some(({ trigger }) => trigger === 'synthetic_failure'));
+});
+
+test('a budget-skipped probe neither runs, grows, nor resets the synthetic streak', async () => {
+  const control = store(); let probes = 0;
+  const common = deps({ controlStore: control, syntheticRequest: async () => { probes += 1; return { ok: false, terminal: 'failed' }; } });
+  const first = await evaluateProMonitor(common);
+  assert.equal(probes, 1); assert.equal(first.syntheticStreak, 1);
+  const second = await evaluateProMonitor(common); // budget lease still held
+  assert.equal(probes, 1, 'skipped run must not spend a paid probe');
+  assert.equal(second.syntheticTerminal, 'failed');
+  assert.equal(second.syntheticStreak, 1, 'skipped run must preserve the streak');
+  assert.ok(!second.triggers.some(({ trigger }) => trigger === 'synthetic_failure'));
+});
+
+test('blind adapters skip the paid probe entirely (2026-07-23 burn regression)', async () => {
+  let probes = 0;
+  const result = await evaluateProMonitor(deps({
+    logQuery: async () => { throw new Error('log service down'); },
+    syntheticRequest: async () => { probes += 1; return { ok: true, terminal: 'done' }; },
+  }));
+  assert.equal(probes, 0, 'a blind run must never spend a paid probe');
+  assert.equal(result.syntheticTerminal, 'failed');
+  assert.equal(result.syntheticStreak, 0, 'skip preserves the fresh streak');
+  assert.ok(result.triggers.some(({ trigger }) => trigger === 'monitor_blind'));
+  assert.ok(!result.triggers.some(({ trigger }) => trigger === 'synthetic_failure'));
 });
 test('max-safe failed synthetic streak fails closed without persistence or alerts', async () => {
   const control = store(); const streakKey = 'patina:monctl:v1:production:pro:synthetic-streak'; control.values.set(streakKey, Number.MAX_SAFE_INTEGER);
@@ -253,7 +281,8 @@ test('dedup lease expires exactly at the one-hour boundary', async () => {
   assert.equal(beforeExpiry.alerts[0].deduped, true);
   assert.equal(atExpiry.alerts[0].sent, true);
   assert.equal(sends, 2);
-  assert.deepEqual(acquireTtls, [3_600_000, 3_600_000, 3_600_000]);
+  // Three runs × (synthetic probe-budget acquire + dedup-lease acquire), all one-hour TTLs.
+  assert.deepEqual(acquireTtls, [3_600_000, 3_600_000, 3_600_000, 3_600_000, 3_600_000, 3_600_000]);
 });
 test('active acknowledgements retain recovery linkage at the exact one-hour dedup boundary', async () => {
   let nowMs = NOW.getTime();


### PR DESCRIPTION
Prevents the 2026-07-23 token-burn class: the synthetic pro probe now never runs on a blind (unrecoverable) monitor pass and is budgeted to one per hour on healthy passes via a KV NX lease. Skipped probes preserve the failure streak exactly, so alerts can neither be fabricated nor suppressed. Also carries the pending ops-doc corrections on dev. Gate: monitor suites 43/43, full 1579 pass / 0 fail.