### PR TITLE
docs: current Gemini, Kimi and DeepSeek contracts

### DIFF
--- a/docs/research/provider-gemini-kimi-deepseek-20260905.json
+++ b/docs/research/provider-gemini-kimi-deepseek-20260905.json
@@ -1,0 +1,1208 @@
+{
+  "schemaVersion": 1,
+  "research": "patina-provider-gemini-kimi-deepseek-20260905",
+  "asOfDate": "2026-09-05",
+  "timezone": "Asia/Seoul",
+  "scope": "Documentation research and static protocol review for writing and scoring; no experimental ranking.",
+  "repoSnapshot": {
+    "commit": "722d814925312c8859f1c6499860597d8ce41482",
+    "protocols": [
+      {
+        "path": "docs/research/model-evaluation-20260904.json",
+        "sha256": "8451be6e9690ba8a5cc32494b7fb7664353b8caa0403b1d772bb0ade7c719e4f"
+      },
+      {
+        "path": "docs/research/model-evaluation-kimi-code-20260905.json",
+        "sha256": "807c9852834c21f5859a3612ed7accf79b3df81b8d5daa3b9059460570826c85"
+      }
+    ],
+    "reviewedPaths": [
+      "scripts/research/model-evaluation-transport.mjs",
+      "scripts/research/kimi-study-transport.mjs",
+      "scripts/research/model-rewrite-benchmark.mjs",
+      "src/api.js",
+      "src/scoring.js",
+      "src/backends/kimi-cli.js",
+      "docs/research/model-evaluation-20260904.md",
+      "docs/research/model-evaluation-kimi-code-20260905.md"
+    ]
+  },
+  "execution": {
+    "liveModelCalls": 0,
+    "providerInventoryCalls": 0,
+    "credentialReads": 0,
+    "accountOrGlobalSettingsChanges": 0,
+    "experimentResultsIncluded": false,
+    "experimentalWinner": null,
+    "actualCostUsd": null
+  },
+  "geminiPolicy": {
+    "transport": "opencodex",
+    "baseURL": "http://127.0.0.1:10100/v1",
+    "routePrefix": "google-antigravity/gemini-",
+    "directGeminiApiAllowed": false,
+    "geminiApiKeyAllowed": false,
+    "localEndpointProbed": false
+  },
+  "evidenceLimits": [
+    "Public documentation supports model availability, request semantics and listed prices, not Patina quality or a runtime's resolved model.",
+    "Original studies and their private receipts remain parent-owned. No private inputs, outputs, receipts, account identifiers or labels were read or copied.",
+    "Google and DeepSeek cached extracts initially disagreed with direct current pages; dated direct model pages and DeepSeek's trailing-slash pricing page are the evidence used.",
+    "Some Kimi platform pages were retrieved through Exa because direct public GETs returned 403. Retrieval dates do not prove the extraction service's crawl time.",
+    "Kimi pricing MDX extracts lost some table headers. Official platform pricing cards independently confirm cache-hit/input/output column meanings for K3, K2.7 Code and K2.6; the HighSpeed row remains from the same K2.7 pricing table.",
+    "Price rows are public list prices per 1000000 tokens. They are not measured costs, forecasts for a Patina request, or rates proved for subscription/proxy transports."
+  ],
+  "providers": {
+    "gemini": {
+      "sources": [
+        "G38",
+        "G37",
+        "GPRO",
+        "GTHINK",
+        "GNEW",
+        "GPRICE",
+        "GACCESS",
+        "GBILL"
+      ],
+      "officialModels": [
+        {
+          "id": "gemini-3.8-flash",
+          "name": "Gemini 3.8 Flash",
+          "status": "stable",
+          "inputTokenLimit": 1048576,
+          "outputTokenLimit": 65536,
+          "structuredOutputs": true,
+          "thinkingLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "defaultThinkingLevel": "medium",
+          "minimalThinkingSupported": false,
+          "samplingPolicy": "Remove deprecated temperature, top_p and top_k for documented migration; effective proxy behavior is unverified.",
+          "sources": [
+            "G38",
+            "GTHINK",
+            "GNEW"
+          ]
+        },
+        {
+          "id": "gemini-3.7-flash",
+          "name": "Gemini 3.7 Flash",
+          "status": "stable",
+          "inputTokenLimit": 1048576,
+          "outputTokenLimit": 65536,
+          "structuredOutputs": true,
+          "thinkingLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "defaultThinkingLevel": "medium",
+          "minimalThinkingSupported": false,
+          "sources": [
+            "G37",
+            "GTHINK"
+          ]
+        },
+        {
+          "id": "gemini-3.1-pro-preview",
+          "name": "Gemini 3.1 Pro Preview",
+          "status": "preview",
+          "inputTokenLimit": 1048576,
+          "outputTokenLimit": 65536,
+          "structuredOutputs": true,
+          "thinkingLevels": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "defaultThinkingLevel": "high",
+          "sources": [
+            "GPRO",
+            "GTHINK"
+          ]
+        }
+      ],
+      "documentedApiPrices": {
+        "currency": "USD",
+        "unitTokens": 1000000,
+        "service": "Gemini Developer API",
+        "mode": "standard paid tier",
+        "appliesToOpenCodexCalls": false,
+        "outputIncludesThinking": true,
+        "rows": [
+          {
+            "modelIds": [
+              "gemini-3.8-flash",
+              "gemini-3.7-flash"
+            ],
+            "validThrough": "2026-12-31",
+            "input": 0.75,
+            "cachedInput": 0.075,
+            "output": 3.75,
+            "cacheStoragePerMillionTokensPerHour": 0.5
+          },
+          {
+            "modelIds": [
+              "gemini-3.8-flash",
+              "gemini-3.7-flash"
+            ],
+            "validFrom": "2027-01-01",
+            "input": 1.5,
+            "cachedInput": 0.15,
+            "output": 7.5,
+            "cacheStoragePerMillionTokensPerHour": 1
+          },
+          {
+            "modelIds": [
+              "gemini-3.1-pro-preview"
+            ],
+            "promptCondition": "<=200000 tokens",
+            "input": 2,
+            "cachedInput": 0.2,
+            "output": 12,
+            "cacheStoragePerMillionTokensPerHour": 4.5
+          },
+          {
+            "modelIds": [
+              "gemini-3.1-pro-preview"
+            ],
+            "promptCondition": ">200000 tokens",
+            "input": 4,
+            "cachedInput": 0.4,
+            "output": 18,
+            "cacheStoragePerMillionTokensPerHour": 4.5
+          }
+        ],
+        "sources": [
+          "GPRICE",
+          "GNEW",
+          "GTHINK"
+        ]
+      },
+      "access": {
+        "documentedInAntigravity": [
+          "Gemini 3.8 Flash",
+          "Gemini 3.7 Flash",
+          "Gemini 3.1 Pro"
+        ],
+        "subscriptionQuotas": "Plan-dependent baseline quota; Google AI Pro/Ultra five-hour refresh subject to weekly limits, other plans weekly.",
+        "overages": "Optional purchased AI credits use Gemini Enterprise Agent Platform consumption pricing. Settings and charges were not inspected.",
+        "proxyCostUsd": null,
+        "sources": [
+          "GACCESS",
+          "GBILL"
+        ]
+      },
+      "documentaryShortlist": {
+        "rewrite": "Compare 3.8 low/medium/high routes with 3.7 and Pro controls. Low is a latency hypothesis, not a measured winner.",
+        "scorer": "Keep the same admitted routes; verify final JSON, calibration and identity before choosing.",
+        "economyGap": "gemini-3.5-flash-lite is documented at $0.30 input/$2.50 output per 1M standard API tokens, but has no admitted route in the current protocol.",
+        "sources": [
+          "GNEW",
+          "GPRICE"
+        ]
+      },
+      "experimentalWinner": null
+    },
+    "kimi": {
+      "sources": [
+        "KMODELS",
+        "KPARAM",
+        "KK3",
+        "KJSON",
+        "KPRICE3",
+        "KPRICE27",
+        "KPRICE26",
+        "KHOME",
+        "KPRODUCT",
+        "KCHANGE",
+        "KCODE",
+        "KACCESS",
+        "KBILL",
+        "KERROR"
+      ],
+      "moonshotApi": {
+        "baseURL": "https://api.moonshot.ai/v1",
+        "billing": "Independent pay-as-you-go API; Kimi membership and Kimi Code quota do not fund this endpoint.",
+        "access": "K3 documentation requires a successful top-up of at least $1; account funding and model access were not checked here.",
+        "models": [
+          {
+            "id": "kimi-k3",
+            "contextWindowTokens": 1048576,
+            "thinking": "always enabled",
+            "reasoningEffort": [
+              "low",
+              "high",
+              "max"
+            ],
+            "defaultReasoningEffort": "max",
+            "thinkingParameterSupported": false,
+            "fixedTemperature": 1,
+            "fixedTopP": 0.95,
+            "maxCompletionTokensDefault": 131072,
+            "maxCompletionTokensParameterCeiling": 1048576,
+            "outputLimitCaveat": "The parameter ceiling does not provide additional context beyond the shared context window.",
+            "structuredOutput": "JSON mode and strict JSON Schema documented.",
+            "sources": [
+              "KK3",
+              "KPARAM",
+              "KJSON",
+              "KPRICE3"
+            ]
+          },
+          {
+            "id": "kimi-k2.6",
+            "contextWindowTokens": 262144,
+            "thinking": "enabled by default; disabled is supported",
+            "reasoningEffortSupported": false,
+            "fixedTemperatureByThinking": {
+              "enabled": 1,
+              "disabled": 0.6
+            },
+            "fixedTopP": 0.95,
+            "structuredOutput": "JSON mode documented; complex schema behavior has provider-documented limits, so validate output.",
+            "sources": [
+              "KPARAM",
+              "KJSON",
+              "KPRICE26"
+            ]
+          },
+          {
+            "id": "kimi-k2.7-code",
+            "contextWindowTokens": 262144,
+            "thinking": "always enabled; preserved thinking always enabled",
+            "reasoningEffortSupported": false,
+            "fixedTemperature": 1,
+            "fixedTopP": 0.95,
+            "structuredOutput": "JSON mode and JSON Schema documented.",
+            "sources": [
+              "KPARAM",
+              "KJSON",
+              "KPRICE27"
+            ]
+          },
+          {
+            "id": "kimi-k2.7-code-highspeed",
+            "contextWindowTokens": 262144,
+            "thinking": "same constraints as kimi-k2.7-code",
+            "fixedTemperature": 1,
+            "fixedTopP": 0.95,
+            "providerDescribedRelationship": "Same model as K2.7 Code with a faster serving option; not a separate capability family.",
+            "measuredSpeedTokensPerSecond": null,
+            "sources": [
+              "KPARAM",
+              "KPRICE27"
+            ]
+          }
+        ],
+        "documentedPrices": {
+          "currency": "USD",
+          "unitTokens": 1000000,
+          "taxIncluded": false,
+          "appliesToNativeKimiCode": false,
+          "rows": [
+            {
+              "model": "kimi-k3",
+              "cachedInput": 0.3,
+              "input": 3,
+              "output": 15,
+              "contextWindowTokens": 1048576,
+              "sources": [
+                "KPRICE3",
+                "KHOME"
+              ]
+            },
+            {
+              "model": "kimi-k2.6",
+              "cachedInput": 0.16,
+              "input": 0.95,
+              "output": 4,
+              "contextWindowTokens": 262144,
+              "sources": [
+                "KPRICE26",
+                "KHOME"
+              ]
+            },
+            {
+              "model": "kimi-k2.7-code",
+              "cachedInput": 0.19,
+              "input": 0.95,
+              "output": 4,
+              "contextWindowTokens": 262144,
+              "sources": [
+                "KPRICE27",
+                "KHOME"
+              ]
+            },
+            {
+              "model": "kimi-k2.7-code-highspeed",
+              "cachedInput": 0.38,
+              "input": 1.9,
+              "output": 8,
+              "contextWindowTokens": 262144,
+              "sources": [
+                "KPRICE27"
+              ]
+            }
+          ]
+        },
+        "retirements": {
+          "date": "2026-08-31",
+          "models": [
+            "kimi-k2.5",
+            "moonshot-v1 series"
+          ],
+          "note": "The dated changelog reports full retirement although the catalog retains historical rows. Do not add them as current fallbacks.",
+          "sources": [
+            "KMODELS",
+            "KCHANGE"
+          ]
+        }
+      },
+      "nativeKimiCode": {
+        "transport": "kimi-cli",
+        "documentedCodingServiceBaseURL": "https://api.kimi.com/coding/v1",
+        "models": [
+          {
+            "id": "k3",
+            "localProfile": "kimi-code/k3",
+            "documentedFamily": "Kimi K3",
+            "context": "Up to 1M for Allegretto and above; Moderato limited to 256K.",
+            "defaultReasoningEffort": "high",
+            "supportedReasoningEffort": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "id": "k3-256k",
+            "localProfile": "kimi-code/k3-256k",
+            "documentedFamily": "Kimi K3",
+            "context": "256K; Moderato and above.",
+            "defaultReasoningEffort": "high",
+            "supportedReasoningEffort": [
+              "low",
+              "high",
+              "max"
+            ]
+          },
+          {
+            "id": "kimi-for-coding",
+            "localProfile": "kimi-code/kimi-for-coding",
+            "documentedFamily": "Kimi K2.7 Code",
+            "context": "256K; all members.",
+            "thinking": "on"
+          },
+          {
+            "id": "kimi-for-coding-highspeed",
+            "localProfile": "kimi-code/kimi-for-coding-highspeed",
+            "documentedFamily": "Kimi K2.7 Code HighSpeed",
+            "context": "256K; Allegretto and above.",
+            "thinking": "on"
+          }
+        ],
+        "quota": "Shared subscription quota: weekly refresh, rolling five-hour limit, and membership monthly cap. Optional Extra Usage is a separate paid wallet.",
+        "relativeQuotaProviderClaims": "K3 1M uses about twice K3-256k quota; HighSpeed uses three times standard quota. These are provider statements, not Patina measurements or USD rates.",
+        "identityCaveat": "Local profile/request trace does not disclose an independently verified server revision or applied effort. Current collector does not explicitly set or verify effort.",
+        "fallbackCaveat": "Kimi Code docs warn that disabling thinking on K3/K2.7 routes to K2.6; a mistyped HighSpeed ID may fall back to standard. No such fallback was observed by this worker.",
+        "deploymentCaveat": "Provider positions Code membership for programming tools and directs own-product integrations to Kimi Platform. Native research access does not establish hosted Patina API access or economics.",
+        "actualCostUsd": null,
+        "sources": [
+          "KCODE",
+          "KACCESS",
+          "KBILL",
+          "KERROR"
+        ]
+      },
+      "documentaryShortlist": {
+        "rewrite": "K3 is the documented flagship candidate; K2.6 non-thinking is the lower-list-price comparison. Code variants remain valid comparisons, not prose winners inferred from coding claims.",
+        "scorer": "K3 and K2.7 Code have documented structured-output support worth testing; support does not establish scorer calibration.",
+        "native": "For short text, retain k3-256k alongside k3 as a quota hypothesis; Code and HighSpeed compare serving behavior within their documented family.",
+        "requiredBeforeApiStudy": "Correct unsupported thinking and sampling settings in a separately registered, reviewed cohort; do not mutate frozen collectors or relabel existing failures."
+      },
+      "experimentalWinner": null
+    },
+    "deepseek": {
+      "sources": [
+        "DPRICE",
+        "DTHINK",
+        "DCHANGE"
+      ],
+      "baseURL": "https://api.deepseek.com",
+      "models": [
+        {
+          "id": "deepseek-v4-flash",
+          "documentedVersion": "DeepSeek-V4-Flash-0731",
+          "versionDate": "2026-07-31",
+          "contextLengthAsPublished": "1M",
+          "maxOutputAsPublished": "384K",
+          "jsonOutput": true
+        },
+        {
+          "id": "deepseek-v4-pro",
+          "documentedVersion": "DeepSeek-V4-Pro-0813",
+          "versionDate": "2026-08-13",
+          "contextLengthAsPublished": "1M",
+          "maxOutputAsPublished": "384K",
+          "jsonOutput": true
+        }
+      ],
+      "additionalDocumentedModel": {
+        "id": "deepseek-v4-flash-vision-exp",
+        "status": "experimental",
+        "releaseDate": "2026-08-21",
+        "scopeDecision": "Not in the locked protocol; image input adds no required coverage to this text-only study.",
+        "sources": [
+          "DPRICE",
+          "DCHANGE"
+        ]
+      },
+      "thinking": {
+        "enabledByDefault": true,
+        "defaultEffort": "high",
+        "toggle": {
+          "thinking": {
+            "type": "enabled or disabled"
+          }
+        },
+        "nativeEfforts": [
+          "low",
+          "high",
+          "max"
+        ],
+        "acceptedAliasMapping": {
+          "medium": "high",
+          "xhigh": "high"
+        },
+        "samplingWhileThinking": "temperature, top_p, presence_penalty and frequency_penalty have no effect.",
+        "reasoningOutputField": "reasoning_content",
+        "sources": [
+          "DTHINK"
+        ]
+      },
+      "documentedPrices": {
+        "currency": "USD",
+        "unitTokens": 1000000,
+        "effectiveFromUtc": "2026-08-16T16:00:00Z",
+        "peakScheduleUtc": "Monday-Friday 01:00-04:00 and 06:00-10:00; all other hours off-peak.",
+        "rows": [
+          {
+            "model": "deepseek-v4-flash",
+            "period": "off-peak",
+            "cachedInput": 0.007,
+            "input": 0.22,
+            "output": 0.66
+          },
+          {
+            "model": "deepseek-v4-flash",
+            "period": "peak",
+            "cachedInput": 0.014,
+            "input": 0.44,
+            "output": 1.32
+          },
+          {
+            "model": "deepseek-v4-pro",
+            "period": "off-peak",
+            "cachedInput": 0.022,
+            "input": 0.66,
+            "output": 1.98
+          },
+          {
+            "model": "deepseek-v4-pro",
+            "period": "peak",
+            "cachedInput": 0.044,
+            "input": 1.32,
+            "output": 3.96
+          }
+        ],
+        "billing": "Deducted from granted or topped-up balance, with granted balance used first; record actual cache usage and request times before estimating spend.",
+        "sources": [
+          "DPRICE",
+          "DCHANGE"
+        ]
+      },
+      "legacyIds": {
+        "ids": [
+          "deepseek-chat",
+          "deepseek-reasoner"
+        ],
+        "documentedDiscontinuationDate": "2026-07-24",
+        "recommendation": "Do not substitute these legacy names for current V4 candidates.",
+        "sources": [
+          "DCHANGE"
+        ]
+      },
+      "documentaryShortlist": {
+        "rewrite": "Keep V4 Flash/Pro with thinking disabled as registered; Flash is the lower-list-price option, not the proven prose winner.",
+        "scorer": "If the parent funds a new study, compare explicit low/high/max reasoning cohorts as needed; do not treat medium/xhigh as additional native levels.",
+        "access": "Funded API input remains missing per parent; documentation does not resolve the blocker."
+      },
+      "experimentalWinner": null
+    }
+  },
+  "candidateMappings": [
+    {
+      "protocol": "docs/research/model-evaluation-20260904.json",
+      "candidateId": "gemini-pro",
+      "transport": "opencodex",
+      "requestedModel": "google-antigravity/gemini-3.1-pro",
+      "documentedCounterpart": "gemini-3.1-pro-preview",
+      "routeEffortLabel": null,
+      "runtimeIdentityVerified": false,
+      "appliedEffortVerified": false,
+      "mappingStatus": "Documented family/control correspondence only; OpenCodex route string is not an official Developer API model ID.",
+      "sources": [
+        "G38",
+        "G37",
+        "GPRO",
+        "GACCESS"
+      ]
+    },
+    {
+      "protocol": "docs/research/model-evaluation-20260904.json",
+      "candidateId": "gemini-3.7",
+      "transport": "opencodex",
+      "requestedModel": "google-antigravity/gemini-3.7-flash",
+      "documentedCounterpart": "gemini-3.7-flash",
+      "routeEffortLabel": null,
+      "runtimeIdentityVerified": false,
+      "appliedEffortVerified": false,
+      "mappingStatus": "Documented family/control correspondence only; OpenCodex route string is not an official Developer API model ID.",
+      "sources": [
+        "G38",
+        "G37",
+        "GPRO",
+        "GACCESS"
+      ]
+    },
+    {
+      "protocol": "docs/research/model-evaluation-20260904.json",
+      "candidateId": "gemini-3.8-low",
+      "transport": "opencodex",
+      "requestedModel": "google-antigravity/gemini-3.8-flash-low",
+      "documentedCounterpart": "gemini-3.8-flash",
+      "routeEffortLabel": "low",
+      "runtimeIdentityVerified": false,
+      "appliedEffortVerified": false,
+      "mappingStatus": "Documented family/control correspondence only; OpenCodex route string is not an official Developer API model ID.",
+      "sources": [
+        "G38",
+        "G37",
+        "GPRO",
+        "GACCESS"
+      ]
+    },
+    {
+      "protocol": "docs/research/model-evaluation-20260904.json",
+      "candidateId": "gemini-3.8-medium",
+      "transport": "opencodex",
+      "requestedModel": "google-antigravity/gemini-3.8-flash-medium",
+      "documentedCounterpart": "gemini-3.8-flash",
+      "routeEffortLabel": "medium",
+      "runtimeIdentityVerified": false,
+      "appliedEffortVerified": false,
+      "mappingStatus": "Documented family/control correspondence only; OpenCodex route string is not an official Developer API model ID.",
+      "sources": [
+        "G38",
+        "G37",
+        "GPRO",
+        "GACCESS"
+      ]
+    },
+    {
+      "protocol": "docs/research/model-evaluation-20260904.json",
+      "candidateId": "gemini-3.8-high",
+      "transport": "opencodex",
+      "requestedModel": "google-antigravity/gemini-3.8-flash-high",
+      "documentedCounterpart": "gemini-3.8-flash",
+      "routeEffortLabel": "high",
+      "runtimeIdentityVerified": false,
+      "appliedEffortVerified": false,
+      "mappingStatus": "Documented family/control correspondence only; OpenCodex route string is not an official Developer API model ID.",
+      "sources": [
+        "G38",
+        "G37",
+        "GPRO",
+        "GACCESS"
+      ]
+    },
+    {
+      "protocol": "docs/research/model-evaluation-20260904.json",
+      "candidateId": "kimi-k3",
+      "transport": "http",
+      "requestedModel": "kimi-k3",
+      "documentedCounterpart": "kimi-k3",
+      "existingExtraBody": {
+        "thinking": {
+          "type": "disabled"
+        }
+      },
+      "runtimeIdentityVerified": false,
+      "reviewAction": "Remove unsupported thinking; select reasoning_effort low/high/max and omit fixed sampling fields.",
+      "sources": [
+        "KPARAM",
+        "KK3"
+      ]
+    },
+    {
+      "protocol": "docs/research/model-evaluation-20260904.json",
+      "candidateId": "kimi-k2.6",
+      "transport": "http",
+      "requestedModel": "kimi-k2.6",
+      "documentedCounterpart": "kimi-k2.6",
+      "existingExtraBody": {
+        "thinking": {
+          "type": "disabled"
+        }
+      },
+      "runtimeIdentityVerified": false,
+      "reviewAction": "thinking disabled is documented; omit sampling fields so non-thinking temperature 0.6 applies.",
+      "sources": [
+        "KPARAM",
+        "KK3"
+      ]
+    },
+    {
+      "protocol": "docs/research/model-evaluation-20260904.json",
+      "candidateId": "kimi-code",
+      "transport": "http",
+      "requestedModel": "kimi-k2.7-code",
+      "documentedCounterpart": "kimi-k2.7-code",
+      "existingExtraBody": {
+        "thinking": {
+          "type": "disabled"
+        }
+      },
+      "runtimeIdentityVerified": false,
+      "reviewAction": "thinking disabled is invalid; omit thinking or use enabled/keep all; omit fixed sampling fields.",
+      "sources": [
+        "KPARAM",
+        "KK3"
+      ]
+    },
+    {
+      "protocol": "docs/research/model-evaluation-20260904.json",
+      "candidateId": "kimi-code-fast",
+      "transport": "http",
+      "requestedModel": "kimi-k2.7-code-highspeed",
+      "documentedCounterpart": "kimi-k2.7-code-highspeed",
+      "existingExtraBody": {
+        "thinking": {
+          "type": "disabled"
+        }
+      },
+      "runtimeIdentityVerified": false,
+      "reviewAction": "Same request constraints as K2.7 Code; treat original scorer transport failures separately from valid output quality.",
+      "sources": [
+        "KPARAM",
+        "KK3"
+      ]
+    },
+    {
+      "protocol": "docs/research/model-evaluation-kimi-code-20260905.json",
+      "candidateId": "kimi-code-k3",
+      "transport": "kimi-cli",
+      "requestedModel": "kimi-code/k3",
+      "documentedCodingServiceId": "k3",
+      "runtimeIdentityVerified": false,
+      "appliedEffortVerified": false,
+      "reviewAction": "Preserve the separate native cohort, selected-profile evidence and unmeasured server identity; wait for parent-owned quota/receipt resolution.",
+      "sources": [
+        "KCODE",
+        "KBILL"
+      ]
+    },
+    {
+      "protocol": "docs/research/model-evaluation-kimi-code-20260905.json",
+      "candidateId": "kimi-code-k3-256k",
+      "transport": "kimi-cli",
+      "requestedModel": "kimi-code/k3-256k",
+      "documentedCodingServiceId": "k3-256k",
+      "runtimeIdentityVerified": false,
+      "appliedEffortVerified": false,
+      "reviewAction": "Preserve the separate native cohort, selected-profile evidence and unmeasured server identity; wait for parent-owned quota/receipt resolution.",
+      "sources": [
+        "KCODE",
+        "KBILL"
+      ]
+    },
+    {
+      "protocol": "docs/research/model-evaluation-kimi-code-20260905.json",
+      "candidateId": "kimi-code-standard",
+      "transport": "kimi-cli",
+      "requestedModel": "kimi-code/kimi-for-coding",
+      "documentedCodingServiceId": "kimi-for-coding",
+      "runtimeIdentityVerified": false,
+      "appliedEffortVerified": false,
+      "reviewAction": "Preserve the separate native cohort, selected-profile evidence and unmeasured server identity; wait for parent-owned quota/receipt resolution.",
+      "sources": [
+        "KCODE",
+        "KBILL"
+      ]
+    },
+    {
+      "protocol": "docs/research/model-evaluation-kimi-code-20260905.json",
+      "candidateId": "kimi-code-highspeed",
+      "transport": "kimi-cli",
+      "requestedModel": "kimi-code/kimi-for-coding-highspeed",
+      "documentedCodingServiceId": "kimi-for-coding-highspeed",
+      "runtimeIdentityVerified": false,
+      "appliedEffortVerified": false,
+      "reviewAction": "Preserve the separate native cohort, selected-profile evidence and unmeasured server identity; wait for parent-owned quota/receipt resolution.",
+      "sources": [
+        "KCODE",
+        "KBILL"
+      ]
+    },
+    {
+      "protocol": "docs/research/model-evaluation-20260904.json",
+      "candidateId": "deepseek-flash",
+      "transport": "http",
+      "requestedModel": "deepseek-v4-flash",
+      "documentedVersion": "DeepSeek-V4-Flash-0731",
+      "existingExtraBody": {
+        "thinking": {
+          "type": "disabled"
+        }
+      },
+      "runtimeIdentityVerified": false,
+      "reviewAction": "Current request control is documented; funded access and measurements remain missing.",
+      "sources": [
+        "DPRICE",
+        "DTHINK"
+      ]
+    },
+    {
+      "protocol": "docs/research/model-evaluation-20260904.json",
+      "candidateId": "deepseek-pro",
+      "transport": "http",
+      "requestedModel": "deepseek-v4-pro",
+      "documentedVersion": "DeepSeek-V4-Pro-0813",
+      "existingExtraBody": {
+        "thinking": {
+          "type": "disabled"
+        }
+      },
+      "runtimeIdentityVerified": false,
+      "reviewAction": "Current request control is documented; funded access and measurements remain missing.",
+      "sources": [
+        "DPRICE",
+        "DTHINK"
+      ]
+    }
+  ],
+  "staticFindings": [
+    {
+      "id": "kimi-thinking-mismatch",
+      "severity": "blocks-comparable-api-cohort",
+      "paths": [
+        "docs/research/model-evaluation-20260904.json"
+      ],
+      "candidateIds": [
+        "kimi-k3",
+        "kimi-code",
+        "kimi-code-fast"
+      ],
+      "finding": "Frozen API protocol disables thinking for models whose current docs require it.",
+      "action": "Parent must review a new candidate protocol before further collection; retain old errors as request/transport evidence.",
+      "sources": [
+        "KPARAM",
+        "KK3"
+      ]
+    },
+    {
+      "id": "sampling-control-mismatch",
+      "severity": "requires-transport-review",
+      "paths": [
+        "src/api.js",
+        "src/scoring.js",
+        "scripts/research/model-evaluation-transport.mjs",
+        "scripts/research/model-rewrite-benchmark.mjs"
+      ],
+      "finding": "HTTP body assigns temperature after extraBody; rewrite requests 0.2, scoring normally 0.1 with a 0 retry. These are not Kimi's fixed settings. Gemini 3.8 documentation says to remove deprecated sampling fields.",
+      "action": "Candidate extraBody alone cannot guarantee omission. Review omission and requested/effective metadata with no-network tests in the parent lane; do not claim temperatures were applied.",
+      "sources": [
+        "KPARAM",
+        "GNEW"
+      ]
+    },
+    {
+      "id": "native-effort-not-pinned",
+      "severity": "comparison-limitation",
+      "paths": [
+        "scripts/research/kimi-study-transport.mjs",
+        "src/backends/kimi-cli.js"
+      ],
+      "finding": "Native collector selects profile but does not explicitly set or verify reasoning effort. Kimi Code documents high as K3 default; Moonshot API documents max.",
+      "action": "Report effort as unverified for existing runs, and keep any future effort-controlled cohort distinct.",
+      "sources": [
+        "KCODE",
+        "KPARAM"
+      ]
+    },
+    {
+      "id": "identity-catalog-not-response",
+      "severity": "interpretation-limit",
+      "paths": [
+        "scripts/research/kimi-study-transport.mjs",
+        "docs/research/model-evaluation-20260904.json",
+        "docs/research/model-evaluation-kimi-code-20260905.json"
+      ],
+      "finding": "Documented provider model names and local aliases do not establish the effective server revision for any study call.",
+      "action": "Retain requested model, transport and parent-audited identity evidence separately.",
+      "sources": [
+        "KCODE",
+        "GPRO",
+        "DPRICE"
+      ]
+    }
+  ],
+  "operatorReportedBlockers": [
+    {
+      "id": "kimi-native-five-hour-quota",
+      "source": "parent assignment, 2026-09-05 KST",
+      "scope": "native Kimi Code cohort",
+      "status": "quota-exhausted",
+      "qualityFailure": false,
+      "nextStep": "Parent resumes after confirmed access recovery under the registered protocol; worker did not inspect or change quota."
+    },
+    {
+      "id": "original-highspeed-scorer-transport",
+      "source": "parent assignment, 2026-09-05 KST",
+      "scope": "original highspeed scorer; exact receipt/cohort attribution retained by parent",
+      "status": "partial-transport-failure",
+      "qualityFailure": false,
+      "nextStep": "Audit terminal receipts, classify infrastructure failures separately, and do not transfer this status to the separate native cohort."
+    },
+    {
+      "id": "deepseek-funded-input",
+      "source": "parent assignment, 2026-09-05 KST",
+      "scope": "DeepSeek API",
+      "status": "funded-api-input-missing",
+      "qualityFailure": false,
+      "nextStep": "Parent supplies funded API access before any live comparison; no calls or funding changes performed."
+    }
+  ],
+  "recommendationBoundary": {
+    "documentaryConclusion": "Retain candidate comparisons with corrected request semantics and explicit transport/accounting boundaries. No final provider winner is established.",
+    "requiredForWinner": [
+      "Parent-audited terminal receipts and model/profile evidence",
+      "Comparable frozen prompts, fixtures, settings and source snapshots",
+      "Scorer schema validity and fixture-bound calibration",
+      "Rewrite number/anchor preservation and independent cross-family MPS/fidelity judgments",
+      "Repeated per-language quality, latency, usage and failure reporting"
+    ],
+    "failureReporting": "Transport/quota/request incompatibility affects operational completion reporting; it is not a zero quality rating or an authorship label. Preserve missingness and distinguish valid-output quality from all-attempt reliability.",
+    "publicData": "Only documentation facts, list prices, public candidate protocols and explicitly attributed blocker summaries.",
+    "productionDefaultChanged": false
+  },
+  "sources": [
+    {
+      "id": "G38",
+      "publisher": "Google",
+      "title": "Gemini 3.8 Flash",
+      "url": "https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash",
+      "retrievedDate": "2026-09-05",
+      "pageDate": "2026-09-02",
+      "dateMeaning": "page last-updated date",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:07:56.353770+00:00",
+      "responseBodySha256": "a3cd9d1a5be3d862707a9ad0b59a2c521d76a51be1ac0aae94c03f48f6e46bab"
+    },
+    {
+      "id": "G37",
+      "publisher": "Google",
+      "title": "Gemini 3.7 Flash",
+      "url": "https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash",
+      "retrievedDate": "2026-09-05",
+      "pageDate": "2026-08-13",
+      "dateMeaning": "page last-updated date",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:07:56.568031+00:00",
+      "responseBodySha256": "85cec2d304b16d44a566dcf44326effc960bb119d24186448d895ec79e3ee275"
+    },
+    {
+      "id": "GPRO",
+      "publisher": "Google",
+      "title": "Gemini 3.1 Pro Preview",
+      "url": "https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview",
+      "retrievedDate": "2026-09-05",
+      "pageDate": "2026-08-18",
+      "dateMeaning": "page last-updated date",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:07:56.560809+00:00",
+      "responseBodySha256": "9ad863f46ae5aaac69a4baca2002522cae8ab3936cffecd4826eebe8f3c629ea"
+    },
+    {
+      "id": "GTHINK",
+      "publisher": "Google",
+      "title": "Gemini thinking",
+      "url": "https://ai.google.dev/gemini-api/docs/thinking",
+      "retrievedDate": "2026-09-05",
+      "pageDate": "2026-09-04",
+      "dateMeaning": "page last-updated date",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:08:14.334463+00:00",
+      "responseBodySha256": "8163d8bd559c5432b7a6dfbfc97a7d78a3a22b17a86fd56597c0d494924e427f"
+    },
+    {
+      "id": "GNEW",
+      "publisher": "Google",
+      "title": "What's new in Gemini 3.8 Flash",
+      "url": "https://ai.google.dev/gemini-api/docs/latest-model",
+      "retrievedDate": "2026-09-05",
+      "pageDate": "2026-09-03",
+      "dateMeaning": "page last-updated date",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:08:14.096192+00:00",
+      "responseBodySha256": "391bab0aa617eadceb7e38eaf143ca258a007819969b4b92e0d337061a60f249"
+    },
+    {
+      "id": "GPRICE",
+      "publisher": "Google",
+      "title": "Gemini Developer API pricing",
+      "url": "https://ai.google.dev/gemini-api/docs/pricing",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:08:39.346353+00:00",
+      "responseBodySha256": "899b7eea1560baed13847ade3b43d728331aa629a7f358de17cba8ba5dad79a8"
+    },
+    {
+      "id": "GACCESS",
+      "publisher": "Google",
+      "title": "Antigravity models",
+      "url": "https://antigravity.google/docs/models/",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:09:25.058962+00:00",
+      "responseBodySha256": "10dbc2810153d06c3adbe830dcb9675e89155580ab44d6d5cffcc2a50ac3769d"
+    },
+    {
+      "id": "GBILL",
+      "publisher": "Google",
+      "title": "Antigravity plans",
+      "url": "https://antigravity.google/docs/plans",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:08:39.061977+00:00",
+      "responseBodySha256": "52d0c4adf2d6ff00ac88c68f54dfcc3bcfaf4fb3376ca24fca31d650e461e14c"
+    },
+    {
+      "id": "KMODELS",
+      "publisher": "Moonshot AI / Kimi",
+      "title": "Kimi API model list",
+      "url": "https://platform.kimi.ai/docs/models.md",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "exa-primary-page-extraction",
+      "limitation": "Origin GET returned 403 on sampled documentation routes; primary-page content was retrieved through Exa, not an authenticated provider call."
+    },
+    {
+      "id": "KPARAM",
+      "publisher": "Moonshot AI / Kimi",
+      "title": "Kimi model parameter reference",
+      "url": "https://platform.kimi.ai/docs/api/models-overview.md",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "exa-primary-page-extraction",
+      "limitation": "Origin GET returned 403 on sampled documentation routes; primary-page content was retrieved through Exa, not an authenticated provider call."
+    },
+    {
+      "id": "KK3",
+      "publisher": "Moonshot AI / Kimi",
+      "title": "Kimi K3 quickstart",
+      "url": "https://platform.kimi.ai/docs/guide/kimi-k3-quickstart.md",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "exa-primary-page-extraction",
+      "limitation": "Origin GET returned 403 on sampled documentation routes; primary-page content was retrieved through Exa, not an authenticated provider call."
+    },
+    {
+      "id": "KJSON",
+      "publisher": "Moonshot AI / Kimi",
+      "title": "Kimi structured output",
+      "url": "https://platform.kimi.ai/docs/guide/response_format.md",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "exa-primary-page-extraction",
+      "limitation": "Origin GET returned 403 on sampled documentation routes; primary-page content was retrieved through Exa, not an authenticated provider call."
+    },
+    {
+      "id": "KPRICE3",
+      "publisher": "Moonshot AI / Kimi",
+      "title": "Kimi K3 API pricing",
+      "url": "https://platform.kimi.ai/docs/pricing/chat-k3.md",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "exa-primary-page-extraction",
+      "limitation": "Origin GET returned 403 on sampled documentation routes; primary-page content was retrieved through Exa, not an authenticated provider call."
+    },
+    {
+      "id": "KPRICE27",
+      "publisher": "Moonshot AI / Kimi",
+      "title": "Kimi K2.7 Code API pricing",
+      "url": "https://platform.kimi.ai/docs/pricing/chat-k27-code.md",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "exa-primary-page-extraction",
+      "limitation": "Origin GET returned 403 on sampled documentation routes; primary-page content was retrieved through Exa, not an authenticated provider call."
+    },
+    {
+      "id": "KPRICE26",
+      "publisher": "Moonshot AI / Kimi",
+      "title": "Kimi K2.6 API pricing",
+      "url": "https://platform.kimi.ai/docs/pricing/chat-k26.md",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "exa-primary-page-extraction",
+      "limitation": "Origin GET returned 403 on sampled documentation routes; primary-page content was retrieved through Exa, not an authenticated provider call."
+    },
+    {
+      "id": "KHOME",
+      "publisher": "Moonshot AI / Kimi",
+      "title": "Kimi API platform pricing cards",
+      "url": "https://platform.kimi.ai/",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "exa-primary-page-extraction"
+    },
+    {
+      "id": "KPRODUCT",
+      "publisher": "Moonshot AI / Kimi",
+      "title": "Compare Kimi products",
+      "url": "https://platform.kimi.ai/docs/guide/product-plans.md",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "exa-primary-page-extraction",
+      "limitation": "Origin GET returned 403 on sampled documentation routes; primary-page content was retrieved through Exa, not an authenticated provider call."
+    },
+    {
+      "id": "KCHANGE",
+      "publisher": "Moonshot AI / Kimi",
+      "title": "Kimi platform changelog",
+      "url": "https://platform.kimi.ai/docs/platform-changelog.md",
+      "retrievedDate": "2026-09-05",
+      "pageDate": "2026-08-31",
+      "dateMeaning": "latest relevant dated entry",
+      "retrievalMethod": "exa-primary-page-extraction",
+      "limitation": "Origin GET returned 403 on sampled documentation routes; primary-page content was retrieved through Exa, not an authenticated provider call."
+    },
+    {
+      "id": "KCODE",
+      "publisher": "Moonshot AI / Kimi",
+      "title": "Kimi Code model configuration",
+      "url": "https://www.kimi.com/code/docs/en/kimi-code/models.html",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:09:25.296083+00:00",
+      "responseBodySha256": "2f753f080cf4f968235b4150ad7cfe4f7adf412a149719cb2a3e90b152ab0372"
+    },
+    {
+      "id": "KACCESS",
+      "publisher": "Moonshot AI / Kimi",
+      "title": "Kimi Code overview and access",
+      "url": "https://www.kimi.com/code/docs/en/",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:08:39.000906+00:00",
+      "responseBodySha256": "4c051559c4dbf4e85c7efb51c4c02b2b8bbbcb0dc2a5886853376e4f994fe197"
+    },
+    {
+      "id": "KBILL",
+      "publisher": "Moonshot AI / Kimi",
+      "title": "Kimi Code membership benefits",
+      "url": "https://www.kimi.com/code/docs/en/kimi-code/membership.html",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:08:39.044070+00:00",
+      "responseBodySha256": "34b137b222a90dfb9ae138109e63b7c2ed588cc3f513d261bf61fa1c9033e988"
+    },
+    {
+      "id": "KERROR",
+      "publisher": "Moonshot AI / Kimi",
+      "title": "Kimi Code error reference",
+      "url": "https://www.kimi.com/code/docs/en/kimi-code/error-reference.html",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:08:39.148736+00:00",
+      "responseBodySha256": "05ed01356625c1c7ee6e37d76dffcbb64b309ab7a16023d3a6a28782bbebea93"
+    },
+    {
+      "id": "DPRICE",
+      "publisher": "DeepSeek",
+      "title": "DeepSeek models and pricing",
+      "url": "https://api-docs.deepseek.com/quick_start/pricing/",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:07:55.825496+00:00",
+      "responseBodySha256": "cf2c6fb2dd8a32a538f12a8176175b8809a3516326a5cb30dfe52d63c490a968"
+    },
+    {
+      "id": "DTHINK",
+      "publisher": "DeepSeek",
+      "title": "DeepSeek thinking mode",
+      "url": "https://api-docs.deepseek.com/guides/thinking_mode/",
+      "retrievedDate": "2026-09-05",
+      "pageDate": null,
+      "dateMeaning": "page date not established",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:08:13.422022+00:00",
+      "responseBodySha256": "f28c43248d26db1f27af0cb082abb00326c957d560d33a21839736edd1d10724"
+    },
+    {
+      "id": "DCHANGE",
+      "publisher": "DeepSeek",
+      "title": "DeepSeek change log",
+      "url": "https://api-docs.deepseek.com/updates/",
+      "retrievedDate": "2026-09-05",
+      "pageDate": "2026-08-21",
+      "dateMeaning": "latest relevant dated entry",
+      "retrievalMethod": "direct-public-https-get",
+      "httpStatus": 200,
+      "retrievedAt": "2026-09-05T05:07:56.251465+00:00",
+      "responseBodySha256": "9f0e83b23b4e5aaf47b973a222821bb033d0541c8eae67d03a5ab73858d4713a"
+    }
+  ]
+}

--- a/docs/research/provider-gemini-kimi-deepseek-20260905.md
+++ b/docs/research/provider-gemini-kimi-deepseek-20260905.md
@@ -1,0 +1,232 @@
+**Gemini, Moonshot/Kimi and DeepSeek for Patina — 2026-09-05 KST**
+
+Documentation supports a shortlist, not an experimental winner. The most useful
+finding is a request mismatch: the registered Moonshot API candidates disable
+thinking for K3 and K2.7 Code, although their current docs require thinking.
+Sampling also needs review before a comparable API cohort can run. The native
+Kimi Code cohort has separate access, defaults and accounting.
+
+This review made no model calls, inventory probes or credential reads. It used
+public documentation retrieved on September 5, 2026, and repository snapshot
+`722d814925312c8859f1c6499860597d8ce41482`. The
+[JSON companion](provider-gemini-kimi-deepseek-20260905.json) records source
+dates, direct-response hashes where available, exact candidate mappings and
+evidence limits. Parent-owned studies and their private receipts were not read.
+
+**Google Gemini.** Google's current pages list stable `gemini-3.8-flash`,
+stable `gemini-3.7-flash`, and preview `gemini-3.1-pro-preview`. The 3.8 page
+was updated September 2, 2026; the migration guide was updated September 3.
+All three document 1,048,576 input tokens, 65,536 output tokens and structured
+output. [G38] [G37] [GPRO] [GNEW]
+
+| Official Developer API ID | Documented thinking levels | Default | Patina candidate |
+| --- | --- | --- | --- |
+| `gemini-3.8-flash` | low / medium / high; minimal errors | medium | `gemini-3.8-low`, `gemini-3.8-medium`, `gemini-3.8-high` |
+| `gemini-3.7-flash` | low / medium / high; minimal errors | medium | `gemini-3.7` |
+| `gemini-3.1-pro-preview` | low / medium / high | high | `gemini-pro` |
+
+Thinking defaults above are provider documentation, not measured settings in
+OpenCodex. The three 3.8 suffixes are route labels for an effort comparison,
+not three official Developer API model IDs. The registered Pro route is
+`google-antigravity/gemini-3.1-pro`; its name differs from the public preview
+endpoint. Keep that distinction until the parent verifies response identity.
+Google documents these families in Antigravity, but does not establish the
+mapping of a local OpenCodex alias. [GTHINK] [GACCESS]
+
+Every Gemini experiment must use **only**
+`http://127.0.0.1:10100/v1` and the registered
+`google-antigravity/gemini-*` route. No Gemini key, direct API call, or Gemini
+CLI fallback is allowed by this study. Nothing in this research probed that
+endpoint.
+
+Google's 3.8 migration guide tells clients to remove `temperature`, `top_p`,
+`top_k` and the old thinking-budget control. Use the documented thinking-level
+control when the transport supports it; do not assume that a route suffix
+proves the applied effort. The guide identifies low effort as suitable for
+drafting and latency-sensitive tasks. That supports testing low against
+medium/high, not declaring it the better writer or scorer. [GNEW]
+
+| Standard paid Developer API pricing, USD / 1M tokens | Input | Cached input | Output, including thinking |
+| --- | ---: | ---: | ---: |
+| 3.8 Flash and 3.7 Flash, through December 31, 2026 | 0.75 | 0.075 | 3.75 |
+| 3.8 Flash and 3.7 Flash, from January 1, 2027 | 1.50 | 0.15 | 7.50 |
+| 3.1 Pro Preview, prompt ≤200k tokens | 2.00 | 0.20 | 12.00 |
+| 3.1 Pro Preview, prompt >200k tokens | 4.00 | 0.40 | 18.00 |
+
+Caching storage adds $0.50 per million token-hours for the Flash introductory
+period, then $1.00; Pro lists $4.50. These are API list prices, **not the
+cost of an OpenCodex request**. Antigravity has plan-dependent quotas and
+optional paid-credit overages; the account's settings and charges were not
+inspected. Keep actual cost unknown. The API pricing page also lists
+`gemini-3.5-flash-lite` at $0.30 input/$2.50 output, but this protocol has no
+admitted route for it. It is an untested economy option, not a substitute to
+insert into a frozen run. [GPRICE] [GBILL]
+
+**Moonshot API.** The documented current candidates are `kimi-k3`,
+`kimi-k2.6`, `kimi-k2.7-code` and `kimi-k2.7-code-highspeed`, served through
+the registered `https://api.moonshot.ai/v1` endpoint. K3 documentation requires
+a successful top-up of at least $1; this worker did not check account funding.
+Kimi membership and Kimi Code benefits do not fund this API. [KMODELS] [KK3]
+[KPRODUCT]
+
+| Official API ID | Context tokens | Reasoning / sampling contract |
+| --- | ---: | --- |
+| `kimi-k3` | 1,048,576 | Always thinks; top-level `reasoning_effort` low / high / max, default max; omit K2.x `thinking`; fixed temperature 1.0 |
+| `kimi-k2.6` | 262,144 | Thinking on by default, can be disabled; fixed temperature 1.0 when on, 0.6 when off |
+| `kimi-k2.7-code` | 262,144 | Thinking and preserved thinking always on; disabling thinking errors; fixed temperature 1.0 |
+| `kimi-k2.7-code-highspeed` | 262,144 | Same constraints and model as K2.7 Code; different serving-speed option |
+
+Kimi says to omit fixed sampling fields. K3 accepts
+`max_completion_tokens`, default 131,072, with a parameter ceiling of
+1,048,576; that ceiling does not create extra space beyond its context.
+K3 and K2.7 require preserved assistant reasoning in multi-turn use. For this
+text study, parse the final `message.content`, not `reasoning_content`.
+Kimi documents JSON mode and structured output, with complex-schema limitations
+on K2.6. These features are reasons to test scorer validity; they are not
+evidence of calibration or reliable authorship detection. [KK3] [KPARAM]
+[KJSON]
+
+| Moonshot API pricing, USD / 1M tokens, excluding applicable tax | Input | Cached input | Output |
+| --- | ---: | ---: | ---: |
+| `kimi-k3` | 3.00 | 0.30 | 15.00 |
+| `kimi-k2.6` | 0.95 | 0.16 | 4.00 |
+| `kimi-k2.7-code` | 0.95 | 0.19 | 4.00 |
+| `kimi-k2.7-code-highspeed` | 1.90 | 0.38 | 8.00 |
+
+The pricing extracts lose some MDX table headers. The official platform's
+pricing cards confirm the column meanings for K3, K2.7 Code and K2.6; the
+HighSpeed row is from the K2.7 pricing table. No listed rate is assigned to
+native Code usage. No advertised tokens-per-second figure is treated as a
+Patina latency measurement. [KPRICE3] [KPRICE26] [KPRICE27] [KHOME]
+
+The dated August 31, 2026 changelog says K2.5 and the Moonshot V1 family were
+retired, even though the catalog still shows historical rows. Do not recommend
+those rows as current fallbacks. [KCHANGE] [KMODELS]
+
+**Native Kimi Code.** Its official coding-service IDs are `k3`,
+`k3-256k`, `kimi-for-coding`, and `kimi-for-coding-highspeed`. Patina's
+`kimi-code/` prefix is a local profile namespace. The provider maps the first
+pair to K3 and the second pair to K2.7 Code; that documented family mapping
+does not disclose a particular study call's server revision. [KACCESS]
+
+| Patina native candidate | Selected profile | Documented service limits |
+| --- | --- | --- |
+| `kimi-code-k3` | `kimi-code/k3` | Moderato+: 256K; Allegretto+: up to 1M |
+| `kimi-code-k3-256k` | `kimi-code/k3-256k` | Moderato+: 256K |
+| `kimi-code-standard` | `kimi-code/kimi-for-coding` | All members: 256K |
+| `kimi-code-highspeed` | `kimi-code/kimi-for-coding-highspeed` | Allegretto+: 256K |
+
+Code documents K3's default effort as **high**, versus **max** for Moonshot
+API. Its docs say K3 1M uses about twice the quota of K3-256k and HighSpeed
+uses three times standard quota. These are provider quota claims, not measured
+costs. The same docs warn that disabling thinking on K3/K2.7 routes to K2.6,
+and a mistyped HighSpeed ID can fall back to standard. No such fallback was
+observed here. Keep effort and server identity unverified where the collector
+does not establish them. [KCODE] [KPARAM]
+
+Code shares membership quota: weekly renewal, a rolling five-hour window and
+a monthly cap. Optional Extra Usage has its own paid balance; it is not a
+Moonshot API balance. Neither subscription pricing nor advertised speed can
+be converted into a per-request charge without account-specific evidence.
+Provider documentation describes Code as a programming service and directs
+own-product integrations to Kimi Platform. Native experimental access therefore
+does not establish a hosted Patina serving plan. [KBILL] [KACCESS] [KPRODUCT]
+
+**DeepSeek.** Current docs name `deepseek-v4-flash` as
+DeepSeek-V4-Flash-0731 and `deepseek-v4-pro` as DeepSeek-V4-Pro-0813.
+The corresponding updates are dated July 31 and August 13, 2026.
+Both document 1M context, up to 384K output and JSON output. These are
+provider labels and limits, not response identities measured in this review.
+The August 21 vision experimental release is outside the text-only protocol.
+[DPRICE] [DCHANGE]
+
+Thinking defaults to enabled/high. The Chat Completions toggle is
+`thinking.type: enabled|disabled`; native effort levels are low/high/max.
+Requested medium and xhigh map to high. Temperature and related sampling
+controls have no effect in thinking mode. The registered Flash/Pro candidates
+explicitly disable thinking, which is documented. A reasoning comparison would
+need a new explicit cohort. [DTHINK]
+
+| DeepSeek API pricing, USD / 1M tokens | Input | Cached input | Output |
+| --- | ---: | ---: | ---: |
+| V4 Flash, off-peak | 0.22 | 0.007 | 0.66 |
+| V4 Flash, peak | 0.44 | 0.014 | 1.32 |
+| V4 Pro, off-peak | 0.66 | 0.022 | 1.98 |
+| V4 Pro, peak | 1.32 | 0.044 | 3.96 |
+
+The schedule took effect August 16, 2026 at 16:00 UTC. Peak hours are
+Monday–Friday 01:00–04:00 and 06:00–10:00 UTC; all other hours are off-peak.
+Charges draw on granted or topped-up balances. An estimate needs actual input,
+cache and output usage plus the applicable time window. Legacy
+`deepseek-chat`/`deepseek-reasoner` names had a documented July 24, 2026
+discontinuation date; they are not recommended replacements. [DPRICE] [DCHANGE]
+
+**Repository implications.** The
+[original protocol](model-evaluation-20260904.json) and
+[native Kimi Code protocol](model-evaluation-kimi-code-20260905.json) remain
+unchanged. The JSON companion maps all 15 in-scope candidate entries to the
+relevant documentation.
+
+| Static finding | Evidence in this snapshot | Parent-owned next step |
+| --- | --- | --- |
+| Unsupported Moonshot thinking settings | `kimi-k3`, `kimi-code`, `kimi-code-fast` all set disabled | Register corrected requests in a new cohort; retain earlier errors |
+| Requested temperature is not a universal control | `src/api.js` assigns temperature after `extraBody`; rewrite uses 0.2, scorer normally 0.1 then 0 on schema retry | Review omission and effective-setting metadata; `extraBody` alone cannot remove it |
+| Native effort is not pinned | `kimi-study-transport.mjs` and `src/backends/kimi-cli.js` select a profile without setting or verifying effort | Report it as unverified; preserve source/cohort boundaries |
+| Catalog identity is not response identity | Native trace parser establishes selected profile; Gemini routes differ from official IDs | Parent audits receipts before assigning model-specific outcomes |
+
+The HTTP client's existing temperature fallback only recognizes certain 400
+unsupported/deprecated messages. It does not prove that Kimi's fixed-value
+errors will recover, nor that a proxy honored the requested temperature. A
+compatibility failure is a request/transport result, not a model-quality score.
+
+The parent reports three blockers as of September 5, 2026 KST: native Kimi
+Code's five-hour quota is exhausted; the original highspeed scorer has a
+partial transport failure; DeepSeek funded API input is missing. This worker
+did not check reset times, balances or receipts. Keep the original highspeed
+failure attached to its parent-audited cohort, and do not transfer it to the
+separate native cohort. Kimi's error reference distinguishes quota exhaustion,
+request errors and overload; those categories require different handling.
+[KERROR]
+
+The documentation-based shortlist is Gemini 3.8 effort variants against
+3.7/Pro controls, Kimi K3 against K2.6 and the Code serving variants, and
+DeepSeek V4 Flash against Pro. Native K3-256k is worth retaining as a quota
+comparison for short text. These are experiment choices. No source establishes
+Patina's best writer, best scorer, per-language quality, human preference or
+actual operating cost. Final selection remains dependent on the registered
+repeats, validated scorer outputs, preserved semantic anchors and independent
+cross-family rewrite judgments.
+
+All public source links below were retrieved September 5, 2026. Google and
+DeepSeek facts use direct public-page fetches: initial cached extracts were
+stale, and DeepSeek's non-trailing-slash pricing route returned a different
+page. Some Kimi platform origin requests returned 403, so those sources use
+Exa's extraction of the primary pages; their crawl freshness cannot be proved
+from the extraction. The JSON records that limitation. No authenticated
+provider endpoint was requested.
+
+[G38]: https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash "Gemini 3.8 Flash; retrieved 2026-09-05; page date 2026-09-02"
+[G37]: https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash "Gemini 3.7 Flash; retrieved 2026-09-05; page date 2026-08-13"
+[GPRO]: https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview "Gemini 3.1 Pro Preview; retrieved 2026-09-05; page date 2026-08-18"
+[GTHINK]: https://ai.google.dev/gemini-api/docs/thinking "Gemini thinking; retrieved 2026-09-05; page date 2026-09-04"
+[GNEW]: https://ai.google.dev/gemini-api/docs/latest-model "What's new in Gemini 3.8 Flash; retrieved 2026-09-05; page date 2026-09-03"
+[GPRICE]: https://ai.google.dev/gemini-api/docs/pricing "Gemini Developer API pricing; retrieved 2026-09-05"
+[GACCESS]: https://antigravity.google/docs/models/ "Antigravity models; retrieved 2026-09-05"
+[GBILL]: https://antigravity.google/docs/plans "Antigravity plans; retrieved 2026-09-05"
+[KMODELS]: https://platform.kimi.ai/docs/models.md "Kimi API model list; retrieved 2026-09-05"
+[KPARAM]: https://platform.kimi.ai/docs/api/models-overview.md "Kimi model parameter reference; retrieved 2026-09-05"
+[KK3]: https://platform.kimi.ai/docs/guide/kimi-k3-quickstart.md "Kimi K3 quickstart; retrieved 2026-09-05"
+[KJSON]: https://platform.kimi.ai/docs/guide/response_format.md "Kimi structured output; retrieved 2026-09-05"
+[KPRICE3]: https://platform.kimi.ai/docs/pricing/chat-k3.md "Kimi K3 API pricing; retrieved 2026-09-05"
+[KPRICE27]: https://platform.kimi.ai/docs/pricing/chat-k27-code.md "Kimi K2.7 Code API pricing; retrieved 2026-09-05"
+[KPRICE26]: https://platform.kimi.ai/docs/pricing/chat-k26.md "Kimi K2.6 API pricing; retrieved 2026-09-05"
+[KHOME]: https://platform.kimi.ai/ "Kimi API platform pricing cards; retrieved 2026-09-05"
+[KPRODUCT]: https://platform.kimi.ai/docs/guide/product-plans.md "Compare Kimi products; retrieved 2026-09-05"
+[KCHANGE]: https://platform.kimi.ai/docs/platform-changelog.md "Kimi platform changelog; retrieved 2026-09-05; page date 2026-08-31"
+[KCODE]: https://www.kimi.com/code/docs/en/kimi-code/models.html "Kimi Code model configuration; retrieved 2026-09-05"
+[KACCESS]: https://www.kimi.com/code/docs/en/ "Kimi Code overview and access; retrieved 2026-09-05"
+[KBILL]: https://www.kimi.com/code/docs/en/kimi-code/membership.html "Kimi Code membership benefits; retrieved 2026-09-05"
+[KERROR]: https://www.kimi.com/code/docs/en/kimi-code/error-reference.html "Kimi Code error reference; retrieved 2026-09-05"
+[DPRICE]: https://api-docs.deepseek.com/quick_start/pricing/ "DeepSeek models and pricing; retrieved 2026-09-05"
+[DTHINK]: https://api-docs.deepseek.com/guides/thinking_mode/ "DeepSeek thinking mode; retrieved 2026-09-05"
+[DCHANGE]: https://api-docs.deepseek.com/updates/ "DeepSeek change log; retrieved 2026-09-05; page date 2026-08-21"


### PR DESCRIPTION
Document current Gemini, Kimi and DeepSeek model contracts

Records 25 primary sources and 15 mappings to the frozen candidate manifests. Separates native Code/proxy/API identities and billing, documented controls and measured settings, and request compatibility gaps from model quality. No live calls or winner claims.

Validation: JSON/mappings/source hashes/prose gate; full 1,885 tests passed, 2 skipped; lint clean. Independent Astra/xhigh review passed.
