### PR TITLE
feat: add community pattern pack management

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -15,6 +15,58 @@ Patina ships 184 pattern entries across four languages. The language-specific re
 - Viral-hook patterns are score/audit-only SNS-marketing signals. They affect `--score` and `--audit`, but rewrite modes skip them because the rhetoric may be intentional.
 - Pattern packs are auto-discovered from `patterns/{lang}-*.md`. To add a language or custom pack, follow [CONTRIBUTING.md](../CONTRIBUTING.md) and the frontmatter format used in the existing packs.
 
+## Community Packs
+
+Community packs add prompt patterns through a separate unsigned GitHub distribution
+path. They do not require a Pro license. `patina pack` remains the licensed Pro
+pack command.
+
+```bash
+patina pattern install en-corporate-bizspeak
+patina pattern list
+patina pattern remove en-corporate-bizspeak
+```
+
+Short names resolve under `devswha/patina-community-packs`, in `packs/<name>`.
+You can also pass `https://github.com/OWNER/REPO/tree/REF/DIRECTORY`. Use a tag,
+commit, or branch without slashes. The installer resolves it to a full commit
+before reading `pack.yaml` and every pattern file. Downloads use public HTTPS
+without credentials; redirects, scripts and archive extraction are unsupported.
+
+The manifest requires these fields:
+
+```yaml
+name: en-corporate-bizspeak
+version: 1.0.0
+language: en
+patterns:
+  - en-community-corporate-bizspeak.md
+compatibility:
+  min: 8.2.0
+  maxExclusive: 9.0.0
+author: devswha
+license: MIT
+```
+
+Pattern files use `LANG-community-NAME.md` and the regular pattern frontmatter:
+`pack` matching the filename stem, `language`, `version`, positive `patterns`
+count, and optional `phase` or `score_only`. Include fire conditions, exclusions,
+meaning-preservation notes, and before/after examples in each pattern's body.
+
+Installation publishes a complete pack directory into this CLI installation's
+`custom/community-packs/`. It never replaces built-in, Pro or hand-written
+custom patterns. Remove an unchanged installation before installing a newer
+version. Locally edited or unrecognized files block loading/removal so they can
+be preserved. A CLI reinstall can replace its installation directory; keep your
+source packs separately. `list` and `remove` work offline; `--json` is available
+on all three commands.
+
+Installed patterns participate in prompt-based rewriting and audit/scoring.
+They do not add deterministic detector features. The Node loader reads the
+managed directory; the agent skill's orchestration is unchanged. Packs are
+unsigned instructions from their authors, so install only sources you trust.
+Stored hashes detect later local changes, not malicious authorship.
+
 ## Supporting References
 
 - [Scoring](../core/scoring.md) — category weights, AI-likeness score, fidelity, and MPS

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,6 +3,7 @@ import { runDoctor } from './commands/doctor.js';
 import { runPersona } from './commands/persona.js';
 import { runPack } from './commands/pack.js';
 import { runInspect } from './commands/inspect.js';
+import { runPattern } from './commands/pattern.js';
 import { handleAuth, printBackendStatus } from './commands/auth.js';
 import { parseArgs, validateModeExclusivity, validateOfflineScoreRequest, validateServeRequest, validatePreviewRequest, validateOutputRouting, validateTransformRequest, validatePersonaRequest, validateVerifyRequest, validateXliffRequest, printHelp } from './cli/args.js';
 import { runDefault } from './cli/run.js';
@@ -30,6 +31,7 @@ const PACKAGE_VERSION = JSON.parse(
  * await main(['--help']);
  */
 export async function main(args) {
+  if (args[0] === 'pattern') return runPattern(args.slice(1));
   if (args[0] === 'inspect') return runInspect(args.slice(1));
   if (args[0] === 'auth') {
     return handleAuth(args.slice(1));

--- a/src/cli/args.js
+++ b/src/cli/args.js
@@ -777,6 +777,9 @@ COMMANDS
   patina persona rm <id>   Remove a custom Persona (built-ins are protected)
   patina pack list         List licensed pro packs (needs PATINA_LICENSE_KEY)
   patina pack install <id> Install a pro pack into custom/
+  patina pattern install <name|URL> Install an unsigned community pattern pack
+  patina pattern list     List installed community pattern packs
+  patina pattern remove <name> Remove an unchanged community pattern pack
 
 MODES
   --diff                  Show changes pattern by pattern

--- a/src/commands/pattern.js
+++ b/src/commands/pattern.js
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getRepoRoot } from '../config.js';
+import { inputError } from '../errors.js';
+import { installCommunityPack, listCommunityPacks, removeCommunityPack } from '../community-patterns.js';
+
+export async function runPattern(args, { repoRoot = getRepoRoot(), fetchImpl = globalThis.fetch, out = console.log } = {}) {
+  const json = args.includes('--json');
+  const positional = args.filter((arg) => arg !== '--json');
+  const [command, name, ...extra] = positional;
+  if (!command || command === 'help' || command === '--help') {
+    out('patina pattern — community pattern packs\n\n  patina pattern install <name|GitHub-tree-URL> [--json]\n  patina pattern list [--json]\n  patina pattern remove <name> [--json]\n\nInstalls into this CLI installation\'s custom/community-packs/. Packs are unsigned prompt content. Only install sources you trust.');
+    return;
+  }
+  if (!['install', 'list', 'remove'].includes(command) || extra.length || (command === 'list' ? name : !name) || positional.some((arg) => arg.startsWith('-'))) {
+    throw inputError('invalid pattern command', 'Supported: install <name|URL>, list, remove <name>; optional --json.', 'Run `patina pattern help`.');
+  }
+  const version = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')).version;
+  let result;
+  if (command === 'list') result = { packs: listCommunityPacks(repoRoot) };
+  else if (command === 'remove') result = removeCommunityPack(name, { repoRoot });
+  else result = await installCommunityPack(name, { repoRoot, version, fetchImpl });
+  if (json) out(JSON.stringify(result, null, 2));
+  else if (command === 'list') out(result.packs.length ? result.packs.map((pack) => `${pack.name}\t${pack.version || '?'}\t${pack.status}${pack.error ? `: ${pack.error}` : ''}`).join('\n') : 'No community pattern packs installed.');
+  else if (command === 'remove') out(`Removed ${result.removed}.`);
+  else out(`Installed ${result.name}@${result.version} from commit ${result.source.commit}.`);
+}

--- a/src/community-patterns.js
+++ b/src/community-patterns.js
@@ -1,0 +1,208 @@
+import { createHash } from 'node:crypto';
+import { closeSync, constants, existsSync, lstatSync, mkdirSync, mkdtempSync, openSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import yaml from 'js-yaml';
+
+const NAME = /^(?:en|ko|zh|ja)-[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const LIMIT = 128 * 1024;
+const digest = (text) => createHash('sha256').update(text).digest('hex');
+const fail = (message) => { throw new Error(`community pattern pack: ${message}`); };
+const compare = (a, b) => { const x = a.split('.').map(Number), y = b.split('.').map(Number); return Math.sign(x[0] - y[0] || x[1] - y[1] || x[2] - y[2]); };
+const mapping = (x) => x && typeof x === 'object' && !Array.isArray(x);
+const hasControls = (text) => [...text].some((char) => char.charCodeAt(0) < 32 || char.charCodeAt(0) === 127);
+const stableVersion = (value) => typeof value === 'string' && VERSION.test(value);
+
+export function validateCommunityManifest(value, version) {
+  if (!mapping(value)) fail('pack.yaml must be a mapping');
+  if (typeof value.name !== 'string' || value.name.length > 80 || !NAME.test(value.name)) fail('invalid pack name');
+  if (!['en', 'ko', 'zh', 'ja'].includes(value.language) || !value.name.startsWith(`${value.language}-`)) fail('name/language mismatch');
+  if (!stableVersion(value.version)) fail('version must be a stable x.y.z string');
+  for (const key of ['author', 'license']) if (typeof value[key] !== 'string' || !value[key].trim() || value[key].length > 200 || hasControls(value[key])) fail(`invalid ${key}`);
+  const range = value.compatibility;
+  if (!mapping(range) || !stableVersion(range.min) || !stableVersion(range.maxExclusive) || compare(range.min, range.maxExclusive) >= 0) fail('compatibility requires min and maxExclusive stable versions');
+  if (Object.keys(range).some((key) => !['min', 'maxExclusive'].includes(key))) fail('unknown compatibility field');
+  if (version && (compare(version, range.min) < 0 || compare(version, range.maxExclusive) >= 0)) fail(`requires Patina >=${range.min} <${range.maxExclusive}; installed ${version}`);
+  if (!Array.isArray(value.patterns) || value.patterns.length < 1 || value.patterns.length > 16 || new Set(value.patterns).size !== value.patterns.length) fail('patterns must list 1–16 unique files');
+  const filePattern = new RegExp(`^${value.language}-community-[a-z0-9]+(?:-[a-z0-9]+)*\\.md$`);
+  if (value.patterns.some((file) => typeof file !== 'string' || file.length > 120 || !filePattern.test(file))) fail('pattern filenames must use LANG-community-NAME.md without directories');
+  const allowed = new Set(['name', 'version', 'language', 'patterns', 'compatibility', 'author', 'license']);
+  if (Object.keys(value).some((key) => !allowed.has(key))) fail('unknown manifest field; hooks and scripts are not supported');
+  return value;
+}
+
+function parseYaml(text) {
+  try { return yaml.load(text, { schema: yaml.JSON_SCHEMA }); } catch { fail('invalid YAML'); }
+}
+
+function parsePattern(text, file, manifest) {
+  const match = text.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+  if (!match) fail(`${file} needs YAML frontmatter`);
+  const frontmatter = parseYaml(match[1]);
+  if (!mapping(frontmatter) || frontmatter.pack !== file.slice(0, -3) || frontmatter.language !== manifest.language || frontmatter.version !== manifest.version) fail(`${file} frontmatter must match its filename, language and version`);
+  if (!Number.isSafeInteger(frontmatter.patterns) || frontmatter.patterns < 1 || frontmatter.patterns > 100 || !match[2].trim()) fail(`${file} needs a pattern count and body`);
+  if (frontmatter.phase !== undefined && !['structure', 'sentence', 'lexical'].includes(frontmatter.phase)) fail(`${file} has an invalid phase`);
+  if (frontmatter.score_only !== undefined && typeof frontmatter.score_only !== 'boolean') fail(`${file} has an invalid score_only flag`);
+  return { file, frontmatter, body: match[2].trim(), isStructure: frontmatter.phase === 'structure', isScoreOnly: frontmatter.score_only === true };
+}
+
+export function communitySource(input) {
+  if (typeof input !== 'string') fail('provide a pack name or GitHub tree URL');
+  if (hasControls(input)) fail('control characters are not supported in source URLs');
+  if (NAME.test(input) && input.length <= 80) return { owner: 'devswha', repo: 'patina-community-packs', ref: 'main', directory: `packs/${input}`, expectedName: input };
+  if (/\/(?:\.|\.\.)(?:\/|$)/.test(input)) fail('dot segments are not supported in source URLs');
+  let url;
+  try { url = new URL(input); } catch { fail('expected a pack name or https://github.com/OWNER/REPO/tree/REF/DIRECTORY'); }
+  if (url.protocol !== 'https:' || url.hostname !== 'github.com' || url.port || url.username || url.password || url.search || url.hash || /%|\\/.test(input)) fail('only plain HTTPS GitHub tree URLs are supported');
+  const parts = url.pathname.replace(/\/$/, '').split('/').slice(1);
+  if (parts.length < 5 || parts[2] !== 'tree' || parts.some((part) => !/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(part) || part === '..')) fail('invalid GitHub tree path; refs containing slashes are not supported');
+  return { owner: parts[0], repo: parts[1], ref: parts[3], directory: parts.slice(4).join('/') };
+}
+
+async function fetchText(url, fetchImpl) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 20_000);
+  try {
+    const response = await fetchImpl(url, { redirect: 'error', signal: controller.signal, headers: { accept: 'application/vnd.github+json', 'user-agent': 'patina-community-packs' } });
+    if (!response.ok) fail(`download failed (HTTP ${response.status})`);
+    if (Number(response.headers.get('content-length')) > LIMIT) fail('download exceeds 128 KiB');
+    const reader = response.body?.getReader();
+    if (!reader) fail('download has no readable body');
+    let size = 0; const chunks = [];
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        size += value.byteLength;
+        if (size > LIMIT) { await reader.cancel(); fail('download exceeds 128 KiB'); }
+        chunks.push(Buffer.from(value));
+      }
+    } finally { reader.releaseLock(); }
+    const text = Buffer.concat(chunks).toString('utf8');
+    if (text.includes('\0') || text.includes('\uFFFD')) fail('download must be valid UTF-8 text');
+    return text;
+  } finally { controller.abort(); clearTimeout(timer); }
+}
+
+function directory(root, name, create) {
+  const path = join(root, name);
+  if (!existsSync(path)) {
+    // lstat also catches dangling symlinks, which existsSync does not see.
+    try { lstatSync(path); fail(`unsafe directory ${name}`); } catch (error) { if (error.code !== 'ENOENT') throw error; }
+    if (!create) return null;
+    mkdirSync(path);
+  }
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) fail(`unsafe directory ${name}`);
+  return path;
+}
+
+function managedRoot(repoRoot, create = false) {
+  // Existing custom/ and licensed packs may legitimately use a symlink. Do not
+  // impose the community manager's stricter rules when its subtree is absent.
+  if (!create) {
+    try { lstatSync(join(repoRoot, 'custom/community-packs')); }
+    catch (error) { if (error.code === 'ENOENT' || error.code === 'ENOTDIR') return null; throw error; }
+  }
+  const custom = directory(realpathSync(repoRoot), 'custom', create);
+  return custom ? directory(custom, 'community-packs', create) : null;
+}
+
+function regularText(path) {
+  const stat = lstatSync(path);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > LIMIT) fail('installed pack contains an unsafe file');
+  const fd = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+  try { return readFileSync(fd, 'utf8'); } finally { closeSync(fd); }
+}
+
+function readInstalled(root, name, version) {
+  if (!NAME.test(name)) fail('invalid installed name');
+  const path = directory(root, name, false);
+  if (!path) fail(`pack ${name} is not installed`);
+  let receipt;
+  try { receipt = JSON.parse(regularText(join(path, 'installed.json'))); } catch { fail(`invalid installation receipt for ${name}`); }
+  if (receipt.schemaVersion !== 1 || !mapping(receipt.hashes) || receipt.name !== name) fail(`invalid installation receipt for ${name}`);
+  const expected = Object.keys(receipt.hashes).sort();
+  if (expected.some((file) => file !== 'pack.yaml' && !/^(en|ko|zh|ja)-community-[a-z0-9-]+\.md$/.test(file))) fail('unsafe installation receipt path');
+  const actual = readdirSync(path).filter((file) => file !== 'installed.json').sort();
+  if (JSON.stringify(expected) !== JSON.stringify(actual)) fail(`pack ${name} has added or removed files`);
+  const files = new Map();
+  for (const file of expected) {
+    const text = regularText(join(path, file));
+    if (digest(text) !== receipt.hashes[file]) fail(`pack ${name} has local changes; preserve them before reinstalling or removing`);
+    files.set(file, text);
+  }
+  const manifest = validateCommunityManifest(parseYaml(files.get('pack.yaml')), version);
+  if (manifest.name !== name || manifest.patterns.length + 1 !== files.size || manifest.patterns.some((file) => !files.has(file))) fail('installation receipt and manifest differ');
+  const patterns = manifest.patterns.map((file) => parsePattern(files.get(file), file, manifest));
+  return { path, manifest, patterns, source: receipt.source };
+}
+
+export function listCommunityPacks(repoRoot) {
+  const root = managedRoot(repoRoot);
+  if (!root) return [];
+  return readdirSync(root).filter((name) => NAME.test(name)).sort().map((name) => {
+    try { const installed = readInstalled(root, name); return { ...installed.manifest, source: installed.source, status: 'installed' }; }
+    catch (error) { return { name, status: 'invalid', error: error.message }; }
+  });
+}
+
+export function loadCommunityPatterns(repoRoot, lang, skipPatterns = []) {
+  const root = managedRoot(repoRoot);
+  if (!root) return [];
+  const packagePath = join(repoRoot, 'package.json');
+  const version = existsSync(packagePath) ? JSON.parse(readFileSync(packagePath, 'utf8')).version : undefined;
+  return readdirSync(root).filter((name) => NAME.test(name) && name.startsWith(`${lang}-`)).sort()
+    .flatMap((name) => readInstalled(root, name, version).patterns).filter((pattern) => !skipPatterns.includes(pattern.file.slice(0, -3)));
+}
+
+function lock(root) {
+  const path = join(root, '.mutation.lock');
+  let fd;
+  try { fd = openSync(path, 'wx', 0o600); } catch { fail('another pack mutation is active; check .mutation.lock if a previous command was interrupted'); }
+  return () => { closeSync(fd); rmSync(path); };
+}
+
+export async function installCommunityPack(input, { repoRoot, version, fetchImpl = globalThis.fetch } = {}) {
+  const source = communitySource(input);
+  let commit;
+  try { commit = JSON.parse(await fetchText(`https://api.github.com/repos/${source.owner}/${source.repo}/commits/${encodeURIComponent(source.ref)}`, fetchImpl)).sha; } catch (error) { throw new Error(`community pattern pack: could not resolve source commit (${error.message})`); }
+  if (typeof commit !== 'string' || !/^[a-f0-9]{40}$/.test(commit)) fail('GitHub did not return a full commit SHA');
+  const base = `https://raw.githubusercontent.com/${source.owner}/${source.repo}/${commit}/${source.directory}/`;
+  const manifestText = await fetchText(`${base}pack.yaml`, fetchImpl);
+  const manifest = validateCommunityManifest(parseYaml(manifestText), version);
+  if (source.expectedName && manifest.name !== source.expectedName) fail('requested name differs from pack.yaml');
+  const files = new Map([['pack.yaml', manifestText]]);
+  for (const file of manifest.patterns) {
+    const text = await fetchText(`${base}${file}`, fetchImpl);
+    parsePattern(text, file, manifest); files.set(file, text);
+  }
+  const root = managedRoot(repoRoot, true), release = lock(root);
+  let stage;
+  try {
+    const destination = join(root, manifest.name);
+    if (existsSync(destination)) fail(`${manifest.name} is already installed; remove it before installing another version`);
+    const existing = new Set(listCommunityPacks(repoRoot).flatMap((pack) => pack.patterns || []));
+    for (const file of manifest.patterns) {
+      if (existing.has(file) || existsSync(join(repoRoot, 'patterns', file)) || existsSync(join(repoRoot, 'custom', 'patterns', file))) fail(`pattern file collision: ${file}`);
+    }
+    stage = mkdtempSync(join(root, '.stage-'));
+    for (const [file, text] of files) writeFileSync(join(stage, file), text, { flag: 'wx', mode: 0o600 });
+    const receipt = { schemaVersion: 1, name: manifest.name, source: { ...source, commit }, hashes: Object.fromEntries([...files].map(([file, text]) => [file, digest(text)])) };
+    writeFileSync(join(stage, 'installed.json'), `${JSON.stringify(receipt, null, 2)}\n`, { flag: 'wx', mode: 0o600 });
+    renameSync(stage, destination); stage = null;
+    return { name: manifest.name, version: manifest.version, path: destination, source: receipt.source };
+  } finally { if (stage) rmSync(stage, { recursive: true, force: true }); release(); }
+}
+
+export function removeCommunityPack(name, { repoRoot } = {}) {
+  if (typeof name !== 'string' || !NAME.test(name)) fail('invalid pack name');
+  const root = managedRoot(repoRoot);
+  if (!root) fail(`${name} is not installed`);
+  const release = lock(root);
+  try {
+    const { path } = readInstalled(root, name);
+    rmSync(path, { recursive: true });
+    return { removed: name };
+  } finally { release(); }
+}

--- a/src/loader.js
+++ b/src/loader.js
@@ -3,6 +3,7 @@ import { resolve, sep } from 'node:path';
 import yaml from 'js-yaml';
 import { validateDocumentTypeName } from './security.js';
 import { inputError, runtimeError } from './errors.js';
+import { loadCommunityPatterns } from './community-patterns.js';
 
 /**
  * Read a UTF-8 text file.
@@ -81,7 +82,13 @@ export function loadPatterns(repoRoot, lang, skipPatterns = []) {
       isScoreOnly: frontmatter?.score_only === true,
     });
   }
-  return packs;
+  for (const pack of loadCommunityPatterns(repoRoot, lang, skipPatterns)) {
+    if (byFile.has(pack.file) || packs.some((loaded) => loaded.file === pack.file)) {
+      throw runtimeError('community pattern filename collision', pack.file, 'Remove the conflicting community pack with `patina pattern remove <name>`.');
+    }
+    packs.push(pack);
+  }
+  return packs.sort((a, b) => a.file.localeCompare(b.file));
 }
 
 /**

--- a/tests/unit/community-patterns.test.js
+++ b/tests/unit/community-patterns.test.js
@@ -1,0 +1,140 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import yaml from 'js-yaml';
+import { communitySource, installCommunityPack, listCommunityPacks, removeCommunityPack, validateCommunityManifest } from '../../src/community-patterns.js';
+import { loadPatterns } from '../../src/loader.js';
+import { runPattern } from '../../src/commands/pattern.js';
+
+const SHA = 'a'.repeat(40);
+const FILE = 'en-community-corporate-bizspeak.md';
+const manifest = () => ({ name: 'en-corporate-bizspeak', version: '1.0.0', language: 'en', patterns: [FILE], compatibility: { min: '8.1.0', maxExclusive: '9.0.0' }, author: 'Test author', license: 'MIT' });
+const pattern = `---\npack: en-community-corporate-bizspeak\nlanguage: en\nversion: 1.0.0\npatterns: 1\n---\n### 1. Corporate filler\n**Before:** We leverage the tool.\n**After:** We use the tool.\n`;
+
+function fixture(t, pack = manifest()) {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'patina-community-test-'));
+  t.after(() => rmSync(repoRoot, { recursive: true, force: true }));
+  writeFileSync(join(repoRoot, 'package.json'), '{"version":"8.1.3"}');
+  mkdirSync(join(repoRoot, 'patterns'));
+  const requests = [];
+  const fetchImpl = async (url, options) => {
+    requests.push({ url, options });
+    if (url.startsWith('https://api.github.com/')) return new Response(JSON.stringify({ sha: SHA }));
+    assert.ok(url.includes(`/${SHA}/`), 'every content read is pinned to one immutable commit');
+    if (url.endsWith('/pack.yaml')) return new Response(yaml.dump(pack));
+    return new Response(pattern);
+  };
+  return { repoRoot, fetchImpl, requests, version: '8.1.3' };
+}
+
+test('community pack installs, loads, lists and removes without credentials or built-in changes', async (t) => {
+  const f = fixture(t);
+  const builtIn = join(f.repoRoot, 'patterns/en-original.md');
+  writeFileSync(builtIn, 'Built-in text');
+  const result = await installCommunityPack('en-corporate-bizspeak', f);
+  assert.equal(result.source.commit, SHA);
+  assert.deepEqual(loadPatterns(f.repoRoot, 'en').map((p) => p.file), [FILE, 'en-original.md']);
+  assert.deepEqual(loadPatterns(f.repoRoot, 'en', [FILE.slice(0, -3)]).map((p) => p.file), ['en-original.md']);
+  assert.equal(listCommunityPacks(f.repoRoot)[0].status, 'installed');
+  assert.equal(f.requests.length, 3);
+  assert.ok(f.requests.every(({ options }) => options.redirect === 'error' && !options.headers.authorization));
+  removeCommunityPack(result.name, f);
+  assert.deepEqual(listCommunityPacks(f.repoRoot), []);
+  assert.equal(readFileSync(builtIn, 'utf8'), 'Built-in text');
+});
+
+test('list is offline and install refuses existing managed or custom content', async (t) => {
+  const f = fixture(t);
+  const output = [];
+  await runPattern(['list', '--json'], { ...f, fetchImpl: () => assert.fail('list must be offline'), out: (text) => output.push(JSON.parse(text)) });
+  assert.deepEqual(output, [{ packs: [] }]);
+  await installCommunityPack('en-corporate-bizspeak', f);
+  await assert.rejects(installCommunityPack('en-corporate-bizspeak', f), /already installed/);
+  removeCommunityPack('en-corporate-bizspeak', f);
+  mkdirSync(join(f.repoRoot, 'custom/patterns'));
+  writeFileSync(join(f.repoRoot, 'custom/patterns', FILE), 'User text');
+  await assert.rejects(installCommunityPack('en-corporate-bizspeak', f), /collision/);
+  assert.equal(readFileSync(join(f.repoRoot, 'custom/patterns', FILE), 'utf8'), 'User text');
+});
+
+test('edited packs are reported, never loaded or destructively removed', async (t) => {
+  const f = fixture(t);
+  const installed = await installCommunityPack('en-corporate-bizspeak', f);
+  writeFileSync(join(installed.path, FILE), 'User changes');
+  assert.equal(listCommunityPacks(f.repoRoot)[0].status, 'invalid');
+  assert.throws(() => loadPatterns(f.repoRoot, 'en'), /local changes/);
+  assert.throws(() => removeCommunityPack(installed.name, f), /local changes/);
+  assert.equal(readFileSync(join(installed.path, FILE), 'utf8'), 'User changes');
+});
+
+test('source paths and metadata reject traversal, mixed language, hooks and unsupported versions', () => {
+  assert.throws(() => communitySource('https://github.com/alice/packs/tree/main/packs/../other'), /dot segments/);
+  for (const char of ['\t', '\n', '\r']) assert.throws(() => communitySource(`https://github.com/alice/packs/tree/main/packs/.${char}./other`), /control characters/);
+  assert.throws(() => validateCommunityManifest({ ...manifest(), version: ['1.0.0'] }), /version/);
+  assert.throws(() => validateCommunityManifest({ ...manifest(), author: '   ' }), /author/);
+  for (const url of ['https://evil.test/a', 'http://github.com/a/b/tree/main/p', 'https://u:p@github.com/a/b/tree/main/p', 'https://github.com/a/b/tree/main/%2e%2e', 'https://github.com/a/b/tree/main/p?token=x', '../outside']) assert.throws(() => communitySource(url));
+  assert.deepEqual(communitySource('https://github.com/alice/packs/tree/v1/packs/en-team'), { owner: 'alice', repo: 'packs', ref: 'v1', directory: 'packs/en-team' });
+  for (const patch of [{ patterns: ['../outside.md'] }, { patterns: ['en-filler.md'] }, { language: 'ko' }, { scripts: { install: 'run' } }, { patterns: [FILE, FILE] }]) assert.throws(() => validateCommunityManifest({ ...manifest(), ...patch }, '8.1.3'));
+  assert.throws(() => validateCommunityManifest(manifest(), '9.0.0'), /requires Patina/);
+});
+
+test('failed downloads cannot publish a partial pack', async (t) => {
+  const f = fixture(t); const normal = f.fetchImpl;
+  f.fetchImpl = (url, options) => url.endsWith(FILE) ? new Response('unavailable', { status: 503 }) : normal(url, options);
+  await assert.rejects(installCommunityPack('en-corporate-bizspeak', f), /503/);
+  assert.deepEqual(listCommunityPacks(f.repoRoot), []);
+});
+
+test('streaming download size limit works without a content-length header', async (t) => {
+  const f = fixture(t); const normal = f.fetchImpl;
+  f.fetchImpl = (url, options) => url.endsWith(FILE) ? new Response('x'.repeat(128 * 1024 + 1)) : normal(url, options);
+  await assert.rejects(installCommunityPack('en-corporate-bizspeak', f), /128 KiB/);
+  assert.deepEqual(listCommunityPacks(f.repoRoot), []);
+});
+
+test('early response rejection aborts the download before clearing its deadline', async (t) => {
+  for (const response of [new Response('unavailable', { status: 503 }), new Response('large', { headers: { 'content-length': String(128 * 1024 + 1) } })]) {
+    const f = fixture(t); let signal;
+    f.fetchImpl = async (_url, options) => { signal = options.signal; return response; };
+    await assert.rejects(installCommunityPack('en-corporate-bizspeak', f));
+    assert.equal(signal.aborted, true);
+  }
+});
+
+test('symlinked legacy custom packs load when no community subtree exists', (t) => {
+  const f = fixture(t), outside = mkdtempSync(join(tmpdir(), 'patina-legacy-custom-'));
+  t.after(() => rmSync(outside, { recursive: true, force: true }));
+  mkdirSync(join(outside, 'patterns')); writeFileSync(join(outside, 'patterns/en-legacy.md'), 'Legacy custom text');
+  symlinkSync(outside, join(f.repoRoot, 'custom'));
+  assert.equal(loadPatterns(f.repoRoot, 'en')[0].body, 'Legacy custom text');
+  assert.deepEqual(listCommunityPacks(f.repoRoot), []);
+});
+
+test('symlinked directories and installed files cannot escape the managed area', async (t) => {
+  const f = fixture(t); const outside = mkdtempSync(join(tmpdir(), 'patina-community-outside-'));
+  t.after(() => rmSync(outside, { recursive: true, force: true }));
+  symlinkSync(outside, join(f.repoRoot, 'custom'));
+  await assert.rejects(installCommunityPack('en-corporate-bizspeak', f), /unsafe directory/);
+  assert.deepEqual(readdirSync(outside), []);
+  rmSync(join(f.repoRoot, 'custom'));
+  const installed = await installCommunityPack('en-corporate-bizspeak', f);
+  const target = join(outside, 'draft.md'); writeFileSync(target, 'Private draft');
+  rmSync(join(installed.path, FILE)); symlinkSync(target, join(installed.path, FILE));
+  assert.throws(() => loadPatterns(f.repoRoot, 'en'), /unsafe file/);
+  assert.throws(() => removeCommunityPack(installed.name, f), /unsafe file/);
+  assert.equal(readFileSync(target, 'utf8'), 'Private draft');
+});
+
+test('receipt traversal and additional files block removal', async (t) => {
+  const f = fixture(t), installed = await installCommunityPack('en-corporate-bizspeak', f);
+  const receiptPath = join(installed.path, 'installed.json');
+  const original = readFileSync(receiptPath, 'utf8');
+  const receipt = JSON.parse(original); receipt.hashes['../outside.md'] = 'x';
+  writeFileSync(receiptPath, JSON.stringify(receipt));
+  assert.throws(() => removeCommunityPack(installed.name, f), /unsafe installation receipt/);
+  writeFileSync(receiptPath, original); writeFileSync(join(installed.path, 'my-notes.txt'), 'Keep me');
+  assert.throws(() => removeCommunityPack(installed.name, f), /added or removed/);
+  assert.equal(readFileSync(join(installed.path, 'my-notes.txt'), 'utf8'), 'Keep me');
+});


### PR DESCRIPTION
Adds `patina pattern install <name|GitHub-tree-URL>`, `list`, and `remove` for unsigned community pattern packs. Installs resolve a public GitHub ref to one commit, validate `pack.yaml` and Markdown metadata, then publish a complete directory. The existing licensed `patina pack` path remains separate.

The manager refuses redirects, scripts, traversal, symlinked managed storage, oversized downloads, filename collisions and removal of locally changed content. Installed patterns load through the existing prompt pipeline and honor skip-patterns; the deterministic detector is unchanged. Legacy custom/Pro symlinks remain compatible when no community subtree is present.

Validation: 1,796 tests (1,794 pass, 2 optional skips), full lint, independent review PASS. Focused tests cover the full install/load/list/remove lifecycle, commit pinning, unsafe files, offline behavior and download cancellation. The separate starter repository contains the reviewed en-corporate-bizspeak pack and schema; schema/runtime parity was checked with nine valid/invalid cases. Live public download and the CLI release remain final integration steps.

Tracks #211.
