### PR TITLE
fix: validate Claude study arguments before temporary allocation

### DIFF
--- a/scripts/research/model-evaluation-transport.mjs
+++ b/scripts/research/model-evaluation-transport.mjs
@@ -76,6 +76,7 @@ export function claudeStudyArgs(candidate) {
 function claudeCompletion(candidate, prompt, timeoutMs) {
   return new Promise((resolve, reject) => {
     if (process.platform === 'win32') return reject(new Error('Native study isolation requires a POSIX shell'));
+    const cliArgs = claudeStudyArgs(candidate);
     const directory = mkdtempSync(join(tmpdir(), 'patina-study-cli-'));
     const statusPath = join(directory, 'status');
     const env = { ...process.env };
@@ -86,7 +87,7 @@ function claudeCompletion(candidate, prompt, timeoutMs) {
     // or allowing its process-group ID to be reused before cleanup.
     const shell = 'exec 3<&0; patina_status=$1; patina_seconds=$2; shift 2; trap ":" TERM; (sleep "$patina_seconds"; /bin/kill -KILL -- -$$) & "$@" <&3 & patina_cli=$!; wait "$patina_cli"; patina_exit=$?; printf "%s" "$patina_exit" > "$patina_status"; while :; do sleep 1; done';
     const child = spawn('/bin/sh', ['-c', shell, 'patina-study', statusPath, String(Math.ceil((timeoutMs + 2000) / 1000)),
-      'claude', ...claudeStudyArgs(candidate)], {
+      'claude', ...cliArgs], {
       cwd: directory, env, stdio: ['pipe', 'pipe', 'pipe'], detached: true,
     });
     let stdout = '';

--- a/tests/unit/claude-study-isolation.test.js
+++ b/tests/unit/claude-study-isolation.test.js
@@ -1,6 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { claudeStudyArgs } from '../../scripts/research/model-evaluation-transport.mjs';
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { claudeStudyArgs, studyCompletion } from '../../scripts/research/model-evaluation-transport.mjs';
 
 test('Claude study isolates personal advisors while retaining the OAuth-capable CLI', () => {
   const args = claudeStudyArgs({ model: 'claude-opus-5', effort: 'high' });
@@ -11,4 +14,17 @@ test('Claude study isolates personal advisors while retaining the OAuth-capable 
   assert.equal(args.includes('--bare'), false);
   assert.equal(claudeStudyArgs({ model: 'claude-haiku-4-5-20251001' }).includes('--effort'), false);
   assert.throws(() => claudeStudyArgs({ model: 'claude-opus-5', effort: 'unrecorded' }), /effort/);
+});
+
+test('invalid study effort is rejected before creating a temporary directory', { skip: process.platform === 'win32' }, async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'patina-invalid-study-test-'));
+  const previous = process.env.TMPDIR;
+  process.env.TMPDIR = directory;
+  try {
+    await assert.rejects(studyCompletion({ id: 'test', provider: 'anthropic', transport: 'claude-cli', model: 'claude-opus-5', effort: 'unrecorded' }, 'test'), /Invalid Claude study effort/);
+    assert.deepEqual(readdirSync(directory), []);
+  } finally {
+    if (previous === undefined) delete process.env.TMPDIR; else process.env.TMPDIR = previous;
+    rmSync(directory, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Invalid Claude study effort previously threw after creating a temporary directory and before cleanup was registered. Validate the CLI arguments before allocating that directory. Valid requests and frozen study worktrees are unchanged.

Validation: regression reproduces the original leak in an owned TMPDIR and confirms zero leftover files; full suite1,886 passed,2 skipped; lint clean. Independent Astra/xhigh review passed and confirmed no allocation, spawn or provider call on invalid input.
