### PR TITLE
research: audit preserved rewrites before adding missing judges

### DIFF
--- a/docs/research/existing-cohort-evaluation.md
+++ b/docs/research/existing-cohort-evaluation.md
@@ -1,0 +1,43 @@
+# Evaluate preserved rewrites with a missing judge seat
+
+Use this collector to add a missing fixed judge without regenerating the text or
+changing an earlier generation/judgment protocol ID. It validates the declared
+parent provider, candidate scope, suite and repeat matrix; public/private
+generation metadata, source/output hashes and numeric safety must agree.
+
+```sh
+node scripts/research/evaluate-existing-rewrites.mjs --live \
+  --parent /path/to/validated/rewrite-openai \
+  --parent-root /path/to/frozen-source \
+  --parent-candidates /path/to/frozen-source/docs/research/model-evaluation-20260904.json \
+  --parent-provider openai \
+  --allow-legacy-parent \
+  --candidates docs/research/model-evaluation-claude-isolated-20260905.json \
+  --judge anthropic-sonnet --output artifacts/claude-evaluation-openai
+```
+
+For a full confirmation cohort, pass `--suite full --repeat 3` and its
+`--parent-candidate` when the source directory contains one selected model.
+The entire declared matrix must exist before any new model call. The selected
+seat must be absent from the parent; this tool never silently replaces a failed
+or differently configured prior evaluation.
+
+Parent directory bindings must match the rows. For older unbound directories,
+`--allow-legacy-parent` enables a mandatory receipt audit; it does not bypass
+validation. Every recorded generation and judgment is checked against its private
+counterpart and completion receipts. Private-only or receipt-only judge evidence
+blocks new calls until the original cohort is recovered. MPS, fidelity and
+naturalness values are recomputed from the saved raw responses before reuse.
+
+Each output directory binds its own protocol before calls and preserves private
+call receipts. New rows carry both `parent_protocol_hash` and their evaluation
+`protocol_hash`; `provenance.json` hashes all parent inputs. Existing parent API
+judgments retain their original identities. Parent files are not rewritten.
+Private judge details stay in private files; public reports contain aggregates.
+
+`--report` creates a report without model calls. A parent with one existing
+independent seat becomes complete only after the missing seat finishes. A parent
+with neither seat needs two separate evaluation directories and a validated
+analysis join; either single-seat report remains incomplete. Global model
+defaults, the production rewrite prompt and human-evaluation requirements do not
+change as a result of this collector.

--- a/scripts/research/evaluate-existing-rewrites.mjs
+++ b/scripts/research/evaluate-existing-rewrites.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { textHash } from '../../tests/quality/live-scorer-benchmark.mjs';
+import { evaluateNumberSafety } from '../../src/features/meaning-proxy.js';
+import { judgeCandidates, judgeRewrite, renderRewriteReport, rewriteFixtures, summarizeRewrites } from './model-rewrite-benchmark.mjs';
+import { acceptedStudyIdentity, acquireStudyWriter, bindStudyProtocol, readUniqueRows } from './study-journal.mjs';
+import { assertStudyActive, installStudySignals, safeStudyError, validateTransport } from './model-evaluation-transport.mjs';
+import { fixtureIdentity, studySemantics } from './study-validation.mjs';
+import { auditParentReceipts } from './parent-cohort-audit.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const SEATS = ['openai-5.5', 'gemini-3.7', 'anthropic-sonnet'];
+const key = (row) => `${row.candidate_id}/${row.fixture_id}/${row.repeat}`;
+const unresolved = (row) => [row.error, ...(row.calls || []).map((call) => call.error)].some((error) =>
+  ['study-cancelled', 'study-call-inflight', 'study-call-unobserved', 'study-journal-persistence-failed'].includes(error));
+const canonical = (value) => Array.isArray(value) ? value.map(canonical)
+  : value && typeof value === 'object' ? Object.fromEntries(Object.keys(value).sort().map((name) => [name, canonical(value[name])])) : value;
+const same = (a, b) => JSON.stringify(canonical(a)) === JSON.stringify(canonical(b));
+const append = (path, row) => appendFileSync(path, `${JSON.stringify(row)}\n`, { mode: 0o600 });
+
+/** Read a complete parent generation cohort without changing its protocol IDs. */
+export async function loadParentCohort({ directory, protocolFile, fixtures, provider, candidateId, repeat = 1, allowLegacyUnbound = false }) {
+  if (!provider || !Number.isSafeInteger(repeat) || repeat < 1 || repeat > 10) throw new Error('Explicit parent provider and valid repeat count are required');
+  const release = acquireStudyWriter(directory, 'evaluation-snapshot');
+  try {
+    const protocolBytes = readFileSync(protocolFile, 'utf8');
+    const protocol = JSON.parse(protocolBytes);
+    const candidates = protocol.candidates.filter((candidate) => candidate.provider === provider && (!candidateId || candidate.id === candidateId));
+    if (!candidates.length || candidates.some((candidate) => !/^[a-z0-9.-]{1,80}$/i.test(candidate.id))) throw new Error('Invalid parent candidate scope');
+    for (const candidate of candidates) validateTransport(candidate);
+    const hashes = { protocol: textHash(protocolBytes) };
+    const read = (name) => {
+      const path = resolve(directory, name); const bytes = readFileSync(path, 'utf8'); hashes[name] = textHash(bytes);
+      return readUniqueRows(path, key);
+    };
+    const generations = read('rewrite-rows.jsonl'), privateRows = read('rewrites.private.jsonl');
+    const expectedKeys = candidates.flatMap((candidate) => Array.from({ length: repeat }, (_, iteration) => fixtures.map((fixture) => `${candidate.id}/${fixture.fixture_id}/${iteration}`)).flat());
+    if (generations.length !== expectedKeys.length || privateRows.length !== expectedKeys.length
+      || generations.some((row) => !expectedKeys.includes(key(row))) || privateRows.some((row) => !expectedKeys.includes(key(row)))) throw new Error('Parent generation matrix is incomplete or has unexpected rows');
+    const privateByKey = new Map(privateRows.map((row) => [key(row), row]));
+    const protocols = new Set();
+    for (const row of generations) {
+      const original = privateByKey.get(key(row)); const { rewrite: _rewrite, ...publicPart } = original;
+      if (!same(row, publicPart)) throw new Error('Parent public/private generation metadata differs');
+      const fixture = fixtures.find((fixture) => fixture.fixture_id === row.fixture_id);
+      const candidate = candidates.find((candidate) => candidate.id === row.candidate_id);
+      if (!/^[a-f0-9]{64}$/.test(row.protocol_hash) || row.text_hash !== fixture.text_hash || row.language !== fixture.language
+        || row.provider !== candidate.provider || row.requested_model !== candidate.model || row.transport !== candidate.transport || unresolved(row)) throw new Error('Unbound parent generation');
+      protocols.add(row.protocol_hash);
+      if (!['ok', 'error'].includes(row.status)) throw new Error('Unknown parent generation status');
+      if (row.status === 'ok') {
+        if (typeof original.rewrite !== 'string' || textHash(original.rewrite) !== row.rewrite_hash
+          || !acceptedStudyIdentity(row.calls?.at(-1), candidate)) throw new Error('Parent rewrite identity/hash mismatch');
+        if (row.number_safety?.ok !== evaluateNumberSafety(fixture.text, original.rewrite, fixture.language).ok) throw new Error('Parent numeric-safety finding differs');
+      }
+    }
+    if (protocols.size !== 1) throw new Error('Mixed parent generation protocols');
+    const bindingPath = resolve(directory, 'study-protocol.json');
+    let bindingMode = 'bound';
+    if (existsSync(bindingPath)) {
+      const bytes = readFileSync(bindingPath, 'utf8'); hashes['study-protocol.json'] = textHash(bytes);
+      const binding = JSON.parse(bytes);
+      if (binding.schemaVersion !== 1 || binding.protocolHash !== [...protocols][0]) throw new Error('Parent directory protocol binding differs');
+    } else {
+      if (!allowLegacyUnbound) throw new Error('Legacy unbound parent requires explicit receipt audit opt-in');
+      bindingMode = 'legacy-receipts-audited';
+    }
+    const judgments = [];
+    for (const id of SEATS) {
+      const name = `judge-${id}.jsonl`, privateName = `judge-${id}.private.jsonl`;
+      if (!existsSync(resolve(directory, name)) && !existsSync(resolve(directory, privateName))) continue;
+      if (!existsSync(resolve(directory, name)) || !existsSync(resolve(directory, privateName))) throw new Error('Parent has private-only or public-only judge evidence; recover it before evaluation');
+      const judge = protocol.candidates.find((candidate) => candidate.id === id);
+      if (!judge) throw new Error('Parent judge missing from protocol');
+      const publicJudgments = read(name), privateJudgments = read(privateName);
+      if (publicJudgments.length !== privateJudgments.length) throw new Error('Parent judge private/public rows differ; recover before evaluation');
+      for (const row of publicJudgments) {
+        const privateRow = privateJudgments.find((privateRow) => key(privateRow) === key(row));
+        if (!privateRow) throw new Error('Parent judge lacks a private receipt');
+        const { private_details: _details, ...publicPart } = privateRow;
+        if (!same(row, publicPart)) throw new Error('Parent judge public/private metadata differs');
+        const generation = privateByKey.get(key(row));
+        const candidate = candidates.find((candidate) => candidate.id === generation?.candidate_id);
+        if (!generation || row.judge_id !== id || row.judge_model !== judge.model || row.judge_provider !== judge.provider || row.judge_transport !== judge.transport
+          || row.protocol_hash !== generation.protocol_hash || row.text_hash !== generation.text_hash || row.rewrite_hash !== generation.rewrite_hash
+          || !judgeCandidates(candidate, protocol).some((seat) => seat.id === id) || unresolved(row)) throw new Error('Unbound parent judgment');
+        if (row.status === 'ok' && !['mps', 'fidelity', 'naturalness'].every((stage) => {
+          const call = row.calls?.filter((call) => call.stage === stage).at(-1);
+          return call?.schema_valid === true && acceptedStudyIdentity(call, judge);
+        })) throw new Error('Parent judgment lacks validated stage evidence');
+        judgments.push(row);
+      }
+    }
+    await auditParentReceipts({ directory, generations, privateRows, judgments, candidates, protocol, fixtures, hashes });
+    const provenance = { schemaVersion: 1, bindingMode, parentProtocolHashes: [...protocols], inputHashes: hashes,
+      scope: { provider, candidateId: candidateId || null, repeat }, fixtures: fixtures.map(fixtureIdentity) };
+    return { generations, privateRows, judgments, candidates, expectedKeys, provenance, snapshotHash: textHash(JSON.stringify(provenance)) };
+  } finally { release(); }
+}
+
+function validateJudgment(row, parent, judge, protocolHash) {
+  const generation = parent.generations.find((generation) => key(generation) === key(row));
+  if (!generation || row.protocol_hash !== protocolHash || row.parent_snapshot_hash !== parent.snapshotHash
+    || row.parent_protocol_hash !== generation.protocol_hash || row.text_hash !== generation.text_hash || row.rewrite_hash !== generation.rewrite_hash
+    || row.judge_id !== judge.id || row.judge_model !== judge.model || row.judge_provider !== judge.provider || row.judge_transport !== judge.transport) throw new Error('Unbound evaluation row');
+  if (!['ok', 'error'].includes(row.status)) throw new Error('Unknown evaluation status');
+  if (row.status === 'ok' && (!Number.isFinite(row.mps) || row.mps < 0 || row.mps > 100
+    || !Number.isFinite(row.fidelity) || row.fidelity < 0 || row.fidelity > 100
+    || !Number.isInteger(row.naturalness) || row.naturalness < 0 || row.naturalness > 4
+    || !Number.isSafeInteger(row.hard_fail_count) || row.hard_fail_count < 0
+    || !['mps', 'fidelity', 'naturalness'].every((stage) => {
+      const call = row.calls?.filter((call) => call.stage === stage).at(-1);
+      return call?.schema_valid === true && call.status === 'ok' && acceptedStudyIdentity(call, judge);
+    }))) throw new Error('Evaluation lacks valid scores or stage evidence');
+}
+
+export async function evaluateExisting({ parent, judge, output, protocolHash, live = false, report = false, evaluate = judgeRewrite }) {
+  if (parent.judgments.some((row) => row.judge_id === judge.id)) throw new Error('Selected seat already has parent observations; do not silently re-evaluate it');
+  validateTransport(judge);
+  for (const candidate of parent.candidates) if (candidate.provider === judge.provider) throw new Error('A judge cannot evaluate its own family');
+  const release = acquireStudyWriter(output, `judge-${judge.id}`);
+  try {
+    bindStudyProtocol(output, protocolHash);
+    const judgeIdentity = { id: judge.id, provider: judge.provider, model: judge.model, transport: judge.transport, effort: judge.effort ?? null };
+    writeFileSync(resolve(output, 'provenance.json'), `${JSON.stringify({ ...parent.provenance, parentSnapshotHash: parent.snapshotHash, evaluationProtocolHash: protocolHash, judge: judgeIdentity }, null, 2)}\n`);
+    const publicPath = resolve(output, `judge-${judge.id}.jsonl`), privatePath = resolve(output, `judge-${judge.id}.private.jsonl`);
+    const rows = readUniqueRows(publicPath, key), done = new Set(rows.map(key));
+    for (const row of rows) validateJudgment(row, parent, judge, protocolHash);
+    const privateRows = readUniqueRows(privatePath, key);
+    if (rows.some((row) => !privateRows.some((privateRow) => key(privateRow) === key(row)))) throw new Error('Evaluation row lacks its private receipt');
+    for (const row of privateRows) {
+      validateJudgment(row, parent, judge, protocolHash);
+      const { private_details: _details, ...safe } = row;
+      if (done.has(key(row))) {
+        if (!same(safe, rows.find((publicRow) => key(publicRow) === key(row)))) throw new Error('Evaluation public/private metadata differs');
+        continue;
+      }
+      append(publicPath, safe); rows.push(safe); done.add(key(row));
+    }
+    if (live && !report) for (const generation of parent.privateRows) {
+      assertStudyActive(); if (generation.status !== 'ok' || done.has(key(generation))) continue;
+      const fixture = parent.fixtures.find((fixture) => fixture.fixture_id === generation.fixture_id);
+      const row = { ...await evaluate(fixture, generation, judge, { journalDirectory: output,
+        logicalId: `${protocolHash}/${key(generation)}/judge/${judge.id}` }),
+        protocol_hash: protocolHash, parent_protocol_hash: generation.protocol_hash, parent_snapshot_hash: parent.snapshotHash, recorded_at: new Date().toISOString() };
+      validateJudgment(row, parent, judge, protocolHash);
+      append(privatePath, row); const { private_details: _details, ...safe } = row; append(publicPath, safe); rows.push(safe); done.add(key(row));
+      console.log(JSON.stringify({ candidate: row.candidate_id, fixture: row.fixture_id, judge: judge.id, status: row.status }));
+    }
+    const combined = [...parent.judgments, ...rows];
+    const provenance = `Parent generation protocol: ${parent.provenance.parentProtocolHashes.join(', ')}.\nEvaluation protocol: ${protocolHash}. Parent and new judgment protocol IDs are preserved separately.\n\n`;
+    writeFileSync(resolve(output, 'rewrite-report.md'), provenance + renderRewriteReport(parent.generations, combined, { protocolHash, expectedKeys: parent.expectedKeys }));
+    writeFileSync(resolve(output, 'rewrite-summary.json'), `${JSON.stringify({ parentSnapshotHash: parent.snapshotHash, evaluationProtocolHash: protocolHash,
+      parentGenerationProtocols: parent.provenance.parentProtocolHashes, summary: summarizeRewrites(parent.generations, combined) }, null, 2)}\n`);
+    return rows;
+  } finally { release(); }
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = { suite: 'screening', repeat: '1' };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--live') options.live = true;
+    else if (argv[i] === '--report') options.report = true;
+    else if (argv[i] === '--allow-legacy-parent') options.allowLegacyUnbound = true;
+    else if (['--parent', '--parent-root', '--parent-candidates', '--parent-provider', '--parent-candidate', '--candidates', '--judge', '--output', '--suite', '--repeat'].includes(argv[i]) && argv[i + 1] && !argv[i + 1].startsWith('--')) options[argv[i].slice(2)] = argv[++i];
+    else throw new Error('Invalid existing-cohort evaluation arguments');
+  }
+  for (const name of ['parent', 'parent-root', 'parent-candidates', 'parent-provider', 'candidates', 'judge', 'output']) if (!options[name]) throw new Error(`Missing --${name}`);
+  if (!options.live && !options.report) throw new Error('Pass --live for paid judgments or --report to generate a report without model calls');
+  installStudySignals();
+  const protocol = JSON.parse(readFileSync(options.candidates, 'utf8'));
+  const judge = protocol.candidates.find((candidate) => candidate.id === options.judge);
+  if (!judge || !SEATS.includes(judge.id)) throw new Error('A fixed judge seat is required');
+  const fixtures = rewriteFixtures(options.suite, resolve(options['parent-root']));
+  const parent = await loadParentCohort({ directory: resolve(options.parent), protocolFile: resolve(options['parent-candidates']), fixtures,
+    provider: options['parent-provider'], candidateId: options['parent-candidate'], repeat: Number(options.repeat), allowLegacyUnbound: options.allowLegacyUnbound });
+  for (const candidate of parent.candidates) if (!judgeCandidates(candidate, protocol).some((seat) => seat.id === judge.id)) throw new Error('Judge is not assigned to this parent family');
+  const protocolHash = textHash(JSON.stringify({ protocol, judge: judge.id, parentSnapshotHash: parent.snapshotHash, semantics: studySemantics(ROOT) }));
+  return evaluateExisting({ parent: { ...parent, fixtures }, judge, protocolHash, output: resolve(options.output), live: options.live, report: options.report });
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main().catch((error) => { console.error(safeStudyError(error)); process.exitCode = 1; });

--- a/scripts/research/parent-cohort-audit.mjs
+++ b/scripts/research/parent-cohort-audit.mjs
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { textHash } from '../../tests/quality/live-scorer-benchmark.mjs';
+import { deliveredRewrite } from '../../tests/quality/live-quality.mjs';
+import { judgeCandidates, judgeRewrite } from './model-rewrite-benchmark.mjs';
+import { safeCallRecord } from './study-journal.mjs';
+
+const key = (row) => `${row.candidate_id}/${row.fixture_id}/${row.repeat}`;
+
+function bindRequest(receipt, logicalId, index, candidate, promptHash, options = {}) {
+  const identity = { logicalId, index, candidate, promptHash, temperature: options.temperature ?? .2,
+    responseFormat: options.responseFormat ?? null, extraBody: options.extraBody ?? null };
+  if (receipt.schemaVersion !== 1 || receipt.promptHash !== promptHash || receipt.requestHash !== textHash(JSON.stringify(identity))) throw new Error('Parent receipt request or prompt binding differs');
+}
+
+export async function auditParentReceipts({ directory, generations, privateRows, judgments, candidates, protocol, fixtures, hashes }) {
+  const expectedGroups = new Map();
+  for (const generation of generations) {
+    const candidate = candidates.find((candidate) => candidate.id === generation.candidate_id);
+    const logical = `${generation.protocol_hash}/${key(generation)}`;
+    expectedGroups.set(textHash(`${logical}/rewrite`), { row: generation, candidate, generation, logicalId: `${logical}/rewrite` });
+    for (const judge of judgeCandidates(candidate, protocol)) {
+      const row = judgments.find((row) => key(row) === key(generation) && row.judge_id === judge.id);
+      expectedGroups.set(textHash(`${logical}/judge/${judge.id}`), { row, candidate: judge, generation, judge: true, logicalId: `${logical}/judge/${judge.id}` });
+    }
+  }
+  const callsRoot = resolve(directory, 'calls');
+  const actualGroups = existsSync(callsRoot) ? readdirSync(callsRoot) : [];
+  for (const group of actualGroups) if (!expectedGroups.has(group)) throw new Error('Parent has an unrecognized call group; reconcile it before evaluation');
+  for (const [group, expected] of expectedGroups) {
+    const path = resolve(callsRoot, group);
+    if (!expected.row) {
+      if (existsSync(path)) throw new Error('Parent has receipt-only judge evidence; recover the original cohort before another evaluation');
+      continue;
+    }
+    const calls = expected.row.calls;
+    if (!Array.isArray(calls)) throw new Error('Parent row has no call evidence');
+    const names = existsSync(path) ? readdirSync(path) : [];
+    if (names.length !== calls.length || names.some((name) => !/^\d+\.private\.json$/.test(name))) throw new Error('Parent call receipts are missing or unresolved');
+    const receipts = calls.map((call, index) => {
+      const file = `calls/${group}/${index + 1}.private.json`;
+      const bytes = readFileSync(resolve(directory, file), 'utf8'); hashes[file] = textHash(bytes);
+      const receipt = JSON.parse(bytes);
+      if (!['completed', 'error'].includes(receipt.state)) throw new Error('Parent call outcome is unresolved');
+      const safe = safeCallRecord(receipt, expected.candidate);
+      for (const field of ['status', 'error', 'schema_valid', 'modelIdentityVerified']) {
+        if ((call[field] ?? null) !== (safe[field] ?? null)) throw new Error('Parent call metadata differs from its receipt');
+      }
+      if (expected.candidate.transport === 'kimi-cli' && call.profileIdentityVerified !== safe.profileIdentityVerified) throw new Error('Parent profile identity differs from its receipt');
+      return receipt;
+    });
+    const original = privateRows.find((row) => key(row) === key(expected.generation));
+    if (!expected.judge) {
+      for (let i = 0; i < receipts.length; i++) bindRequest(receipts[i], expected.logicalId, i + 1, expected.candidate, expected.generation.prompt_hash, { temperature: .2 });
+      if (expected.row.status === 'ok' && (!receipts.length || deliveredRewrite(receipts.at(-1).response?.text || '') !== original.rewrite)) throw new Error('Parent generation differs from its completion receipt');
+      continue;
+    }
+    const fixture = fixtures.find((fixture) => fixture.fixture_id === original.fixture_id);
+    let index = 0, requestFailure = null;
+    // Offline replay rebuilds the production prompts and scores. It never calls
+    // a transport and cannot replenish a paid request's deadline.
+    const replay = await judgeRewrite(fixture, original, expected.candidate, { logicalId: expected.logicalId,
+      complete: async (candidate, prompt, options) => {
+        if (requestFailure) throw requestFailure;
+        const receipt = receipts[index++];
+        try {
+          if (!receipt) throw new Error('Parent replay needs an unrecorded call');
+          bindRequest(receipt, expected.logicalId, index, candidate, textHash(prompt), options);
+        } catch (error) { requestFailure = error; throw error; }
+        for (const attempt of receipt.transportAttempts || []) options.onAttempt?.(attempt);
+        if (receipt.state !== 'completed') throw new Error(receipt.error);
+        return receipt.response;
+      } });
+    if (requestFailure) throw requestFailure;
+    if (index !== receipts.length) throw new Error('Parent replay did not consume its exact call sequence');
+    for (const field of ['status', 'error', 'mps', 'fidelity', 'naturalness', 'hard_fail_count']) {
+      if ((expected.row[field] ?? null) !== (replay[field] ?? null)) throw new Error('Parent judge scores differ from their completion receipts');
+    }
+  }
+}

--- a/scripts/research/study-job.mjs
+++ b/scripts/research/study-job.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url';
 
 const SELF = fileURLToPath(import.meta.url);
 const ROOT = resolve(dirname(SELF), '../..');
-const ENTRIES = new Set(['tests/quality/live-scorer-benchmark.mjs', 'scripts/research/model-rewrite-benchmark.mjs']);
+const ENTRIES = new Set(['tests/quality/live-scorer-benchmark.mjs', 'scripts/research/model-rewrite-benchmark.mjs', 'scripts/research/evaluate-existing-rewrites.mjs']);
 
 export function processIdentity(pid) {
   if (!Number.isSafeInteger(pid) || pid < 1) return null;

--- a/scripts/research/study-validation.mjs
+++ b/scripts/research/study-validation.mjs
@@ -48,7 +48,7 @@ export function validateRawFidelity(text) {
 export function studySemantics(repoRoot) {
   const fixed = ['.patina.default.yaml', 'package.json', 'src/scoring.js', 'src/json-response.js', 'src/prompt-builder.js',
     'src/features/meaning-proxy.js', 'tests/quality/live-quality.mjs', 'tests/quality/live-scorer-benchmark.mjs',
-    'scripts/research/model-rewrite-benchmark.mjs', 'scripts/research/model-evaluation-transport.mjs', 'scripts/research/kimi-study-transport.mjs', 'scripts/research/claude-study-stream.mjs',
+    'scripts/research/model-rewrite-benchmark.mjs', 'scripts/research/model-evaluation-transport.mjs', 'scripts/research/kimi-study-transport.mjs', 'scripts/research/claude-study-stream.mjs', 'scripts/research/evaluate-existing-rewrites.mjs', 'scripts/research/parent-cohort-audit.mjs',
     'scripts/research/study-validation.mjs', 'scripts/research/study-journal.mjs', 'scripts/research/study-job.mjs', 'scripts/research/study-inputs.mjs'];
   const paths = [...fixed];
   for (const directory of ['src', 'patterns', 'core', 'document-types', 'lexicon', 'personas']) {

--- a/tests/unit/existing-cohort-evaluation.test.js
+++ b/tests/unit/existing-cohort-evaluation.test.js
@@ -1,0 +1,166 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadParentCohort, evaluateExisting } from '../../scripts/research/evaluate-existing-rewrites.mjs';
+import { textHash } from '../quality/live-scorer-benchmark.mjs';
+import { judgeRewrite } from '../../scripts/research/model-rewrite-benchmark.mjs';
+
+const generator = { id: 'openai-test', provider: 'openai', model: 'gpt-test', transport: 'opencodex', baseURL: 'http://127.0.0.1:10100/v1' };
+const judge = { id: 'anthropic-sonnet', provider: 'anthropic', model: 'claude-sonnet-5', transport: 'claude-cli' };
+const gemini = { id: 'gemini-3.7', provider: 'gemini', model: 'google-antigravity/gemini-test', transport: 'opencodex', baseURL: generator.baseURL };
+const fixture = { fixture_id: 'one', text: 'We shipped 12 fixes.', text_hash: textHash('We shipped 12 fixes.'), language: 'en' };
+const parentHash = 'a'.repeat(64), evaluationHash = 'b'.repeat(64);
+
+function receipt(root, logicalId, index, candidate, text, options = {}) {
+  const directory = join(root, 'calls', textHash(logicalId)); mkdirSync(directory, { recursive: true });
+  const promptHash = textHash(options.prompt || 'Frozen generation prompt');
+  const identity = { logicalId, index, candidate, promptHash, temperature: options.temperature ?? .2,
+    responseFormat: options.responseFormat ?? null, extraBody: options.extraBody ?? null };
+  const response = { text, effectiveModels: [candidate.model], durationMs: 10, attempts: 1 };
+  writeFileSync(join(directory, `${index}.private.json`), JSON.stringify({ schemaVersion: 1, state: 'completed', schemaValid: true,
+    requestHash: textHash(JSON.stringify(identity)), promptHash, temperature: identity.temperature, response, transportAttempts: [] }));
+  return response;
+}
+
+async function addParentJudgment(root, row, mps = 0) {
+  const logical = `${parentHash}/${generator.id}/${fixture.fixture_id}/0/judge/${gemini.id}`;
+  let index = 0;
+  const anchors = mps === 89.9 ? Array.from({ length: 10 }, (_, i) => ({ type: 'claim', content: `claim ${i}`, verdict: i < 9 ? 'PASS' : 'SOFT_FAIL' }))
+    : [{ type: 'claim', content: '12 fixes', verdict: 'HARD_FAIL' }];
+  const rawMps = JSON.stringify({ anchors, pass_count: mps === 89.9 ? 9 : 0, total_count: anchors.length, polarity_pass_count: 0, polarity_total_count: 0, mps });
+  const result = await judgeRewrite(fixture, { ...row, rewrite: fixture.text }, gemini, { complete: async (candidate, prompt, options) => {
+    const text = prompt.includes('Meaning Preservation evaluator') ? rawMps : prompt.includes('Fidelity evaluator')
+      ? '{"claims_preserved":3,"no_fabrication":3,"audience_register_match":3}' : '{"naturalness":3}';
+    return receipt(root, logical, ++index, candidate, text, { ...options, prompt });
+  } });
+  assert.equal(result.status, 'ok');
+  const privateRow = { ...result, protocol_hash: parentHash };
+  const { private_details: _details, ...publicRow } = privateRow;
+  writeFileSync(join(root, 'judge-gemini-3.7.jsonl'), JSON.stringify(publicRow) + '\n');
+  writeFileSync(join(root, 'judge-gemini-3.7.private.jsonl'), JSON.stringify(privateRow) + '\n');
+  return { publicRow, privateRow, logical };
+}
+
+function setup(t) {
+  const root = mkdtempSync(join(tmpdir(), 'patina-parent-eval-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const protocolFile = join(root, 'protocol.json');
+  writeFileSync(protocolFile, JSON.stringify({ candidates: [generator, { ...generator, id: 'openai-5.5' }, gemini, judge] }));
+  const row = { schemaVersion: 1, candidate_id: generator.id, fixture_id: fixture.fixture_id, repeat: 0,
+    provider: generator.provider, requested_model: generator.model, transport: generator.transport, language: fixture.language,
+    protocol_hash: parentHash, prompt_hash: textHash('Frozen generation prompt'), text_hash: fixture.text_hash, rewrite_hash: fixture.text_hash,
+    status: 'ok', number_safety: { ok: true }, duration_ms: 10,
+    calls: [{ effectiveModels: [generator.model], modelIdentityVerified: true, status: 'ok', schema_valid: true }] };
+  writeFileSync(join(root, 'rewrite-rows.jsonl'), JSON.stringify(row) + '\n');
+  writeFileSync(join(root, 'rewrites.private.jsonl'), JSON.stringify({ ...row, rewrite: fixture.text }) + '\n');
+  writeFileSync(join(root, 'study-protocol.json'), JSON.stringify({ schemaVersion: 1, protocolHash: parentHash }));
+  receipt(root, `${parentHash}/${generator.id}/${fixture.fixture_id}/0/rewrite`, 1, generator, fixture.text);
+  const options = { directory: root, protocolFile, fixtures: [fixture], provider: 'openai', candidateId: generator.id };
+  return { root, row, options };
+}
+
+test('new judgments preserve parent identities, resume once, and never regenerate outputs', async (t) => {
+  const { root, options } = setup(t);
+  const before = readFileSync(join(root, 'rewrites.private.jsonl'), 'utf8');
+  const parent = { ...await loadParentCohort(options), fixtures: [fixture] };
+  let calls = 0;
+  const evaluate = async (_fixture, generation, seat) => {
+    calls++;
+    return { candidate_id: generation.candidate_id, fixture_id: generation.fixture_id, repeat: generation.repeat,
+      text_hash: generation.text_hash, rewrite_hash: generation.rewrite_hash, judge_id: seat.id, judge_model: seat.model,
+      judge_provider: seat.provider, judge_transport: seat.transport, status: 'ok', mps: 100, fidelity: 100, naturalness: 3,
+      hard_fail_count: 0, calls: ['mps', 'fidelity', 'naturalness'].map((stage) => ({ stage, status: 'ok', schema_valid: true, modelIdentityVerified: true })), private_details: { rationale: 'private reasoning must not be public' } };
+  };
+  const args = { parent, judge, output: join(root, 'evaluation'), protocolHash: evaluationHash, live: true, evaluate };
+  const rows = await evaluateExisting(args); await evaluateExisting(args);
+  assert.equal(calls, 1);
+  assert.equal(rows[0].parent_protocol_hash, parentHash);
+  assert.equal(rows[0].protocol_hash, evaluationHash);
+  assert.equal(readFileSync(join(root, 'rewrites.private.jsonl'), 'utf8'), before);
+  assert.doesNotMatch(readFileSync(join(root, 'evaluation/judge-anthropic-sonnet.jsonl'), 'utf8'), /private reasoning/);
+  assert.match(readFileSync(join(root, 'evaluation/rewrite-report.md'), 'utf8'), /complete: \*\*no/);
+  await assert.rejects(evaluateExisting({ ...args, protocolHash: 'c'.repeat(64) }), /different protocol/);
+});
+
+test('private-only and receipt-only parent judge evidence prevents a new paid evaluation', async (t) => {
+  for (const kind of ['private-only', 'receipt-only']) {
+    const { root, options } = setup(t);
+    if (kind === 'private-only') writeFileSync(join(root, 'judge-anthropic-sonnet.private.jsonl'), '{"candidate_id":"openai-test","fixture_id":"one","repeat":0}\n');
+    else receipt(root, `${parentHash}/${generator.id}/${fixture.fixture_id}/0/judge/${judge.id}`, 1, judge, 'Already paid');
+    await assert.rejects(loadParentCohort(options), /private-only|receipt-only/);
+  }
+});
+
+test('parent scores must match private rows and the original model completion', async (t) => {
+  for (const inconsistentPublic of [true, false]) {
+    const { root, row, options } = setup(t);
+    const saved = await addParentJudgment(root, row);
+    saved.publicRow.mps = 100; saved.publicRow.hard_fail_count = 0;
+    writeFileSync(join(root, 'judge-gemini-3.7.jsonl'), JSON.stringify(saved.publicRow) + '\n');
+    if (!inconsistentPublic) writeFileSync(join(root, 'judge-gemini-3.7.private.jsonl'), JSON.stringify({ ...saved.privateRow, mps: 100, hard_fail_count: 0 }) + '\n');
+    await assert.rejects(loadParentCohort(options), inconsistentPublic ? /public\/private metadata/ : /scores differ/);
+  }
+});
+
+test('parent binding is checked and legacy parents require explicit full receipt auditing', async (t) => {
+  const { root, options } = setup(t);
+  writeFileSync(join(root, 'study-protocol.json'), JSON.stringify({ schemaVersion: 1, protocolHash: evaluationHash }));
+  await assert.rejects(loadParentCohort(options), /binding differs/);
+  rmSync(join(root, 'study-protocol.json'));
+  await assert.rejects(loadParentCohort(options), /explicit receipt audit/);
+  const parent = await loadParentCohort({ ...options, allowLegacyUnbound: true });
+  assert.equal(parent.provenance.bindingMode, 'legacy-receipts-audited');
+  assert.ok(Object.keys(parent.provenance.inputHashes).some((path) => path.startsWith('calls/')));
+});
+
+test('incomplete matrices, tampered private content and same-family evaluation fail before calls', async (t) => {
+  const { root, options } = setup(t);
+  await assert.rejects(loadParentCohort({ ...options, repeat: 2 }), /incomplete/);
+  const parent = { ...await loadParentCohort(options), fixtures: [fixture] };
+  await assert.rejects(evaluateExisting({ parent, judge: generator, output: join(root, 'bad'), protocolHash: evaluationHash, live: true }), /own family/);
+  const row = JSON.parse(readFileSync(join(root, 'rewrites.private.jsonl'), 'utf8'));
+  writeFileSync(join(root, 'rewrites.private.jsonl'), JSON.stringify({ ...row, rewrite: 'Changed 13 fixes.' }) + '\n');
+  await assert.rejects(loadParentCohort(options), /hash mismatch/);
+});
+
+test('public evaluation tampering cannot override its private receipt', async (t) => {
+  const { root, options, row } = setup(t);
+  const parent = { ...await loadParentCohort(options), fixtures: [fixture] };
+  const args = { parent, judge, output: join(root, 'eval'), protocolHash: evaluationHash, live: true, evaluate: async () => ({
+    candidate_id: row.candidate_id, fixture_id: row.fixture_id, repeat: 0, text_hash: row.text_hash, rewrite_hash: row.rewrite_hash,
+    judge_id: judge.id, judge_provider: judge.provider, judge_model: judge.model, judge_transport: judge.transport,
+    status: 'error', calls: [], private_details: {},
+  }) };
+  await evaluateExisting(args);
+  const path = join(root, 'eval/judge-anthropic-sonnet.jsonl');
+  const saved = JSON.parse(readFileSync(path, 'utf8')); saved.mps = 100; writeFileSync(path, JSON.stringify(saved) + '\n');
+  await assert.rejects(evaluateExisting(args), /metadata differs/);
+});
+
+test('foreign request identities and altered prompt bindings are rejected', async (t) => {
+  for (const alterPrompt of [false, true]) {
+    const { root, row, options } = setup(t);
+    const { logical } = await addParentJudgment(root, row);
+    const path = join(root, 'calls', textHash(logical), '1.private.json');
+    const saved = JSON.parse(readFileSync(path, 'utf8'));
+    const promptHash = alterPrompt ? textHash('A different fixture prompt') : saved.promptHash;
+    saved.promptHash = promptHash;
+    saved.requestHash = textHash(JSON.stringify({ logicalId: alterPrompt ? logical : 'another-fixture', index: 1,
+      candidate: gemini, promptHash, temperature: saved.temperature, responseFormat: null, extraBody: null }));
+    writeFileSync(path, JSON.stringify(saved));
+    await assert.rejects(loadParentCohort(options), /request or prompt binding/);
+  }
+});
+
+test('MPS replay cannot round a failing 89.9 up through the safety threshold', async (t) => {
+  const { root, row, options } = setup(t);
+  const saved = await addParentJudgment(root, row, 89.9);
+  assert.equal(saved.publicRow.mps, 89.9);
+  for (const name of ['judge-gemini-3.7.jsonl', 'judge-gemini-3.7.private.jsonl']) {
+    const path = join(root, name), value = JSON.parse(readFileSync(path, 'utf8'));
+    value.mps = 90; writeFileSync(path, JSON.stringify(value) + '\n');
+  }
+  await assert.rejects(loadParentCohort(options), /scores differ/);
+});


### PR DESCRIPTION
Adds a missing fixed judge seat to preserved rewrite outputs without regenerating them or changing their original protocol identities. Parent public/private records, directory bindings, exact request/prompt hashes and saved completion values are verified first. Legacy unbound parents require explicit opt-in plus the complete receipt audit.

The collector replays saved judge responses through production scoring code without network calls, preserves exact MPS thresholds, and rejects private-only/receipt-only evidence that could cause duplicate payment. New judgments use an independent immutable output protocol with parent hashes, private receipts and cross-family checks.

Validation: independent review PASS; full tests (1,857 tests; 1,855 pass, 2 optional skips), lint, and eight regression cases including copied requests, changed prompt hashes, private/public mismatches, incomplete recovery and 89.9-to-90 threshold tampering. Both real preserved OpenAI/Gemini parent cohorts pass the offline audit. No new paid judgments have been run yet.
