### PR TITLE
fix(playground): accurate BYOK key wording on the pricing card

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -190,7 +190,7 @@
             <ul class="price__feats">
               <li>Bring your own provider key</li>
               <li>Up to 20,000 characters</li>
-              <li>Key stays in your browser</li>
+              <li>Sent only with your requests</li>
               <li>Never stored or logged</li>
             </ul>
             <button class="price__cta" type="button" id="price-byok">Use API mode</button>


### PR DESCRIPTION
Pricing audit found one inaccurate claim: 'Key stays in your browser'. BYOK keys transit the server per request (never stored/logged — that line stays). Replaced with 'Sent only with your requests'. All other pricing claims verified against the shipped contract: free 20/day + 4,000 chars (413 enforced live), BYOK 20,000, Pro 100/mo + 20,000 each + 50,000/mo (defaults confirmed unset in env).