### PR TITLE
research: join audited evaluations and select confirmation candidates

### DIFF
--- a/docs/research/model-evaluation-joins.md
+++ b/docs/research/model-evaluation-joins.md
@@ -1,0 +1,33 @@
+# Join independent evaluation outputs
+
+`scripts/research/join-model-evaluations.mjs PLAN.json` performs an analysis-only
+join. It never calls a model. The plan names the parent generation cohort, its
+declared scope, the original evaluator source checkout and protocol, the separate
+evaluation directories and a new output directory.
+
+```json
+{
+  "parent": "/path/to/rewrite-screen",
+  "parentRoot": "/path/to/generation-source",
+  "parentCandidates": "/path/to/generation-protocol.json",
+  "parentProvider": "anthropic",
+  "candidates": "/path/to/evaluation-protocol.json",
+  "evaluationSourceRoot": "/path/to/frozen-evaluator-source",
+  "evaluations": ["/path/to/openai-judgments", "/path/to/gemini-judgments"],
+  "output": "/path/to/new-analysis"
+}
+```
+
+For legacy unbound parents, add `allowLegacyParent: true`; the complete parent
+receipt audit is still mandatory. Optional `suite`, `repeat` and
+`parentCandidate` must match the original generation matrix.
+
+The join verifies parent snapshots, evaluator source/protocol hashes, complete
+rows, public/private parity and request-bound raw completion values. It preserves
+each original protocol ID and records the analysis script hash. Missing,
+unresolved, duplicate or same-family judgments cannot yield a complete report.
+
+Finalist selection follows the registered safe-output rate, naturalness median
+and generation latency order. An exact tie uses candidate ID order for
+reproducibility; it does not establish a unique quality winner. Finalists are
+selected for the full repeated study, not promoted to production defaults.

--- a/scripts/research/join-model-evaluations.mjs
+++ b/scripts/research/join-model-evaluations.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { textHash } from '../../tests/quality/live-scorer-benchmark.mjs';
+import { acquireStudyWriter, readUniqueRows } from './study-journal.mjs';
+import { loadParentCohort } from './evaluate-existing-rewrites.mjs';
+import { auditParentReceipts } from './parent-cohort-audit.mjs';
+import { judgeCandidates, renderRewriteReport, rewriteFixtures, summarizeRewrites } from './model-rewrite-benchmark.mjs';
+import { studySemantics } from './study-validation.mjs';
+
+const key = (row) => `${row.candidate_id}/${row.fixture_id}/${row.repeat}`;
+const canonical = (value) => Array.isArray(value) ? value.map(canonical) : value && typeof value === 'object'
+  ? Object.fromEntries(Object.keys(value).sort().map((name) => [name, canonical(value[name])])) : value;
+const same = (a, b) => JSON.stringify(canonical(a)) === JSON.stringify(canonical(b));
+
+export async function joinEvaluations({ parent, fixtures, directories, protocol, evaluationSemantics }) {
+  const judgments = [...parent.judgments], evidence = [];
+  for (const directory of [...new Set(directories.map((path) => resolve(path)))].sort()) {
+    const release = acquireStudyWriter(directory, 'analysis-snapshot');
+    try {
+      const provenanceBytes = readFileSync(resolve(directory, 'provenance.json'), 'utf8');
+      const provenance = JSON.parse(provenanceBytes);
+      const judge = protocol.candidates.find((candidate) => candidate.id === provenance.judge?.id);
+      if (!judge || provenance.parentSnapshotHash !== parent.snapshotHash) throw new Error('Evaluation belongs to another parent snapshot');
+      const expected = textHash(JSON.stringify({ protocol, judge: judge.id, parentSnapshotHash: parent.snapshotHash, semantics: evaluationSemantics }));
+      const binding = JSON.parse(readFileSync(resolve(directory, 'study-protocol.json'), 'utf8'));
+      if (binding.schemaVersion !== 1 || binding.protocolHash !== expected || provenance.evaluationProtocolHash !== expected) throw new Error('Evaluation source/protocol binding differs');
+      const publicFile = `judge-${judge.id}.jsonl`, privateFile = `judge-${judge.id}.private.jsonl`;
+      const rows = readUniqueRows(resolve(directory, publicFile), key), privateRows = readUniqueRows(resolve(directory, privateFile), key);
+      if (rows.length !== privateRows.length || rows.length !== parent.generations.filter((row) => row.status === 'ok').length) throw new Error('Evaluation is incomplete');
+      const hashes = { 'provenance.json': textHash(provenanceBytes), [publicFile]: textHash(readFileSync(resolve(directory, publicFile))), [privateFile]: textHash(readFileSync(resolve(directory, privateFile))) };
+      for (const row of rows) {
+        const stored = privateRows.find((stored) => key(stored) === key(row));
+        if (!stored) throw new Error('Missing private evaluation row');
+        const { private_details: _details, ...safe } = stored;
+        if (!same(row, safe)) throw new Error('Evaluation public/private values differ');
+        const generation = parent.generations.find((generation) => key(generation) === key(row));
+        const candidate = parent.candidates.find((candidate) => candidate.id === generation?.candidate_id);
+        if (!generation || generation.status !== 'ok' || row.protocol_hash !== expected || row.parent_protocol_hash !== generation.protocol_hash
+          || row.parent_snapshot_hash !== parent.snapshotHash || row.text_hash !== generation.text_hash || row.rewrite_hash !== generation.rewrite_hash
+          || row.judge_id !== judge.id || row.judge_model !== judge.model || row.judge_provider !== judge.provider || row.judge_transport !== judge.transport
+          || !judgeCandidates(candidate, protocol).some((seat) => seat.id === judge.id)) throw new Error('Unbound evaluation judgment');
+      }
+      await auditParentReceipts({ directory, generations: parent.generations, privateRows: parent.privateRows, judgments: rows,
+        candidates: parent.candidates, protocol, fixtures, hashes, includeGenerations: false, judgmentProtocolHash: expected, judgeIds: [judge.id] });
+      judgments.push(...rows); evidence.push({ judge: judge.id, protocolHash: expected, hashes });
+    } finally { release(); }
+  }
+  const summary = summarizeRewrites(parent.generations, judgments);
+  const report = renderRewriteReport(parent.generations, judgments, { expectedKeys: parent.expectedKeys, protocolHash: 'see separate parent/evaluation provenance' });
+  if (!report.includes('Collection complete: **yes**')) throw new Error('Joined evaluation still has missing or unresolved work');
+  return { summary, report, evidence };
+}
+
+export function selectRewriteFinalists(summary) {
+  const groups = {};
+  for (const [id, value] of Object.entries(summary)) {
+    if (value.pending_judgments) throw new Error('Cannot select finalists with pending judgments');
+    (groups[value.provider] ||= []).push({ id, ...value });
+  }
+  return Object.fromEntries(Object.entries(groups).map(([provider, values]) => [provider,
+    values.sort((a, b) => b.safe_rate - a.safe_rate
+      || (b.naturalness.median ?? -Infinity) - (a.naturalness.median ?? -Infinity)
+      || (a.generation_latency_ms.median ?? Infinity) - (b.generation_latency_ms.median ?? Infinity)
+      || a.id.localeCompare(b.id)).slice(0, 2).map((row) => row.id)]));
+}
+
+async function main() {
+  if (process.argv.length !== 3) throw new Error('Usage: join-model-evaluations PLAN.json (no model calls)');
+  const plan = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+  const fixtures = rewriteFixtures(plan.suite || 'screening', resolve(plan.parentRoot));
+  const parent = await loadParentCohort({ directory: resolve(plan.parent), protocolFile: resolve(plan.parentCandidates), fixtures,
+    provider: plan.parentProvider, candidateId: plan.parentCandidate, repeat: plan.repeat || 1, allowLegacyUnbound: plan.allowLegacyParent === true });
+  const protocol = JSON.parse(readFileSync(plan.candidates, 'utf8'));
+  const result = await joinEvaluations({ parent, fixtures, directories: plan.evaluations, protocol, evaluationSemantics: studySemantics(resolve(plan.evaluationSourceRoot)) });
+  const output = resolve(plan.output);
+  if ([plan.parent, ...plan.evaluations].some((path) => resolve(path) === output)) throw new Error('Analysis output must be separate from input cohorts');
+  mkdirSync(output, { recursive: true });
+  const provenance = { parent: parent.provenance, parentSnapshotHash: parent.snapshotHash, evaluations: result.evidence,
+    analysisScriptHash: textHash(readFileSync(fileURLToPath(import.meta.url))) };
+  writeFileSync(resolve(output, 'provenance.json'), `${JSON.stringify(provenance, null, 2)}\n`);
+  writeFileSync(resolve(output, 'rewrite-report.md'), `Parent and evaluation protocols are preserved in provenance.json.\n\n${result.report}`);
+  writeFileSync(resolve(output, 'rewrite-summary.json'), `${JSON.stringify({ summary: result.summary, finalists: selectRewriteFinalists(result.summary) }, null, 2)}\n`);
+  console.log(JSON.stringify({ output, finalists: selectRewriteFinalists(result.summary) }));
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main().catch((error) => { console.error(error.message); process.exitCode = 1; });

--- a/scripts/research/parent-cohort-audit.mjs
+++ b/scripts/research/parent-cohort-audit.mjs
@@ -13,15 +13,17 @@ function bindRequest(receipt, logicalId, index, candidate, promptHash, options =
   if (receipt.schemaVersion !== 1 || receipt.promptHash !== promptHash || receipt.requestHash !== textHash(JSON.stringify(identity))) throw new Error('Parent receipt request or prompt binding differs');
 }
 
-export async function auditParentReceipts({ directory, generations, privateRows, judgments, candidates, protocol, fixtures, hashes }) {
+export async function auditParentReceipts({ directory, generations, privateRows, judgments, candidates, protocol, fixtures, hashes,
+  includeGenerations = true, judgmentProtocolHash, judgeIds }) {
   const expectedGroups = new Map();
   for (const generation of generations) {
     const candidate = candidates.find((candidate) => candidate.id === generation.candidate_id);
     const logical = `${generation.protocol_hash}/${key(generation)}`;
-    expectedGroups.set(textHash(`${logical}/rewrite`), { row: generation, candidate, generation, logicalId: `${logical}/rewrite` });
-    for (const judge of judgeCandidates(candidate, protocol)) {
+    if (includeGenerations) expectedGroups.set(textHash(`${logical}/rewrite`), { row: generation, candidate, generation, logicalId: `${logical}/rewrite` });
+    for (const judge of judgeCandidates(candidate, protocol).filter((judge) => !judgeIds || judgeIds.includes(judge.id))) {
       const row = judgments.find((row) => key(row) === key(generation) && row.judge_id === judge.id);
-      expectedGroups.set(textHash(`${logical}/judge/${judge.id}`), { row, candidate: judge, generation, judge: true, logicalId: `${logical}/judge/${judge.id}` });
+      const judgeLogical = `${judgmentProtocolHash || generation.protocol_hash}/${key(generation)}/judge/${judge.id}`;
+      expectedGroups.set(textHash(judgeLogical), { row, candidate: judge, generation, judge: true, logicalId: judgeLogical });
     }
   }
   const callsRoot = resolve(directory, 'calls');

--- a/tests/unit/model-evaluation-join.test.js
+++ b/tests/unit/model-evaluation-join.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { textHash } from '../quality/live-scorer-benchmark.mjs';
+import { generateRewrite, judgeRewrite } from '../../scripts/research/model-rewrite-benchmark.mjs';
+import { loadParentCohort, evaluateExisting } from '../../scripts/research/evaluate-existing-rewrites.mjs';
+import { joinEvaluations, selectRewriteFinalists } from '../../scripts/research/join-model-evaluations.mjs';
+
+async function fixture(t) {
+  const root = mkdtempSync(join(tmpdir(), 'patina-evaluation-join-')); t.after(() => rmSync(root, { recursive: true, force: true }));
+  const generator = { id: 'generator', provider: 'openai', model: 'gpt-test', transport: 'opencodex', baseURL: 'http://127.0.0.1:10100/v1' };
+  const gemini = { id: 'gemini-3.7', provider: 'gemini', model: 'google-antigravity/gemini-test', transport: 'opencodex', baseURL: generator.baseURL };
+  const claude = { id: 'anthropic-sonnet', provider: 'anthropic', model: 'claude-sonnet-5', transport: 'claude-cli' };
+  const protocol = { candidates: [generator, { ...generator, id: 'openai-5.5' }, gemini, claude] };
+  const source = { fixture_id: 'one', text: 'We shipped 12 fixes.', language: 'en', text_hash: textHash('We shipped 12 fixes.') };
+  const parentHash = 'a'.repeat(64), protocolFile = join(root, 'protocol.json'), semantics = { test: 'isolated-fixture' };
+  writeFileSync(protocolFile, JSON.stringify(protocol)); writeFileSync(join(root, 'study-protocol.json'), JSON.stringify({ schemaVersion: 1, protocolHash: parentHash }));
+  const response = (candidate, text) => ({ text, effectiveModels: [candidate.model], durationMs: 1, attempts: 1 });
+  const generation = { ...await generateRewrite(source, generator, 'Frozen generation prompt', { journalDirectory: root,
+    logicalId: `${parentHash}/generator/one/0/rewrite`, complete: async (candidate) => response(candidate, source.text) }), repeat: 0, protocol_hash: parentHash };
+  const { rewrite: _text, ...publicGeneration } = generation;
+  writeFileSync(join(root, 'rewrite-rows.jsonl'), JSON.stringify(publicGeneration) + '\n');
+  writeFileSync(join(root, 'rewrites.private.jsonl'), JSON.stringify(generation) + '\n');
+  const parent = await loadParentCohort({ directory: root, protocolFile, fixtures: [source], provider: 'openai', candidateId: generator.id });
+  const directories = [];
+  for (const judge of [gemini, claude]) {
+    const output = join(root, judge.id); directories.push(output);
+    const protocolHash = textHash(JSON.stringify({ protocol, judge: judge.id, parentSnapshotHash: parent.snapshotHash, semantics }));
+    await evaluateExisting({ parent: { ...parent, fixtures: [source] }, judge, output, protocolHash, live: true,
+      evaluate: (f, g, j, options) => judgeRewrite(f, g, j, { ...options, complete: async (candidate, prompt) => response(candidate,
+        prompt.includes('Meaning Preservation evaluator') ? '{"anchors":[{"type":"claim","content":"12 fixes","verdict":"PASS"}],"pass_count":1,"total_count":1,"polarity_pass_count":0,"polarity_total_count":0,"mps":100}'
+          : prompt.includes('Fidelity evaluator') ? '{"claims_preserved":3,"no_fabrication":3,"audience_register_match":3}' : '{"naturalness":3}') }) });
+  }
+  return { root, parent, fixtures: [source], directories, protocol, evaluationSemantics: semantics };
+}
+
+test('two independently bound evaluation directories join without relabeling parent protocols', async (t) => {
+  const args = await fixture(t); const result = await joinEvaluations(args);
+  assert.equal(result.summary.generator.safe, 1); assert.equal(result.evidence.length, 2);
+  assert.match(result.report, /complete: \*\*yes/);
+  assert.equal(args.parent.generations[0].protocol_hash, 'a'.repeat(64));
+  await assert.rejects(joinEvaluations({ ...args, directories: [args.directories[0]] }), /missing or unresolved/);
+});
+
+test('wrong snapshots and altered public/private scores cannot certify joined results', async (t) => {
+  const args = await fixture(t);
+  const provenancePath = join(args.directories[0], 'provenance.json'), original = readFileSync(provenancePath, 'utf8');
+  const value = JSON.parse(original); value.parentSnapshotHash = 'f'.repeat(64); writeFileSync(provenancePath, JSON.stringify(value));
+  await assert.rejects(joinEvaluations(args), /another parent/);
+  writeFileSync(provenancePath, original);
+  for (const suffix of ['jsonl', 'private.jsonl']) {
+    const path = join(args.directories[0], `judge-gemini-3.7.${suffix}`), row = JSON.parse(readFileSync(path, 'utf8'));
+    row.mps = 0; writeFileSync(path, JSON.stringify(row) + '\n');
+  }
+  await assert.rejects(joinEvaluations(args), /scores differ/);
+});
+
+test('finalists follow safety, naturalness and latency; pending work is rejected', () => {
+  const row = (safe_rate, median, latency) => ({ provider: 'test', pending_judgments: 0, safe_rate, naturalness: { median }, generation_latency_ms: { median: latency } });
+  assert.deepEqual(selectRewriteFinalists({ a: row(.9, 3, 10), b: row(.8, 4, 1), c: row(.9, 4, 20) }), { test: ['c', 'a'] });
+  assert.throws(() => selectRewriteFinalists({ a: { ...row(1, 4, 1), pending_judgments: 1 } }), /pending/);
+});


### PR DESCRIPTION
Adds an analysis-only join for independently collected judge outputs. It preserves parent and evaluation protocol identities, recomputes evaluator-source bindings, checks complete public/private rows, and replays request-bound saved completions before producing a complete report.

Finalist selection follows the registered safe-output rate, naturalness median and latency order, with stable ID ordering only for exact ties. It cannot select through pending or unresolved judgments, and does not change production defaults.

Validation: independent review PASS; 1,865 tests (1,863 pass, 2 optional skips), full lint/typecheck/spellcheck, and real offline audit of the OpenAI and Claude screening cohorts. Regression cases reject altered snapshots and public/private scores, and retain exact safety-threshold semantics. The OpenAI and Claude finalists now proceed to the larger repeated study; these are not final model recommendations.
