### PR TITLE
Add MiniMax-M3 image and video input support

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -336,6 +336,7 @@ async function readStreamedCompletion(response, onMetadata) {
  *
  * @param {object} options LLM request options.
  * @param {string} options.prompt User prompt sent as the single chat message.
+ * @param {string|Array<object>} [options.messageContent] Optional structured content for the user message.
  * @param {string} [options.apiKey] Bearer token for the provider.
  * @param {string} [options.baseURL] OpenAI-compatible API base URL. Defaults to https://api.openai.com/v1.
  * @param {string} [options.model] Model id to request. Defaults to gpt-5.5.
@@ -360,6 +361,7 @@ async function readStreamedCompletion(response, onMetadata) {
  */
 export async function callLLM({
   prompt,
+  messageContent,
   apiKey,
   baseURL = 'https://api.openai.com/v1',
   model = DEFAULT_BEST_MODELS.openai,
@@ -397,7 +399,7 @@ export async function callLLM({
         // Spread first so callers can never clobber the protocol fields below.
         ...(extraBody && typeof extraBody === 'object' && !Array.isArray(extraBody) ? extraBody : {}),
         model,
-        messages: [{ role: 'user', content: prompt }],
+        messages: [{ role: 'user', content: messageContent ?? prompt }],
       };
   // Skip `temperature` up front when this process already saw the model
   // reject it (e.g. claude-sonnet-5) — avoids a guaranteed 400 round trip.
@@ -569,4 +571,3 @@ export async function callLLM({
   if (typeof lastStatus === 'number') /** @type {any} */ (err).status = lastStatus;
   throw err;
 }
-

--- a/src/backends/index.js
+++ b/src/backends/index.js
@@ -1,3 +1,5 @@
+import { readFileSync, statSync } from 'node:fs';
+import { extname } from 'node:path';
 import { callLLM } from '../api.js';
 import * as codexCli from './codex-cli.js';
 import * as claudeCli from './claude-cli.js';
@@ -16,8 +18,95 @@ import {
   withBackendConcurrencySlot,
 } from './contract.js';
 
+const MINIMAX_MEDIA_HOSTS = new Set(['api.minimax.io', 'api.minimaxi.com']);
+const MINIMAX_MAX_REQUEST_BYTES = 64 * 1024 * 1024;
+const MEDIA_TYPES = {
+  image: {
+    maxBytes: 10 * 1024 * 1024,
+    mimeByExtension: {
+      '.gif': 'image/gif',
+      '.jpeg': 'image/jpeg',
+      '.jpg': 'image/jpeg',
+      '.png': 'image/png',
+      '.webp': 'image/webp',
+    },
+  },
+  video: {
+    maxBytes: 50 * 1024 * 1024,
+    mimeByExtension: {
+      '.avi': 'video/avi',
+      '.mkv': 'video/x-matroska',
+      '.mov': 'video/mov',
+      '.mp4': 'video/mp4',
+    },
+  },
+};
+
+function supportsMiniMaxMedia({ model, baseURL } = {}) {
+  if (model !== 'MiniMax-M3') return false;
+  try {
+    return MINIMAX_MEDIA_HOSTS.has(new URL(baseURL).hostname);
+  } catch {
+    return false;
+  }
+}
+
+function normalizeMiniMaxAttachment(value, kind) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`MiniMax-M3 ${kind} input must be a URL, data URL, or local file path`);
+  }
+  const source = value.trim();
+  const limits = MEDIA_TYPES[kind];
+
+  if (/^https?:\/\//i.test(source) || (kind === 'video' && source.startsWith('mm_file://'))) {
+    return source;
+  }
+
+  if (source.startsWith('data:')) {
+    const match = source.match(/^data:([^;,]+);base64,(.+)$/s);
+    const allowedMimes = new Set(Object.values(limits.mimeByExtension));
+    if (!match || !allowedMimes.has(match[1]) || Buffer.from(match[2], 'base64').byteLength > limits.maxBytes) {
+      throw new Error(`MiniMax-M3 ${kind} data URL has an unsupported type or exceeds its size limit`);
+    }
+    return source;
+  }
+
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(source)) {
+    throw new Error(`MiniMax-M3 ${kind} input uses an unsupported URL scheme`);
+  }
+
+  const mime = limits.mimeByExtension[extname(source).toLowerCase()];
+  if (!mime) {
+    throw new Error(`MiniMax-M3 ${kind} file has an unsupported extension`);
+  }
+  if (statSync(source).size > limits.maxBytes) {
+    throw new Error(`MiniMax-M3 ${kind} file exceeds its size limit`);
+  }
+  return `data:${mime};base64,${readFileSync(source).toString('base64')}`;
+}
+
+function buildMiniMaxMessageContent(prompt, images = [], videos = []) {
+  const content = [
+    { type: 'text', text: prompt },
+    ...images.map((image) => ({
+      type: 'image_url',
+      image_url: { url: normalizeMiniMaxAttachment(image, 'image') },
+    })),
+    ...videos.map((video) => ({
+      type: 'video_url',
+      video_url: { url: normalizeMiniMaxAttachment(video, 'video') },
+    })),
+  ];
+  if (Buffer.byteLength(JSON.stringify(content)) > MINIMAX_MAX_REQUEST_BYTES) {
+    throw new Error('MiniMax-M3 media request exceeds the 64 MB body limit');
+  }
+  return content;
+}
+
 const openaiHttp = {
   name: 'openai-http',
+  supportsImages: supportsMiniMaxMedia,
+  supportsVideos: supportsMiniMaxMedia,
   isAvailable: () => true,
   isAuthenticated: () => inspectHttpApiKeySource().ok,
   authHint: () => inspectHttpApiKeySource().detail,
@@ -34,13 +123,17 @@ const openaiHttp = {
     seed,
     onResponse,
     images,
+    videos,
   }) => {
-    if (Array.isArray(images) && images.length > 0) {
-      // By design, not a gap: OCR stays on local CLI backends so image bytes
-      // never ride an HTTP API call.
-      throw new Error('openai-http backend: image input is not supported — use codex-cli, claude-cli, or gemini-cli for OCR');
+    const hasImages = Array.isArray(images) && images.length > 0;
+    const hasVideos = Array.isArray(videos) && videos.length > 0;
+    if ((hasImages || hasVideos) && !supportsMiniMaxMedia({ model, baseURL })) {
+      throw new Error('HTTP media input is supported only for MiniMax-M3 on an official MiniMax endpoint');
     }
-    return callLLM({ prompt, apiKey, baseURL, model, signal, timeout, deadline, maxRetries, temperature, seed, onResponse });
+    const messageContent = hasImages || hasVideos
+      ? buildMiniMaxMessageContent(prompt, images, videos)
+      : undefined;
+    return callLLM({ prompt, messageContent, apiKey, baseURL, model, signal, timeout, deadline, maxRetries, temperature, seed, onResponse });
   },
 };
 
@@ -97,7 +190,7 @@ export function listBackends() {
       agentRuntime: safety.agentRuntime,
       available: b.isAvailable(),
       authenticated: b.isAuthenticated(),
-      supportsImages: Boolean(b.supportsImages),
+      supportsImages: typeof b.supportsImages === 'boolean' ? b.supportsImages : false,
       authHint: b.authHint(),
       loginCommand: b.loginCommand || null,
       installHint: b.installHint || null,
@@ -165,16 +258,17 @@ export function selectBackendChain({ name, model, modelSource } = {}) {
   };
 }
 
-// Image-capable backends in default OCR preference order: claude verbatim
-// Korean fidelity (measured), gemini near-verbatim and slightly faster,
-// codex native -i attachment. kimi-cli and openai-http reject images.
+// Image-capable local backends in default OCR preference order.
 const OCR_BACKEND_ORDER = ['claude-cli', 'gemini-cli', 'codex-cli'];
 
 // Resolve the backend chain for OCR calls: keep the user's selected
 // image-capable backends (their order), otherwise fall back to the available
 // + authenticated capable CLIs.
-export function selectOcrBackends(selectedBackends = [], { logger } = {}) {
-  const capable = selectedBackends.filter((backend) => REGISTRY[backend.name]?.supportsImages);
+export function selectOcrBackends(selectedBackends = [], { logger, model, baseURL } = {}) {
+  const capable = selectedBackends.filter((backend) => {
+    const support = REGISTRY[backend.name]?.supportsImages;
+    return typeof support === 'function' ? support({ model, baseURL }) : Boolean(support);
+  });
   if (capable.length > 0) return capable;
   const fallback = OCR_BACKEND_ORDER
     .map((name) => REGISTRY[name])
@@ -206,6 +300,7 @@ export async function invokeBackendChain({
   onResponse,
   logger,
   images,
+  videos,
 }) {
   if (!Array.isArray(backends) || backends.length === 0) {
     throw inputError(
@@ -250,6 +345,7 @@ export async function invokeBackendChain({
           onResponse,
           logger,
           images,
+          videos,
         }),
       });
     } catch (err) {

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -1109,12 +1109,16 @@ async function runPreviewJob({
 
 async function runOcrStage({ pageHtml, sourceUrl, parsed, backends, resolved, timeoutMs, cancellation, logger }) {
   // A test-injected OCR runner replaces backend selection entirely (CI has no
-  // installed vision CLI). In production we require a real image-capable CLI.
-  const ocrBackends = hasOcrRunnerOverride() ? [] : selectOcrBackends(backends, { logger });
+  // installed vision backend). In production we require a real image-capable backend.
+  const ocrBackends = hasOcrRunnerOverride() ? [] : selectOcrBackends(backends, {
+    logger,
+    model: resolved.model,
+    baseURL: resolved.baseURL,
+  });
   if (!hasOcrRunnerOverride() && ocrBackends.length === 0) {
     throw runtimeError(
       'no image-capable backend for --ocr',
-      'OCR needs an available, authenticated claude-cli, gemini-cli, or codex-cli (kimi-cli and openai-http cannot read images).',
+      'OCR needs an available, authenticated image-capable backend. MiniMax-M3 is supported through a configured MiniMax provider.',
       'Run `patina doctor` to check backend status, or drop --ocr.'
     );
   }
@@ -1142,14 +1146,16 @@ async function runOcrStage({ pageHtml, sourceUrl, parsed, backends, resolved, ti
     }
     cancellation.throwIfCanceled();
 
-    // No model override: an OCR fallback backend may differ from the text
-    // backend, so each CLI uses its own default model.
+    const ocrModel = ocrBackends.some((backend) => backend.name === 'openai-http')
+      ? resolved.model
+      : undefined;
     const invokeChain = ({ prompt, images }) => invokeBackendChain({
       backends: ocrBackends,
       prompt,
       images,
       apiKey: resolved.apiKey,
       baseURL: resolved.baseURL,
+      model: ocrModel,
       signal: cancellation.signal,
       timeout: timeoutMs,
       maxConcurrency: parsed.maxConcurrency,

--- a/tests/e2e/backends.test.js
+++ b/tests/e2e/backends.test.js
@@ -1,9 +1,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   invokeBackendChain,
   selectBackend,
   selectBackendChain,
+  selectOcrBackends,
   listBackends,
 } from '../../src/backends/index.js';
 import {
@@ -122,6 +126,81 @@ describe('Backend Selection', () => {
 
   it('throws on unknown backend name', () => {
     assert.throws(() => selectBackend({ name: 'invented-backend' }), /Unknown backend/);
+  });
+});
+
+describe('MiniMax-M3 media input', () => {
+  it('sends image and video content through both MiniMax endpoints', async () => {
+    const originalFetch = globalThis.fetch;
+    const directory = mkdtempSync(join(tmpdir(), 'patina-minimax-media-'));
+    const imagePath = join(directory, 'sample.png');
+    writeFileSync(imagePath, 'sample image bytes');
+    const requests = [];
+    globalThis.fetch = async (url, options) => {
+      requests.push({ url, body: JSON.parse(options.body) });
+      return {
+        ok: true,
+        headers: { get: () => 'application/json' },
+        json: async () => ({
+          choices: [{ message: { content: 'read media' } }],
+          model: 'MiniMax-M3',
+        }),
+      };
+    };
+
+    try {
+      const { backends } = selectBackendChain({ name: 'openai-http' });
+      for (const baseURL of ['https://api.minimax.io/v1', 'https://api.minimaxi.com/v1']) {
+        assert.deepStrictEqual(
+          selectOcrBackends(backends, { model: 'MiniMax-M3', baseURL }),
+          backends
+        );
+        const result = await invokeBackendChain({
+          backends,
+          prompt: 'Read the attachments',
+          apiKey: 'test-key',
+          baseURL,
+          model: 'MiniMax-M3',
+          maxRetries: 0,
+          images: [imagePath],
+          videos: ['https://example.test/sample.mp4'],
+        });
+        assert.strictEqual(result, 'read media');
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+      rmSync(directory, { recursive: true, force: true });
+    }
+
+    assert.deepStrictEqual(requests.map((request) => request.url), [
+      'https://api.minimax.io/v1/chat/completions',
+      'https://api.minimaxi.com/v1/chat/completions',
+    ]);
+    for (const request of requests) {
+      const content = request.body.messages[0].content;
+      assert.deepStrictEqual(content[0], { type: 'text', text: 'Read the attachments' });
+      assert.match(content[1].image_url.url, /^data:image\/png;base64,/);
+      assert.deepStrictEqual(content[2], {
+        type: 'video_url',
+        video_url: { url: 'https://example.test/sample.mp4' },
+      });
+    }
+  });
+
+  it('keeps media disabled outside the MiniMax-M3 preset', async () => {
+    const { backends } = selectBackendChain({ name: 'openai-http' });
+    await assert.rejects(
+      invokeBackendChain({
+        backends,
+        prompt: 'Read the attachment',
+        apiKey: 'test-key',
+        baseURL: 'https://api.minimax.io/v1',
+        model: 'MiniMax-M2.7',
+        maxRetries: 0,
+        images: ['https://example.test/sample.png'],
+      }),
+      /media input is supported only for MiniMax-M3/
+    );
   });
 });
 


### PR DESCRIPTION
Reason: MiniMax-M3 declares image and video modalities, but the existing HTTP backend rejected media attachments.

This change:

- sends documented image and video content parts for MiniMax-M3 on both official regional endpoints;
- lets the configured MiniMax provider use Patina's existing OCR image pipeline;
- validates local attachment types and documented size limits while keeping media disabled for other models and endpoints; and
- covers local image encoding, video URLs, regional routing, and the non-target guard with focused tests.

Checks:

- `npm run lint`
- `node --test tests/e2e/backends.test.js`
- `npm test` (1,651 tests passed; the unrelated existing HOME/cwd deduplication case in `tests/unit/config.test.js` failed)
