### PR TITLE
feat(dataset): add reviewed export and protected Hugging Face publishing

### DIFF
--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -1,0 +1,44 @@
+name: Publish benchmark dataset
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the reviewed export to the configured Hugging Face dataset
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  dataset:
+    if: github.repository == 'devswha/patina' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: hf-dataset-production
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Export hash-reviewed public fixtures
+        run: node scripts/export-hf-dataset.mjs --output artifacts/hf-export
+      - uses: actions/upload-artifact@v4
+        with:
+          name: patina-hf-dataset
+          path: artifacts/hf-export
+      - name: Publish reviewed main history
+        if: inputs.publish == true
+        env:
+          HF_TOKEN: ${{ secrets.HF_DATASET_WRITE_TOKEN }}
+          HF_DATASET_REPO: ${{ vars.HF_DATASET_REPO }}
+        run: |
+          test -n "$HF_TOKEN"
+          test -n "$HF_DATASET_REPO"
+          git fetch origin main
+          node scripts/publish-hf-dataset.mjs --directory artifacts/hf-export --repository "$HF_DATASET_REPO" --publish

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ custom/
 
 # Ops / runtime logs
 node_modules
+artifacts/hf-export/
 .env
 .gjc/
 plans/

--- a/docs/integrations/huggingface.md
+++ b/docs/integrations/huggingface.md
@@ -1,0 +1,34 @@
+# Hugging Face regression dataset
+
+The export contains the 49 public suspect-zone fixtures and their repository
+MIT license. It excludes private rebaseline texts and human-panel responses.
+The `ai` and `natural` classes describe fixture style; they do not establish
+authorship.
+
+```bash
+npm run dataset:export -- --output artifacts/hf-export
+npm run dataset:publish -- --directory artifacts/hf-export \
+  --repository OWNER/patina-suspect-zones
+```
+
+Publication is opt-in: add `--publish` and provide `HF_TOKEN` through the
+environment. The default command validates the bundle without network access.
+Use the authenticated account or an organization it can manage. The owner
+namespace must be selected explicitly; the tool never silently switches accounts.
+
+The per-file license review is
+`docs/research/hf-fixture-license-review.json`. A changed or additional fixture
+must be reviewed and committed before publication. The publisher verifies the
+export against that reviewed source and refuses unreviewed Git history,
+unmanaged target datasets, checksum changes and source downgrades.
+
+The **Publish benchmark dataset** workflow supports a manual dry run and an
+explicit publish run from reviewed main history. Configure the repository
+environment secret `HF_DATASET_WRITE_TOKEN` in `hf-dataset-production` and
+variable `HF_DATASET_REPO=OWNER/patina-suspect-zones` before publishing. Restrict
+that environment to the `main` branch. The job also checks out `main` explicitly
+and rejects dispatches from other branches. There is no automatic release upload until the namespace and
+credential configuration have been confirmed.
+
+The published URL and cross-links will be added after successful remote
+verification. An exported folder alone is not a published dataset.

--- a/docs/research/hf-fixture-license-review.json
+++ b/docs/research/hf-fixture-license-review.json
@@ -1,0 +1,303 @@
+{
+  "schemaVersion": 1,
+  "reviewedAt": "2026-09-04",
+  "scope": "49 repository regression fixtures only; no private rebaseline corpora or human-panel responses",
+  "licensePath": "LICENSE",
+  "licenseSha256": "558dbc06a12e4c33f5e042985713f286fce6897c68599ee0fe68e5de4c824df2",
+  "entries": [
+    {
+      "path": "tests/fixtures/suspect-zones/en/ai/en-ai-01.md",
+      "sha256": "c94f054bf15872040383bf65bd2db14647c52dac938515fb5e8e41654460c460",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/en/ai/en-ai-02.md",
+      "sha256": "6766d6621dd6decbc76fc3bc8f4ecda8a61f74e330177bcb07e545c47d9b7bf8",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/en/ai/en-ai-03.md",
+      "sha256": "e69661476677431d3093147222d505154af07dcf572f7e925cbf31f826ab43cf",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/en/ai/en-ai-04.md",
+      "sha256": "18185ad221967a72d09e583b81e17e5580251172acb9f255edcf65a6cccc3fa8",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/en/ai/en-ai-05.md",
+      "sha256": "90adbe0e557adb75b12a1c1bda8094e9452bb7d5b15b07ff139a1902fc07e41b",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/en/ai/en-ai-06-chat-register.md",
+      "sha256": "b48a8acb9e18fcc482fb6519cd6c20e6dfdd42a9bddcc762138b5027a026f741",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/en/ai/en-ai-07-discourse-candor.md",
+      "sha256": "2b305ec4aa96992f08f354a6fe75b8cf06ecacaa2cccc084d66727d94ba4fbd3",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/en/natural/en-nat-01.md",
+      "sha256": "061a84b5d26d22f1196da02a23860fbc3f6e37114a7d09c99777236c21629ecb",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/en/natural/en-nat-02.md",
+      "sha256": "8b634dd6ddf27f9b829b42def797b622ac010c93c85498ba64be74c013c27094",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/en/natural/en-nat-03.md",
+      "sha256": "9e11b1fc39cbc01f99dcb6ad23cfbe9f6d8134e28036c662e42ae8ede042e963",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/en/natural/en-nat-04.md",
+      "sha256": "4b5961115a59fc33bdcdeb8c7ea662b400b2b4ba2c51fe02a959ca9d9602e3b0",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/en/natural/en-nat-05.md",
+      "sha256": "413e0366aa525b5bbc82bfd975e92c05f82a3dcc4367bc2b6919dfeb4456a1d6",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/en/natural/en-nat-06-single-opener.md",
+      "sha256": "1030ea9d10b0e5e1b4efac5c3b748a8d3ed6d3b908879c787705035aae175076",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ja/ai/ja-ai-01.md",
+      "sha256": "5928e85d6e461839a4a3ba8560f74ed0ba24b543f83e9aa06c6e58a72ab44ca3",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ja/ai/ja-ai-02.md",
+      "sha256": "a9a1207331b2bf58ef0d0629c8bbcf7e17c03f057370280d5125663bfd722eb7",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ja/ai/ja-ai-03.md",
+      "sha256": "550faa1f5f7b3ebbbb0db38201dea13db2d406af09cb0f2c6818492d8c886090",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ja/ai/ja-ai-04-lexicon.md",
+      "sha256": "51586169a69f29c3c28e8c546e50e16c46e905778dc9320d577cda725b3c21c8",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ja/ai/ja-ai-05-formulaic-summary.md",
+      "sha256": "646859ea4d277ec02a13caca33a723944d74635e29c926ef0e1322b716569114",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ja/ai/ja-ai-06-broad-tech.md",
+      "sha256": "fa0f317ff9b79ba9378d51f17873832b57f5b6a347bc7746fe9d3741916a2779",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ja/natural/ja-nat-01.md",
+      "sha256": "eeb68b06f8cc49f69d3802ab7d9b92af47cd17d08f7dae16c2ed811fcab59c5a",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ja/natural/ja-nat-02.md",
+      "sha256": "81d76389c481b892d872e5076fd2ac8a2e69583b6c457b747abb49149e12bce4",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ja/natural/ja-nat-03.md",
+      "sha256": "b12de1b29bb8845556ad80ebb9613d10baa062cf36fad23947a0e977d9de96f2",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ja/natural/ja-nat-04-lexicon-cold.md",
+      "sha256": "ae4679681b31bf372ed3fb32e8301d6d8357fab1ed93016af8aca4afb3d4db04",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ja/natural/ja-nat-05-station-note.md",
+      "sha256": "a222bdbe175d9ad52aa2a9720dad280ec920077a9fff44b7822f70cf9aed280e",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ja/natural/ja-nat-06-maintenance-log.md",
+      "sha256": "88f631488f32437e005bcfca73e74e1eee0b1f661685e294fc896097a30c9294",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ko/ai/ko-ai-01.md",
+      "sha256": "cf89db1eeee7bb1f47976e42b0eaed0724bf1036a279dadae824bb03342a3fa2",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ko/ai/ko-ai-02.md",
+      "sha256": "15f86ce845a9401608157d7824d8039233056ea604d3e76049c38d8177aa610a",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ko/ai/ko-ai-03.md",
+      "sha256": "3fa51aa517877a73435b2bdeb37d617a6a2c46ffaae2156292375927453cfe0e",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ko/ai/ko-ai-04.md",
+      "sha256": "8fce516c0031cc5cca64e6ac122cdb372857fe69c66750cf73465a9fa16d902a",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ko/ai/ko-ai-05.md",
+      "sha256": "34f86794d623701dce9276ab8e246788cb9bb577a6e2e00b539787e6971f61d6",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ko/ai/ko-ai-06-chat-register.md",
+      "sha256": "72bf485f5f327c1bc86f4cd7767246abfc6164e89948249550d03656c58e6e92",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ko/ai/ko-ai-07-ko-diagnostic.md",
+      "sha256": "f121bab66810ecea109598e9f8cc6e47afb53427b7f9c08818145adba285ad36",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ko/natural/ko-nat-01.md",
+      "sha256": "cdbe22f0deaa8543d0753d8fac531a0e5356907b441940e8092247b69c1cafc7",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ko/natural/ko-nat-02.md",
+      "sha256": "cc58383459597584455c4b04a86f906d8464388911a9e5a2421406ce869f6e02",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ko/natural/ko-nat-03.md",
+      "sha256": "f150f7cd3b9343626a0ca4ce15d89a7b97486fd59771b1fe117f4e545d2ef9bf",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ko/natural/ko-nat-04.md",
+      "sha256": "733e881bae43db28d625971f80eab2ce6a42d48e2847904d9bc8cda4da635029",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/ko/natural/ko-nat-05.md",
+      "sha256": "2313e94cf1ac4f8a790df43ed98faed2abf9c74940ebd007c8cbcb713f283b0b",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/zh/ai/zh-ai-01.md",
+      "sha256": "fa0d7149e078f347b4a32f414d65f13c22da18d9e31a3066966d970afa0da71b",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/zh/ai/zh-ai-02.md",
+      "sha256": "dcb96b0b77ef655581a095ad8094ec877576c598fc9a1173beb1db7238199743",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/zh/ai/zh-ai-03.md",
+      "sha256": "948201f7d2cd666df5438fd31f03bf34b8eb0bfb1be0f50b1902b458d6ed565b",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/zh/ai/zh-ai-04-lexicon.md",
+      "sha256": "7cf41ca65763c499a050b0dec98404a07e5486ce1144c00aa9766c7e2f17df3d",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/zh/ai/zh-ai-05-formulaic-summary.md",
+      "sha256": "b64635fdb718aa4c24188174f0d9778edec42e523bf8d20aa1d5125e4bdba83d",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/zh/ai/zh-ai-06-broad-tech.md",
+      "sha256": "a2e69c1da1124460c5a2b9e22e1949dff865f9a9fe279a0763e79e9bf9fe42f5",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/zh/natural/zh-nat-01.md",
+      "sha256": "2005534f5671e7ac91eb496ad230370e512b37d4eb7dbc2354f13c4ccd4338d3",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/zh/natural/zh-nat-02.md",
+      "sha256": "c45b0494e156a36eb3506211b13becbabbeaba44ac81544b7d6595cca91996cf",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/zh/natural/zh-nat-03.md",
+      "sha256": "4d3a350c0b67aceb9bf0e2803bfb5999b512e571ce76f2acdcabff9a7551f7fa",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/zh/natural/zh-nat-04-lexicon-cold.md",
+      "sha256": "7f8c2155993628cfbbcab35334354355ce73e013eee09f38df6b96bdd5121390",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/zh/natural/zh-nat-05-market-note.md",
+      "sha256": "c5e73f0b576276c8eba3119b4592e7338b2cacafd94fbe7a6a4404488aed9f86",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    },
+    {
+      "path": "tests/fixtures/suspect-zones/zh/natural/zh-nat-06-maintenance-log.md",
+      "sha256": "8f02bf759586fc74d9f0bfed6c289aaa5afe8dab63f67b445e6b8340737c73c2",
+      "license": "MIT",
+      "basis": "Repository MIT license; inspected regression fixture, no external attribution or redistribution restriction in its metadata. Authorship is not independently certified."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "scripts": {
     "test": "node --test tests/unit/*.test.js tests/e2e/*.test.js",
     "test:unit": "node --test tests/unit/*.test.js",
+    "dataset:export": "node scripts/export-hf-dataset.mjs",
+    "dataset:publish": "node scripts/publish-hf-dataset.mjs",
     "launch-config:generate": "node scripts/generate-launch-config.mjs",
     "test:e2e": "node --test tests/e2e/*.test.js",
     "benchmark": "node tests/quality/benchmark.mjs",

--- a/scripts/export-hf-dataset.mjs
+++ b/scripts/export-hf-dataset.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { closeSync, constants, existsSync, lstatSync, mkdirSync, openSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { dirname, resolve, sep } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+export const DATASET_FILES = ['README.md', 'LICENSE', 'data/test.jsonl', 'source-manifest.json'];
+export const sha256 = (value) => createHash('sha256').update(value).digest('hex');
+
+export function exportDataset({ repoRoot = ROOT, output, sourceCommit } = {}) {
+  if (!output) throw new Error('An output directory is required');
+  const directory = resolve(output);
+  if (directory === resolve(repoRoot) || existsSync(resolve(directory, '.git'))) throw new Error('Refusing to overwrite a repository root');
+  const review = JSON.parse(readFileSync(resolve(repoRoot, 'docs/research/hf-fixture-license-review.json'), 'utf8'));
+  if (review.licensePath !== 'LICENSE') throw new Error('Only the repository LICENSE may be exported');
+  const license = readFileSync(resolve(repoRoot, review.licensePath));
+  if (review.schemaVersion !== 1 || sha256(license) !== review.licenseSha256) throw new Error('License review is missing or stale');
+  const tracked = execFileSync('git', ['-C', repoRoot, 'ls-files', 'tests/fixtures/suspect-zones/*/*/*.md'], { encoding: 'utf8' }).trim().split('\n').filter(Boolean).sort();
+  const reviewed = review.entries.map((entry) => entry.path).sort();
+  if (new Set(reviewed).size !== reviewed.length || JSON.stringify(tracked) !== JSON.stringify(reviewed)) throw new Error('The fixture set changed; review redistribution before exporting');
+  const commit = sourceCommit || execFileSync('git', ['-C', repoRoot, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+  if (!/^[a-f0-9]{40}$/.test(commit)) throw new Error('Source commit must be a full Git SHA');
+  const version = JSON.parse(execFileSync('git', ['-C', repoRoot, 'show', `${commit}:package.json`], { encoding: 'utf8' })).version;
+  if (sha256(execFileSync('git', ['-C', repoRoot, 'show', `${commit}:LICENSE`])) !== sha256(license)) throw new Error('License is not bound to the source commit');
+  const rows = [];
+  for (const entry of [...review.entries].sort((a, b) => a.path.localeCompare(b.path))) {
+    if (!/^tests\/fixtures\/suspect-zones\/(en|ko|zh|ja)\/(ai|natural)\/[a-z0-9-]+\.md$/.test(entry.path) || entry.license !== 'MIT') throw new Error('Unapproved fixture path or license');
+    const path = resolve(repoRoot, entry.path);
+    if (!realpathSync(path).startsWith(realpathSync(resolve(repoRoot, 'tests/fixtures/suspect-zones')) + sep)) throw new Error('Fixture escaped the reviewed tree');
+    const bytes = readFileSync(path);
+    if (sha256(bytes) !== entry.sha256) throw new Error(`Fixture changed after license review: ${entry.path}`);
+    if (sha256(execFileSync('git', ['-C', repoRoot, 'show', `${commit}:${entry.path}`])) !== entry.sha256) throw new Error('Uncommitted fixture cannot be published as a committed source');
+    const match = bytes.toString('utf8').match(/^---\r?\n([\s\S]*?)\r?\n---\s*\r?\n([\s\S]*)$/);
+    if (!match) throw new Error('Missing fixture metadata');
+    const meta = yaml.load(match[1]); const text = match[2].trim();
+    if (!text || typeof meta.fixture_id !== 'string' || !/^[a-z0-9-]+$/.test(meta.fixture_id)
+      || !['en', 'ko', 'zh', 'ja'].includes(meta.language) || !['ai', 'natural'].includes(meta.class) || typeof meta.expected_hot !== 'boolean'
+      || !entry.path.includes(`/${meta.language}/${meta.class}/`)) throw new Error('Invalid fixture data');
+    rows.push({ id: meta.fixture_id, language: meta.language, style_class: meta.class, expected_hot: meta.expected_hot,
+      text, text_sha256: sha256(text), source_path: entry.path, source_sha256: entry.sha256, license: 'MIT',
+      provenance: 'Designed repository regression fixture; not a verified human/AI authorship label' });
+  }
+  if (new Set(rows.map((row) => row.id)).size !== rows.length) throw new Error('Duplicate fixture IDs');
+  const counts = Object.fromEntries(['en', 'ko', 'zh', 'ja'].map((lang) => [lang, { total: rows.filter((row) => row.language === lang).length,
+    hot: rows.filter((row) => row.language === lang && row.expected_hot).length }]));
+  const data = `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`;
+  const manifest = { schemaVersion: 1, sourceRepository: 'devswha/patina', sourceCommit: commit, sourceVersion: version,
+    rowCount: rows.length, languages: counts, dataSha256: sha256(data), licenseSha256: sha256(license),
+    licenseReviewSha256: sha256(readFileSync(resolve(repoRoot, 'docs/research/hf-fixture-license-review.json'))) };
+  const card = datasetCard(manifest);
+  const files = { 'README.md': card, LICENSE: license.toString('utf8'), 'data/test.jsonl': data,
+    'source-manifest.json': `${JSON.stringify(manifest, null, 2)}\n` };
+  const priorPath = resolve(directory, 'source-manifest.json');
+  if (DATASET_FILES.some((name) => existsSync(resolve(directory, name)))) {
+    if (!existsSync(priorPath)) throw new Error('Output contains files not owned by this exporter');
+    const prior = JSON.parse(readFileSync(priorPath, 'utf8'));
+    if (prior.sourceRepository !== 'devswha/patina' || !prior.fileHashes) throw new Error('Output ownership cannot be verified');
+    for (const name of DATASET_FILES.filter((name) => name !== 'source-manifest.json')) {
+      if (!existsSync(resolve(directory, name)) || sha256(readFileSync(resolve(directory, name))) !== prior.fileHashes[name]) throw new Error('Exported file was edited; choose a new output directory');
+    }
+  }
+  manifest.fileHashes = Object.fromEntries(Object.entries(files).filter(([name]) => name !== 'source-manifest.json').map(([name, value]) => [name, sha256(value)]));
+  files['source-manifest.json'] = `${JSON.stringify(manifest, null, 2)}\n`;
+  mkdirSync(resolve(directory, 'data'), { recursive: true });
+  const realOutput = realpathSync(directory);
+  if (!realpathSync(resolve(directory, 'data')).startsWith(realOutput + sep)) throw new Error('Export data directory escaped the output root');
+  for (const [name, content] of Object.entries(files)) {
+    const path = resolve(directory, name);
+    if (lstatSync(path, { throwIfNoEntry: false })?.isSymbolicLink()) throw new Error('Refusing to overwrite a symlink');
+    const fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | (constants.O_NOFOLLOW || 0), 0o644);
+    try { writeFileSync(fd, content); } finally { closeSync(fd); }
+  }
+  return { directory, manifest, files: DATASET_FILES };
+}
+
+export function datasetCard(manifest) {
+  const breakdown = Object.entries(manifest.languages).map(([lang, count]) => `| ${lang} | ${count.total} | ${count.hot} | ${count.total - count.hot} |`).join('\n');
+  return `---
+pretty_name: Patina suspect-zone regression fixtures
+license: mit
+language:
+  - en
+  - ko
+  - zh
+  - ja
+task_categories:
+  - text-classification
+tags:
+  - writing-assistance
+  - stylometry
+  - regression-tests
+configs:
+  - config_name: default
+    data_files:
+      - split: test
+        path: data/test.jsonl
+---
+
+# Patina suspect-zone regression fixtures
+
+These ${manifest.rowCount} fixtures test whether Patina flags paragraphs as editing
+hotspots. They were designed to exercise known stylometry, lexicon and discourse
+signals. **The labels do not certify who wrote a text.** A \`natural\` style class
+is a regression control, not evidence of human authorship.
+
+Source: [devswha/patina](https://github.com/devswha/patina), version
+${manifest.sourceVersion}, commit \`${manifest.sourceCommit}\`. Every row preserves its
+source path, source-file hash, text hash and repository MIT license.
+
+| Language | Total | Expected hot | Natural-style controls |
+|---|---:|---:|---:|
+${breakdown}
+
+## Fields and intended use
+
+- \`text\`: the fixture body, without YAML metadata.
+- \`language\`: en, ko, zh or ja.
+- \`style_class\`: the source fixture's ai/natural design label.
+- \`expected_hot\`: expected editing-hotspot result from the regression suite.
+- \`source_path\`, \`source_sha256\`, \`text_sha256\`: source/provenance checks.
+
+Use the test split to reproduce deterministic regressions. The repository's
+[benchmark report](https://github.com/devswha/patina/blob/${manifest.sourceCommit}/docs/benchmarks/latest.md)
+describes the measured result and uncertainty for that exact fixture suite.
+Run \`npm run benchmark\` in the corresponding checkout to reproduce it.
+
+## Limits
+
+This is a small, intentionally constructed set, not an independent sample of
+real-world writing. It cannot support authorship accusations, detector-bypass
+claims, or broad language/model accuracy claims. It contains no private
+rebaseline generations, user submissions or human-panel ratings. The separate
+600-generated/200-human rebaseline is not this dataset.
+
+## Licensing and maintenance
+
+The included LICENSE is the source repository's MIT license. The checked-in
+per-file redistribution review pins all fixture hashes; adding or changing a
+fixture requires a review update before export. Review evidence establishes the
+repository licensing basis, not independently verified authorship.
+
+This card and split are generated from the source repository. Submit corrections
+there so future releases retain them. \`source-manifest.json\` records the source
+version, commit and dataset checksum.
+`;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  let output;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--output' && argv[i + 1]) output = argv[++i];
+    else if (argv[i] === '--help') { console.log('export-hf-dataset --output DIRECTORY'); return; }
+    else throw new Error(`Unknown argument: ${argv[i]}`);
+  }
+  const result = exportDataset({ output });
+  console.log(JSON.stringify({ output: result.directory, rows: result.manifest.rowCount, sourceCommit: result.manifest.sourceCommit }));
+}
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/publish-hf-dataset.mjs
+++ b/scripts/publish-hf-dataset.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import { mkdtempSync, readFileSync, realpathSync, rmSync } from 'node:fs';
+import { dirname, resolve, sep } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { DATASET_FILES, exportDataset, sha256 } from './export-hf-dataset.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const HUB = 'https://huggingface.co';
+
+export function readDatasetBundle(directory) {
+  const root = realpathSync(directory);
+  const files = DATASET_FILES.map((name) => {
+    const path = realpathSync(resolve(root, name));
+    if (!path.startsWith(root + sep)) throw new Error('Dataset file escaped its export directory');
+    const content = readFileSync(path);
+    if (content.length > 1024 * 1024) throw new Error('Dataset file exceeds the regular-file publication limit');
+    return { path: name, content };
+  });
+  const manifest = JSON.parse(files.find((file) => file.path === 'source-manifest.json').content.toString('utf8'));
+  if (manifest.schemaVersion !== 1 || manifest.sourceRepository !== 'devswha/patina' || !/^[a-f0-9]{40}$/.test(manifest.sourceCommit)) throw new Error('Invalid source manifest');
+  for (const file of files.filter((file) => file.path !== 'source-manifest.json')) if (manifest.fileHashes?.[file.path] !== sha256(file.content)) throw new Error('Dataset export checksum mismatch');
+  if (manifest.dataSha256 !== sha256(files.find((file) => file.path === 'data/test.jsonl').content)) throw new Error('Dataset data checksum mismatch');
+  return { files, manifest };
+}
+
+export async function publishDataset({ directory, repository, token, fetchImpl = globalThis.fetch, dryRun = true, repoRoot = ROOT } = {}) {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*\/patina-suspect-zones$/.test(repository || '')) throw new Error('Explicit owner/patina-suspect-zones repository is required');
+  const bundle = readDatasetBundle(directory);
+  if (dryRun) return { dryRun: true, repository, files: bundle.files.map((file) => file.path), rows: bundle.manifest.rowCount };
+  if (!token) throw new Error('HF_TOKEN is required for publication');
+  // Publish only data sourced from the reviewed released/integration history.
+  execFileSync('git', ['-C', repoRoot, 'merge-base', '--is-ancestor', bundle.manifest.sourceCommit, 'origin/main']);
+  const reviewed = execFileSync('git', ['-C', repoRoot, 'show', `${bundle.manifest.sourceCommit}:docs/research/hf-fixture-license-review.json`]);
+  if (sha256(reviewed) !== bundle.manifest.licenseReviewSha256) throw new Error('Redistribution review is not bound to the source commit');
+  const verification = mkdtempSync(resolve(tmpdir(), 'patina-hf-verify-'));
+  try {
+    exportDataset({ repoRoot, output: verification, sourceCommit: bundle.manifest.sourceCommit });
+    for (const file of bundle.files) if (sha256(file.content) !== sha256(readFileSync(resolve(verification, file.path)))) throw new Error('Bundle differs from the reviewed source export');
+  } finally { rmSync(verification, { recursive: true, force: true }); }
+  const request = async (path, { method = 'GET', body, contentType = 'application/json', allow404 = false } = {}) => {
+    const controller = new AbortController(); const timer = setTimeout(() => controller.abort(), 30000);
+    try {
+      let url = new URL(path, HUB);
+      let response;
+      for (let redirects = 0; redirects < 4; redirects++) {
+        response = await fetchImpl(url.toString(), { method, redirect: 'manual', signal: controller.signal,
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': contentType, Accept: 'application/json' }, body });
+        if (![301, 302, 303, 307, 308].includes(response.status)) break;
+        if (method !== 'GET') throw new Error('Refusing a redirected mutation');
+        const target = new URL(response.headers.get('location'), url);
+        if (target.origin !== HUB || target.username || target.password) throw new Error('Refusing a cross-origin authenticated redirect');
+        url = target;
+      }
+      if (allow404 && response.status === 404) return null;
+      if (!response.ok) throw new Error(`Hugging Face request failed (HTTP ${response.status})`);
+      return await response.json();
+    } finally { clearTimeout(timer); }
+  };
+  const user = await request('/api/whoami-v2');
+  const [owner, name] = repository.split('/');
+  if (owner !== user.name && !(user.orgs || []).some((org) => org.name === owner)) throw new Error('Authenticated Hugging Face namespace differs from the requested repository');
+  let remote = await request(`/api/datasets/${repository}`, { allow404: true });
+  if (!remote) {
+    await request('/api/repos/create', { method: 'POST', body: JSON.stringify({ type: 'dataset', name, organization: owner, private: false }) });
+    remote = await request(`/api/datasets/${repository}`);
+  } else {
+    if (remote.private === true) throw new Error('Refusing to change an existing private dataset');
+    const existing = await request(`/datasets/${repository}/resolve/main/source-manifest.json`, { allow404: true });
+    if (!existing || existing.sourceRepository !== 'devswha/patina') throw new Error('Refusing to overwrite an unrelated or unmanaged dataset');
+    if (!/^[a-f0-9]{40}$/.test(existing.sourceCommit || '')) throw new Error('Existing dataset source is invalid');
+    execFileSync('git', ['-C', repoRoot, 'merge-base', '--is-ancestor', existing.sourceCommit, bundle.manifest.sourceCommit]);
+  }
+  if (!/^[a-f0-9]{40}$/.test(remote.sha || '')) throw new Error('Hugging Face did not return a commit to compare against');
+  const operations = [{ key: 'header', value: { summary: `Refresh Patina ${bundle.manifest.sourceVersion} regression fixtures`,
+    description: `Reviewed source ${bundle.manifest.sourceCommit}`, parentCommit: remote.sha } },
+  ...bundle.files.map((file) => ({ key: 'file', value: { path: file.path, encoding: 'base64', content: file.content.toString('base64') } }))];
+  const commit = await request(`/api/datasets/${repository}/commit/main`, { method: 'POST', contentType: 'application/x-ndjson',
+    body: `${operations.map((operation) => JSON.stringify(operation)).join('\n')}\n` });
+  if (!/^[a-f0-9]{40}$/.test(commit.commitOid || '')) throw new Error('Publication returned no verifiable commit');
+  const verify = await request(`/api/datasets/${repository}`);
+  if (verify.sha !== commit.commitOid) throw new Error('Published dataset head could not be verified');
+  for (const file of bundle.files) {
+    const controller = new AbortController(); const timer = setTimeout(() => controller.abort(), 30000);
+    try {
+      // These files are public. CDN redirects never receive the account token.
+      const response = await fetchImpl(`${HUB}/datasets/${repository}/resolve/${commit.commitOid}/${file.path}`, {
+        method: 'GET', redirect: 'follow', signal: controller.signal, headers: { Accept: 'application/octet-stream' },
+      });
+      if (!response.ok) throw new Error(`Published file unavailable (HTTP ${response.status})`);
+      const content = Buffer.from(await response.arrayBuffer());
+      if (sha256(content) !== sha256(file.content)) throw new Error('Published file checksum mismatch');
+    } finally { clearTimeout(timer); }
+  }
+  return { dryRun: false, repository, commit: commit.commitOid, rows: bundle.manifest.rowCount };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = { dryRun: true };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--publish') options.dryRun = false;
+    else if (argv[i] === '--directory' && argv[i + 1]) options.directory = argv[++i];
+    else if (argv[i] === '--repository' && argv[i + 1]) options.repository = argv[++i];
+    else if (argv[i] === '--help') { console.log('publish-hf-dataset --directory EXPORT --repository OWNER/patina-suspect-zones [--publish]'); return; }
+    else throw new Error(`Unknown argument: ${argv[i]}`);
+  }
+  console.log(JSON.stringify(await publishDataset({ ...options, token: process.env.HF_TOKEN })));
+}
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main().catch((error) => { console.error(error.message); process.exitCode = 1; });

--- a/tests/unit/hf-dataset.test.js
+++ b/tests/unit/hf-dataset.test.js
@@ -1,0 +1,127 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { cpSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { DATASET_FILES, exportDataset, sha256 } from '../../scripts/export-hf-dataset.mjs';
+import { publishDataset, readDatasetBundle } from '../../scripts/publish-hf-dataset.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+function fixtureRepository() {
+  const root = mkdtempSync(join(tmpdir(), 'patina-hf-test-'));
+  for (const path of ['LICENSE', 'package.json', 'docs/research/hf-fixture-license-review.json']) {
+    mkdirSync(dirname(join(root, path)), { recursive: true }); cpSync(join(ROOT, path), join(root, path));
+  }
+  cpSync(join(ROOT, 'tests/fixtures/suspect-zones'), join(root, 'tests/fixtures/suspect-zones'), { recursive: true });
+  const git = (...args) => execFileSync('git', ['-C', root, '-c', 'core.hooksPath=/dev/null', '-c', 'commit.gpgsign=false', '-c', 'user.name=Fixture', '-c', 'user.email=fixture@example.invalid', ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+  git('init'); git('add', '.'); git('commit', '-m', 'fixture'); git('update-ref', 'refs/remotes/origin/main', 'HEAD');
+  return { root, git, output: join(root, 'export') };
+}
+
+test('export preserves all 49 reviewed fixtures, labels, licensing and provenance deterministically', () => {
+  const f = fixtureRepository();
+  try {
+    const first = exportDataset({ repoRoot: f.root, output: f.output });
+    assert.equal(first.manifest.rowCount, 49);
+    assert.deepEqual(Object.fromEntries(Object.entries(first.manifest.languages).map(([lang, value]) => [lang, value.total])), { en: 13, ko: 12, zh: 12, ja: 12 });
+    const original = readFileSync(join(f.output, 'data/test.jsonl'), 'utf8');
+    exportDataset({ repoRoot: f.root, output: f.output });
+    assert.equal(readFileSync(join(f.output, 'data/test.jsonl'), 'utf8'), original);
+    const rows = original.trim().split('\n').map(JSON.parse);
+    assert.equal(new Set(rows.map((row) => row.id)).size, 49);
+    for (const row of rows) { assert.equal(row.license, 'MIT'); assert.equal(sha256(row.text), row.text_sha256); }
+    assert.match(readFileSync(join(f.output, 'README.md'), 'utf8'), /do not certify who wrote/);
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('unreviewed and uncommitted fixture changes cannot be exported', () => {
+  const f = fixtureRepository();
+  try {
+    const reviewPath = join(f.root, 'docs/research/hf-fixture-license-review.json');
+    const review = JSON.parse(readFileSync(reviewPath, 'utf8')); const row = review.entries[0];
+    writeFileSync(join(f.root, row.path), readFileSync(join(f.root, row.path), 'utf8') + '\nNew content.\n');
+    assert.throws(() => exportDataset({ repoRoot: f.root, output: f.output }), /changed after license review/);
+    row.sha256 = sha256(readFileSync(join(f.root, row.path))); writeFileSync(reviewPath, JSON.stringify(review));
+    assert.throws(() => exportDataset({ repoRoot: f.root, output: f.output }), /Uncommitted fixture/);
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('exports do not overwrite unmanaged or edited output files', () => {
+  const f = fixtureRepository();
+  try {
+    mkdirSync(f.output); writeFileSync(join(f.output, 'README.md'), 'user content');
+    assert.throws(() => exportDataset({ repoRoot: f.root, output: f.output }), /not owned/);
+    rmSync(f.output, { recursive: true }); exportDataset({ repoRoot: f.root, output: f.output });
+    writeFileSync(join(f.output, 'README.md'), 'user edits');
+    assert.throws(() => exportDataset({ repoRoot: f.root, output: f.output }), /edited/);
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('dangling output symlinks cannot create files outside the export', () => {
+  const f = fixtureRepository();
+  try {
+    mkdirSync(f.output); const outside = join(f.root, 'unrelated.txt');
+    symlinkSync(outside, join(f.output, 'README.md'));
+    assert.throws(() => exportDataset({ repoRoot: f.root, output: f.output }), /symlink/);
+    assert.equal(existsSync(outside), false);
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('source version is read from the declared commit, not working-tree edits', () => {
+  const f = fixtureRepository();
+  try {
+    const expected = JSON.parse(readFileSync(join(f.root, 'package.json'), 'utf8')).version;
+    const pkg = JSON.parse(readFileSync(join(f.root, 'package.json'), 'utf8')); pkg.version = '99.99.99';
+    writeFileSync(join(f.root, 'package.json'), JSON.stringify(pkg));
+    const result = exportDataset({ repoRoot: f.root, output: f.output });
+    assert.equal(result.manifest.sourceVersion, expected);
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('bundle checks refuse tampering and path escapes; dry runs never use the network', async () => {
+  const f = fixtureRepository();
+  try {
+    exportDataset({ repoRoot: f.root, output: f.output });
+    const result = await publishDataset({ repoRoot: f.root, directory: f.output, repository: 'devswha/patina-suspect-zones', fetchImpl: () => assert.fail('dry-run network call') });
+    assert.equal(result.dryRun, true); assert.deepEqual(result.files, DATASET_FILES);
+    writeFileSync(join(f.output, 'data/test.jsonl'), 'private substitute');
+    assert.throws(() => readDatasetBundle(f.output), /checksum/);
+    rmSync(join(f.output, 'data/test.jsonl')); symlinkSync(join(f.root, 'LICENSE'), join(f.output, 'data/test.jsonl'));
+    assert.throws(() => readDatasetBundle(f.output), /escaped/);
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('publication validates owner, pins parent commit, and uploads only reviewed files', async () => {
+  const f = fixtureRepository();
+  try {
+    exportDataset({ repoRoot: f.root, output: f.output });
+    const old = '1'.repeat(40); const current = '2'.repeat(40); let created = false; let committed = false;
+    const json = (value, status = 200) => new Response(JSON.stringify(value), { status, headers: { 'Content-Type': 'application/json' } });
+    const calls = [];
+    const fetchImpl = async (url, options) => {
+      calls.push({ url, options }); assert.ok(url.startsWith('https://huggingface.co/'));
+      if (url.includes(`/resolve/${current}/`)) {
+        assert.equal(options.headers.Authorization, undefined);
+        const path = url.split(`/resolve/${current}/`)[1];
+        return new Response(readFileSync(join(f.output, path)), { status: 200 });
+      }
+      if (url.endsWith('/api/whoami-v2')) return json({ name: 'devswha', orgs: [] });
+      if (url.endsWith('/api/repos/create')) { created = true; assert.equal(JSON.parse(options.body).private, false); return json({}); }
+      if (url.endsWith('/commit/main')) {
+        const operations = options.body.trim().split('\n').map(JSON.parse);
+        assert.equal(operations[0].value.parentCommit, old);
+        assert.deepEqual(operations.slice(1).map((row) => row.value.path), DATASET_FILES);
+        for (const operation of operations.slice(1)) assert.deepEqual(Buffer.from(operation.value.content, 'base64'), readFileSync(join(f.output, operation.value.path)));
+        committed = true; return json({ commitOid: current });
+      }
+      return created ? json({ sha: committed ? current : old }) : json({}, 404);
+    };
+    const result = await publishDataset({ repoRoot: f.root, directory: f.output, repository: 'devswha/patina-suspect-zones', token: 'test-token', fetchImpl, dryRun: false });
+    assert.equal(result.commit, current); assert.equal(result.rows, 49);
+    assert.equal(calls.filter((call) => call.options.method === 'POST').length, 2);
+    await assert.rejects(publishDataset({ repoRoot: f.root, directory: f.output, repository: 'someone-else/patina-suspect-zones', token: 'test-token', dryRun: false,
+      fetchImpl: async () => json({ name: 'devswha', orgs: [] }) }), /namespace differs/);
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
Add a reproducible Hugging Face export of the 49 public suspect-zone regression fixtures, with per-file licensing review, source hashes, a dataset card and a test split. Labels describe editing hotspots and natural-style controls, not verified authorship. Private corpora and human-panel responses are excluded.

Publication is explicit and guarded by checksums, reviewed main ancestry, source review, namespace ownership, parent-commit checks and commit-specific remote file verification. The manual workflow uses reviewed main code and a main-restricted `hf-dataset-production` environment; no publishing credential has been configured yet.

Validation: seven focused tests, full tests/lint/typecheck and release metadata checks passed; independent read-only review passed. Namespace selection remains pending because the connected Hugging Face account is `devsw` while #212 names `devswha`. No remote dataset has been published yet. Refs #212.
