### PR TITLE
feat: source-bound sentence diagnostics for editor audits

### DIFF
--- a/docs/integrations/editor-inspection.md
+++ b/docs/integrations/editor-inspection.md
@@ -13,8 +13,13 @@ text), `language`, `score`, `available`, and `diagnostics`. Each diagnostic has
 UTF-16 `start`/`end` offsets, a stable code, a message and signal names. It
 contains no raw draft text. Editors can use their normal offset-to-position API.
 
-Paragraph findings describe the analyzer's paragraph-level evidence. They do
-not claim sentence-level or authorship certainty. Document-level leakage and
+Paragraph findings describe the analyzer's paragraph-level evidence. Where
+lexical cues can be located, additional `scope: "sentence"` findings identify
+the sentences contributing those cues. They do not assert an independent
+sentence-level or authorship verdict. Inline/fenced code, URLs and HTML tags
+are masked for these local hints. A localized paragraph retains its aggregate
+record with `localized: true`, allowing editors to prefer the narrower ranges.
+Document-level leakage and
 private structural-model findings are marked separately. NFC analysis is mapped
 back to whole original graphemes, including decomposed accents and emoji.
 
@@ -26,3 +31,10 @@ backend and rewrite options are rejected.
 Use inspection for background editor hints. Explicit `--audit` or rewrite
 commands can still invoke the user's configured backend; apply rewritten text
 only after a diff preview and an unchanged-document check.
+
+`patina --audit --format json` also includes an `inspection` object for the
+original input alongside the model's audit text. The model does not invent these
+offsets. Oversized or unavailable inspection leaves the audit report usable with
+`inspection.available: false`. At most 2,000 diagnostics are returned, with
+`diagnosticsTruncated` marking additional findings; document-level evidence is
+retained first. The underlying score and detector gates are unchanged.

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -37,6 +37,7 @@ import { evaluatePersonaGate } from '../personas/gates.js';
 import { personaMatchScore } from '../features/persona-match.js';
 import { pathToFileURL } from 'node:url';
 import { humanizeXliffDocument, resolveUniqueCap } from './xliff.js';
+import { inspectAuditSource } from '../inspection.js';
 
 /**
  * Run the default patina pipeline for an already-parsed CLI invocation:
@@ -345,7 +346,8 @@ export async function runDefault(parsed, logger) {
 
         let output;
         let scoreValidationOutput = null;
-        output = formatOutput(result, mode, parsed, { register: registerResolution, logger, auditBackstop, persona: personaReport });
+        const inspection = mode === 'audit' && parsed.format === 'json' ? inspectAuditSource(text, { language: lang, config, repoRoot }) : null;
+        output = formatOutput(result, mode, parsed, { register: registerResolution, logger, auditBackstop, persona: personaReport, inspection });
         if (mode === 'score') {
           scoreValidationOutput = formatOutput(result, mode, { ...parsed, format: 'markdown' }, { logger });
         }

--- a/src/inspection-masks.js
+++ b/src/inspection-masks.js
@@ -1,0 +1,69 @@
+// Conservative source-length-preserving masks for localized editor hints.
+// The detector itself still receives the original text.
+export function maskInspectionNonProse(text) {
+  const output = text.split(''), boundaries = [];
+  const blank = (start, end) => { for (let i = start; i < end; i++) if (text[i] !== '\n' && text[i] !== '\r') output[i] = ' '; };
+  let fence = null;
+  for (let start = 0; start < text.length;) {
+    const newline = text.indexOf('\n', start), end = newline < 0 ? text.length : newline + 1;
+    let cursor = start; while (cursor < end && text[cursor] === ' ' && cursor - start < 4) cursor++;
+    const character = text[cursor]; let width = 0;
+    if (cursor - start <= 3 && (character === '`' || character === '~')) while (text[cursor + width] === character) width++;
+    const rest = text.slice(cursor + width, end).trim();
+    if (fence) {
+      blank(start, end);
+      if (character === fence.character && width >= fence.width && !rest) { fence = null; boundaries.push(end); }
+    } else if (width >= 3 && (character !== '`' || !rest.includes('`'))) {
+      fence = { character, width }; boundaries.push(start); blank(start, end);
+    }
+    start = end;
+  }
+  for (const match of text.matchAll(/\n[ \t\r]*\n/g)) boundaries.push(match.index + match[0].length);
+  boundaries.sort((a, b) => a - b);
+
+  // Index backtick runs once. Matching lookup remains linear on long inputs
+  // with unmatched delimiters, rather than rescanning the suffix for each run.
+  const runs = [], byStart = new Map(); let boundary = 0;
+  for (let i = 0; i < text.length;) {
+    while (boundary < boundaries.length && boundaries[boundary] <= i) boundary++;
+    if (output[i] !== '`') { i++; continue; }
+    const start = i; while (output[i] === '`') i++;
+    const run = { start, end: i, width: i - start, group: boundary, next: -1 };
+    byStart.set(start, runs.length); runs.push(run);
+  }
+  const next = new Map();
+  for (let i = runs.length - 1; i >= 0; i--) {
+    const key = `${runs[i].group}/${runs[i].width}`;
+    runs[i].next = next.get(key) ?? -1; next.set(key, i);
+  }
+
+  for (let i = 0; i < text.length;) {
+    if (output[i] === '`') {
+      const run = runs[byStart.get(i)];
+      if (run?.next >= 0) { const end = runs[run.next].end; blank(i, end); i = end; continue; }
+      i = run?.end || i + 1; continue;
+    }
+    if (output[i] !== '<' || !/[a-zA-Z!/?]/.test(text[i + 1] || '')) { i++; continue; }
+    if (text.startsWith('<!--', i)) {
+      const close = text.indexOf('-->', i + 4), end = close < 0 ? text.length : close + 3;
+      blank(i, end); i = end; continue;
+    }
+    let quote = null, end = i + 1;
+    for (; end < text.length; end++) {
+      const char = text[end];
+      if (quote) { if (char === quote) quote = null; }
+      else if (char === '"' || char === "'") quote = char;
+      else if (char === '>') { end++; break; }
+    }
+    const tag = text.slice(i, end).match(/^<\s*(script|style)(?=[\s>])/i)?.[1]?.toLowerCase();
+    if (tag) {
+      const closingTag = new RegExp(`</${tag}(?=[\\s/>])`, 'ig');
+      closingTag.lastIndex = end;
+      const close = closingTag.exec(text);
+      if (!close) end = text.length;
+      else { const closeEnd = text.indexOf('>', close.index); end = closeEnd < 0 ? text.length : closeEnd + 1; }
+    }
+    blank(i, end); i = end;
+  }
+  return output.join('');
+}

--- a/src/inspection.js
+++ b/src/inspection.js
@@ -1,11 +1,13 @@
 import { createHash } from 'node:crypto';
-import { analyzeText, splitParagraphs } from './features/index.js';
+import { analyzeText, splitParagraphs, tokenize, computeDensity, loadLexicon } from './features/index.js';
 import { loadConfig, getRepoRoot } from './config.js';
 import { loadPatterns } from './loader.js';
 import { scoreDeterministicSignals } from './scoring.js';
 import { detectLanguage } from '../scripts/prose-score.mjs';
+import { maskInspectionNonProse } from './inspection-masks.js';
 
 export const MAX_INSPECTION_CHARS = 200000;
+export const MAX_INSPECTION_DIAGNOSTICS = 2000;
 
 // Offsets are UTF-16, matching VS Code and JavaScript editor APIs. NFC analysis
 // can shorten decomposed graphemes; map each normalized unit back to its whole
@@ -33,6 +35,21 @@ function paragraphSignals(paragraph) {
   ].filter(Boolean);
 }
 
+function sentenceFindings(paragraph, paragraphStart, masked, lexicon, evidence, lang) {
+  if (!evidence.lexicon?.hot || !lexicon) return [];
+  const known = new Set(evidence.lexicon.hits || []), findings = [];
+  for (const { segment, index } of new Intl.Segmenter(lang, { granularity: 'sentence' }).segment(paragraph)) {
+    const leading = segment.length - segment.trimStart().length;
+    const start = paragraphStart + index + leading;
+    const end = paragraphStart + index + segment.trimEnd().length;
+    if (start >= end) continue;
+    const text = masked.slice(start, end);
+    const hits = computeDensity(text, tokenize(text, { lang }), lexicon).hits.filter((hit) => known.has(hit));
+    if (hits.length) findings.push({ start, end, evidenceCount: hits.length });
+  }
+  return findings;
+}
+
 export function inspectText(text, { language = 'auto', file = '', config, repoRoot = getRepoRoot() } = {}) {
   if (typeof text !== 'string' || !text.trim()) throw new TypeError('Inspection requires non-empty text');
   if (text.length > MAX_INSPECTION_CHARS) throw new RangeError(`Inspection supports at most ${MAX_INSPECTION_CHARS} characters; inspect a selection instead`);
@@ -40,27 +57,42 @@ export function inspectText(text, { language = 'auto', file = '', config, repoRo
   const settings = globalThis.structuredClone(config || loadConfig());
   const lang = detectLanguage(file, text.normalize('NFC'), language); settings.language = lang;
   const patterns = loadPatterns(repoRoot, lang, settings['skip-patterns'] || []);
-  let analysis;
+  let analysis, lexicon;
   const score = scoreDeterministicSignals({ text, config: settings, patterns, repoRoot,
-    logger: { warn() {} }, analyzer: (value, options) => { analysis = analyzeText(value, options); return analysis; } });
+    logger: { warn() {} }, analyzer: (value, options) => {
+      lexicon = options.lexicon ?? loadLexicon(lang, repoRoot);
+      analysis = analyzeText(value, { ...options, lexicon }); return analysis;
+    } });
   const base = { schemaVersion: 1, language: lang, sourceHash: createHash('sha256').update(text).digest('hex'),
     deterministicOnly: true, offsetEncoding: 'utf-16', score: score?.overall ?? null,
     interpretation: score?.interpretation ?? null, paragraphCount: score?.paragraphCount ?? 0 };
   if (!analysis || !Number.isFinite(score?.overall)) return { ...base, available: false, diagnostics: [], reason: score?.skipReason || 'analysis-unavailable' };
   const mapping = normalizedOffsetMap(text);
+  const masked = maskInspectionNonProse(mapping.normalized).replace(/https?:\/\/\S+/g, (value) => ' '.repeat(value.length));
   const paragraphs = splitParagraphs(mapping.normalized);
-  const diagnostics = []; let cursor = 0;
+  const diagnostics = []; let cursor = 0, diagnosticsTruncated = false;
+  const add = (row) => { if (diagnostics.length < MAX_INSPECTION_DIAGNOSTICS) diagnostics.push(row); else diagnosticsTruncated = true; };
+  if (analysis.markupLeakage?.leaked) add({ start: 0, end: text.length, code: 'model-output-leakage', scope: 'document', severity: 'warning', message: 'Model-output markup or self-identification is present.', signals: ['model-output-leakage'] });
+  if (analysis.structuralClassifier?.hot) add({ start: 0, end: text.length, code: 'structural-model', scope: 'document', severity: 'warning', message: 'The configured structural model flagged this document.', signals: ['structural-model'] });
   for (let i = 0; i < paragraphs.length; i++) {
     const paragraph = paragraphs[i];
     const start = mapping.normalized.indexOf(paragraph, cursor);
     if (start < 0) throw new Error('Analysis paragraph could not be mapped to the source');
     cursor = start + paragraph.length;
     if (!analysis.paragraphs[i]?.hot) continue;
-    diagnostics.push({ start: mapping.starts[start], end: mapping.ends[cursor - 1],
-      code: 'ai-like-paragraph', severity: 'warning', paragraph: i + 1,
+    const sentences = sentenceFindings(paragraph, start, masked, lexicon, analysis.paragraphs[i], lang);
+    add({ start: mapping.starts[start], end: mapping.ends[cursor - 1],
+      code: 'ai-like-paragraph', scope: 'paragraph', localized: sentences.length > 0 && diagnostics.length + 1 < MAX_INSPECTION_DIAGNOSTICS, severity: 'warning', paragraph: i + 1,
       message: 'This paragraph has AI-like editing signals.', signals: paragraphSignals(analysis.paragraphs[i]) });
+    for (const sentence of sentences) add({ start: mapping.starts[sentence.start], end: mapping.ends[sentence.end - 1],
+      code: 'ai-like-sentence', scope: 'sentence', severity: 'warning', paragraph: i + 1, evidenceCount: sentence.evidenceCount,
+      message: 'This sentence contains lexical cues contributing to the paragraph’s writing signals.', signals: ['ai-lexicon-density'] });
   }
-  if (analysis.markupLeakage?.leaked) diagnostics.push({ start: 0, end: text.length, code: 'model-output-leakage', severity: 'warning', message: 'Model-output markup or self-identification is present.', signals: ['model-output-leakage'] });
-  if (analysis.structuralClassifier?.hot) diagnostics.push({ start: 0, end: text.length, code: 'structural-model', severity: 'warning', message: 'The configured structural model flagged this document.', signals: ['structural-model'] });
-  return { ...base, available: true, diagnostics, skipped: score.skipped, skipReason: score.skipReason };
+  return { ...base, available: true, diagnostics, diagnosticsTruncated, skipped: score.skipped, skipReason: score.skipReason };
+}
+
+export function inspectAuditSource(text, options = {}) {
+  try { return inspectText(text, options); }
+  catch { return { schemaVersion: 1, deterministicOnly: true, sourceHash: createHash('sha256').update(text).digest('hex'),
+    language: options.language, offsetEncoding: 'utf-16', available: false, score: null, diagnostics: [], reason: 'inspection-unavailable' }; }
 }

--- a/src/output.js
+++ b/src/output.js
@@ -16,6 +16,7 @@ import { TRANSLATIONESE_RULES } from './features/translationese.js';
  * @param {object} [opts.stdout] Stdout-like stream for color decisions.
  * @param {string} [opts.auditBackstop] Deterministic audit-mode section.
  * @param {object|null} [opts.persona] Persona metadata to append.
+ * @param {object|null} [opts.inspection] Source-bound deterministic audit diagnostics.
  * @returns {string} User-facing formatted output.
  * @throws {TypeError} When JSON output carries unserializable values.
  * @example
@@ -34,7 +35,7 @@ export function formatOutput(result, mode, parsed = {}, opts = {}) {
     body += opts.auditBackstop;
   }
   if (format === 'json') {
-    return formatJsonOutput({ result, mode, body, register, gate: parsed.gate, persona });
+    return formatJsonOutput({ result, mode, body, register, gate: parsed.gate, persona, inspection: opts.inspection });
   }
   return formatTextOutput(body);
 }
@@ -328,8 +329,9 @@ function formatTextOutput(body) {
   return body.trim();
 }
 
-function formatJsonOutput({ result, mode, body, register, gate, persona }) {
+function formatJsonOutput({ result, mode, body, register, gate, persona, inspection }) {
   const overall = extractOverall(result, body);
+  const scoreDetails = extractScoreDetails(result);
   const payload = {
     mode,
     format: 'json',
@@ -345,10 +347,9 @@ function formatJsonOutput({ result, mode, body, register, gate, persona }) {
     gateResult: buildGateResult(overall, gate),
     persona: persona || null,
     output: body,
+    ...(mode === 'audit' && inspection ? { inspection } : {}),
+    ...(scoreDetails ? { scores: scoreDetails } : {}),
   };
-
-  const scoreDetails = extractScoreDetails(result);
-  if (scoreDetails) payload.scores = scoreDetails;
 
 
   return JSON.stringify(payload, null, 2);

--- a/tests/unit/inspection.test.js
+++ b/tests/unit/inspection.test.js
@@ -2,7 +2,9 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { inspectText, normalizedOffsetMap } from '../../src/inspection.js';
+import { inspectText, inspectAuditSource, normalizedOffsetMap } from '../../src/inspection.js';
+import { formatOutput } from '../../src/output.js';
+import { maskInspectionNonProse } from '../../src/inspection-masks.js';
 import { loadConfig } from '../../src/config.js';
 
 const sample = "In today's rapidly evolving landscape, this comprehensive solution unlocks unprecedented opportunities. Furthermore, it fosters seamless collaboration and takes productivity to the next level.";
@@ -66,4 +68,71 @@ test('automatic Korean detection is invariant under NFC/NFD source encoding', ()
   const nfc = inspectText(text); const nfd = inspectText(text.normalize('NFD'));
   assert.equal(nfc.language, 'ko'); assert.equal(nfd.language, 'ko'); assert.equal(nfc.score, nfd.score);
   assert.notEqual(nfc.sourceHash, nfd.sourceHash);
+});
+
+test('sentence hints localize lexical evidence and preserve a calm neighboring sentence', () => {
+  const text = 'I fixed the typo. ' + sample;
+  const result = inspectText(text, { language: 'en' });
+  const sentences = result.diagnostics.filter((row) => row.scope === 'sentence');
+  assert.ok(sentences.length > 0);
+  for (const row of sentences) {
+    assert.ok(!text.slice(row.start, row.end).includes('I fixed the typo.'));
+    assert.equal(row.code, 'ai-like-sentence'); assert.ok(row.evidenceCount > 0);
+  }
+  assert.equal(result.diagnostics.find((row) => row.scope === 'paragraph').localized, true);
+});
+
+test('sentence hints skip inline and fenced code without changing the score', () => {
+  for (const text of ['``pivotal transformative landscape``', '```js\nconst x = "pivotal transformative landscape";\n```']) {
+    const result = inspectText(text, { language: 'en' });
+    assert.equal(result.diagnostics.filter((row) => row.scope === 'sentence').length, 0);
+  }
+  const source = `cafe\u0301 👩‍💻. ${sample}\r\n\r\n${sample}`;
+  for (const row of inspectText(source, { language: 'en' }).diagnostics.filter((row) => row.scope === 'sentence')) {
+    assert.ok(row.end <= source.length);
+    assert.ok(source.slice(row.start, row.end).trim().length > 0);
+  }
+});
+
+test('JSON audit metadata is source-bound and large audit reports remain usable', () => {
+  const inspection = inspectAuditSource(sample, { language: 'en' });
+  const result = JSON.parse(formatOutput('Audit report.', 'audit', { format: 'json' }, { inspection }));
+  assert.equal(result.output, 'Audit report.');
+  assert.equal(result.inspection.sourceHash, inspection.sourceHash);
+  assert.ok(result.inspection.diagnostics.some((row) => row.scope === 'sentence'));
+  const huge = inspectAuditSource('x'.repeat(200001), { language: 'en' });
+  assert.equal(huge.available, false); assert.equal(huge.score, null);
+  assert.equal(JSON.parse(formatOutput('Kept.', 'rewrite', { format: 'json' }, { inspection })).inspection, undefined);
+});
+
+test('localized masks handle multiline code, indented fences and quoted HTML attributes', () => {
+  for (const text of ['`seamless\ntransformative curated`', '<span\n title="seamless transformative curated">ordinary</span>', '<span title="x > seamless transformative curated">ordinary</span>']) {
+    assert.equal(inspectText(text, { language: 'en' }).diagnostics.filter((row) => row.scope === 'sentence').length, 0);
+    assert.equal(maskInspectionNonProse(text).length, text.length);
+  }
+  const text = '```\nseamless transformative curated\n   ```\n\n' + sample;
+  const diagnostics = inspectText(text, { language: 'en' }).diagnostics.filter((row) => row.scope === 'sentence');
+  assert.ok(diagnostics.length > 0); assert.ok(diagnostics.every((row) => row.start >= text.indexOf(sample)));
+});
+
+test('long fence runs remain bounded below the inspection input limit', () => {
+  const bin = fileURLToPath(new URL('../../bin/patina.js', import.meta.url));
+  const result = JSON.parse(execFileSync(process.execPath, [bin, 'inspect', '--lang', 'en'], { input: '~'.repeat(4000), encoding: 'utf8', timeout: 1500 }));
+  assert.equal(result.available, true);
+});
+
+test('HTML masks preserve Unicode offsets and require an exact closing tag name', () => {
+  const prefix = 'İstanbul '.repeat(12);
+  for (const tag of ['script', 'style']) {
+    const code = `<${tag}>x = "</${tag}ure> seamless transformative curated";</${tag.toUpperCase()}>`;
+    const source = `${prefix}${code}\n\n${sample}`;
+    const masked = maskInspectionNonProse(source);
+    assert.equal(masked.length, source.length);
+    assert.equal(masked.slice(0, prefix.length), prefix);
+    assert.equal(masked.slice(prefix.length, prefix.length + code.length).trim(), '');
+    assert.equal(masked.slice(source.indexOf(sample)), sample);
+    const hints = inspectText(source, { language: 'en' }).diagnostics.filter((row) => row.scope === 'sentence');
+    assert.ok(hints.length > 0);
+    assert.ok(hints.every((row) => row.start >= source.indexOf(sample)));
+  }
 });


### PR DESCRIPTION
Editor inspection now localizes lexical evidence to source-bound sentence ranges while preserving paragraph and document findings. JSON audits include the same deterministic inspection metadata, so editor clients can highlight the audited source without another model request.

Code fences, inline code, HTML attributes, script/style bodies and Unicode normalization preserve original UTF-16 positions. Oversized source inspection does not discard the audit report.

Validation: full suite 1,869 passed, 2 skipped; lint clean. Live audit through OpenCodex returned a report and verified sentence ranges. Independent read-only review passed after fixing mask performance, Unicode offsets and closing-tag boundaries.

Supports #206.
