### PR TITLE
docs: fix the axes table rendering in all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,16 +122,16 @@ Scores are editing signals with false positives and false negatives, not proof o
 Patina does not infer one axis from another. Omit Persona and Register to keep
 the source voice and register.
 
-| Axis | Controls | Does not control | CLI | Config | Playground |
-|---|---|---|---|---|---|
-| **Document Type** | Genre, purpose, structural conventions, pattern policy | Voice, casual/professional delivery, meaning floors | `--document-type` | `document-type` | Document |
-| **Persona** | Reusable voice fingerprint: vocabulary, rhythm, explanation habits | Genre, pattern policy, register, meaning floors | `--persona` | `persona` | Voice |
-| **Register** | `casual` or `professional` delivery | Genre, persona identity, pattern policy | `--register` | `register` | Register |
+| Axis | Controls | Does not control | Select with |
+|---|---|---|---|
+| **Document Type** | Genre, purpose, structural conventions, pattern policy | Voice, casual/professional delivery, meaning floors | `--document-type` · config `document-type` · Playground "Document Type" |
+| **Persona** | Reusable voice fingerprint: vocabulary, rhythm, explanation habits | Genre, pattern policy, register, meaning floors | `--persona` · config `persona` · Playground "Persona" |
+| **Register** | `casual` or `professional` delivery | Genre, persona identity, pattern policy | `--register` · config `register` · Playground "Register" |
+
 Meaning preservation is the outer guard. If instructions appear to overlap,
 field ownership resolves them: Document Type wins for document structure and
 domain constraints, Persona for idiolect and rhythm, and Register for
 casual/professional markers. An explicit value never fills an omitted axis.
-
 
 Examples:
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -110,11 +110,11 @@ printf '%s\n' 'Coffee has emerged as a pivotal cultural phenomenon.' \
 
 patina は一つの軸から別の軸を推論しません。Persona と Register を省略すると、原文のボイスとレジスターを保持します。
 
-| 軸 | 制御するもの | 制御しないもの | CLI | 設定 | Playground |
-|---|---|---|---|---|---|
-| **Document Type** | ジャンル、目的、構造慣習、パターン方針 | ボイス、casual/professional の伝え方、意味保全フロア | `--document-type` | `document-type` | Document |
-| **Persona** | 再利用ボイス指紋：語彙、リズム、説明習慣 | ジャンル、パターン方針、Register、意味保全フロア | `--persona` | `persona` | Voice |
-| **Register** | `casual` または `professional` の伝え方 | ジャンル、Persona の同一性、パターン方針 | `--register` | `register` | Register |
+| 軸 | 制御するもの | 制御しないもの | 選択方法 |
+|---|---|---|---|
+| **Document Type** | ジャンル、目的、構造慣習、パターン方針 | ボイス、casual/professional の伝え方、意味保全フロア | `--document-type` · 設定 `document-type` · Playground "Document Type" |
+| **Persona** | 再利用ボイス指紋：語彙、リズム、説明習慣 | ジャンル、パターン方針、Register、意味保全フロア | `--persona` · 設定 `persona` · Playground "Persona" |
+| **Register** | `casual` または `professional` の伝え方 | ジャンル、Persona の同一性、パターン方針 | `--register` · 設定 `register` · Playground "Register" |
 
 ```bash
 patina --document-type email --register professional note.md

--- a/README_KR.md
+++ b/README_KR.md
@@ -110,11 +110,12 @@ printf '%s\n' 'Coffee has emerged as a pivotal cultural phenomenon.' \
 
 patina는 한 축에서 다른 축을 추론하지 않습니다. Persona와 Register를 생략하면 원문의 목소리와 레지스터를 보존합니다.
 
-| 축 | 정하는 것 | 정하지 않는 것 | CLI | 설정 | Playground |
-|---|---|---|---|---|---|
-| **Document Type** | 장르·용도·구조 관습·패턴 정책 | 목소리, casual/professional 전달 방식, 의미 보존 하한 | `--document-type` | `document-type` | Document |
-| **Persona** | 재사용 보이스 지문: 어휘·리듬·설명 습관 | 장르, 패턴 정책, Register, 의미 보존 하한 | `--persona` | `persona` | Voice |
-| **Register** | `casual` 또는 `professional` 전달 방식 | 장르, Persona 정체성, 패턴 정책 | `--register` | `register` | Register |
+| 축 | 정하는 것 | 정하지 않는 것 | 선택 방법 |
+|---|---|---|---|
+| **Document Type** | 장르·용도·구조 관습·패턴 정책 | 목소리, casual/professional 전달 방식, 의미 보존 하한 | `--document-type` · 설정 `document-type` · Playground "Document Type" |
+| **Persona** | 재사용 보이스 지문: 어휘·리듬·설명 습관 | 장르, 패턴 정책, Register, 의미 보존 하한 | `--persona` · 설정 `persona` · Playground "Persona" |
+| **Register** | `casual` 또는 `professional` 전달 방식 | 장르, Persona 정체성, 패턴 정책 | `--register` · 설정 `register` · Playground "Register" |
+
 의미 보존은 세 축 바깥의 공통 하한입니다. 지시가 겹쳐 보이면 소유 필드로
 판단합니다. 문서 구조와 도메인 제약은 Document Type, 고유 어휘와 리듬은 Persona,
 casual/professional 표지는 Register가 정합니다. 명시된 한 축으로 생략된 다른 축을

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -112,11 +112,11 @@ printf '%s\n' 'Coffee has emerged as a pivotal cultural phenomenon.' \
 
 patina 不会从一个轴推断另一个轴。省略 Persona 和 Register 时，会保留原文的声音与语域。
 
-| 轴 | 控制 | 不控制 | CLI | 配置 | Playground |
-|---|---|---|---|---|---|
-| **Document Type** | 体裁、用途、结构惯例、模式策略 | 声音、casual/professional 表达、含义保留下限 | `--document-type` | `document-type` | Document |
-| **Persona** | 可复用声音指纹：词汇、节奏、解释习惯 | 体裁、模式策略、Register、含义保留下限 | `--persona` | `persona` | Voice |
-| **Register** | `casual` 或 `professional` 表达方式 | 体裁、Persona 身份、模式策略 | `--register` | `register` | Register |
+| 轴 | 控制 | 不控制 | 选择方式 |
+|---|---|---|---|
+| **Document Type** | 体裁、用途、结构惯例、模式策略 | 声音、casual/professional 表达、含义保留下限 | `--document-type` · 配置 `document-type` · Playground "Document Type" |
+| **Persona** | 可复用声音指纹：词汇、节奏、解释习惯 | 体裁、模式策略、Register、含义保留下限 | `--persona` · 配置 `persona` · Playground "Persona" |
+| **Register** | `casual` 或 `professional` 表达方式 | 体裁、Persona 身份、模式策略 | `--register` · 配置 `register` · Playground "Register" |
 
 ```bash
 patina --document-type email --register professional note.md


### PR DESCRIPTION
Owner-reported: EN/KR were missing the blank line after the table and all four languages used a 6-column layout that GitHub squeezes until code tokens wrap vertically. Now 4 columns with a combined 'Select with' cell. Docs only.