### PR TITLE
release: pricing copy fix + go-live ops records

### DIFF
--- a/docs/operations/free-tier-deepseek-flip-20260803.md
+++ b/docs/operations/free-tier-deepseek-flip-20260803.md
@@ -1,0 +1,49 @@
+# Free tier flipped to deepseek-v4-flash (2026-08-03)
+
+## Why
+
+The free tier was hard down: the production Gemini key returns HTTP 429
+"monthly spending cap exceeded" (recorded in
+[`dep-prod-disabled-20260803.md`](dep-prod-disabled-20260803.md)). The
+deepseek-0731 remeasurement chain
+([`serving-engine-deepseek-0731-correction-20260803.md`](serving-engine-deepseek-0731-correction-20260803.md))
+established gate parity at ~1/8 the cost, and the owner approved the
+free-tier switch on 2026-08-03.
+
+## Validation before the flip
+
+- 22 fixtures × `--repeat 3` at `reasoning_effort: low`: 17 pass / 2 warn /
+  3 error on worst-of-three status; every MEDIAN score clears the floors
+  (lowest median MPS 80). The three errors are single below-70 MPS samples on
+  `en-email-01` / `ko-blog-01` / `ko-news-01` — per-run variance, not a
+  register failure. In production such a sample is refused by the MPS floor
+  gate (customer sees a retryable error), never delivered silently.
+- Code: PR #677 (reviewed) — rewrite reasoning cut scoped to free+deepseek,
+  scorer cut extended to deepseek, streaming extraBody passthrough. Shipped
+  to main via release PR #678.
+
+## The flip
+
+Vercel env (preview 2026-08-03, then production after #678):
+`PATINA_FREE_PROVIDER=deepseek`, `PATINA_FREE_MODEL=deepseek-v4-flash`,
+`PATINA_FREE_API_KEY=<deepseek key>`. Explicit redeploy after the env change.
+
+## Post-flip production smoke (patina.vibetip.help)
+
+| probe | result |
+|---|---|
+| free ko rewrite | 200, 34.2s end-to-end, MPS 100, fidelity 100 |
+| number safety | `14:30`, `23,000` preserved |
+| scaffold leakage | none (`[SELF_AUDIT]` absent) |
+| pro unknown license | 403 `license not entitled` (Polar gate intact) |
+| launch config | still the disabled shape |
+
+## Standing notes
+
+- The Pro tier still runs gemini-3.6-flash on `PATINA_PRO_API_KEY`; if that
+  key shares the capped Gemini project, Pro serving is still blocked until
+  the owner clears the spend cap — unverifiable without a live license.
+- Rollback: restore the three `PATINA_FREE_*` values to the gemini set and
+  redeploy (values retained in the secret manager history).
+- Watch item: DeepSeek announced (date TBA) 2x peak-hour output pricing;
+  reassess cost if activated.

--- a/docs/operations/gate-b-readiness-20260803.md
+++ b/docs/operations/gate-b-readiness-20260803.md
@@ -19,10 +19,12 @@
 
 ## Blocking — owner actions, in order
 
-1. **Gemini spend cap (incident).** The production runner's Gemini key returns
-   HTTP 429 "monthly spending cap exceeded"; the free tier fails terminally and
-   healthy-service evidence cannot be recorded. Raise/clear the cap at
-   AI Studio → spend, then the agent re-runs the free/pro smokes.
+1. ~~**Gemini spend cap (incident).**~~ **RESOLVED 2026-08-03**: the owner
+   cleared the spend cap; a direct gemini-3.6-flash probe answers again. The
+   free tier no longer depends on it (flipped to deepseek,
+   [`free-tier-deepseek-flip-20260803.md`](free-tier-deepseek-flip-20260803.md));
+   the Pro serving path (gemini) is unblocked but can only be exercised
+   end-to-end once a license exists (item 2).
 2. **`PATINA_SYNTHETIC_PRO_LICENSE`.** The pro-monitor synthetic probe needs a
    real license; the prior verification license was shredded. Issue one via the
    bounded forever-100% verification code (a zero-amount checkout), hand only

--- a/docs/operations/live-open-20260804.md
+++ b/docs/operations/live-open-20260804.md
@@ -1,0 +1,42 @@
+# PAY_OPEN — checkout enabled on production (2026-08-04)
+
+## Authorization
+
+The owner (holding every gate role: Maintainer, Payment Runtime Owner,
+Deployment Owner, Release Authority) authorized opening payment in the
+operator session on 2026-08-04 ("ㅇㅇ 켜라"), after reviewing the state
+summarized in [`gate-b-readiness-20260803.md`](gate-b-readiness-20260803.md):
+Polar approval/payout/KYC cleared, secret manager complete, the binding
+integration shipped, the disabled production deploy verified, rollback drills
+measured (2026-07-23), and the production Pro path verified with a
+currently-issued license
+([`synthetic-license-20260804.md`](synthetic-license-20260804.md)).
+
+**Deviation, recorded honestly**: the formal `OBS-ALERT-v1` ACKed-receipt
+cycle had not yet produced its first receipt at open time — the synthetic
+license that enables the monitor's real path was provisioned the same day.
+The owner opened with the monitor newly armed rather than waiting a cycle.
+Watch item: confirm the first healthy receipt.
+
+## The flip
+
+Production env: `PATINA_PRO_CHECKOUT_ENABLED=true`,
+`PATINA_PRO_CHECKOUT_URL=https://buy.polar.sh/polar_cl_qKqt…` (replacing the
+retired Lemon Squeezy URL), `PATINA_PRO_GATE_EVIDENCE_ID=
+PAY-B-20260729-POLAR-ea8385dc-4c9c3f17`; explicit redeploy.
+
+## Post-open verification (2026-08-04)
+
+| probe | result |
+|---|---|
+| `/launch-config.js` | `{channel: production, enabled: true, checkoutOrigin: https://buy.polar.sh, checkoutPath: /polar_cl_qKqt…, evidence: PAY-B-20260729-POLAR-ea8385dc-4c9c3f17}` — exactly the bound tuple |
+| Checkout link | 200 |
+| Playground CTA | "Upgrade to Pro — $9.99/mo" renders; clicking opens a live Polar checkout session (`polar.sh/checkout/polar_c_…`) in a new tab |
+| Free tier | 200, healthy (deepseek) |
+| Pro tier | verified same day with a real license: 200, 10.2s, MPS/fidelity 100 |
+
+## Rollback
+
+Sale-close drill procedure in [`rollback-drills.md`](rollback-drills.md):
+flip `PATINA_PRO_CHECKOUT_ENABLED=false`, redeploy, verify the six-field
+disabled shape — measured well under the 10-minute bound.

--- a/docs/operations/synthetic-license-20260804.md
+++ b/docs/operations/synthetic-license-20260804.md
@@ -1,0 +1,42 @@
+# Synthetic Pro license provisioned; production Pro path verified (2026-08-04)
+
+> Closes item 2 of [`gate-b-readiness-20260803.md`](gate-b-readiness-20260803.md).
+> No raw key, discount code, or token value appears in this record.
+
+## Provisioning (agent-run via the Polar API, owner-supplied OAT)
+
+1. The standing verification code ("patina test", 100% forever, 1/3 redeemed)
+   is **per-customer limited**: both the owner email and a plus-alias drew
+   `DiscountRedemptionLimitReached` — Polar normalizes the customer identity.
+2. A fresh bounded code was created instead: 100%, `duration: forever`,
+   `max_redemptions: 1`, expiry +3 days, scoped to the `patina pro` product.
+3. Zero-amount checkout created and confirmed card-free
+   (`total: 0`, `is_payment_required: false`, status `confirmed`) for the
+   dedicated monitor identity `devswha+monitor@gmail.com`.
+4. License `****-2FCE6A` (benefit `4c9c3f17…`, status `granted`) fetched via
+   the org API and piped directly into the Vercel Production env as
+   `PATINA_SYNTHETIC_PRO_LICENSE` — never echoed, never written to the repo.
+5. The one-shot discount was **deleted** after use (204); the OAT was removed
+   from the local env and its dashboard revocation recommended to the owner
+   (it transited an operator chat).
+
+## Production Pro-path verification (patina.vibetip.help, post-redeploy)
+
+| probe | result |
+|---|---|
+| tier=pro with the new license | **HTTP 200**, start→done, 10.2s |
+| MPS / fidelity | 100 / 100 |
+| number safety | `14:30`, `23,000` preserved |
+| license leakage in response | none |
+
+This is the first end-to-end Pro observation since the Gemini spend cap was
+cleared: the Polar validate → entitle → gemini-3.6-flash rewrite chain works
+on the deployed production environment with a currently-issued license.
+
+## Follow-ups
+
+- The pro-monitor cron (`*/15`) can now exercise the real path; the next
+  Gate-B step is an ACKed healthy `OBS-ALERT-v1` receipt with `realPath: true`.
+- The monitor seat consumes the standard 100-rewrites/month allowance; at the
+  cron cadence the synthetic probe budget must stay within it (monitor design
+  already accounts for this).

--- a/playground/index.html
+++ b/playground/index.html
@@ -190,7 +190,7 @@
             <ul class="price__feats">
               <li>Bring your own provider key</li>
               <li>Up to 20,000 characters</li>
-              <li>Key stays in your browser</li>
+              <li>Sent only with your requests</li>
               <li>Never stored or logged</li>
             </ul>
             <button class="price__cta" type="button" id="price-byok">Use API mode</button>


### PR DESCRIPTION
Ships the BYOK wording fix to the live page plus the ops evidence docs (#679–#682).