### PR TITLE
ops: POLAR_APPROVAL + SECRET_MANAGER evidence records

### DIFF
--- a/docs/operations/polar-approval-20260803.md
+++ b/docs/operations/polar-approval-20260803.md
@@ -1,0 +1,45 @@
+# POLAR_APPROVAL — account approved, payout connected, identity verified (2026-08-03)
+
+> Exit evidence for the `POLAR_APPROVAL` blocker in
+> [`v6.4-preflight-hold.json`](v6.4-preflight-hold.json). Immutable record:
+> append corrections as new dated sections, never edit the observation below.
+
+## Observation
+
+Observed by the **owner** in the Polar dashboard (Finance → Account) on
+2026-08-03 and reported verbatim in the operator session:
+
+| Dashboard section | Reported state |
+|---|---|
+| Account Review | **"Account approved — Your product and organization details have been reviewed and approved."** |
+| Payout Account | **"Payout account connected — Your Stripe payout account is configured and ready to receive payouts."** |
+| Identity Verification | **"Identity verified — Your identity has been successfully verified."** |
+
+All three clear simultaneously: the up-to-14-day first-payout review described
+in [`polar-onboarding-steps.md`](polar-onboarding-steps.md) has completed, the
+Stripe Connect Express payout account is attached, and KYC is done. No external
+approval remains between the account and money reaching the owner.
+
+## Approved identities
+
+The approval covers the production identities verified by read-back in
+[`pay-b-binding-polar-20260729.json`](pay-b-binding-polar-20260729.json)
+(evidence `PAY-B-20260729-POLAR-ea8385dc-4c9c3f17`):
+
+| Identity | Value |
+|---|---|
+| Organization | `9a9180b7-2d13-422e-b9a7-316bed61c51d` |
+| Product | `ea8385dc-e21f-44bd-8ccd-2725437abb70` ("patina pro", $9.99/mo USD) |
+| Benefit | `4c9c3f17-f3b9-47cd-9ca4-4295ad3957b4` (license_keys) |
+| Production checkout URL | `https://buy.polar.sh/polar_cl_qKqtaZKLhUNJetr1h7XHY6wn8lRJEtG5DAPr02tG1pW` |
+
+## Limits of this record
+
+- Reported from the owner's authenticated dashboard session; no API field
+  exposes the same three-way review state for independent re-observation, so
+  re-verification means the owner re-opening Finance → Account.
+- Approval does not waive the remaining hold blockers: `SECRET_MANAGER`,
+  `GATE_B`, `DEP_PROD_DISABLED`, `GATE_D`, `ROLLBACK_DRILLS`, and `PAY_OPEN`
+  still gate `PATINA_PRO_CHECKOUT_ENABLED=true`.
+- Polar holds accounts to a 0.4% chargeback rate and 48-hour support response;
+  approval is ongoing compliance, not a one-time clearance.

--- a/docs/operations/secret-manager-record-20260803.md
+++ b/docs/operations/secret-manager-record-20260803.md
@@ -1,0 +1,43 @@
+# SECRET_MANAGER — presence-only record, Vercel production scope (2026-08-03)
+
+> Exit evidence for the `SECRET_MANAGER` blocker in
+> [`v6.4-preflight-hold.json`](v6.4-preflight-hold.json). Names only — **no
+> values appear in this file.** Verified via `vercel env ls` / a value check
+> limited to the two boolean gate flags, from the owner's authenticated CLI.
+
+## Present in the Vercel *Production* environment
+
+`KV_REST_API_URL`, `KV_REST_API_TOKEN`, `PATINA_LICENSE_PROVIDER`,
+`POLAR_ORGANIZATION_ID`, `POLAR_PRO_BENEFIT_ID`, `PATINA_PRO_API_KEY`,
+`PATINA_LICENSE_HMAC_SECRET`, `PATINA_QUOTA_HMAC_SECRET`,
+`PATINA_FREE_API_KEY`, `PATINA_PRO_PROVIDER`, `PATINA_PRO_MODEL`,
+`PATINA_PRO_CHECKOUT_ENABLED`, `PATINA_PRO_CHECKOUT_URL`,
+`PATINA_DEPLOYMENT_CHANNEL`, `PATINA_OBSERVABILITY_REST_API_URL`,
+`PATINA_OBSERVABILITY_REST_API_TOKEN`, `CRON_SECRET`,
+`PATINA_PUBLIC_BASE_URL`, `PATINA_PUBLIC_BASE_URL_SHA256`,
+`PATINA_SYNTHETIC_OBSERVER_SECRET`, `PATINA_VERCEL_LOG_QUERY_URL`,
+`PATINA_VERCEL_LOG_QUERY_URL_SHA256`, `PATINA_VERCEL_LOG_QUERY_TOKEN`,
+`PATINA_ALERT_DISCORD_WEBHOOK`.
+
+`VERCEL_GIT_COMMIT_SHA` is injected by Vercel at build time, not a dashboard
+variable.
+
+## Gate-flag values (the only values checked)
+
+- `PATINA_PRO_ALLOW_FREE_KEY` = `false` — satisfies the "absent or exactly
+  false" requirement.
+- `PATINA_PRO_CHECKOUT_ENABLED` = `false` — checkout stays disabled.
+- `PATINA_DEPLOYMENT_CHANNEL` = `production`.
+
+## Not yet present (deliberate — set at live open)
+
+| Name | When | Value source |
+|---|---|---|
+| `PATINA_PRO_GATE_EVIDENCE_ID` | Live-open step, with the enable flag | `PAY-B-20260729-POLAR-ea8385dc-4c9c3f17` (source-controlled binding) |
+| `PATINA_SYNTHETIC_PRO_LICENSE` | Before Gate-B OBS monitoring | Owner issues a fresh license via the bounded forever-100% verification code; the prior verification license was shredded after use |
+
+## Retired names still present
+
+`LS_STORE_ID`, `LS_PRO_PRODUCT_ID`, `LS_PRO_VARIANT_ID` remain configured but
+are inert while `PATINA_LICENSE_PROVIDER=polar`. Remove them after live open
+stabilizes; they are no longer required by the rewritten hold.


### PR DESCRIPTION
Two blocker exit-evidence records for the v6.4 hold's Polar go-live sequence:

- `polar-approval-20260803.md` — owner-observed Polar dashboard: account approved, payout account connected, identity verified (2026-08-03). Covers the identities in `PAY-B-20260729-POLAR-ea8385dc-4c9c3f17`.
- `secret-manager-record-20260803.md` — presence-only production env record (no values; only the two boolean gate flags were value-checked: ALLOW_FREE_KEY=false, CHECKOUT_ENABLED=false). Names the deliberate live-open gaps (GATE_EVIDENCE_ID, SYNTHETIC_PRO_LICENSE).

Docs only; no code paths touched. Checkout remains disabled.