### PR TITLE
fix: verify webhooks after Vercel JSON parsing

### DIFF
--- a/api/polar-webhook.js
+++ b/api/polar-webhook.js
@@ -25,6 +25,14 @@ async function requestBody(req) {
       const bytes = Buffer.from(req.body);
       return bytes.byteLength > BODY_LIMIT ? { tooLarge: true } : { bytes };
     }
+    // Vercel's Node helper may parse JSON before invoking a plain /api
+    // function even when bodyParser:false is present. Re-serializing remains
+    // fail-closed: verification succeeds only when these bytes exactly match
+    // the provider-signed compact JSON payload.
+    if (req.body && typeof req.body === 'object' && !Array.isArray(req.body)) {
+      const bytes = Buffer.from(JSON.stringify(req.body));
+      return bytes.byteLength > BODY_LIMIT ? { tooLarge: true } : { bytes };
+    }
     return { invalid: true };
   }
   if (!req || typeof req[Symbol.asyncIterator] !== 'function') return { invalid: true };

--- a/tests/unit/polar-webhook.test.js
+++ b/tests/unit/polar-webhook.test.js
@@ -96,6 +96,23 @@ test('target first delivery increments once while duplicates and non-targets do 
   assert.deepEqual(first.chunks, []);
 });
 
+test('parsed Vercel JSON bodies are re-serialized and still require an exact signature', async () => {
+  const calls = [];
+  const handler = createPolarWebhookHandler({ env, now: () => now, store: { incrementOnce: async (...args) => { calls.push(args); return true; } } });
+  const body = JSON.stringify(event);
+  const request = /** @type {any} */ (signedRequest({ body }));
+  request.body = event;
+  const accepted = response();
+  await handler(request, accepted);
+  assert.equal(accepted.statusCode, 202);
+  assert.equal(calls.length, 1);
+
+  request.body = { ...event, type: 'order.created' };
+  const rejected = response();
+  await handler(request, rejected);
+  assert.equal(rejected.statusCode, 403);
+});
+
 test('Upstash command stores only a stable HMAC delivery digest and aggregate counter', async () => {
   const calls = [];
   const store = createPolarWebhookStore({ PATINA_OBSERVABILITY_REST_API_URL: 'https://observability.upstash.io/', PATINA_OBSERVABILITY_REST_API_TOKEN: 'token' }, async (...args) => {


### PR DESCRIPTION
## Fix
Vercel's plain Node `/api` helper may supply an already-parsed JSON body even with `bodyParser:false`. Re-serialize that object before Standard Webhooks verification.

This stays fail-closed: only an exact byte match to Polar's signed compact JSON is accepted. Arrays and oversized bodies remain rejected.

## Production evidence
A signed-shape smoke request reached `/api/polar-webhook` but returned 400 before signature/config evaluation, identifying the parsed-body adapter gap.

## Verification
- webhook unit tests: 6 pass, including parsed Vercel body acceptance and tamper rejection
- npm run lint: pass
- npm test: 1684 pass, 2 skipped