### PR TITLE
Ops: G002 in-process collector + cache probe

### DIFF
--- a/docs/operations/g002-collector-redesign.md
+++ b/docs/operations/g002-collector-redesign.md
@@ -60,11 +60,11 @@ issue receipt -> attach to Gate B. Estimated one focused session.
 
 ## 2026-07-24 revision: in-process collection (implemented)
 
-The log-scrape path above assumed the Vercel log-query service, which is gone.
-`runWebRewriteStream` already returns validated one-based attempt records
-(requested/effective model, raw usage, retry reason, outcome) to its
-in-process caller, so the implemented collector runs the pinned source commit
-locally instead of scraping a deployment:
+The log-scrape plan above leaned on the Vercel log-query service. That
+service is gone. There is a shorter path anyway: `runWebRewriteStream` hands
+its caller the validated one-based attempt records, raw usage included. The
+implemented collector therefore runs the pinned source commit locally and
+never scrapes a deployment:
 
 - `scripts/g002-cache-probe.mjs`: two-call empirical check of whether the
   Anthropic OpenAI-compat path honors `cache_control` (run this FIRST; it
@@ -77,8 +77,9 @@ locally instead of scraping a deployment:
 - Key handling: `PATINA_PRO_API_KEY_LOCAL` or `~/.patina/pro-key.local`,
   never printed, never committed.
 
-Known economics before running (napkin, to be replaced by measurement):
-uncached sonnet-5 lands near $150/1M chars against a $3.40 60%-margin
-budget at the advertised 1M-chars/month cap — the gate will refuse, and the
-decision space is: cut the advertised monthly cap, change the pro model, or
-reprice. The measured numbers pick the branch.
+Napkin math before the run, to be replaced by measurement. Uncached
+sonnet-5 costs somewhere near $150 per million characters. The 60% margin
+budget at the advertised million-character monthly cap is $3.40. Expect the
+gate to refuse. A refusal narrows the product decision to three branches:
+cut the advertised monthly cap, change the pro model, or reprice. The
+measured numbers pick the branch.

--- a/docs/operations/g002-collector-redesign.md
+++ b/docs/operations/g002-collector-redesign.md
@@ -57,3 +57,28 @@ Step 1 is a small, test-covered handler change (staging-gated logging);
 step 2 is a standalone script with no runtime footprint. Run order: deploy
 preview -> run collector (3 probes ≈ 9–18 paid calls on the staging model) ->
 issue receipt -> attach to Gate B. Estimated one focused session.
+
+## 2026-07-24 revision: in-process collection (implemented)
+
+The log-scrape path above assumed the Vercel log-query service, which is gone.
+`runWebRewriteStream` already returns validated one-based attempt records
+(requested/effective model, raw usage, retry reason, outcome) to its
+in-process caller, so the implemented collector runs the pinned source commit
+locally instead of scraping a deployment:
+
+- `scripts/g002-cache-probe.mjs`: two-call empirical check of whether the
+  Anthropic OpenAI-compat path honors `cache_control` (run this FIRST; it
+  decides whether the probes measure cached or uncached economics).
+- `scripts/g002-collect.mjs`: runs the three probes through the real
+  pipeline, assembles `rawG002` + `providerBillingFacts`, and pipes into
+  `issuePayBCostReceipt`. `deploymentId` is recorded as `local-<commit>`.
+  On a margin-gate refusal it still reports the measured COGS, the margin at
+  the 1M-char cap, and the monthly char cap that would clear 60%.
+- Key handling: `PATINA_PRO_API_KEY_LOCAL` or `~/.patina/pro-key.local`,
+  never printed, never committed.
+
+Known economics before running (napkin, to be replaced by measurement):
+uncached sonnet-5 lands near $150/1M chars against a $3.40 60%-margin
+budget at the advertised 1M-chars/month cap — the gate will refuse, and the
+decision space is: cut the advertised monthly cap, change the pro model, or
+reprice. The measured numbers pick the branch.

--- a/scripts/g002-cache-probe.mjs
+++ b/scripts/g002-cache-probe.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Empirical check: does the Anthropic OpenAI-compatibility endpoint honor
+// prompt caching (cache_control) for our provider preset? Two identical
+// requests with a >1024-token shared prefix; the second response's usage
+// should show cached prompt tokens if caching works. Costs a few cents.
+//
+// Key handling: reads PATINA_PRO_API_KEY_LOCAL or ~/.patina/pro-key.local.
+// The key is never printed.
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const MODEL = process.env.G002_MODEL || 'claude-sonnet-5';
+const BASE = 'https://api.anthropic.com/v1';
+
+function loadKey() {
+  if (process.env.PATINA_PRO_API_KEY_LOCAL) return process.env.PATINA_PRO_API_KEY_LOCAL.trim();
+  try { return readFileSync(join(homedir(), '.patina', 'pro-key.local'), 'utf8').trim(); } catch {}
+  console.error('no key: set PATINA_PRO_API_KEY_LOCAL or write ~/.patina/pro-key.local');
+  process.exit(2);
+}
+
+const prefix = 'You are a careful editor. Reference glossary follows.\n' + Array.from({ length: 300 }, (_, i) => `term-${i}: definition of term ${i} with enough words to pad the shared prefix for cache eligibility.`).join('\n');
+
+async function call(key, tail, cacheControl) {
+  const content = cacheControl
+    ? [{ type: 'text', text: prefix, cache_control: { type: 'ephemeral' } }, { type: 'text', text: tail }]
+    : prefix + tail;
+  const res = await fetch(`${BASE}/chat/completions`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${key}` },
+    body: JSON.stringify({ model: MODEL, max_tokens: 16, messages: [{ role: 'user', content }] }),
+  });
+  const body = await res.json().catch(() => ({}));
+  return { status: res.status, usage: body.usage ?? null, error: body.error?.message ?? null };
+}
+
+const key = loadKey();
+for (const mode of [true, false]) {
+  const label = mode ? 'cache_control blocks' : 'plain string content';
+  const first = await call(key, '\nSay OK.', mode);
+  if (first.status !== 200) { console.log(`[${label}] first call: HTTP ${first.status} ${first.error ?? ''}`); continue; }
+  const second = await call(key, '\nSay OK again.', mode);
+  console.log(`[${label}] first usage:`, JSON.stringify(first.usage));
+  console.log(`[${label}] second usage:`, JSON.stringify(second.usage));
+}
+console.log('interpret: cached_tokens / cache_read_input_tokens > 0 on the second call means caching works on this path.');

--- a/scripts/g002-collect.mjs
+++ b/scripts/g002-collect.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// G002 in-process collector: runs the three PAY-B-COST probes through the real
+// runWebRewriteStream pipeline (rewrite + MPS + fidelity on the production
+// model), captures the exact per-attempt provider usage the stream privately
+// aggregates, and issues the PAY-B-COST-v1 receipt.
+//
+// Design note (supersedes the log-scrape idea in g002-collector-redesign.md):
+// the Vercel log-query service from the removed ops harness is gone, and the
+// stream already RETURNS validated one-based attempt records to its in-process
+// caller. Running the pinned source commit locally gives byte-exact attempt
+// capture with no deployment scraping. deploymentId is recorded as
+// `local-<commit>` to say exactly what it was.
+//
+// Usage:
+//   node scripts/g002-collect.mjs --pricing docs/operations/pricing-claude-sonnet-5.json [--out docs/operations/pay-b-cost-<date>.json]
+// Key: PATINA_PRO_API_KEY_LOCAL or ~/.patina/pro-key.local (never printed).
+import { execFileSync } from 'node:child_process';
+import { randomUUID, createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { runWebRewriteStream } from '../src/web-rewrite-stream.js';
+import { collectPayBCostSourceBundle, issuePayBCostReceipt, sha256Canonical, canonicalJson } from './pay-b-cost-receipt.mjs';
+
+const MODEL = process.env.G002_MODEL || 'claude-sonnet-5';
+const BASE = 'https://api.anthropic.com/v1';
+const PROVIDER = 'claude';
+const EVIDENCE_ID = 'PAY-B-20260723-1236551-1932893';
+const COLLECTOR_VERSION = 'g002-inproc-v1';
+
+// Three realistic customer-register probes (KO business, EN blog, KO SNS).
+const PROBES = [
+  {
+    id: 'probe-ko-business',
+    lang: 'ko',
+    text: [
+      '금번 분기 실적 발표와 관련하여 안내드립니다. 당사는 빠르게 변화하는 시장 환경 속에서도 혁신적인 기술력을 바탕으로 고객 여러분께 차별화된 가치를 제공하기 위해 끊임없이 노력해 왔습니다.',
+      '3분기 매출은 전년 동기 대비 12% 증가한 48억 원을 기록하였으며, 신규 가입 고객은 2만 3천 명을 넘어섰습니다. 이는 단순한 수치상의 성장이 아니라, 당사가 추진해 온 디지털 전환 전략이 시장에서 긍정적인 평가를 받고 있음을 보여주는 결과라고 할 수 있습니다.',
+      '앞으로도 당사는 고객 중심 경영을 최우선 가치로 삼아, 지속 가능한 성장을 위한 기반을 다져나가겠습니다. 여러분의 변함없는 관심과 성원을 부탁드립니다.',
+    ].join('\n\n'),
+  },
+  {
+    id: 'probe-en-blog',
+    lang: 'en',
+    text: [
+      "In today's fast-paced digital landscape, building a personal brand isn't just an option — it's a necessity. Here's the thing: most creators focus on polishing their content, but what nobody tells you is that distribution matters far more than perfection.",
+      'When I started my newsletter two years ago, I spent weeks agonizing over every sentence. The result: three subscribers, two of whom were my parents. Then I changed my approach and started publishing twice a week, imperfections and all. Within six months the list grew to 4,800 readers.',
+      "The lesson isn't complicated. Consistent, good-enough publishing beats sporadic perfection, and the compounding effect of showing up regularly is what actually builds an audience over time.",
+    ].join('\n\n'),
+  },
+  {
+    id: 'probe-ko-sns',
+    lang: 'ko',
+    text: [
+      '솔직히 말하면, 저는 이 앱을 처음 봤을 때 별 기대가 없었습니다. 시중에 비슷한 서비스가 이미 넘쳐나니까요.',
+      '그런데 일주일 써보고 생각이 완전히 바뀌었습니다. 반전: 하루 10분 투자로 업무 정리 시간이 절반으로 줄었습니다. 아무도 말해주지 않는 사실 하나 — 도구는 기능이 아니라 습관을 만들어줄 때 가치가 있습니다.',
+      '한 달 무료니까 일단 써보시고, 안 맞으면 지우면 됩니다. 저는 유료 전환했습니다.',
+    ].join('\n\n'),
+  },
+];
+
+function loadKey() {
+  if (process.env.PATINA_PRO_API_KEY_LOCAL) return process.env.PATINA_PRO_API_KEY_LOCAL.trim();
+  try { return readFileSync(join(homedir(), '.patina', 'pro-key.local'), 'utf8').trim(); } catch {}
+  console.error('no key: set PATINA_PRO_API_KEY_LOCAL or write ~/.patina/pro-key.local');
+  process.exit(2);
+}
+
+function arg(name, fallback = null) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 && process.argv[index + 1] ? process.argv[index + 1] : fallback;
+}
+
+const pricingPath = arg('--pricing');
+if (!pricingPath) { console.error('usage: g002-collect.mjs --pricing <pricing.json> [--out <receipt.json>]'); process.exit(2); }
+const pricing = JSON.parse(readFileSync(pricingPath, 'utf8'));
+const sourceCommitSha = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+const outPath = arg('--out', `docs/operations/pay-b-cost-${new Date().toISOString().slice(0, 10).replaceAll('-', '')}.json`);
+const apiKey = loadKey();
+
+const rawProbes = [];
+let effectiveModel = null;
+for (const probe of PROBES) {
+  console.error(`[g002] running ${probe.id} (${probe.text.length} chars)…`);
+  const result = await runWebRewriteStream({
+    request: { mode: 'first', lang: probe.lang, tier: 'pro', text: probe.text, apiKey, baseURL: BASE, model: MODEL },
+    emit: () => {},
+    timeout: 180_000,
+  });
+  if (!result.attempts?.valid) throw new Error(`${probe.id}: attempt records invalid`);
+  if (!result.ok) console.error(`[g002] ${probe.id} terminal: ${result.code} (cost data still valid if stages succeeded)`);
+  for (const stage of ['rewrite', 'mps', 'fidelity']) {
+    const records = result.attempts[stage];
+    if (!records.length || records.at(-1).outcome !== 'success') throw new Error(`${probe.id}/${stage}: no terminal success — rerun`);
+    const terminal = records.at(-1);
+    if (effectiveModel === null) effectiveModel = terminal.effectiveModel;
+    if (terminal.effectiveModel !== effectiveModel) throw new Error(`${probe.id}/${stage}: effective model drift ${terminal.effectiveModel}`);
+  }
+  rawProbes.push({ id: probe.id, inputChars: probe.text.length, stages: { rewrite: result.attempts.rewrite, mps: result.attempts.mps, fidelity: result.attempts.fidelity } });
+}
+
+const rawG002 = { channel: 'staging', collectorVersion: COLLECTOR_VERSION, deploymentId: `local-${sourceCommitSha}`, effectiveModel, provider: PROVIDER, requestedModel: MODEL, sourceCommitSha, probes: rawProbes };
+const providerBillingFacts = [];
+for (const probe of rawProbes) {
+  for (const stage of ['rewrite', 'mps', 'fidelity']) {
+    for (const record of probe.stages[stage]) {
+      const billed = record.outcome === 'success' && record.usage !== null;
+      providerBillingFacts.push({
+        probeId: probe.id,
+        stage,
+        attemptIndex: record.attemptIndex,
+        billingEvidence: {
+          version: 'provider-billing-v1',
+          source: 'provider_usage',
+          provider: PROVIDER,
+          billed,
+          rawUsageSha256: billed ? sha256Canonical(record.usage) : null,
+          providerReportedAmountUsdMicros: null,
+          externalReferenceSha256: createHash('sha256').update(`${probe.id}:${stage}:${record.attemptIndex}:${sourceCommitSha}`).digest('hex'),
+          unbilledReason: billed ? null : 'provider_error_without_usage',
+        },
+      });
+    }
+  }
+}
+
+const sourceBundle = collectPayBCostSourceBundle(rawG002, providerBillingFacts);
+const evidence = {
+  schemaVersion: 'PAY-B-COST-v1',
+  receiptId: randomUUID(),
+  issuedAt: new Date().toISOString(),
+  channel: 'staging',
+  collectorVersion: COLLECTOR_VERSION,
+  deploymentId: rawG002.deploymentId,
+  provider: PROVIDER,
+  requestedModel: MODEL,
+  effectiveModel,
+  sourceCommitSha,
+  sourceBundle,
+  sourceBundleSha256: sha256Canonical(sourceBundle),
+  pricing,
+  financial: {
+    unitChars: 1_000_000,
+    feeUsdMicros: 999_500,
+    refundReserveUsdMicros: 499_500,
+    bootstrap: { seed: EVIDENCE_ID, iterations: 10_000, confidenceBps: 9500 },
+  },
+};
+try {
+  const receipt = issuePayBCostReceipt(evidence);
+  writeFileSync(outPath, `${canonicalJson(receipt)}\n`);
+  console.error(`[g002] receipt written: ${outPath}`);
+  console.error(`[g002] upper COGS/1M chars: $${(receipt.financial.selectedUpperCogsUsdMicros / 1e6).toFixed(2)} | gross margin: ${(receipt.financial.grossMarginBps / 100).toFixed(1)}% (gate >=60%) — PASSED`);
+} catch (error) {
+  // The issuer mutates financial with the derived numbers before enforcing the
+  // margin gate, so a rejection still leaves the real measurements available.
+  const f = evidence.financial;
+  console.error(`[g002] receipt REFUSED: ${error.message}`);
+  if (Number.isFinite(f.selectedUpperCogsUsdMicros)) {
+    console.error(`[g002] measured upper COGS/1M chars: $${(f.selectedUpperCogsUsdMicros / 1e6).toFixed(2)}`);
+    console.error(`[g002] net revenue/mo: $${(f.netRevenueUsdMicros / 1e6).toFixed(2)} | gross margin at the 1M-char cap: ${(f.grossMarginBps / 100).toFixed(1)}%`);
+    const cap60 = Math.floor((f.netRevenueUsdMicros * 0.4) / (f.selectedUpperCogsUsdMicros / 1_000_000));
+    console.error(`[g002] monthly char cap that clears 60% margin at this COGS: ~${cap60.toLocaleString()} chars`);
+  }
+  process.exitCode = 3;
+}


### PR DESCRIPTION
PAY-B-COST measurement tooling: in-process collector (real pipeline, per-attempt usage capture, honest local-<commit> deployment id, margin-refusal reporting with the decision numbers) and the Anthropic OpenAI-compat cache_control empirical probe. Docs revised and prose-gated. No runtime surface changes.