### PR TITLE
research: publish receipt-bound live scorer diagnostics

### DIFF
--- a/docs/benchmarks/live-scorer-20260905.json
+++ b/docs/benchmarks/live-scorer-20260905.json
@@ -1,0 +1,12096 @@
+{
+  "schemaVersion": 1,
+  "reportDate": "2026-09-05",
+  "timezone": "Asia/Seoul",
+  "issue": 412,
+  "status": "completed-fixture-diagnostics; rebaseline-evidence-missing",
+  "scope": "src/scoring.js scoreText AI-likeness diagnostics; not rewrite quality or authenticated authorship accuracy",
+  "totals": {
+    "datasets": 6,
+    "candidates": 11,
+    "uniqueFixtures": 49,
+    "observed": 931,
+    "valid": 930,
+    "errors": 1
+  },
+  "metricDefinitions": {
+    "overall": "Recorded production scoreText overall, after deterministic reconciliation; valid rows only.",
+    "rawLLM": "Receipt-validated raw_overall; equals llm_overall on valid rows. Invalid schema values are excluded.",
+    "deterministic": "Recorded deterministic_overall on all observed rows, including scorer errors. No recomputation from hash-only resolved inputs.",
+    "patternPack": "Recorded category.score; omissions counted, never filled with zero. A pack score is not an individual pattern accuracy.",
+    "distribution": "Finite values only; median averages the middle pair; p95 is nearest-rank ceil(0.95*n); unrounded JSON statistics.",
+    "receiptManifest": "SHA-256 of JSON.stringify(sorted [{group,index,sha256,requestHash,promptHash}]); group = SHA-256(originalProtocol/candidate/fixture/repeat/score). File sha256 covers original bytes. Sort by group then index. Request/prompt commitments hash sorted original hash arrays, including duplicates."
+  },
+  "limitations": [
+    "The 49 suspect-zones inputs are curated regression controls (26 expected_hot, 23 expected_not_hot), not authenticated real-world human-vs-AI truth or human preference ratings.",
+    "No rebaseline corpus was collected in these six datasets. Its runner support is not evidence of a completed rebaseline experiment.",
+    "A and C retain separate protocol and effective-input hashes. Lexicon fingerprints include absolute paths; different hashes alone do not prove different lexical content. Repeats are the same 49 inputs, not additional independent samples.",
+    "Resolved configuration and complete deterministic analyses were not archived, only hashed. Protocol IDs are preserved and cross-bound to rows/receipts; they cannot be fully recomputed here. Prompt hashes bind requests but do not independently reconstruct prompt text.",
+    "Overall and deterministic scalars are source-bound collector observations, not independently replayed production outputs. Receipt schema, raw scores, categories, model metadata, matrix membership, and committed source/fixture bytes are independently checked.",
+    "Original raw-score validation permits partial packs and does not enforce arithmetic consistency. Reported arithmetic diagnostics do not change original validity or repair model outputs.",
+    "Model names are exact requested/returned OpenCodex identifiers observed in these calls. Metadata equality does not authenticate upstream model weights, current catalog availability, reasoning execution, or provider-wide reliability.",
+    "Serial call timing, one initial pass and selected two-repeat cohorts cannot establish a winner, calibrated threshold, or default model. No live score CI gate, cost estimate, rewrite-quality claim, or human label is introduced.",
+    "Only the six explicitly selected terminal A/C matrices are included. Other study lanes are outside this completed comparison."
+  ],
+  "acceptance": {
+    "supported": [
+      "opt-in production scorer fixture collection",
+      "per-language and per-pattern-pack distributions",
+      "explicit validity and availability denominators",
+      "diagnostics without a CI score gate"
+    ],
+    "gaps": [
+      "completed rebaseline corpus measurements",
+      "resolved configuration and deterministic analysis snapshots for full offline replay"
+    ],
+    "closure": "Partial evidence for #412. The fixture diagnostic deliverable is complete; do not claim its rebaseline scope is complete."
+  },
+  "priorAudit": {
+    "sha256": "4a0b6c81d8b9195e417571d123164c806b07129924d02d4a36f85d373e061190",
+    "checkedAt": "2026-09-05T01:09:19.300Z",
+    "sourceCommit": "66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c",
+    "coveredDatasets": [
+      "scorer-openai",
+      "scorer-gemini",
+      "scorer-gemini-low-confirm"
+    ]
+  },
+  "datasets": [
+    {
+      "id": "scorer-openai",
+      "source": "A",
+      "sourceCommit": "66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c",
+      "study": "patina-model-evaluation-20260904",
+      "protocolHash": "7c79c2edf1b86407a5279eff9dc0f14d02e1e8e24e75b73f1f2a4e3dbc60706a",
+      "repeat": 1,
+      "uniqueFixtures": 49,
+      "collection": {
+        "state": "completed",
+        "startedAt": "2026-09-04T22:59:05.699Z",
+        "endedAt": "2026-09-05T00:10:10.391Z",
+        "expected": 294,
+        "observed": 294,
+        "valid": 293,
+        "errors": 1,
+        "missing": 0,
+        "calls": 294,
+        "transportAttempts": 294,
+        "identityVerifiedResponses": 294,
+        "schemaFailures": 1,
+        "errorCounts": {
+          "invalid-json": 0,
+          "invalid-score-schema": 1,
+          "invalid-score-category": 0,
+          "transport-error": 0
+        }
+      },
+      "provenance": {
+        "artifacts": {
+          "artifacts/model-evaluation-20260904/validated/scorer-openai/scorer-rows.jsonl": "2d03f9349394209d72118f88acf502d5caf920f3a5368f0dd4943e318f8dbb5b",
+          "artifacts/model-evaluation-20260904/validated/scorer-openai/scorer-summary.json": "87fb51353bd1c1b58daae85860a71736e6d33ce4d40ecca66ce0a150c3fef8ed",
+          "artifacts/model-evaluation-20260904/validated/scorer-openai/semantics.json": "6c9bfa42d5344e628643d976204c5fc467855f40bf8378e886114208424dc93a",
+          "artifacts/model-evaluation-20260904/validated/jobs/scorer-openai/job.json": "b42ef5c0e107674301b7205cba253a0c029dbc659ff4c6737583baf8d1fe7605",
+          "docs/research/model-evaluation-20260904.json": "8451be6e9690ba8a5cc32494b7fb7664353b8caa0403b1d772bb0ade7c719e4f"
+        },
+        "semanticsSha256": "f1aa3eace29b8f24804d7526ca12957a91243b187b2cbe857692e345828c8b6a",
+        "effectiveInputs": {
+          "configuration": "5f2c949ae8304cdf68f1f051b649d90c1a4c554629bca9760de65ddb128a6319",
+          "sourceVoice": false,
+          "patterns": {
+            "en": "d1e674e74d1dda3c40c5008e1f6ff07f1b7d398c88fd38d7114301a62e5b4c9a",
+            "ko": "d49eea71abfe9b33113e722616271150375a59da31ae4541fb4b2c955bba0ed3",
+            "zh": "0c611d2062f625029e1d2d28115db2d16c26a8f2fe2ae6d8d74409987c3193b3",
+            "ja": "5b9f50877d6b21f90fe04060366bfe7b2802bd60ea9a3036f44a75621a52c658"
+          },
+          "lexicons": {
+            "en": "1ae483d4e7ab88592289acf34eff3a2c4ddbef1f735b09bff1a34887cd062457",
+            "ko": "ec9851f0bcf0c736589b9d73454426025f6fbad907d5616829aeb5006c2ac1fa",
+            "zh": "f4b8ef3f2db64aae2defec0ec032ed52360025c9daf2992956d6766f21cf5e3b",
+            "ja": "1573f330a4692f3dc9901f854b28f5d1a47704f74b75d0bfb184dda02bea9d54"
+          },
+          "structuralModels": {
+            "en": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "ko": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "zh": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "ja": {
+              "status": "absent",
+              "contentHash": null
+            }
+          }
+        },
+        "fixtureIdentitySha256": "74ad644620b833401d44bb5c788090d6daef7542a2e0a568619a35d38d4a33b5",
+        "expectedKeysSha256": "bf1831a20d73a3bd121620412fcdec14f91ed786ae3765899f35c5c76c3bed74",
+        "receiptManifestSha256": "0c8d04a6f4df12c0b8ad6a5b261f046609f0a93c22ba65f6ebeb26850f297cf5",
+        "receiptCount": 294,
+        "requestHashesSha256": "7a368778f8adbc36c72c19318a6d3acd52969640568e1cf592e997d4f4c773c6",
+        "promptHashesSha256": "712dc068df8452f82f0f532fe656ac17a013ed7b2056e81889b7179d1172a106",
+        "sourceFilesVerifiedAgainstCommit": 158,
+        "scorerSha256": "8df8a476e0183222fae74bee85f00d8da7ffd907bae9181501859f32afaa5762",
+        "parserSha256": "b970b824824a06bf79eff617918aeaa2d337410b00ab266b7769f84db45b1fdc",
+        "patternCatalog": {
+          "en": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "ko": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "zh": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "ja": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          }
+        },
+        "directoryProtocolBinding": "legacy-absent",
+        "protocolRecomputed": false,
+        "fullScorerReplay": false
+      },
+      "diagnostics": {
+        "categoryArithmeticMismatches": 2,
+        "overallWeightedSumMismatches": 0,
+        "arithmeticTolerance": 0.11
+      },
+      "candidates": [
+        {
+          "id": "openai-astra",
+          "provider": "openai",
+          "transport": "opencodex",
+          "requestedModel": "gpt-6-astra",
+          "responseModel": "gpt-6-astra",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": "low",
+          "observed": 49,
+          "uniqueFixtures": 49,
+          "valid": 49,
+          "errors": 0,
+          "availability": {
+            "validNumerator": 49,
+            "observedDenominator": 49
+          },
+          "scores": {
+            "overall": {
+              "n": 49,
+              "min": 0,
+              "median": 0.44,
+              "mean": 6.572871428571428,
+              "p95": 25.24,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 49,
+              "min": 0,
+              "median": 0.44,
+              "mean": 4.670014285714286,
+              "p95": 23.14,
+              "max": 29.81
+            },
+            "deterministic": {
+              "n": 49,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 1,
+            "delta": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 1.9028571428571428,
+              "p95": 0,
+              "max": 93.24
+            }
+          },
+          "expected": 49,
+          "byLanguage": {
+            "en": {
+              "observed": 13,
+              "uniqueFixtures": 13,
+              "valid": 13,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 13,
+                "observedDenominator": 13
+              },
+              "scores": {
+                "overall": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 8.247692307692308,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.0753846153846154,
+                  "p95": 6.76,
+                  "max": 6.76
+                },
+                "deterministic": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 7.172307692307692,
+                  "p95": 93.24,
+                  "max": 93.24
+                }
+              }
+            },
+            "ko": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 1.505,
+                  "mean": 3.8725,
+                  "p95": 12.02,
+                  "max": 12.02
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 1.505,
+                  "mean": 3.8725,
+                  "p95": 12.02,
+                  "max": 12.02
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0.555,
+                  "mean": 7.351666666666667,
+                  "p95": 29.81,
+                  "max": 29.81
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0.555,
+                  "mean": 7.351666666666667,
+                  "p95": 29.81,
+                  "max": 29.81
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0.5,
+                  "mean": 6.680058333333332,
+                  "p95": 25.24,
+                  "max": 25.24
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0.5,
+                  "mean": 6.680058333333332,
+                  "p95": 25.24,
+                  "max": 25.24
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 26,
+              "uniqueFixtures": 26,
+              "valid": 26,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 26,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 5.93,
+                  "mean": 12.263488461538461,
+                  "p95": 29.81,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 5.525,
+                  "mean": 8.677334615384616,
+                  "p95": 25.24,
+                  "max": 29.81
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.586153846153846,
+                  "p95": 0,
+                  "max": 93.24
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 23,
+              "uniqueFixtures": 23,
+              "valid": 23,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 23,
+                "observedDenominator": 23
+              },
+              "scores": {
+                "overall": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.13999999999999999,
+                  "p95": 0.67,
+                  "max": 1.11
+                },
+                "rawLLM": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.13999999999999999,
+                  "p95": 0.67,
+                  "max": 1.11
+                },
+                "deterministic": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0.44,
+                  "mean": 6.572871428571428,
+                  "p95": 25.24,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0.44,
+                  "mean": 4.670014285714286,
+                  "p95": 23.14,
+                  "max": 29.81
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.9028571428571428,
+                  "p95": 0,
+                  "max": 93.24
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/content": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.709230769230769,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "en/filler": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.71,
+                "p95": 16.67,
+                "max": 16.67
+              }
+            },
+            "en/language": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.2823076923076921,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "en/structure": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.0261538461538462,
+                "p95": 6.67,
+                "max": 6.67
+              }
+            },
+            "en/style": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0.5492307692307692,
+                "p95": 7.14,
+                "max": 7.14
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.2823076923076921,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ko/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 3.2408333333333332,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ko/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.39,
+                "p95": 5.56,
+                "max": 5.56
+              }
+            },
+            "ko/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 4.166666666666667,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ko/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 8.3325,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "ko/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.549166666666667,
+                "p95": 21.43,
+                "max": 21.43
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 10.185833333333333,
+                "p95": 55.56,
+                "max": 55.56
+              }
+            },
+            "zh/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 12.036666666666667,
+                "p95": 50,
+                "max": 50
+              }
+            },
+            "zh/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 13.425833333333335,
+                "p95": 50,
+                "max": 50
+              }
+            },
+            "zh/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 3.3333333333333335,
+                "p95": 20,
+                "max": 20
+              }
+            },
+            "zh/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 8.333333333333334,
+                "p95": 28.57,
+                "max": 28.57
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.3891666666666664,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ja/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 16.666391666666666,
+                "p95": 61.1111,
+                "max": 61.1111
+              }
+            },
+            "ja/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 8.796016666666667,
+                "p95": 44.4444,
+                "max": 44.4444
+              }
+            },
+            "ja/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.481483333333333,
+                "p95": 44.44,
+                "max": 44.44
+              }
+            },
+            "ja/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 3.33335,
+                "mean": 7.7775,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "ja/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 3.5717833333333338,
+                "p95": 14.29,
+                "max": 14.29
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": null
+        },
+        {
+          "id": "openai-sol",
+          "provider": "openai",
+          "transport": "opencodex",
+          "requestedModel": "gpt-5.6-sol",
+          "responseModel": "gpt-5.6-sol",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": "low",
+          "observed": 49,
+          "uniqueFixtures": 49,
+          "valid": 49,
+          "errors": 0,
+          "availability": {
+            "validNumerator": 49,
+            "observedDenominator": 49
+          },
+          "scores": {
+            "overall": {
+              "n": 49,
+              "min": 0,
+              "median": 3.7,
+              "mean": 11.179591836734692,
+              "p95": 33.4,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 49,
+              "min": 0,
+              "median": 3.7,
+              "mean": 9.424489795918369,
+              "p95": 31.8,
+              "max": 35.5
+            },
+            "deterministic": {
+              "n": 49,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 1,
+            "delta": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 1.7551020408163265,
+              "p95": 0,
+              "max": 86
+            }
+          },
+          "expected": 49,
+          "byLanguage": {
+            "en": {
+              "observed": 13,
+              "uniqueFixtures": 13,
+              "valid": 13,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 13,
+                "observedDenominator": 13
+              },
+              "scores": {
+                "overall": {
+                  "n": 13,
+                  "min": 0.4,
+                  "median": 2.4,
+                  "mean": 12.253846153846155,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 13,
+                  "min": 0.4,
+                  "median": 2.4,
+                  "mean": 5.638461538461538,
+                  "p95": 19.3,
+                  "max": 19.3
+                },
+                "deterministic": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 6.615384615384615,
+                  "p95": 86,
+                  "max": 86
+                }
+              }
+            },
+            "ko": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 10.100000000000001,
+                  "mean": 10.366666666666667,
+                  "p95": 29.1,
+                  "max": 29.1
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 10.100000000000001,
+                  "mean": 10.366666666666667,
+                  "p95": 29.1,
+                  "max": 29.1
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 5.85,
+                  "mean": 11.825000000000001,
+                  "p95": 33.4,
+                  "max": 33.4
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 5.85,
+                  "mean": 11.825000000000001,
+                  "p95": 33.4,
+                  "max": 33.4
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 2.5,
+                  "mean": 10.183333333333334,
+                  "p95": 35.5,
+                  "max": 35.5
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 2.5,
+                  "mean": 10.183333333333334,
+                  "p95": 35.5,
+                  "max": 35.5
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 26,
+              "uniqueFixtures": 26,
+              "valid": 26,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 26,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 26,
+                  "min": 1.1,
+                  "median": 16.5,
+                  "mean": 20.326923076923077,
+                  "p95": 35.5,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 26,
+                  "min": 1.1,
+                  "median": 15.600000000000001,
+                  "mean": 17.01923076923077,
+                  "p95": 33.4,
+                  "max": 35.5
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.3076923076923075,
+                  "p95": 0,
+                  "max": 86
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 23,
+              "uniqueFixtures": 23,
+              "valid": 23,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 23,
+                "observedDenominator": 23
+              },
+              "scores": {
+                "overall": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0.4,
+                  "mean": 0.8391304347826087,
+                  "p95": 3.5,
+                  "max": 3.7
+                },
+                "rawLLM": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0.4,
+                  "mean": 0.8391304347826087,
+                  "p95": 3.5,
+                  "max": 3.7
+                },
+                "deterministic": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 3.7,
+                  "mean": 11.179591836734692,
+                  "p95": 33.4,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 3.7,
+                  "mean": 9.424489795918369,
+                  "p95": 31.8,
+                  "max": 35.5
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.7551020408163265,
+                  "p95": 0,
+                  "max": 86
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/content": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 7.699999999999999,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            },
+            "en/filler": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 5.6,
+                "mean": 7.699999999999999,
+                "p95": 44.4,
+                "max": 44.4
+              }
+            },
+            "en/language": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 5.6,
+                "mean": 8.13076923076923,
+                "p95": 27.8,
+                "max": 27.8
+              }
+            },
+            "en/structure": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 13.3,
+                "mean": 12.299999999999999,
+                "p95": 46.7,
+                "max": 46.7
+              }
+            },
+            "en/style": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.646153846153846,
+                "p95": 14.3,
+                "max": 14.3
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 3,
+                "p95": 11.1,
+                "max": 11.1
+              }
+            },
+            "ko/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 5.55,
+                "mean": 9.725,
+                "p95": 38.9,
+                "max": 38.9
+              }
+            },
+            "ko/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.55,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            },
+            "ko/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 8.35,
+                "mean": 13.416666666666666,
+                "p95": 44.4,
+                "max": 44.4
+              }
+            },
+            "ko/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 16.65,
+                "mean": 18.325,
+                "p95": 53.3,
+                "max": 53.3
+              }
+            },
+            "ko/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 10.7,
+                "mean": 14.875000000000002,
+                "p95": 42.9,
+                "max": 42.9
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 3.25,
+                "p95": 11.1,
+                "max": 11.1
+              }
+            },
+            "zh/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 12.958333333333334,
+                "p95": 44.4,
+                "max": 44.4
+              }
+            },
+            "zh/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 14.35,
+                "p95": 61.1,
+                "max": 61.1
+              }
+            },
+            "zh/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 11.149999999999999,
+                "mean": 20.833333333333332,
+                "p95": 61.1,
+                "max": 61.1
+              }
+            },
+            "zh/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 6.65,
+                "mean": 14.433333333333332,
+                "p95": 53.3,
+                "max": 53.3
+              }
+            },
+            "zh/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 7.15,
+                "mean": 11.916666666666666,
+                "p95": 28.6,
+                "max": 28.6
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 2.783333333333333,
+                "p95": 11.1,
+                "max": 11.1
+              }
+            },
+            "ja/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 15.741666666666665,
+                "p95": 72.2,
+                "max": 72.2
+              }
+            },
+            "ja/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 12.041666666666666,
+                "p95": 55.6,
+                "max": 55.6
+              }
+            },
+            "ja/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 5.6,
+                "mean": 13.424999999999999,
+                "p95": 44.4,
+                "max": 44.4
+              }
+            },
+            "ja/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 10,
+                "mean": 15,
+                "p95": 46.7,
+                "max": 46.7
+              }
+            },
+            "ja/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.958333333333333,
+                "p95": 28.6,
+                "max": 28.6
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.474999999999999,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": null
+        },
+        {
+          "id": "openai-terra",
+          "provider": "openai",
+          "transport": "opencodex",
+          "requestedModel": "gpt-5.6-terra",
+          "responseModel": "gpt-5.6-terra",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": "low",
+          "observed": 49,
+          "uniqueFixtures": 49,
+          "valid": 49,
+          "errors": 0,
+          "availability": {
+            "validNumerator": 49,
+            "observedDenominator": 49
+          },
+          "scores": {
+            "overall": {
+              "n": 49,
+              "min": 0,
+              "median": 2,
+              "mean": 7.9938775510204065,
+              "p95": 28.47,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 49,
+              "min": 0,
+              "median": 2,
+              "mean": 6.042857142857144,
+              "p95": 25.36,
+              "max": 29.9
+            },
+            "deterministic": {
+              "n": 49,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 1,
+            "delta": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 1.9510204081632652,
+              "p95": 0,
+              "max": 95.6
+            }
+          },
+          "expected": 49,
+          "byLanguage": {
+            "en": {
+              "observed": 13,
+              "uniqueFixtures": 13,
+              "valid": 13,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 13,
+                "observedDenominator": 13
+              },
+              "scores": {
+                "overall": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 1.7,
+                  "mean": 9.946153846153846,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 1.7,
+                  "mean": 2.5923076923076924,
+                  "p95": 7.9,
+                  "max": 7.9
+                },
+                "deterministic": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 7.3538461538461535,
+                  "p95": 95.6,
+                  "max": 95.6
+                }
+              }
+            },
+            "ko": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 3,
+                  "mean": 5.666666666666667,
+                  "p95": 20.6,
+                  "max": 20.6
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 3,
+                  "mean": 5.666666666666667,
+                  "p95": 20.6,
+                  "max": 20.6
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 1.835,
+                  "mean": 7.297499999999999,
+                  "p95": 24.9,
+                  "max": 24.9
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 1.835,
+                  "mean": 7.297499999999999,
+                  "p95": 24.9,
+                  "max": 24.9
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 2,
+                  "mean": 8.902500000000002,
+                  "p95": 29.9,
+                  "max": 29.9
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 2,
+                  "mean": 8.902500000000002,
+                  "p95": 29.9,
+                  "max": 29.9
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 26,
+              "uniqueFixtures": 26,
+              "valid": 26,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 26,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 26,
+                  "min": 1.1,
+                  "median": 7.75,
+                  "mean": 14.765384615384615,
+                  "p95": 29.9,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 26,
+                  "min": 1.1,
+                  "median": 7.3,
+                  "mean": 11.088461538461537,
+                  "p95": 28.47,
+                  "max": 29.9
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.6769230769230767,
+                  "p95": 0,
+                  "max": 95.6
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 23,
+              "uniqueFixtures": 23,
+              "valid": 23,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 23,
+                "observedDenominator": 23
+              },
+              "scores": {
+                "overall": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.33913043478260874,
+                  "p95": 1.3,
+                  "max": 1.7
+                },
+                "rawLLM": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.33913043478260874,
+                  "p95": 1.3,
+                  "max": 1.7
+                },
+                "deterministic": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 2,
+                  "mean": 7.9938775510204065,
+                  "p95": 28.47,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 2,
+                  "mean": 6.042857142857144,
+                  "p95": 25.36,
+                  "max": 29.9
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.9510204081632652,
+                  "p95": 0,
+                  "max": 95.6
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/content": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 2.576923076923077,
+                "p95": 11.1,
+                "max": 11.1
+              }
+            },
+            "en/filler": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 3.423076923076923,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            },
+            "en/language": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 5.6,
+                "mean": 5.1461538461538465,
+                "p95": 22.2,
+                "max": 22.2
+              }
+            },
+            "en/structure": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 6.1461538461538465,
+                "p95": 20,
+                "max": 20
+              }
+            },
+            "en/style": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.715384615384615,
+                "p95": 11.1,
+                "max": 11.1
+              }
+            },
+            "ko/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.566666666666666,
+                "p95": 16.7,
+                "max": 16.7
+              }
+            },
+            "ko/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 2.3166666666666664,
+                "p95": 16.7,
+                "max": 16.7
+              }
+            },
+            "ko/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 2.8,
+                "mean": 6.483333333333333,
+                "p95": 22.2,
+                "max": 22.2
+              }
+            },
+            "ko/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 3.35,
+                "mean": 10,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            },
+            "ko/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 9.533333333333333,
+                "p95": 42.9,
+                "max": 42.9
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0.9333333333333332,
+                "p95": 5.6,
+                "max": 5.6
+              }
+            },
+            "zh/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 9.260833333333332,
+                "p95": 50,
+                "max": 50
+              }
+            },
+            "zh/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.552499999999999,
+                "p95": 22.2,
+                "max": 22.2
+              }
+            },
+            "zh/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 12.495833333333332,
+                "p95": 44.44,
+                "max": 44.44
+              }
+            },
+            "zh/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.110833333333333,
+                "p95": 26.7,
+                "max": 26.7
+              }
+            },
+            "zh/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 7.145,
+                "mean": 10.720833333333331,
+                "p95": 28.6,
+                "max": 28.6
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0.9249999999999999,
+                "p95": 11.1,
+                "max": 11.1
+              }
+            },
+            "ja/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 15.7425,
+                "p95": 66.67,
+                "max": 66.67
+              }
+            },
+            "ja/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 9.256666666666666,
+                "p95": 38.89,
+                "max": 38.89
+              }
+            },
+            "ja/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 2.8,
+                "mean": 11.116666666666667,
+                "p95": 55.6,
+                "max": 55.6
+              }
+            },
+            "ja/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 3.35,
+                "mean": 10.560833333333333,
+                "p95": 40,
+                "max": 40
+              }
+            },
+            "ja/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 7.1450000000000005,
+                "p95": 28.6,
+                "max": 28.6
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 4.6275,
+                "p95": 22.22,
+                "max": 22.22
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": null
+        },
+        {
+          "id": "openai-luna",
+          "provider": "openai",
+          "transport": "opencodex",
+          "requestedModel": "gpt-5.6-luna",
+          "responseModel": "gpt-5.6-luna",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": "low",
+          "observed": 49,
+          "uniqueFixtures": 49,
+          "valid": 48,
+          "errors": 1,
+          "availability": {
+            "validNumerator": 48,
+            "observedDenominator": 49
+          },
+          "scores": {
+            "overall": {
+              "n": 48,
+              "min": 0,
+              "median": 2.41,
+              "mean": 7.299375,
+              "p95": 21.92,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 48,
+              "min": 0,
+              "median": 2.41,
+              "mean": 5.354375,
+              "p95": 21.9,
+              "max": 22.3
+            },
+            "deterministic": {
+              "n": 49,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 1,
+            "delta": {
+              "n": 48,
+              "min": 0,
+              "median": 0,
+              "mean": 1.945,
+              "p95": 0,
+              "max": 93.36
+            }
+          },
+          "expected": 49,
+          "byLanguage": {
+            "en": {
+              "observed": 13,
+              "uniqueFixtures": 13,
+              "valid": 13,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 13,
+                "observedDenominator": 13
+              },
+              "scores": {
+                "overall": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 3.3,
+                  "mean": 10.669230769230769,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 3.3,
+                  "mean": 3.487692307692308,
+                  "p95": 11.3,
+                  "max": 11.3
+                },
+                "deterministic": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 7.181538461538461,
+                  "p95": 93.36,
+                  "max": 93.36
+                }
+              }
+            },
+            "ko": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 11,
+              "errors": 1,
+              "availability": {
+                "validNumerator": 11,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 11,
+                  "min": 0,
+                  "median": 2.11,
+                  "mean": 4.356363636363636,
+                  "p95": 18.48,
+                  "max": 18.48
+                },
+                "rawLLM": {
+                  "n": 11,
+                  "min": 0,
+                  "median": 2.11,
+                  "mean": 4.356363636363636,
+                  "p95": 18.48,
+                  "max": 18.48
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 11,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 1.79,
+                  "mean": 6.461666666666667,
+                  "p95": 22.3,
+                  "max": 22.3
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 1.79,
+                  "mean": 6.461666666666667,
+                  "p95": 22.3,
+                  "max": 22.3
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 3.2,
+                  "mean": 7.184166666666667,
+                  "p95": 21.9,
+                  "max": 21.9
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 3.2,
+                  "mean": 7.184166666666667,
+                  "p95": 21.9,
+                  "max": 21.9
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 26,
+              "uniqueFixtures": 26,
+              "valid": 25,
+              "errors": 1,
+              "availability": {
+                "validNumerator": 25,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 25,
+                  "min": 0,
+                  "median": 8.6,
+                  "mean": 13.101600000000001,
+                  "p95": 22.3,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 25,
+                  "min": 0,
+                  "median": 7.73,
+                  "mean": 9.3672,
+                  "p95": 21.92,
+                  "max": 22.3
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 25,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.7344,
+                  "p95": 0,
+                  "max": 93.36
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 23,
+              "uniqueFixtures": 23,
+              "valid": 23,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 23,
+                "observedDenominator": 23
+              },
+              "scores": {
+                "overall": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0.44,
+                  "mean": 0.9926086956521738,
+                  "p95": 3.3,
+                  "max": 5.7
+                },
+                "rawLLM": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0.44,
+                  "mean": 0.9926086956521738,
+                  "p95": 3.3,
+                  "max": 5.7
+                },
+                "deterministic": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 48,
+              "errors": 1,
+              "availability": {
+                "validNumerator": 48,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 48,
+                  "min": 0,
+                  "median": 2.41,
+                  "mean": 7.299375,
+                  "p95": 21.92,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 48,
+                  "min": 0,
+                  "median": 2.41,
+                  "mean": 5.354375,
+                  "p95": 21.9,
+                  "max": 22.3
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 48,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.945,
+                  "p95": 0,
+                  "max": 93.36
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/content": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 5.558461538461538,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            },
+            "en/filler": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 5.56,
+                "mean": 4.286153846153846,
+                "p95": 22.2,
+                "max": 22.2
+              }
+            },
+            "en/language": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 3.7,
+                "mean": 4.984615384615385,
+                "p95": 22.2,
+                "max": 22.2
+              }
+            },
+            "en/structure": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 4.628461538461538,
+                "p95": 26.7,
+                "max": 26.7
+              }
+            },
+            "en/style": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 2.0076923076923077,
+                "p95": 9.5,
+                "max": 9.5
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.853846153846154,
+                "p95": 11.1,
+                "max": 11.1
+              }
+            },
+            "ko/communication": {
+              "validRows": 11,
+              "missing": 0,
+              "score": {
+                "n": 11,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 11,
+              "missing": 0,
+              "score": {
+                "n": 11,
+                "min": 0,
+                "median": 0,
+                "mean": 3.543636363636364,
+                "p95": 16.7,
+                "max": 16.7
+              }
+            },
+            "ko/filler": {
+              "validRows": 11,
+              "missing": 0,
+              "score": {
+                "n": 11,
+                "min": 0,
+                "median": 5.56,
+                "mean": 4.553636363636364,
+                "p95": 16.67,
+                "max": 16.67
+              }
+            },
+            "ko/language": {
+              "validRows": 11,
+              "missing": 0,
+              "score": {
+                "n": 11,
+                "min": 0,
+                "median": 3.7,
+                "mean": 5.9,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "ko/structure": {
+              "validRows": 11,
+              "missing": 0,
+              "score": {
+                "n": 11,
+                "min": 0,
+                "median": 0,
+                "mean": 8.484545454545454,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "ko/style": {
+              "validRows": 11,
+              "missing": 0,
+              "score": {
+                "n": 11,
+                "min": 0,
+                "median": 0,
+                "mean": 5.191818181818181,
+                "p95": 28.57,
+                "max": 28.57
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 11,
+              "missing": 0,
+              "score": {
+                "n": 11,
+                "min": 0,
+                "median": 0,
+                "mean": 0.8454545454545456,
+                "p95": 5.6,
+                "max": 5.6
+              }
+            },
+            "zh/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.482499999999999,
+                "p95": 38.9,
+                "max": 38.9
+              }
+            },
+            "zh/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.5575,
+                "p95": 27.8,
+                "max": 27.8
+              }
+            },
+            "zh/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 10.180833333333332,
+                "p95": 44.44,
+                "max": 44.44
+              }
+            },
+            "zh/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 3.335,
+                "mean": 7.778333333333333,
+                "p95": 26.7,
+                "max": 26.7
+              }
+            },
+            "zh/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 3.57,
+                "mean": 9.526666666666666,
+                "p95": 28.6,
+                "max": 28.6
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.3891666666666664,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ja/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 12.027500000000002,
+                "p95": 44.4,
+                "max": 44.4
+              }
+            },
+            "ja/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 8.799166666666666,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "ja/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 5.6,
+                "mean": 12.498333333333333,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            },
+            "ja/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 3.335,
+                "mean": 8.880833333333333,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            },
+            "ja/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 3.5741666666666667,
+                "p95": 14.3,
+                "max": 14.3
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.3916666666666666,
+                "p95": 11.1,
+                "max": 11.1
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": null
+        },
+        {
+          "id": "openai-5.5",
+          "provider": "openai",
+          "transport": "opencodex",
+          "requestedModel": "gpt-5.5",
+          "responseModel": "gpt-5.5",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": "low",
+          "observed": 49,
+          "uniqueFixtures": 49,
+          "valid": 49,
+          "errors": 0,
+          "availability": {
+            "validNumerator": 49,
+            "observedDenominator": 49
+          },
+          "scores": {
+            "overall": {
+              "n": 49,
+              "min": 0,
+              "median": 6,
+              "mean": 11.596326530612245,
+              "p95": 34.5,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 49,
+              "min": 0,
+              "median": 6,
+              "mean": 9.84122448979592,
+              "p95": 31.8,
+              "max": 37.1
+            },
+            "deterministic": {
+              "n": 49,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 1,
+            "delta": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 1.7551020408163265,
+              "p95": 0,
+              "max": 86
+            }
+          },
+          "expected": 49,
+          "byLanguage": {
+            "en": {
+              "observed": 13,
+              "uniqueFixtures": 13,
+              "valid": 13,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 13,
+                "observedDenominator": 13
+              },
+              "scores": {
+                "overall": {
+                  "n": 13,
+                  "min": 0.9,
+                  "median": 5.9,
+                  "mean": 13.953846153846154,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 13,
+                  "min": 0.9,
+                  "median": 5.9,
+                  "mean": 7.338461538461538,
+                  "p95": 23.8,
+                  "max": 23.8
+                },
+                "deterministic": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 6.615384615384615,
+                  "p95": 86,
+                  "max": 86
+                }
+              }
+            },
+            "ko": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 8.865,
+                  "mean": 12.063333333333334,
+                  "p95": 34.5,
+                  "max": 34.5
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 8.865,
+                  "mean": 12.063333333333334,
+                  "p95": 34.5,
+                  "max": 34.5
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 4.1,
+                  "mean": 10.541666666666666,
+                  "p95": 37.1,
+                  "max": 37.1
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 4.1,
+                  "mean": 10.541666666666666,
+                  "p95": 37.1,
+                  "max": 37.1
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 4.5,
+                  "mean": 9.63,
+                  "p95": 31.6,
+                  "max": 31.6
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 4.5,
+                  "mean": 9.63,
+                  "p95": 31.6,
+                  "max": 31.6
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 26,
+              "uniqueFixtures": 26,
+              "valid": 26,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 26,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 26,
+                  "min": 2.9,
+                  "median": 14.385,
+                  "mean": 20.752307692307696,
+                  "p95": 37.1,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 26,
+                  "min": 2.9,
+                  "median": 14.1,
+                  "mean": 17.444615384615386,
+                  "p95": 34.5,
+                  "max": 37.1
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.3076923076923075,
+                  "p95": 0,
+                  "max": 86
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 23,
+              "uniqueFixtures": 23,
+              "valid": 23,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 23,
+                "observedDenominator": 23
+              },
+              "scores": {
+                "overall": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0.56,
+                  "mean": 1.246086956521739,
+                  "p95": 5.9,
+                  "max": 6
+                },
+                "rawLLM": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0.56,
+                  "mean": 1.246086956521739,
+                  "p95": 5.9,
+                  "max": 6
+                },
+                "deterministic": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 6,
+                  "mean": 11.596326530612245,
+                  "p95": 34.5,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 6,
+                  "mean": 9.84122448979592,
+                  "p95": 31.8,
+                  "max": 37.1
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.7551020408163265,
+                  "p95": 0,
+                  "max": 86
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/content": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 5.6,
+                "mean": 10.276923076923076,
+                "p95": 50,
+                "max": 50
+              }
+            },
+            "en/filler": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 5.56,
+                "mean": 5.989230769230769,
+                "p95": 22.2,
+                "max": 22.2
+              }
+            },
+            "en/language": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 11.1,
+                "mean": 11.123076923076923,
+                "p95": 38.9,
+                "max": 38.9
+              }
+            },
+            "en/structure": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 6.7,
+                "mean": 11.797692307692309,
+                "p95": 46.7,
+                "max": 46.7
+              }
+            },
+            "en/style": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 4.38,
+                "p95": 21.4,
+                "max": 21.4
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 5.56,
+                "mean": 5.135384615384615,
+                "p95": 16.7,
+                "max": 16.7
+              }
+            },
+            "ko/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 2.8,
+                "mean": 14.818333333333333,
+                "p95": 50,
+                "max": 50
+              }
+            },
+            "ko/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 5.6,
+                "mean": 8.810833333333333,
+                "p95": 27.8,
+                "max": 27.8
+              }
+            },
+            "ko/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 11.105,
+                "mean": 14.346666666666666,
+                "p95": 38.9,
+                "max": 38.9
+              }
+            },
+            "ko/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 16.65,
+                "mean": 20.549999999999997,
+                "p95": 60,
+                "max": 60
+              }
+            },
+            "ko/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 10.715,
+                "mean": 16.078333333333337,
+                "p95": 42.9,
+                "max": 42.9
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.3999999999999997,
+                "p95": 5.6,
+                "max": 5.6
+              }
+            },
+            "zh/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 10.183333333333332,
+                "p95": 44.4,
+                "max": 44.4
+              }
+            },
+            "zh/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 12.5,
+                "p95": 55.6,
+                "max": 55.6
+              }
+            },
+            "zh/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 8.35,
+                "mean": 19.90833333333333,
+                "p95": 77.8,
+                "max": 77.8
+              }
+            },
+            "zh/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 6.65,
+                "mean": 12.775,
+                "p95": 40,
+                "max": 40
+              }
+            },
+            "zh/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 7.15,
+                "mean": 10.725,
+                "p95": 28.6,
+                "max": 28.6
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 2.783333333333333,
+                "p95": 11.1,
+                "max": 11.1
+              }
+            },
+            "ja/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 16.2,
+                "p95": 66.7,
+                "max": 66.7
+              }
+            },
+            "ja/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 9.725,
+                "p95": 38.9,
+                "max": 38.9
+              }
+            },
+            "ja/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 8.35,
+                "mean": 15.284999999999998,
+                "p95": 55.6,
+                "max": 55.6
+              }
+            },
+            "ja/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 6.65,
+                "mean": 13.330833333333333,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            },
+            "ja/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 4.749999999999999,
+                "p95": 21.4,
+                "max": 21.4
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 3.246666666666666,
+                "p95": 16.7,
+                "max": 16.7
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": null
+        },
+        {
+          "id": "openai-mini",
+          "provider": "openai",
+          "transport": "opencodex",
+          "requestedModel": "gpt-5.4-mini",
+          "responseModel": "gpt-5.4-mini",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": "low",
+          "observed": 49,
+          "uniqueFixtures": 49,
+          "valid": 49,
+          "errors": 0,
+          "availability": {
+            "validNumerator": 49,
+            "observedDenominator": 49
+          },
+          "scores": {
+            "overall": {
+              "n": 49,
+              "min": 0,
+              "median": 1,
+              "mean": 5.27242309685779,
+              "p95": 17.3,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 49,
+              "min": 0,
+              "median": 1,
+              "mean": 3.2815251376741177,
+              "p95": 17.2,
+              "max": 18.6
+            },
+            "deterministic": {
+              "n": 49,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 1,
+            "delta": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 1.9908979591836735,
+              "p95": 0,
+              "max": 97.554
+            }
+          },
+          "expected": 49,
+          "byLanguage": {
+            "en": {
+              "observed": 13,
+              "uniqueFixtures": 13,
+              "valid": 13,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 13,
+                "observedDenominator": 13
+              },
+              "scores": {
+                "overall": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 1.11,
+                  "mean": 9.542837606837606,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 1.11,
+                  "mean": 2.0386837606837607,
+                  "p95": 7.4,
+                  "max": 7.4
+                },
+                "deterministic": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 7.504153846153846,
+                  "p95": 97.554,
+                  "max": 97.554
+                }
+              }
+            },
+            "ko": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 4.142857142857142,
+                  "mean": 4.418095238095238,
+                  "p95": 17.3,
+                  "max": 17.3
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 4.142857142857142,
+                  "mean": 4.418095238095238,
+                  "p95": 17.3,
+                  "max": 17.3
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0.5,
+                  "mean": 4.605833333333334,
+                  "p95": 18.6,
+                  "max": 18.6
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0.5,
+                  "mean": 4.605833333333334,
+                  "p95": 18.6,
+                  "max": 18.6
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 2.1670583333333333,
+                  "p95": 9.9047,
+                  "max": 9.9047
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 2.1670583333333333,
+                  "p95": 9.9047,
+                  "max": 9.9047
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 26,
+              "uniqueFixtures": 26,
+              "valid": 26,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 26,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 5.545,
+                  "mean": 9.731481135531137,
+                  "p95": 18.6,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 5.145,
+                  "mean": 5.979404212454213,
+                  "p95": 17.3,
+                  "max": 18.6
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.752076923076923,
+                  "p95": 0,
+                  "max": 97.554
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 23,
+              "uniqueFixtures": 23,
+              "valid": 23,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 23,
+                "observedDenominator": 23
+              },
+              "scores": {
+                "overall": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.23174879227053138,
+                  "p95": 2.2222222222222223,
+                  "max": 3.108
+                },
+                "rawLLM": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.23174879227053138,
+                  "p95": 2.2222222222222223,
+                  "max": 3.108
+                },
+                "deterministic": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 1,
+                  "mean": 5.27242309685779,
+                  "p95": 17.3,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 1,
+                  "mean": 3.2815251376741177,
+                  "p95": 17.2,
+                  "max": 18.6
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.9908979591836735,
+                  "p95": 0,
+                  "max": 97.554
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/content": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 2.567863247863248,
+                "p95": 22.22222222222222,
+                "max": 22.22222222222222
+              }
+            },
+            "en/filler": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 2.5635042735042735,
+                "p95": 16.67,
+                "max": 16.67
+              }
+            },
+            "en/language": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 5.555897435897435,
+                "p95": 27.8,
+                "max": 27.8
+              }
+            },
+            "en/structure": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 2.0512820512820515,
+                "p95": 13.3,
+                "max": 13.3
+              }
+            },
+            "en/style": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.855925925925926,
+                "p95": 11.11111111111111,
+                "max": 11.11111111111111
+              }
+            },
+            "ko/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 5.557777777777778,
+                "mean": 7.402222222222222,
+                "p95": 22.2,
+                "max": 22.2
+              }
+            },
+            "ko/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 9.983333333333334,
+                "mean": 8.3275,
+                "p95": 20,
+                "max": 20
+              }
+            },
+            "ko/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 8.330714285714286,
+                "p95": 57.1,
+                "max": 57.1
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.091666666666666,
+                "p95": 27.8,
+                "max": 27.8
+              }
+            },
+            "zh/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 4.635,
+                "p95": 22.22,
+                "max": 22.22
+              }
+            },
+            "zh/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 7.864259259259259,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            },
+            "zh/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.558055555555555,
+                "p95": 20,
+                "max": 20
+              }
+            },
+            "zh/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.945,
+                "p95": 23.8,
+                "max": 23.8
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 4.635183333333333,
+                "p95": 22.2222,
+                "max": 22.2222
+              }
+            },
+            "ja/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 4.630558333333333,
+                "p95": 22.2,
+                "max": 22.2
+              }
+            },
+            "ja/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 2.3175916666666665,
+                "p95": 11.1111,
+                "max": 11.1111
+              }
+            },
+            "ja/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 2.225,
+                "p95": 13.3,
+                "max": 13.3
+              }
+            },
+            "ja/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.190475,
+                "p95": 14.2857,
+                "max": 14.2857
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": null
+        }
+      ]
+    },
+    {
+      "id": "scorer-gemini",
+      "source": "A",
+      "sourceCommit": "66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c",
+      "study": "patina-model-evaluation-20260904",
+      "protocolHash": "c175a0f7e1c3495d4b95c0a5f6bd5efb81ceb794c5dda95a58b55ceed1023d2c",
+      "repeat": 1,
+      "uniqueFixtures": 49,
+      "collection": {
+        "state": "completed",
+        "startedAt": "2026-09-04T22:59:05.766Z",
+        "endedAt": "2026-09-04T23:52:46.392Z",
+        "expected": 245,
+        "observed": 245,
+        "valid": 245,
+        "errors": 0,
+        "missing": 0,
+        "calls": 245,
+        "transportAttempts": 245,
+        "identityVerifiedResponses": 245,
+        "schemaFailures": 0,
+        "errorCounts": {
+          "invalid-json": 0,
+          "invalid-score-schema": 0,
+          "invalid-score-category": 0,
+          "transport-error": 0
+        }
+      },
+      "provenance": {
+        "artifacts": {
+          "artifacts/model-evaluation-20260904/validated/scorer-gemini/scorer-rows.jsonl": "c394be7ee5987993807746ce1f846b76622c504e2e3e6687ebf5b43979733717",
+          "artifacts/model-evaluation-20260904/validated/scorer-gemini/scorer-summary.json": "4fa4abaaef8de5b0b8009b29945024390db81806d8f0427410aaf53411549a8e",
+          "artifacts/model-evaluation-20260904/validated/scorer-gemini/semantics.json": "49bd7af986c1cd39caa8970eb0cd88666d5619282d5855c85b95b0bacc57d323",
+          "artifacts/model-evaluation-20260904/validated/jobs/scorer-gemini/job.json": "e7b1346e8dbeef153cb322903b1d62703ed8bda7eeeab27fcf6879d9bd2a7800",
+          "docs/research/model-evaluation-20260904.json": "8451be6e9690ba8a5cc32494b7fb7664353b8caa0403b1d772bb0ade7c719e4f"
+        },
+        "semanticsSha256": "f1aa3eace29b8f24804d7526ca12957a91243b187b2cbe857692e345828c8b6a",
+        "effectiveInputs": {
+          "configuration": "5f2c949ae8304cdf68f1f051b649d90c1a4c554629bca9760de65ddb128a6319",
+          "sourceVoice": false,
+          "patterns": {
+            "en": "d1e674e74d1dda3c40c5008e1f6ff07f1b7d398c88fd38d7114301a62e5b4c9a",
+            "ko": "d49eea71abfe9b33113e722616271150375a59da31ae4541fb4b2c955bba0ed3",
+            "zh": "0c611d2062f625029e1d2d28115db2d16c26a8f2fe2ae6d8d74409987c3193b3",
+            "ja": "5b9f50877d6b21f90fe04060366bfe7b2802bd60ea9a3036f44a75621a52c658"
+          },
+          "lexicons": {
+            "en": "1ae483d4e7ab88592289acf34eff3a2c4ddbef1f735b09bff1a34887cd062457",
+            "ko": "ec9851f0bcf0c736589b9d73454426025f6fbad907d5616829aeb5006c2ac1fa",
+            "zh": "f4b8ef3f2db64aae2defec0ec032ed52360025c9daf2992956d6766f21cf5e3b",
+            "ja": "1573f330a4692f3dc9901f854b28f5d1a47704f74b75d0bfb184dda02bea9d54"
+          },
+          "structuralModels": {
+            "en": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "ko": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "zh": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "ja": {
+              "status": "absent",
+              "contentHash": null
+            }
+          }
+        },
+        "fixtureIdentitySha256": "74ad644620b833401d44bb5c788090d6daef7542a2e0a568619a35d38d4a33b5",
+        "expectedKeysSha256": "5510a81b6a1ecff382dbc17bc0462ec3ffc24657331731f445d7ed1d6546b73d",
+        "receiptManifestSha256": "3ab1bc1628d99bd2360a10d4f9583732fd480504279cb8b1612200aab5be6ef8",
+        "receiptCount": 245,
+        "requestHashesSha256": "9c27f8cd2f8a4845101b266ec01ccc590e36e2878ed7bc452c4ac3af3f68c5c3",
+        "promptHashesSha256": "1c7228326c6d58a48199ff82e730d37e8cb5cce056cf5e5d8c64f129ed1b9232",
+        "sourceFilesVerifiedAgainstCommit": 158,
+        "scorerSha256": "8df8a476e0183222fae74bee85f00d8da7ffd907bae9181501859f32afaa5762",
+        "parserSha256": "b970b824824a06bf79eff617918aeaa2d337410b00ab266b7769f84db45b1fdc",
+        "patternCatalog": {
+          "en": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "ko": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "zh": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "ja": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          }
+        },
+        "directoryProtocolBinding": "legacy-absent",
+        "protocolRecomputed": false,
+        "fullScorerReplay": false
+      },
+      "diagnostics": {
+        "categoryArithmeticMismatches": 4,
+        "overallWeightedSumMismatches": 1,
+        "arithmeticTolerance": 0.11
+      },
+      "candidates": [
+        {
+          "id": "gemini-pro",
+          "provider": "gemini",
+          "transport": "opencodex",
+          "requestedModel": "google-antigravity/gemini-3.1-pro",
+          "responseModel": "google-antigravity/gemini-3.1-pro",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": null,
+          "observed": 49,
+          "uniqueFixtures": 49,
+          "valid": 49,
+          "errors": 0,
+          "availability": {
+            "validNumerator": 49,
+            "observedDenominator": 49
+          },
+          "scores": {
+            "overall": {
+              "n": 49,
+              "min": 0,
+              "median": 3.55,
+              "mean": 10.699387755102041,
+              "p95": 38.93,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 49,
+              "min": 0,
+              "median": 3.55,
+              "mean": 8.85734693877551,
+              "p95": 35.24,
+              "max": 40.58
+            },
+            "deterministic": {
+              "n": 49,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 1,
+            "delta": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 1.8420408163265307,
+              "p95": 0,
+              "max": 90.26
+            }
+          },
+          "expected": 49,
+          "byLanguage": {
+            "en": {
+              "observed": 13,
+              "uniqueFixtures": 13,
+              "valid": 13,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 13,
+                "observedDenominator": 13
+              },
+              "scores": {
+                "overall": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 10.819230769230769,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.876153846153846,
+                  "p95": 18,
+                  "max": 18
+                },
+                "deterministic": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 6.943076923076924,
+                  "p95": 90.26,
+                  "max": 90.26
+                }
+              }
+            },
+            "ko": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 4.875,
+                  "mean": 9.325000000000001,
+                  "p95": 31.81,
+                  "max": 31.81
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 4.875,
+                  "mean": 9.325000000000001,
+                  "p95": 31.81,
+                  "max": 31.81
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 5.065,
+                  "mean": 13.289166666666668,
+                  "p95": 40.58,
+                  "max": 40.58
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 5.065,
+                  "mean": 13.289166666666668,
+                  "p95": 40.58,
+                  "max": 40.58
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 4.7,
+                  "mean": 9.354166666666666,
+                  "p95": 35.24,
+                  "max": 35.24
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 4.7,
+                  "mean": 9.354166666666666,
+                  "p95": 35.24,
+                  "max": 35.24
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 26,
+              "uniqueFixtures": 26,
+              "valid": 26,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 26,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 15.615,
+                  "mean": 20.020384615384614,
+                  "p95": 40.58,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 13.84,
+                  "mean": 16.548846153846153,
+                  "p95": 38.93,
+                  "max": 40.58
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.471538461538462,
+                  "p95": 0,
+                  "max": 90.26
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 23,
+              "uniqueFixtures": 23,
+              "valid": 23,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 23,
+                "observedDenominator": 23
+              },
+              "scores": {
+                "overall": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.16260869565217392,
+                  "p95": 0,
+                  "max": 3.74
+                },
+                "rawLLM": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.16260869565217392,
+                  "p95": 0,
+                  "max": 3.74
+                },
+                "deterministic": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 3.55,
+                  "mean": 10.699387755102041,
+                  "p95": 38.93,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 3.55,
+                  "mean": 8.85734693877551,
+                  "p95": 35.24,
+                  "max": 40.58
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.8420408163265307,
+                  "p95": 0,
+                  "max": 90.26
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/content": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 4.273846153846154,
+                "p95": 38.89,
+                "max": 38.89
+              }
+            },
+            "en/filler": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 3.4192307692307695,
+                "p95": 16.67,
+                "max": 16.67
+              }
+            },
+            "en/language": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 8.11923076923077,
+                "p95": 27.78,
+                "max": 27.78
+              }
+            },
+            "en/structure": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 8.204615384615384,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "en/style": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.0992307692307692,
+                "p95": 14.29,
+                "max": 14.29
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0.8546153846153846,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ko/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.948799999999999,
+                "p95": 44.44,
+                "max": 44.44
+              }
+            },
+            "ko/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 2.78,
+                "mean": 9.259166666666667,
+                "p95": 44.44,
+                "max": 44.44
+              }
+            },
+            "ko/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0.1111,
+                "mean": 8.043516666666667,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "ko/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 3.635,
+                "mean": 16.716666666666665,
+                "p95": 53.33,
+                "max": 53.33
+              }
+            },
+            "ko/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 7.14,
+                "mean": 9.524166666666666,
+                "p95": 28.57,
+                "max": 28.57
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 4.175924999999999,
+                "p95": 22.22,
+                "max": 22.22
+              }
+            },
+            "zh/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 11.110833333333332,
+                "p95": 50,
+                "max": 50
+              }
+            },
+            "zh/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 16.6675,
+                "p95": 77.78,
+                "max": 77.78
+              }
+            },
+            "zh/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 5.555,
+                "mean": 22.685000000000002,
+                "p95": 66.67,
+                "max": 66.67
+              }
+            },
+            "zh/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 16.665,
+                "mean": 20.554999999999996,
+                "p95": 53.33,
+                "max": 53.33
+              }
+            },
+            "zh/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 7.145,
+                "mean": 11.905833333333334,
+                "p95": 42.86,
+                "max": 42.86
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.4816666666666665,
+                "p95": 22.22,
+                "max": 22.22
+              }
+            },
+            "ja/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 14.352500000000001,
+                "p95": 66.67,
+                "max": 66.67
+              }
+            },
+            "ja/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 11.574166666666665,
+                "p95": 44.44,
+                "max": 44.44
+              }
+            },
+            "ja/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 2.78,
+                "mean": 11.108333333333334,
+                "p95": 44.44,
+                "max": 44.44
+              }
+            },
+            "ja/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 10,
+                "mean": 16.110833333333332,
+                "p95": 53.33,
+                "max": 53.33
+              }
+            },
+            "ja/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.359166666666667,
+                "p95": 14.3,
+                "max": 14.3
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 4.628333333333333,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": null
+        },
+        {
+          "id": "gemini-3.7",
+          "provider": "gemini",
+          "transport": "opencodex",
+          "requestedModel": "google-antigravity/gemini-3.7-flash",
+          "responseModel": "google-antigravity/gemini-3.7-flash",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": null,
+          "observed": 49,
+          "uniqueFixtures": 49,
+          "valid": 49,
+          "errors": 0,
+          "availability": {
+            "validNumerator": 49,
+            "observedDenominator": 49
+          },
+          "scores": {
+            "overall": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 5.09265306122449,
+              "p95": 18.09,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 3.2122448979591844,
+              "p95": 16.46,
+              "max": 21.92
+            },
+            "deterministic": {
+              "n": 49,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 1,
+            "delta": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 1.8804081632653062,
+              "p95": 0,
+              "max": 92.14
+            }
+          },
+          "expected": 49,
+          "byLanguage": {
+            "en": {
+              "observed": 13,
+              "uniqueFixtures": 13,
+              "valid": 13,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 13,
+                "observedDenominator": 13
+              },
+              "scores": {
+                "overall": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 7.914615384615384,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.8269230769230769,
+                  "p95": 7.86,
+                  "max": 7.86
+                },
+                "deterministic": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 7.087692307692308,
+                  "p95": 92.14,
+                  "max": 92.14
+                }
+              }
+            },
+            "ko": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 2.6791666666666667,
+                  "p95": 13.01,
+                  "max": 13.01
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 2.6791666666666667,
+                  "p95": 13.01,
+                  "max": 13.01
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.146666666666667,
+                  "p95": 21.92,
+                  "max": 21.92
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.146666666666667,
+                  "p95": 21.92,
+                  "max": 21.92
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 4.3950000000000005,
+                  "p95": 15.93,
+                  "max": 15.93
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 4.3950000000000005,
+                  "p95": 15.93,
+                  "max": 15.93
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 26,
+              "uniqueFixtures": 26,
+              "valid": 26,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 26,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 3.23,
+                  "mean": 9.55923076923077,
+                  "p95": 21.92,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 3.23,
+                  "mean": 6.015384615384617,
+                  "p95": 18.09,
+                  "max": 21.92
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.543846153846154,
+                  "p95": 0,
+                  "max": 92.14
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 23,
+              "uniqueFixtures": 23,
+              "valid": 23,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 23,
+                "observedDenominator": 23
+              },
+              "scores": {
+                "overall": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.043478260869565216,
+                  "p95": 0,
+                  "max": 1
+                },
+                "rawLLM": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.043478260869565216,
+                  "p95": 0,
+                  "max": 1
+                },
+                "deterministic": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.09265306122449,
+                  "p95": 18.09,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.2122448979591844,
+                  "p95": 16.46,
+                  "max": 21.92
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.8804081632653062,
+                  "p95": 0,
+                  "max": 92.14
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/content": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0.42769230769230765,
+                "p95": 5.56,
+                "max": 5.56
+              }
+            },
+            "en/filler": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0.8546153846153846,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "en/language": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.2823076923076921,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "en/structure": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.5384615384615385,
+                "p95": 13.33,
+                "max": 13.33
+              }
+            },
+            "en/style": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.0992307692307692,
+                "p95": 14.29,
+                "max": 14.29
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0.42769230769230765,
+                "p95": 5.56,
+                "max": 5.56
+              }
+            },
+            "ko/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 2.776666666666667,
+                "p95": 22.22,
+                "max": 22.22
+              }
+            },
+            "ko/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0.93,
+                "p95": 5.6,
+                "max": 5.6
+              }
+            },
+            "ko/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 3.2441666666666666,
+                "p95": 16.7,
+                "max": 16.7
+              }
+            },
+            "ko/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 4.4425,
+                "p95": 20,
+                "max": 20
+              }
+            },
+            "ko/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 4.764166666666667,
+                "p95": 14.3,
+                "max": 14.3
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 4.629166666666666,
+                "p95": 22.22,
+                "max": 22.22
+              }
+            },
+            "zh/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 7.406666666666666,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "zh/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 8.334166666666667,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "zh/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.110833333333333,
+                "p95": 26.67,
+                "max": 26.67
+              }
+            },
+            "zh/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.952500000000001,
+                "p95": 28.57,
+                "max": 28.57
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 2.315,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ja/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 7.406666666666666,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "ja/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.944166666666667,
+                "p95": 38.89,
+                "max": 38.89
+              }
+            },
+            "ja/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.0925,
+                "p95": 22.22,
+                "max": 22.22
+              }
+            },
+            "ja/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.555,
+                "p95": 26.67,
+                "max": 26.67
+              }
+            },
+            "ja/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 3.1749999999999994,
+                "p95": 14.29,
+                "max": 14.29
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.8516666666666666,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": null
+        },
+        {
+          "id": "gemini-3.8-low",
+          "provider": "gemini",
+          "transport": "opencodex",
+          "requestedModel": "google-antigravity/gemini-3.8-flash-low",
+          "responseModel": "google-antigravity/gemini-3.8-flash-low",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": null,
+          "observed": 49,
+          "uniqueFixtures": 49,
+          "valid": 49,
+          "errors": 0,
+          "availability": {
+            "validNumerator": 49,
+            "observedDenominator": 49
+          },
+          "scores": {
+            "overall": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 6.547755102040816,
+              "p95": 34.69,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 4.746530612244897,
+              "p95": 31.35,
+              "max": 38.04
+            },
+            "deterministic": {
+              "n": 49,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 1,
+            "delta": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 1.8012244897959184,
+              "p95": 0,
+              "max": 88.26
+            }
+          },
+          "expected": 49,
+          "byLanguage": {
+            "en": {
+              "observed": 13,
+              "uniqueFixtures": 13,
+              "valid": 13,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 13,
+                "observedDenominator": 13
+              },
+              "scores": {
+                "overall": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 7.794615384615384,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.0053846153846153,
+                  "p95": 11.74,
+                  "max": 11.74
+                },
+                "deterministic": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 6.78923076923077,
+                  "p95": 88.26,
+                  "max": 88.26
+                }
+              }
+            },
+            "ko": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 2.924166666666667,
+                  "p95": 12.5,
+                  "max": 12.5
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 2.924166666666667,
+                  "p95": 12.5,
+                  "max": 12.5
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0.28,
+                  "mean": 9.105833333333331,
+                  "p95": 38.04,
+                  "max": 38.04
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0.28,
+                  "mean": 9.105833333333331,
+                  "p95": 38.04,
+                  "max": 38.04
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 6.2625,
+                  "p95": 31.35,
+                  "max": 31.35
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 6.2625,
+                  "p95": 31.35,
+                  "max": 31.35
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 26,
+              "uniqueFixtures": 26,
+              "valid": 26,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 26,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 4.22,
+                  "mean": 12.318461538461538,
+                  "p95": 38.04,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 4.22,
+                  "mean": 8.923846153846153,
+                  "p95": 34.69,
+                  "max": 38.04
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.394615384615385,
+                  "p95": 0,
+                  "max": 88.26
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 23,
+              "uniqueFixtures": 23,
+              "valid": 23,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 23,
+                "observedDenominator": 23
+              },
+              "scores": {
+                "overall": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.024347826086956525,
+                  "p95": 0,
+                  "max": 0.56
+                },
+                "rawLLM": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.024347826086956525,
+                  "p95": 0,
+                  "max": 0.56
+                },
+                "deterministic": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 6.547755102040816,
+                  "p95": 34.69,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 4.746530612244897,
+                  "p95": 31.35,
+                  "max": 38.04
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.8012244897959184,
+                  "p95": 0,
+                  "max": 88.26
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/content": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/filler": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.2823076923076924,
+                "p95": 16.67,
+                "max": 16.67
+              }
+            },
+            "en/language": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.709230769230769,
+                "p95": 22.22,
+                "max": 22.22
+              }
+            },
+            "en/structure": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 2.563846153846154,
+                "p95": 20,
+                "max": 20
+              }
+            },
+            "en/style": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.0992307692307692,
+                "p95": 14.29,
+                "max": 14.29
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0.8546153846153846,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ko/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 2.313333333333333,
+                "p95": 22.2,
+                "max": 22.2
+              }
+            },
+            "ko/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.8516666666666666,
+                "p95": 11.1,
+                "max": 11.1
+              }
+            },
+            "ko/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 2.7775,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ko/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.665833333333334,
+                "p95": 20,
+                "max": 20
+              }
+            },
+            "ko/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 4.764166666666667,
+                "p95": 14.3,
+                "max": 14.3
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 10.185833333333333,
+                "p95": 38.89,
+                "max": 38.89
+              }
+            },
+            "zh/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 11.575000000000001,
+                "p95": 55.56,
+                "max": 55.56
+              }
+            },
+            "zh/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 14.351666666666667,
+                "p95": 61.11,
+                "max": 61.11
+              }
+            },
+            "zh/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 12.222500000000002,
+                "p95": 53.33,
+                "max": 53.33
+              }
+            },
+            "zh/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 8.928333333333333,
+                "p95": 42.86,
+                "max": 42.86
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 3.2408333333333332,
+                "p95": 22.22,
+                "max": 22.22
+              }
+            },
+            "ja/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 10.185,
+                "p95": 55.56,
+                "max": 55.56
+              }
+            },
+            "ja/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 10.184166666666666,
+                "p95": 44.44,
+                "max": 44.44
+              }
+            },
+            "ja/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 9.259166666666667,
+                "p95": 38.89,
+                "max": 38.89
+              }
+            },
+            "ja/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 8.889166666666666,
+                "p95": 40,
+                "max": 40
+              }
+            },
+            "ja/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 2.3816666666666664,
+                "p95": 14.29,
+                "max": 14.29
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.8516666666666666,
+                "p95": 22.22,
+                "max": 22.22
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": null
+        },
+        {
+          "id": "gemini-3.8-medium",
+          "provider": "gemini",
+          "transport": "opencodex",
+          "requestedModel": "google-antigravity/gemini-3.8-flash-medium",
+          "responseModel": "google-antigravity/gemini-3.8-flash-medium",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": null,
+          "observed": 49,
+          "uniqueFixtures": 49,
+          "valid": 49,
+          "errors": 0,
+          "availability": {
+            "validNumerator": 49,
+            "observedDenominator": 49
+          },
+          "scores": {
+            "overall": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 5.336326530612245,
+              "p95": 21.79,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 3.5012244897959186,
+              "p95": 17.6,
+              "max": 27.47
+            },
+            "deterministic": {
+              "n": 49,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 1,
+            "delta": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 1.8351020408163266,
+              "p95": 0,
+              "max": 89.92
+            }
+          },
+          "expected": 49,
+          "byLanguage": {
+            "en": {
+              "observed": 13,
+              "uniqueFixtures": 13,
+              "valid": 13,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 13,
+                "observedDenominator": 13
+              },
+              "scores": {
+                "overall": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 8,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.083076923076923,
+                  "p95": 10.08,
+                  "max": 10.08
+                },
+                "deterministic": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 6.916923076923077,
+                  "p95": 89.92,
+                  "max": 89.92
+                }
+              }
+            },
+            "ko": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 2.6841666666666666,
+                  "p95": 9.6,
+                  "max": 9.6
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 2.6841666666666666,
+                  "p95": 9.6,
+                  "max": 9.6
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.456666666666667,
+                  "p95": 27.47,
+                  "max": 27.47
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.456666666666667,
+                  "p95": 27.47,
+                  "max": 27.47
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 4.9825,
+                  "p95": 21.79,
+                  "max": 21.79
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 4.9825,
+                  "p95": 21.79,
+                  "max": 21.79
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 26,
+              "uniqueFixtures": 26,
+              "valid": 26,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 26,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 4,
+                  "mean": 10.035384615384613,
+                  "p95": 27.47,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 4,
+                  "mean": 6.576923076923077,
+                  "p95": 21.79,
+                  "max": 27.47
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.4584615384615387,
+                  "p95": 0,
+                  "max": 89.92
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 23,
+              "uniqueFixtures": 23,
+              "valid": 23,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 23,
+                "observedDenominator": 23
+              },
+              "scores": {
+                "overall": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.024347826086956525,
+                  "p95": 0,
+                  "max": 0.56
+                },
+                "rawLLM": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.024347826086956525,
+                  "p95": 0,
+                  "max": 0.56
+                },
+                "deterministic": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.336326530612245,
+                  "p95": 21.79,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.5012244897959186,
+                  "p95": 17.6,
+                  "max": 27.47
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.8351020408163266,
+                  "p95": 0,
+                  "max": 89.92
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/content": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0.8546153846153846,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "en/filler": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.2823076923076921,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "en/language": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.2823076923076924,
+                "p95": 16.67,
+                "max": 16.67
+              }
+            },
+            "en/structure": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 2.0507692307692307,
+                "p95": 13.33,
+                "max": 13.33
+              }
+            },
+            "en/style": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.0992307692307692,
+                "p95": 14.29,
+                "max": 14.29
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.2823076923076924,
+                "p95": 16.67,
+                "max": 16.67
+              }
+            },
+            "ko/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.8508333333333333,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ko/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0.93,
+                "p95": 5.6,
+                "max": 5.6
+              }
+            },
+            "ko/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 2.7808333333333333,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ko/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.113333333333333,
+                "p95": 20,
+                "max": 20
+              }
+            },
+            "ko/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 4.765833333333333,
+                "p95": 14.3,
+                "max": 14.3
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.555,
+                "p95": 44.44,
+                "max": 44.44
+              }
+            },
+            "zh/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 7.4075,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "zh/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 7.870833333333334,
+                "p95": 44.44,
+                "max": 44.44
+              }
+            },
+            "zh/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 7.2225,
+                "p95": 26.67,
+                "max": 26.67
+              }
+            },
+            "zh/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.547499999999999,
+                "p95": 28.57,
+                "max": 28.57
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.8524999999999998,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ja/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 9.716666666666667,
+                "p95": 38.89,
+                "max": 38.89
+              }
+            },
+            "ja/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 8.790833333333333,
+                "p95": 44.4,
+                "max": 44.4
+              }
+            },
+            "ja/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.551666666666667,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            },
+            "ja/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.666666666666667,
+                "p95": 26.7,
+                "max": 26.7
+              }
+            },
+            "ja/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 2.3825,
+                "p95": 14.3,
+                "max": 14.3
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0.9258333333333333,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": null
+        },
+        {
+          "id": "gemini-3.8-high",
+          "provider": "gemini",
+          "transport": "opencodex",
+          "requestedModel": "google-antigravity/gemini-3.8-flash-high",
+          "responseModel": "google-antigravity/gemini-3.8-flash-high",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": null,
+          "observed": 49,
+          "uniqueFixtures": 49,
+          "valid": 49,
+          "errors": 0,
+          "availability": {
+            "validNumerator": 49,
+            "observedDenominator": 49
+          },
+          "scores": {
+            "overall": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 5.364897959183673,
+              "p95": 20.48,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 3.507755102040816,
+              "p95": 19.6,
+              "max": 24.46
+            },
+            "deterministic": {
+              "n": 49,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 1,
+            "delta": {
+              "n": 49,
+              "min": 0,
+              "median": 0,
+              "mean": 1.8571428571428572,
+              "p95": 0,
+              "max": 91
+            }
+          },
+          "expected": 49,
+          "byLanguage": {
+            "en": {
+              "observed": 13,
+              "uniqueFixtures": 13,
+              "valid": 13,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 13,
+                "observedDenominator": 13
+              },
+              "scores": {
+                "overall": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 7.82923076923077,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.8292307692307692,
+                  "p95": 9,
+                  "max": 9
+                },
+                "deterministic": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 13,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 7,
+                  "p95": 91,
+                  "max": 91
+                }
+              }
+            },
+            "ko": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 2.956666666666667,
+                  "p95": 11,
+                  "max": 11
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 2.956666666666667,
+                  "p95": 11,
+                  "max": 11
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 4.943333333333334,
+                  "p95": 20.48,
+                  "max": 20.48
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 4.943333333333334,
+                  "p95": 20.48,
+                  "max": 20.48
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 12,
+              "uniqueFixtures": 12,
+              "valid": 12,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 12,
+                "observedDenominator": 12
+              },
+              "scores": {
+                "overall": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.525000000000001,
+                  "p95": 24.46,
+                  "max": 24.46
+                },
+                "rawLLM": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.525000000000001,
+                  "p95": 24.46,
+                  "max": 24.46
+                },
+                "deterministic": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 12,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 26,
+              "uniqueFixtures": 26,
+              "valid": 26,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 26,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 2.89,
+                  "mean": 10.089230769230769,
+                  "p95": 24.46,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 2.89,
+                  "mean": 6.589230769230769,
+                  "p95": 20.48,
+                  "max": 24.46
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.5,
+                  "p95": 0,
+                  "max": 91
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 23,
+              "uniqueFixtures": 23,
+              "valid": 23,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 23,
+                "observedDenominator": 23
+              },
+              "scores": {
+                "overall": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.024347826086956525,
+                  "p95": 0,
+                  "max": 0.56
+                },
+                "rawLLM": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.024347826086956525,
+                  "p95": 0,
+                  "max": 0.56
+                },
+                "deterministic": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 23,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.364897959183673,
+                  "p95": 20.48,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.507755102040816,
+                  "p95": 19.6,
+                  "max": 24.46
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.8571428571428572,
+                  "p95": 0,
+                  "max": 91
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/content": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0.42769230769230765,
+                "p95": 5.56,
+                "max": 5.56
+              }
+            },
+            "en/filler": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0.8538461538461538,
+                "p95": 11.1,
+                "max": 11.1
+              }
+            },
+            "en/language": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.2846153846153845,
+                "p95": 16.7,
+                "max": 16.7
+              }
+            },
+            "en/structure": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.536153846153846,
+                "p95": 13.3,
+                "max": 13.3
+              }
+            },
+            "en/style": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 1.1,
+                "p95": 14.3,
+                "max": 14.3
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 13,
+              "missing": 0,
+              "score": {
+                "n": 13,
+                "min": 0,
+                "median": 0,
+                "mean": 0.43076923076923074,
+                "p95": 5.6,
+                "max": 5.6
+              }
+            },
+            "ko/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.8499999999999999,
+                "p95": 22.2,
+                "max": 22.2
+              }
+            },
+            "ko/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 2.3216666666666668,
+                "p95": 16.7,
+                "max": 16.7
+              }
+            },
+            "ko/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 3.2391666666666663,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ko/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.660833333333334,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            },
+            "ko/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 4.765,
+                "p95": 14.3,
+                "max": 14.3
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.555,
+                "p95": 22.22,
+                "max": 22.22
+              }
+            },
+            "zh/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.4816666666666665,
+                "p95": 27.78,
+                "max": 27.78
+              }
+            },
+            "zh/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.944166666666667,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "zh/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 6.110833333333333,
+                "p95": 26.67,
+                "max": 26.67
+              }
+            },
+            "zh/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 5.952500000000001,
+                "p95": 28.57,
+                "max": 28.57
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.8533333333333333,
+                "p95": 5.56,
+                "max": 5.56
+              }
+            },
+            "ja/communication": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 9.721666666666666,
+                "p95": 38.9,
+                "max": 38.9
+              }
+            },
+            "ja/filler": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 7.87,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            },
+            "ja/language": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 7.099166666666666,
+                "p95": 38.89,
+                "max": 38.89
+              }
+            },
+            "ja/structure": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 7.2225,
+                "p95": 26.7,
+                "max": 26.7
+              }
+            },
+            "ja/style": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 3.5741666666666667,
+                "p95": 14.3,
+                "max": 14.3
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 12,
+              "missing": 0,
+              "score": {
+                "n": 12,
+                "min": 0,
+                "median": 0,
+                "mean": 1.3891666666666669,
+                "p95": 16.67,
+                "max": 16.67
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": null
+        }
+      ]
+    },
+    {
+      "id": "scorer-gemini-low-confirm",
+      "source": "A",
+      "sourceCommit": "66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c",
+      "study": "patina-model-evaluation-20260904",
+      "protocolHash": "94dbaa1798640081212148bbdd484436ffc17eb74dd969eb530c7e3940144755",
+      "repeat": 2,
+      "uniqueFixtures": 49,
+      "collection": {
+        "state": "completed",
+        "startedAt": "2026-09-05T00:11:11.614Z",
+        "endedAt": "2026-09-05T00:29:45.835Z",
+        "expected": 98,
+        "observed": 98,
+        "valid": 98,
+        "errors": 0,
+        "missing": 0,
+        "calls": 98,
+        "transportAttempts": 98,
+        "identityVerifiedResponses": 98,
+        "schemaFailures": 0,
+        "errorCounts": {
+          "invalid-json": 0,
+          "invalid-score-schema": 0,
+          "invalid-score-category": 0,
+          "transport-error": 0
+        }
+      },
+      "provenance": {
+        "artifacts": {
+          "artifacts/model-evaluation-20260904/validated/scorer-gemini-low-confirm/scorer-rows.jsonl": "024426170c7893a32fa700b74c432e9b9dd324d2ec9b7cc9f86935fb6a357d8e",
+          "artifacts/model-evaluation-20260904/validated/scorer-gemini-low-confirm/scorer-summary.json": "f2d5137f55c95d372e6fa889d6b9fe442227c110879caf89461e0926a93d0acf",
+          "artifacts/model-evaluation-20260904/validated/scorer-gemini-low-confirm/semantics.json": "bec8ea0c1c1cb087368d1d6893a335015504793fa537ca7fb76326b146a7e679",
+          "artifacts/model-evaluation-20260904/validated/jobs/scorer-gemini-low-confirm/job.json": "672359dbbf2e3562336c5dca004dbce6a742edcd664ac6c052122c62a69fcdcc",
+          "docs/research/model-evaluation-20260904.json": "8451be6e9690ba8a5cc32494b7fb7664353b8caa0403b1d772bb0ade7c719e4f"
+        },
+        "semanticsSha256": "f1aa3eace29b8f24804d7526ca12957a91243b187b2cbe857692e345828c8b6a",
+        "effectiveInputs": {
+          "configuration": "5f2c949ae8304cdf68f1f051b649d90c1a4c554629bca9760de65ddb128a6319",
+          "sourceVoice": false,
+          "patterns": {
+            "en": "d1e674e74d1dda3c40c5008e1f6ff07f1b7d398c88fd38d7114301a62e5b4c9a",
+            "ko": "d49eea71abfe9b33113e722616271150375a59da31ae4541fb4b2c955bba0ed3",
+            "zh": "0c611d2062f625029e1d2d28115db2d16c26a8f2fe2ae6d8d74409987c3193b3",
+            "ja": "5b9f50877d6b21f90fe04060366bfe7b2802bd60ea9a3036f44a75621a52c658"
+          },
+          "lexicons": {
+            "en": "1ae483d4e7ab88592289acf34eff3a2c4ddbef1f735b09bff1a34887cd062457",
+            "ko": "ec9851f0bcf0c736589b9d73454426025f6fbad907d5616829aeb5006c2ac1fa",
+            "zh": "f4b8ef3f2db64aae2defec0ec032ed52360025c9daf2992956d6766f21cf5e3b",
+            "ja": "1573f330a4692f3dc9901f854b28f5d1a47704f74b75d0bfb184dda02bea9d54"
+          },
+          "structuralModels": {
+            "en": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "ko": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "zh": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "ja": {
+              "status": "absent",
+              "contentHash": null
+            }
+          }
+        },
+        "fixtureIdentitySha256": "74ad644620b833401d44bb5c788090d6daef7542a2e0a568619a35d38d4a33b5",
+        "expectedKeysSha256": "830608e8861707f0eb8680a76d38c569ce74dec65aaaa199a634d9f9336ce8ad",
+        "receiptManifestSha256": "c0a6914fb61359e0930cf9a4aae5f1700207e8c8cf6683545ac3255ac49aaff4",
+        "receiptCount": 98,
+        "requestHashesSha256": "72a3e958002c394f995f920f5faaae8e09f8c94b3e1c4b044093bae6aee3bcfa",
+        "promptHashesSha256": "21c92c6d658fd1494491de91da384625dc905d06938ec120ce12b74dd9ea5f5a",
+        "sourceFilesVerifiedAgainstCommit": 158,
+        "scorerSha256": "8df8a476e0183222fae74bee85f00d8da7ffd907bae9181501859f32afaa5762",
+        "parserSha256": "b970b824824a06bf79eff617918aeaa2d337410b00ab266b7769f84db45b1fdc",
+        "patternCatalog": {
+          "en": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "ko": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "zh": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "ja": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          }
+        },
+        "directoryProtocolBinding": "legacy-absent",
+        "protocolRecomputed": false,
+        "fullScorerReplay": false
+      },
+      "diagnostics": {
+        "categoryArithmeticMismatches": 0,
+        "overallWeightedSumMismatches": 0,
+        "arithmeticTolerance": 0.11
+      },
+      "candidates": [
+        {
+          "id": "gemini-3.8-low",
+          "provider": "gemini",
+          "transport": "opencodex",
+          "requestedModel": "google-antigravity/gemini-3.8-flash-low",
+          "responseModel": "google-antigravity/gemini-3.8-flash-low",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": null,
+          "observed": 98,
+          "uniqueFixtures": 49,
+          "valid": 98,
+          "errors": 0,
+          "availability": {
+            "validNumerator": 98,
+            "observedDenominator": 98
+          },
+          "scores": {
+            "overall": {
+              "n": 98,
+              "min": 0,
+              "median": 0,
+              "mean": 5.282959183673469,
+              "p95": 22.24,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 98,
+              "min": 0,
+              "median": 0,
+              "mean": 3.435306122448979,
+              "p95": 19.79,
+              "max": 31.25
+            },
+            "deterministic": {
+              "n": 98,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 2,
+            "delta": {
+              "n": 98,
+              "min": 0,
+              "median": 0,
+              "mean": 1.8476530612244897,
+              "p95": 0,
+              "max": 92.14
+            }
+          },
+          "expected": 98,
+          "byLanguage": {
+            "en": {
+              "observed": 26,
+              "uniqueFixtures": 13,
+              "valid": 26,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 26,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 7.743846153846154,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.7796153846153847,
+                  "p95": 7.86,
+                  "max": 11.07
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 2,
+                "delta": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 6.964230769230769,
+                  "p95": 88.93,
+                  "max": 92.14
+                }
+              }
+            },
+            "ko": {
+              "observed": 24,
+              "uniqueFixtures": 12,
+              "valid": 24,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 24,
+                "observedDenominator": 24
+              },
+              "scores": {
+                "overall": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 2.734583333333333,
+                  "p95": 9.01,
+                  "max": 13.3
+                },
+                "rawLLM": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 2.734583333333333,
+                  "p95": 9.01,
+                  "max": 13.3
+                },
+                "deterministic": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 24,
+              "uniqueFixtures": 12,
+              "valid": 24,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 24,
+                "observedDenominator": 24
+              },
+              "scores": {
+                "overall": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.312083333333333,
+                  "p95": 25.36,
+                  "max": 31.25
+                },
+                "rawLLM": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.312083333333333,
+                  "p95": 25.36,
+                  "max": 31.25
+                },
+                "deterministic": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 24,
+              "uniqueFixtures": 12,
+              "valid": 24,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 24,
+                "observedDenominator": 24
+              },
+              "scores": {
+                "overall": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.1362499999999995,
+                  "p95": 20,
+                  "max": 22.24
+                },
+                "rawLLM": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.1362499999999995,
+                  "p95": 20,
+                  "max": 22.24
+                },
+                "deterministic": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 52,
+              "uniqueFixtures": 26,
+              "valid": 52,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 52,
+                "observedDenominator": 52
+              },
+              "scores": {
+                "overall": {
+                  "n": 52,
+                  "min": 0,
+                  "median": 1.335,
+                  "mean": 9.934807692307693,
+                  "p95": 31.25,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 52,
+                  "min": 0,
+                  "median": 1.335,
+                  "mean": 6.452692307692307,
+                  "p95": 22.24,
+                  "max": 31.25
+                },
+                "deterministic": {
+                  "n": 52,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 2,
+                "delta": {
+                  "n": 52,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.4821153846153843,
+                  "p95": 0,
+                  "max": 92.14
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 46,
+              "uniqueFixtures": 23,
+              "valid": 46,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 46,
+                "observedDenominator": 46
+              },
+              "scores": {
+                "overall": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.024347826086956525,
+                  "p95": 0,
+                  "max": 0.56
+                },
+                "rawLLM": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.024347826086956525,
+                  "p95": 0,
+                  "max": 0.56
+                },
+                "deterministic": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.304693877551021,
+                  "p95": 22.24,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.424285714285714,
+                  "p95": 19.35,
+                  "max": 31.25
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.8804081632653062,
+                  "p95": 0,
+                  "max": 92.14
+                }
+              }
+            },
+            {
+              "repeat": 1,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 5.261224489795919,
+                  "p95": 20,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.446326530612245,
+                  "p95": 19.79,
+                  "max": 25.36
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.8148979591836736,
+                  "p95": 0,
+                  "max": 88.93
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/content": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/filler": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 1.0684615384615386,
+                "p95": 11.11,
+                "max": 16.67
+              }
+            },
+            "en/language": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 1.281923076923077,
+                "p95": 11.11,
+                "max": 22.22
+              }
+            },
+            "en/structure": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 1.5384615384615385,
+                "p95": 13.33,
+                "max": 13.33
+              }
+            },
+            "en/style": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 1.0992307692307692,
+                "p95": 14.29,
+                "max": 14.29
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 0.6411538461538461,
+                "p95": 5.56,
+                "max": 11.11
+              }
+            },
+            "ko/communication": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 2.0829166666666663,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ko/filler": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0.9283333333333333,
+                "p95": 5.56,
+                "max": 5.6
+              }
+            },
+            "ko/language": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 3.471666666666667,
+                "p95": 11.11,
+                "max": 16.67
+              }
+            },
+            "ko/structure": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 4.996666666666667,
+                "p95": 13.33,
+                "max": 26.67
+              }
+            },
+            "ko/style": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 5.0616666666666665,
+                "p95": 14.3,
+                "max": 21.43
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/communication": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/content": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 5.3237499999999995,
+                "p95": 27.78,
+                "max": 33.33
+              }
+            },
+            "zh/filler": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 9.0275,
+                "p95": 38.89,
+                "max": 50
+              }
+            },
+            "zh/language": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 8.797083333333333,
+                "p95": 38.89,
+                "max": 55.56
+              }
+            },
+            "zh/structure": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 5.832916666666667,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "zh/style": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 5.357499999999999,
+                "p95": 28.57,
+                "max": 28.57
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 2.0837499999999998,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ja/communication": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 9.257916666666667,
+                "p95": 44.44,
+                "max": 44.44
+              }
+            },
+            "ja/filler": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 8.101666666666667,
+                "p95": 38.89,
+                "max": 50
+              }
+            },
+            "ja/language": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 7.640416666666667,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "ja/structure": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 7.500833333333335,
+                "p95": 26.67,
+                "max": 26.67
+              }
+            },
+            "ja/style": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 1.78625,
+                "p95": 14.29,
+                "max": 14.29
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": {
+            "pairs": 49,
+            "scores": {
+              "overall": {
+                "n": 49,
+                "min": 0,
+                "median": 0,
+                "mean": 0.7197959183673471,
+                "p95": 4.290000000000001,
+                "max": 5.890000000000001
+              },
+              "rawLLM": {
+                "n": 49,
+                "min": 0,
+                "median": 0,
+                "mean": 0.7853061224489798,
+                "p95": 4.290000000000001,
+                "max": 5.890000000000001
+              },
+              "deterministic": {
+                "n": 49,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "scorer-gemini-pro-confirm",
+      "source": "A",
+      "sourceCommit": "66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c",
+      "study": "patina-model-evaluation-20260904",
+      "protocolHash": "980a3d6501f47cafb02a12a3c0c94f1aaf7d5ca3c8583a25207ec9ccef516fda",
+      "repeat": 2,
+      "uniqueFixtures": 49,
+      "collection": {
+        "state": "completed",
+        "startedAt": "2026-09-05T00:43:15.099Z",
+        "endedAt": "2026-09-05T01:28:00.442Z",
+        "expected": 98,
+        "observed": 98,
+        "valid": 98,
+        "errors": 0,
+        "missing": 0,
+        "calls": 98,
+        "transportAttempts": 98,
+        "identityVerifiedResponses": 98,
+        "schemaFailures": 0,
+        "errorCounts": {
+          "invalid-json": 0,
+          "invalid-score-schema": 0,
+          "invalid-score-category": 0,
+          "transport-error": 0
+        }
+      },
+      "provenance": {
+        "artifacts": {
+          "artifacts/model-evaluation-20260904/validated/scorer-gemini-pro-confirm/scorer-rows.jsonl": "de2790baf5622c35bb4ee0a3ed507eacf41583c940e390dbc049c6dda690ea21",
+          "artifacts/model-evaluation-20260904/validated/scorer-gemini-pro-confirm/scorer-summary.json": "920bf863b6d3dd559f645476820e96d1c94f45388ac06c0e40b047c2032bd936",
+          "artifacts/model-evaluation-20260904/validated/scorer-gemini-pro-confirm/semantics.json": "7a5d2d2000ef71bbceceecea394c567fdb9d045512d8c7b031e87d10ac4542eb",
+          "artifacts/model-evaluation-20260904/validated/jobs/scorer-gemini-pro-confirm/job.json": "4d2aaeab407e8607d2ee87d4071c2d5e21b7a24d8e93036686190e814228af4d",
+          "docs/research/model-evaluation-20260904.json": "8451be6e9690ba8a5cc32494b7fb7664353b8caa0403b1d772bb0ade7c719e4f"
+        },
+        "semanticsSha256": "f1aa3eace29b8f24804d7526ca12957a91243b187b2cbe857692e345828c8b6a",
+        "effectiveInputs": {
+          "configuration": "5f2c949ae8304cdf68f1f051b649d90c1a4c554629bca9760de65ddb128a6319",
+          "sourceVoice": false,
+          "patterns": {
+            "en": "d1e674e74d1dda3c40c5008e1f6ff07f1b7d398c88fd38d7114301a62e5b4c9a",
+            "ko": "d49eea71abfe9b33113e722616271150375a59da31ae4541fb4b2c955bba0ed3",
+            "zh": "0c611d2062f625029e1d2d28115db2d16c26a8f2fe2ae6d8d74409987c3193b3",
+            "ja": "5b9f50877d6b21f90fe04060366bfe7b2802bd60ea9a3036f44a75621a52c658"
+          },
+          "lexicons": {
+            "en": "1ae483d4e7ab88592289acf34eff3a2c4ddbef1f735b09bff1a34887cd062457",
+            "ko": "ec9851f0bcf0c736589b9d73454426025f6fbad907d5616829aeb5006c2ac1fa",
+            "zh": "f4b8ef3f2db64aae2defec0ec032ed52360025c9daf2992956d6766f21cf5e3b",
+            "ja": "1573f330a4692f3dc9901f854b28f5d1a47704f74b75d0bfb184dda02bea9d54"
+          },
+          "structuralModels": {
+            "en": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "ko": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "zh": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "ja": {
+              "status": "absent",
+              "contentHash": null
+            }
+          }
+        },
+        "fixtureIdentitySha256": "74ad644620b833401d44bb5c788090d6daef7542a2e0a568619a35d38d4a33b5",
+        "expectedKeysSha256": "a76cb46c88f9953b13f19b97a9d49b5bbdb8e046ecee02bf7bf048b0f3d1008d",
+        "receiptManifestSha256": "ec7cbd135a3f4d783f020a5a7fe04e9eb83b4ccc755d136ee2e8a2737874bb75",
+        "receiptCount": 98,
+        "requestHashesSha256": "8b0f7c3349b12d66f67bab90f77a09862fca75bffdf5592149e1da1fbdfc9549",
+        "promptHashesSha256": "21c92c6d658fd1494491de91da384625dc905d06938ec120ce12b74dd9ea5f5a",
+        "sourceFilesVerifiedAgainstCommit": 158,
+        "scorerSha256": "8df8a476e0183222fae74bee85f00d8da7ffd907bae9181501859f32afaa5762",
+        "parserSha256": "b970b824824a06bf79eff617918aeaa2d337410b00ab266b7769f84db45b1fdc",
+        "patternCatalog": {
+          "en": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "ko": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "zh": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "ja": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          }
+        },
+        "directoryProtocolBinding": "legacy-absent",
+        "protocolRecomputed": false,
+        "fullScorerReplay": false
+      },
+      "diagnostics": {
+        "categoryArithmeticMismatches": 32,
+        "overallWeightedSumMismatches": 7,
+        "arithmeticTolerance": 0.11
+      },
+      "candidates": [
+        {
+          "id": "gemini-pro",
+          "provider": "gemini",
+          "transport": "opencodex",
+          "requestedModel": "google-antigravity/gemini-3.1-pro",
+          "responseModel": "google-antigravity/gemini-3.1-pro",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": null,
+          "observed": 98,
+          "uniqueFixtures": 49,
+          "valid": 98,
+          "errors": 0,
+          "availability": {
+            "validNumerator": 98,
+            "observedDenominator": 98
+          },
+          "scores": {
+            "overall": {
+              "n": 98,
+              "min": 0,
+              "median": 3.035,
+              "mean": 10.80734693877551,
+              "p95": 36.25,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 98,
+              "min": 0,
+              "median": 3.035,
+              "mean": 9.00061224489796,
+              "p95": 35.69,
+              "max": 44.03
+            },
+            "deterministic": {
+              "n": 98,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 2,
+            "delta": {
+              "n": 98,
+              "min": 0,
+              "median": 0,
+              "mean": 1.806734693877551,
+              "p95": 0,
+              "max": 89.92
+            }
+          },
+          "expected": 98,
+          "byLanguage": {
+            "en": {
+              "observed": 26,
+              "uniqueFixtures": 13,
+              "valid": 26,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 26,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 2.385,
+                  "mean": 11.165384615384616,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 2.385,
+                  "mean": 4.355384615384616,
+                  "p95": 16,
+                  "max": 18.23
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 2,
+                "delta": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 6.8100000000000005,
+                  "p95": 87.14,
+                  "max": 89.92
+                }
+              }
+            },
+            "ko": {
+              "observed": 24,
+              "uniqueFixtures": 12,
+              "valid": 24,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 24,
+                "observedDenominator": 24
+              },
+              "scores": {
+                "overall": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 6.07,
+                  "mean": 8.411666666666667,
+                  "p95": 21.81,
+                  "max": 26.25
+                },
+                "rawLLM": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 6.07,
+                  "mean": 8.411666666666667,
+                  "p95": 21.81,
+                  "max": 26.25
+                },
+                "deterministic": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 24,
+              "uniqueFixtures": 12,
+              "valid": 24,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 24,
+                "observedDenominator": 24
+              },
+              "scores": {
+                "overall": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 1.645,
+                  "mean": 13.074583333333331,
+                  "p95": 41.83,
+                  "max": 44.03
+                },
+                "rawLLM": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 1.645,
+                  "mean": 13.074583333333331,
+                  "p95": 41.83,
+                  "max": 44.03
+                },
+                "deterministic": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 24,
+              "uniqueFixtures": 12,
+              "valid": 24,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 24,
+                "observedDenominator": 24
+              },
+              "scores": {
+                "overall": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 3.645,
+                  "mean": 10.547916666666666,
+                  "p95": 36.25,
+                  "max": 36.25
+                },
+                "rawLLM": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 3.645,
+                  "mean": 10.547916666666666,
+                  "p95": 36.25,
+                  "max": 36.25
+                },
+                "deterministic": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 52,
+              "uniqueFixtures": 26,
+              "valid": 52,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 52,
+                "observedDenominator": 52
+              },
+              "scores": {
+                "overall": {
+                  "n": 52,
+                  "min": 0,
+                  "median": 16.515,
+                  "mean": 20.158076923076926,
+                  "p95": 44.03,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 52,
+                  "min": 0,
+                  "median": 15,
+                  "mean": 16.753076923076925,
+                  "p95": 36.25,
+                  "max": 44.03
+                },
+                "deterministic": {
+                  "n": 52,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 2,
+                "delta": {
+                  "n": 52,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.4050000000000002,
+                  "p95": 0,
+                  "max": 89.92
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 46,
+              "uniqueFixtures": 23,
+              "valid": 46,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 46,
+                "observedDenominator": 46
+              },
+              "scores": {
+                "overall": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.23695652173913045,
+                  "p95": 2.29,
+                  "max": 2.78
+                },
+                "rawLLM": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.23695652173913045,
+                  "p95": 2.29,
+                  "max": 2.78
+                },
+                "deterministic": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 4.22,
+                  "mean": 10.784897959183674,
+                  "p95": 35.69,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 4.22,
+                  "mean": 8.949795918367347,
+                  "p95": 35.25,
+                  "max": 36.25
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.8351020408163266,
+                  "p95": 0,
+                  "max": 89.92
+                }
+              }
+            },
+            {
+              "repeat": 1,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 2.73,
+                  "mean": 10.82979591836735,
+                  "p95": 41.83,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 2.73,
+                  "mean": 9.051428571428573,
+                  "p95": 36.25,
+                  "max": 44.03
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.7783673469387755,
+                  "p95": 0,
+                  "max": 87.14
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/content": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 3.418846153846154,
+                "p95": 27.78,
+                "max": 33.33
+              }
+            },
+            "en/filler": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 4.27423076923077,
+                "p95": 27.78,
+                "max": 27.78
+              }
+            },
+            "en/language": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 2.8354999999999997,
+                "mean": 9.406192307692306,
+                "p95": 33.33,
+                "max": 33.33
+              }
+            },
+            "en/structure": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 8.21269230769231,
+                "p95": 33.33,
+                "max": 46.67
+              }
+            },
+            "en/style": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 1.3738461538461537,
+                "p95": 14.29,
+                "max": 14.29
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 1.9234615384615383,
+                "p95": 16.67,
+                "max": 22.22
+              }
+            },
+            "ko/communication": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 5.101945833333333,
+                "p95": 27.78,
+                "max": 27.78
+              }
+            },
+            "ko/filler": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 6.7215291666666666,
+                "p95": 33.33,
+                "max": 38.89
+              }
+            },
+            "ko/language": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0.1389,
+                "mean": 7.649491666666667,
+                "p95": 27.78,
+                "max": 33.33
+              }
+            },
+            "ko/structure": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 6.67,
+                "mean": 18.078054166666664,
+                "p95": 53.33,
+                "max": 60
+              }
+            },
+            "ko/style": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 3.69285,
+                "mean": 8.645774999999999,
+                "p95": 28.57,
+                "max": 28.57
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 2.318795833333333,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "zh/communication": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 1.0416666666666667,
+                "p95": 0,
+                "max": 25
+              }
+            },
+            "zh/content": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 10.655279166666666,
+                "p95": 50,
+                "max": 61.11
+              }
+            },
+            "zh/filler": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 15.305695833333333,
+                "p95": 66.67,
+                "max": 83.33
+              }
+            },
+            "zh/language": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0.05555,
+                "mean": 19.24384166666667,
+                "p95": 61.11,
+                "max": 66.67
+              }
+            },
+            "zh/structure": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0.16665,
+                "mean": 16.694025,
+                "p95": 60,
+                "max": 66.67
+              }
+            },
+            "zh/style": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0.07145,
+                "mean": 9.244108333333331,
+                "p95": 28.57,
+                "max": 28.57
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 4.867779166666666,
+                "p95": 22.22,
+                "max": 22.22
+              }
+            },
+            "ja/communication": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 13.227404166666668,
+                "p95": 66.67,
+                "max": 66.67
+              }
+            },
+            "ja/filler": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 9.974166666666667,
+                "p95": 50,
+                "max": 50
+              }
+            },
+            "ja/language": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0.028,
+                "mean": 11.131683333333333,
+                "p95": 44.44,
+                "max": 50
+              }
+            },
+            "ja/structure": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0.16665,
+                "mean": 13.919720833333335,
+                "p95": 40,
+                "max": 60
+              }
+            },
+            "ja/style": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0.0355,
+                "mean": 5.967362499999999,
+                "p95": 28.57,
+                "max": 28.57
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 2.7867541666666664,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": {
+            "pairs": 49,
+            "scores": {
+              "overall": {
+                "n": 49,
+                "min": 0,
+                "median": 0.5599999999999987,
+                "mean": 2.0097959183673466,
+                "p95": 9.899999999999999,
+                "max": 11.68
+              },
+              "rawLLM": {
+                "n": 49,
+                "min": 0,
+                "median": 0.6699999999999999,
+                "mean": 2.0665306122448976,
+                "p95": 9.899999999999999,
+                "max": 11.68
+              },
+              "deterministic": {
+                "n": 49,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "scorer-openai-terra-confirm",
+      "source": "C",
+      "sourceCommit": "7de2d0b6d78d905804e8e863392df11d3048265e",
+      "study": "patina-model-evaluation-20260904",
+      "protocolHash": "583b9f6ac3f7e1d7effd6da0ab99abad065cc7f91271bc893f46eccb818936a3",
+      "repeat": 2,
+      "uniqueFixtures": 49,
+      "collection": {
+        "state": "completed",
+        "startedAt": "2026-09-05T00:59:04.300Z",
+        "endedAt": "2026-09-05T01:19:56.483Z",
+        "expected": 98,
+        "observed": 98,
+        "valid": 98,
+        "errors": 0,
+        "missing": 0,
+        "calls": 98,
+        "transportAttempts": 98,
+        "identityVerifiedResponses": 98,
+        "schemaFailures": 0,
+        "errorCounts": {
+          "invalid-json": 0,
+          "invalid-score-schema": 0,
+          "invalid-score-category": 0,
+          "transport-error": 0
+        }
+      },
+      "provenance": {
+        "artifacts": {
+          "artifacts/model-evaluation-20260905/validated/scorer-openai-terra-confirm/scorer-rows.jsonl": "a870efd684409d9a1d787bcfec0e116b159ada09d7f5fa05afe5eaf6edbee6af",
+          "artifacts/model-evaluation-20260905/validated/scorer-openai-terra-confirm/scorer-summary.json": "0f67fafb8e8a22a5b0d42356132dc501ee705827f130a849b3de33f2dc5fe38e",
+          "artifacts/model-evaluation-20260905/validated/scorer-openai-terra-confirm/semantics.json": "8c320ea91c3d2a682388aae018ef66bb1cd26f6525b4a33b910044258f6e9c34",
+          "artifacts/model-evaluation-20260905/validated/jobs/scorer-openai-terra-confirm/job.json": "30b5f71a922381cd2b90d7d5b144247583b58d37411882fdc19c25ee57c96ede",
+          "docs/research/model-evaluation-20260904.json": "8451be6e9690ba8a5cc32494b7fb7664353b8caa0403b1d772bb0ade7c719e4f",
+          "artifacts/model-evaluation-20260905/validated/scorer-openai-terra-confirm/study-protocol.json": "64285a6ea5b6681d2c9aee9b78e9504d0cfb6ced89762d283a09fb9068c8d9dd"
+        },
+        "semanticsSha256": "f0cbe5721fea509e3300ba18b7974ea5db2318f7f1f3fdaf5312568326fe5d69",
+        "effectiveInputs": {
+          "configuration": "d232f0c6e66d83bfb260fa38e52225df04d30c75ce16657a03bdde37ff854005",
+          "sourceVoice": false,
+          "patterns": {
+            "en": "d1e674e74d1dda3c40c5008e1f6ff07f1b7d398c88fd38d7114301a62e5b4c9a",
+            "ko": "d49eea71abfe9b33113e722616271150375a59da31ae4541fb4b2c955bba0ed3",
+            "zh": "0c611d2062f625029e1d2d28115db2d16c26a8f2fe2ae6d8d74409987c3193b3",
+            "ja": "5b9f50877d6b21f90fe04060366bfe7b2802bd60ea9a3036f44a75621a52c658"
+          },
+          "lexicons": {
+            "en": "3811fe34a70de5d96a21831aec591a717a9c2a229983573a71208f57ebee9e5d",
+            "ko": "2d0ea2476e7f45219d4ba171a376cfc977ba76a19bbc3b0dd09b7ac67cd7f530",
+            "zh": "3d7170266879ae3b412c3d299aad8fc48904999d72786c26a8a63d317353d093",
+            "ja": "6d01eb45cc0a8e9a29c3187b18bbfcd869f0365dc923fd56ecf3d8d53d2cf237"
+          },
+          "structuralModels": {
+            "en": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "ko": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "zh": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "ja": {
+              "status": "absent",
+              "contentHash": null
+            }
+          }
+        },
+        "fixtureIdentitySha256": "74ad644620b833401d44bb5c788090d6daef7542a2e0a568619a35d38d4a33b5",
+        "expectedKeysSha256": "75c1f548925c25ca32043eb8d9f552850b7d2f4c6b63b939b7c7012391c39867",
+        "receiptManifestSha256": "c75985eda5224b383761351472efa4d389de50cad76d21ed0e70672b21d6bc75",
+        "receiptCount": 98,
+        "requestHashesSha256": "0186d7d8c9907a2798c93ce9ca847020d2232fbbcb7f066e93161af59b0a1d9f",
+        "promptHashesSha256": "21c92c6d658fd1494491de91da384625dc905d06938ec120ce12b74dd9ea5f5a",
+        "sourceFilesVerifiedAgainstCommit": 163,
+        "scorerSha256": "8df8a476e0183222fae74bee85f00d8da7ffd907bae9181501859f32afaa5762",
+        "parserSha256": "b970b824824a06bf79eff617918aeaa2d337410b00ab266b7769f84db45b1fdc",
+        "patternCatalog": {
+          "en": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "ko": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "zh": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "ja": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          }
+        },
+        "directoryProtocolBinding": "present",
+        "protocolRecomputed": false,
+        "fullScorerReplay": false
+      },
+      "diagnostics": {
+        "categoryArithmeticMismatches": 0,
+        "overallWeightedSumMismatches": 0,
+        "arithmeticTolerance": 0.11
+      },
+      "candidates": [
+        {
+          "id": "openai-terra",
+          "provider": "openai",
+          "transport": "opencodex",
+          "requestedModel": "gpt-5.6-terra",
+          "responseModel": "gpt-5.6-terra",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": "low",
+          "observed": 98,
+          "uniqueFixtures": 49,
+          "valid": 98,
+          "errors": 0,
+          "availability": {
+            "validNumerator": 98,
+            "observedDenominator": 98
+          },
+          "scores": {
+            "overall": {
+              "n": 98,
+              "min": 0,
+              "median": 2,
+              "mean": 7.91877551020408,
+              "p95": 28.8,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 98,
+              "min": 0,
+              "median": 2,
+              "mean": 5.948367346938775,
+              "p95": 26.4,
+              "max": 30.5
+            },
+            "deterministic": {
+              "n": 98,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 2,
+            "delta": {
+              "n": 98,
+              "min": 0,
+              "median": 0,
+              "mean": 1.970408163265306,
+              "p95": 0,
+              "max": 97
+            }
+          },
+          "expected": 98,
+          "byLanguage": {
+            "en": {
+              "observed": 26,
+              "uniqueFixtures": 13,
+              "valid": 26,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 26,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 2.4,
+                  "mean": 10.267692307692307,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 2.4,
+                  "mean": 2.8407692307692303,
+                  "p95": 8.44,
+                  "max": 8.6
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 2,
+                "delta": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 7.426923076923076,
+                  "p95": 96.1,
+                  "max": 97
+                }
+              }
+            },
+            "ko": {
+              "observed": 24,
+              "uniqueFixtures": 12,
+              "valid": 24,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 24,
+                "observedDenominator": 24
+              },
+              "scores": {
+                "overall": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 2,
+                  "mean": 5.262083333333334,
+                  "p95": 17.3,
+                  "max": 20.7
+                },
+                "rawLLM": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 2,
+                  "mean": 5.262083333333334,
+                  "p95": 17.3,
+                  "max": 20.7
+                },
+                "deterministic": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 24,
+              "uniqueFixtures": 12,
+              "valid": 24,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 24,
+                "observedDenominator": 24
+              },
+              "scores": {
+                "overall": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 1.605,
+                  "mean": 8.505416666666667,
+                  "p95": 30.25,
+                  "max": 30.5
+                },
+                "rawLLM": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 1.605,
+                  "mean": 8.505416666666667,
+                  "p95": 30.25,
+                  "max": 30.5
+                },
+                "deterministic": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 24,
+              "uniqueFixtures": 12,
+              "valid": 24,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 24,
+                "observedDenominator": 24
+              },
+              "scores": {
+                "overall": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 1.5,
+                  "mean": 7.444166666666667,
+                  "p95": 26.4,
+                  "max": 28.5
+                },
+                "rawLLM": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 1.5,
+                  "mean": 7.444166666666667,
+                  "p95": 26.4,
+                  "max": 28.5
+                },
+                "deterministic": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 52,
+              "uniqueFixtures": 26,
+              "valid": 52,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 52,
+                "observedDenominator": 52
+              },
+              "scores": {
+                "overall": {
+                  "n": 52,
+                  "min": 0,
+                  "median": 8.6,
+                  "mean": 14.403846153846153,
+                  "p95": 30.5,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 52,
+                  "min": 0,
+                  "median": 8.504999999999999,
+                  "mean": 10.690384615384612,
+                  "p95": 28.8,
+                  "max": 30.5
+                },
+                "deterministic": {
+                  "n": 52,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 2,
+                "delta": {
+                  "n": 52,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.713461538461538,
+                  "p95": 0,
+                  "max": 97
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 46,
+              "uniqueFixtures": 23,
+              "valid": 46,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 46,
+                "observedDenominator": 46
+              },
+              "scores": {
+                "overall": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.5878260869565216,
+                  "p95": 2.11,
+                  "max": 4.2
+                },
+                "rawLLM": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0.5878260869565216,
+                  "p95": 2.11,
+                  "max": 4.2
+                },
+                "deterministic": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 2,
+                  "mean": 7.862857142857144,
+                  "p95": 26.4,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 2,
+                  "mean": 5.88326530612245,
+                  "p95": 24.9,
+                  "max": 30.5
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.9795918367346939,
+                  "p95": 0,
+                  "max": 97
+                }
+              }
+            },
+            {
+              "repeat": 1,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 2,
+                  "mean": 7.9746938775510205,
+                  "p95": 28.8,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 2,
+                  "mean": 6.013469387755102,
+                  "p95": 28.5,
+                  "max": 30.25
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.9612244897959183,
+                  "p95": 0,
+                  "max": 96.1
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 0.9615384615384616,
+                "p95": 8.3,
+                "max": 16.7
+              }
+            },
+            "en/content": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 3.210384615384615,
+                "p95": 16.67,
+                "max": 27.8
+              }
+            },
+            "en/filler": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 2.573076923076923,
+                "p95": 16.7,
+                "max": 27.8
+              }
+            },
+            "en/language": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 5.6,
+                "mean": 4.93076923076923,
+                "p95": 16.67,
+                "max": 16.67
+              }
+            },
+            "en/structure": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 5.123076923076923,
+                "p95": 20,
+                "max": 20
+              }
+            },
+            "en/style": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 0.5476923076923076,
+                "p95": 7.1,
+                "max": 7.14
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 2.7853846153846153,
+                "p95": 11.11,
+                "max": 11.11
+              }
+            },
+            "ko/communication": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 6.025833333333334,
+                "p95": 16.7,
+                "max": 22.22
+              }
+            },
+            "ko/filler": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 2.0900000000000003,
+                "p95": 11.1,
+                "max": 11.1
+              }
+            },
+            "ko/language": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 5.58,
+                "mean": 4.644166666666667,
+                "p95": 16.7,
+                "max": 16.7
+              }
+            },
+            "ko/structure": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 3.35,
+                "mean": 10.554166666666667,
+                "p95": 40,
+                "max": 53.3
+              }
+            },
+            "ko/style": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 8.332083333333333,
+                "p95": 28.6,
+                "max": 42.9
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0.9291666666666666,
+                "p95": 5.6,
+                "max": 11.1
+              }
+            },
+            "zh/communication": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0.6958333333333333,
+                "p95": 0,
+                "max": 16.7
+              }
+            },
+            "zh/content": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 9.255833333333333,
+                "p95": 33.33,
+                "max": 44.4
+              }
+            },
+            "zh/filler": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 8.104166666666666,
+                "p95": 33.33,
+                "max": 38.89
+              }
+            },
+            "zh/language": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 2.78,
+                "mean": 15.972083333333336,
+                "p95": 61.1,
+                "max": 61.11
+              }
+            },
+            "zh/structure": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 9.164166666666667,
+                "p95": 33.33,
+                "max": 46.67
+              }
+            },
+            "zh/style": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 9.528749999999999,
+                "p95": 28.6,
+                "max": 28.6
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 1.3904166666666666,
+                "p95": 11.1,
+                "max": 11.11
+              }
+            },
+            "ja/communication": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 13.203750000000001,
+                "p95": 50,
+                "max": 55.6
+              }
+            },
+            "ja/filler": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 6.715833333333333,
+                "p95": 27.8,
+                "max": 38.9
+              }
+            },
+            "ja/language": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 2.8,
+                "mean": 10.267916666666666,
+                "p95": 38.9,
+                "max": 50
+              }
+            },
+            "ja/structure": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 8.892916666666666,
+                "p95": 33.3,
+                "max": 40
+              }
+            },
+            "ja/style": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 6.848749999999999,
+                "p95": 28.6,
+                "max": 28.6
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 1.1583333333333332,
+                "p95": 11.1,
+                "max": 11.1
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": {
+            "pairs": 49,
+            "scores": {
+              "overall": {
+                "n": 49,
+                "min": 0,
+                "median": 0.73,
+                "mean": 1.371020408163265,
+                "p95": 4.09,
+                "max": 8.329999999999998
+              },
+              "rawLLM": {
+                "n": 49,
+                "min": 0,
+                "median": 0.7999999999999998,
+                "mean": 1.3893877551020408,
+                "p95": 4.09,
+                "max": 8.329999999999998
+              },
+              "deterministic": {
+                "n": 49,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "scorer-openai-5.5-confirm",
+      "source": "C",
+      "sourceCommit": "7de2d0b6d78d905804e8e863392df11d3048265e",
+      "study": "patina-model-evaluation-20260904",
+      "protocolHash": "f07aff116b48a289aa3acaa16934ac4f643a84c94318fd504e37a3f27c0aa502",
+      "repeat": 2,
+      "uniqueFixtures": 49,
+      "collection": {
+        "state": "completed",
+        "startedAt": "2026-09-05T01:25:22.092Z",
+        "endedAt": "2026-09-05T01:49:08.775Z",
+        "expected": 98,
+        "observed": 98,
+        "valid": 98,
+        "errors": 0,
+        "missing": 0,
+        "calls": 98,
+        "transportAttempts": 98,
+        "identityVerifiedResponses": 98,
+        "schemaFailures": 0,
+        "errorCounts": {
+          "invalid-json": 0,
+          "invalid-score-schema": 0,
+          "invalid-score-category": 0,
+          "transport-error": 0
+        }
+      },
+      "provenance": {
+        "artifacts": {
+          "artifacts/model-evaluation-20260905/validated/scorer-openai-5.5-confirm/scorer-rows.jsonl": "077633d83a5dc0222e025aa746bfa4973c27df82c403ece7d4f954c805953456",
+          "artifacts/model-evaluation-20260905/validated/scorer-openai-5.5-confirm/scorer-summary.json": "7fef455706f82aeb80366fa383c7124884b84d0375f988b8e8c8689ba070a976",
+          "artifacts/model-evaluation-20260905/validated/scorer-openai-5.5-confirm/semantics.json": "54a5dc0ca5b537fe64dd0e3bb3c3b3d4c012cccf5ce1a0b7a1dbca373bc345d1",
+          "artifacts/model-evaluation-20260905/validated/jobs/scorer-openai-5.5-confirm/job.json": "d2b4c094d7ab0579ddf7c72e24438314e6114ed670e1cb0198ef94d6823d037f",
+          "docs/research/model-evaluation-20260904.json": "8451be6e9690ba8a5cc32494b7fb7664353b8caa0403b1d772bb0ade7c719e4f",
+          "artifacts/model-evaluation-20260905/validated/scorer-openai-5.5-confirm/study-protocol.json": "66f3e893b5da95e74922eaf88f86565358aa34778eb28a103dfd9b7354115581"
+        },
+        "semanticsSha256": "f0cbe5721fea509e3300ba18b7974ea5db2318f7f1f3fdaf5312568326fe5d69",
+        "effectiveInputs": {
+          "configuration": "d232f0c6e66d83bfb260fa38e52225df04d30c75ce16657a03bdde37ff854005",
+          "sourceVoice": false,
+          "patterns": {
+            "en": "d1e674e74d1dda3c40c5008e1f6ff07f1b7d398c88fd38d7114301a62e5b4c9a",
+            "ko": "d49eea71abfe9b33113e722616271150375a59da31ae4541fb4b2c955bba0ed3",
+            "zh": "0c611d2062f625029e1d2d28115db2d16c26a8f2fe2ae6d8d74409987c3193b3",
+            "ja": "5b9f50877d6b21f90fe04060366bfe7b2802bd60ea9a3036f44a75621a52c658"
+          },
+          "lexicons": {
+            "en": "3811fe34a70de5d96a21831aec591a717a9c2a229983573a71208f57ebee9e5d",
+            "ko": "2d0ea2476e7f45219d4ba171a376cfc977ba76a19bbc3b0dd09b7ac67cd7f530",
+            "zh": "3d7170266879ae3b412c3d299aad8fc48904999d72786c26a8a63d317353d093",
+            "ja": "6d01eb45cc0a8e9a29c3187b18bbfcd869f0365dc923fd56ecf3d8d53d2cf237"
+          },
+          "structuralModels": {
+            "en": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "ko": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "zh": {
+              "status": "absent",
+              "contentHash": null
+            },
+            "ja": {
+              "status": "absent",
+              "contentHash": null
+            }
+          }
+        },
+        "fixtureIdentitySha256": "74ad644620b833401d44bb5c788090d6daef7542a2e0a568619a35d38d4a33b5",
+        "expectedKeysSha256": "f77dc36816a1eb393ed8a7751fd4f2cadb1586c25eb0f80e031122a5c709cd39",
+        "receiptManifestSha256": "1779ab0f1b1a4f8512e05152a7f7086f6c16cb6d78dc2f0c50cff5b97bc02032",
+        "receiptCount": 98,
+        "requestHashesSha256": "14165c154ed381fc9b7971af6339f6cba001e43f6e62850b8ed96c3d15facd56",
+        "promptHashesSha256": "21c92c6d658fd1494491de91da384625dc905d06938ec120ce12b74dd9ea5f5a",
+        "sourceFilesVerifiedAgainstCommit": 163,
+        "scorerSha256": "8df8a476e0183222fae74bee85f00d8da7ffd907bae9181501859f32afaa5762",
+        "parserSha256": "b970b824824a06bf79eff617918aeaa2d337410b00ab266b7769f84db45b1fdc",
+        "patternCatalog": {
+          "en": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "ko": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "zh": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          },
+          "ja": {
+            "communication": 4,
+            "content": 6,
+            "filler": 6,
+            "language": 9,
+            "structure": 5,
+            "style": 7,
+            "viral-hook": 9
+          }
+        },
+        "directoryProtocolBinding": "present",
+        "protocolRecomputed": false,
+        "fullScorerReplay": false
+      },
+      "diagnostics": {
+        "categoryArithmeticMismatches": 0,
+        "overallWeightedSumMismatches": 0,
+        "arithmeticTolerance": 0.11
+      },
+      "candidates": [
+        {
+          "id": "openai-5.5",
+          "provider": "openai",
+          "transport": "opencodex",
+          "requestedModel": "gpt-5.5",
+          "responseModel": "gpt-5.5",
+          "identityEvidence": "OpenCodex response metadata; not upstream attestation",
+          "requestedReasoningEffort": "low",
+          "observed": 98,
+          "uniqueFixtures": 49,
+          "valid": 98,
+          "errors": 0,
+          "availability": {
+            "validNumerator": 98,
+            "observedDenominator": 98
+          },
+          "scores": {
+            "overall": {
+              "n": 98,
+              "min": 0,
+              "median": 4.199999999999999,
+              "mean": 10.833265306122447,
+              "p95": 31.8,
+              "max": 100
+            },
+            "rawLLM": {
+              "n": 98,
+              "min": 0,
+              "median": 4.199999999999999,
+              "mean": 9.054693877551019,
+              "p95": 31.1,
+              "max": 31.8
+            },
+            "deterministic": {
+              "n": 98,
+              "min": 0,
+              "median": 100,
+              "mean": 53.06122448979592,
+              "p95": 100,
+              "max": 100
+            }
+          },
+          "reconciliation": {
+            "changed": 2,
+            "delta": {
+              "n": 98,
+              "min": 0,
+              "median": 0,
+              "mean": 1.7785714285714287,
+              "p95": 0,
+              "max": 89.3
+            }
+          },
+          "expected": 98,
+          "byLanguage": {
+            "en": {
+              "observed": 26,
+              "uniqueFixtures": 13,
+              "valid": 26,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 26,
+                "observedDenominator": 26
+              },
+              "scores": {
+                "overall": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 3.6500000000000004,
+                  "mean": 12.262692307692307,
+                  "p95": 100,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 3.6500000000000004,
+                  "mean": 5.5588461538461535,
+                  "p95": 15,
+                  "max": 15.3
+                },
+                "deterministic": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.84615384615385,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 2,
+                "delta": {
+                  "n": 26,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 6.703846153846154,
+                  "p95": 85,
+                  "max": 89.3
+                }
+              }
+            },
+            "ko": {
+              "observed": 24,
+              "uniqueFixtures": 12,
+              "valid": 24,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 24,
+                "observedDenominator": 24
+              },
+              "scores": {
+                "overall": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 7.15,
+                  "mean": 9.879166666666668,
+                  "p95": 27.5,
+                  "max": 27.5
+                },
+                "rawLLM": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 7.15,
+                  "mean": 9.879166666666668,
+                  "p95": 27.5,
+                  "max": 27.5
+                },
+                "deterministic": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 58.333333333333336,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "zh": {
+              "observed": 24,
+              "uniqueFixtures": 12,
+              "valid": 24,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 24,
+                "observedDenominator": 24
+              },
+              "scores": {
+                "overall": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 1.55,
+                  "mean": 10.26875,
+                  "p95": 31.8,
+                  "max": 31.8
+                },
+                "rawLLM": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 1.55,
+                  "mean": 10.26875,
+                  "p95": 31.8,
+                  "max": 31.8
+                },
+                "deterministic": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            },
+            "ja": {
+              "observed": 24,
+              "uniqueFixtures": 12,
+              "valid": 24,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 24,
+                "observedDenominator": 24
+              },
+              "scores": {
+                "overall": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 4.65,
+                  "mean": 10.803333333333333,
+                  "p95": 31.1,
+                  "max": 31.8
+                },
+                "rawLLM": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 4.65,
+                  "mean": 10.803333333333333,
+                  "p95": 31.1,
+                  "max": 31.8
+                },
+                "deterministic": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 50,
+                  "mean": 50,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 24,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byFixtureControl": {
+            "expected_hot": {
+              "observed": 52,
+              "uniqueFixtures": 26,
+              "valid": 52,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 52,
+                "observedDenominator": 52
+              },
+              "scores": {
+                "overall": {
+                  "n": 52,
+                  "min": 2,
+                  "median": 14.65,
+                  "mean": 19.706923076923076,
+                  "p95": 31.8,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 52,
+                  "min": 2,
+                  "median": 14.3,
+                  "mean": 16.354999999999997,
+                  "p95": 31.8,
+                  "max": 31.8
+                },
+                "deterministic": {
+                  "n": 52,
+                  "min": 100,
+                  "median": 100,
+                  "mean": 100,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 2,
+                "delta": {
+                  "n": 52,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 3.351923076923077,
+                  "p95": 0,
+                  "max": 89.3
+                }
+              }
+            },
+            "expected_not_hot": {
+              "observed": 46,
+              "uniqueFixtures": 23,
+              "valid": 46,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 46,
+                "observedDenominator": 46
+              },
+              "scores": {
+                "overall": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0.2,
+                  "mean": 0.8021739130434782,
+                  "p95": 3.7,
+                  "max": 4.4
+                },
+                "rawLLM": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0.2,
+                  "mean": 0.8021739130434782,
+                  "p95": 3.7,
+                  "max": 4.4
+                },
+                "deterministic": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              },
+              "reconciliation": {
+                "changed": 0,
+                "delta": {
+                  "n": 46,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 0,
+                  "p95": 0,
+                  "max": 0
+                }
+              }
+            }
+          },
+          "byRepeat": [
+            {
+              "repeat": 0,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 3.5,
+                  "mean": 10.37857142857143,
+                  "p95": 31.25,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 3.5,
+                  "mean": 8.556122448979593,
+                  "p95": 30.1,
+                  "max": 31.8
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.8224489795918366,
+                  "p95": 0,
+                  "max": 89.3
+                }
+              }
+            },
+            {
+              "repeat": 1,
+              "observed": 49,
+              "uniqueFixtures": 49,
+              "valid": 49,
+              "errors": 0,
+              "availability": {
+                "validNumerator": 49,
+                "observedDenominator": 49
+              },
+              "scores": {
+                "overall": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 4.4,
+                  "mean": 11.287959183673472,
+                  "p95": 31.8,
+                  "max": 100
+                },
+                "rawLLM": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 4.4,
+                  "mean": 9.55326530612245,
+                  "p95": 31.1,
+                  "max": 31.8
+                },
+                "deterministic": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 100,
+                  "mean": 53.06122448979592,
+                  "p95": 100,
+                  "max": 100
+                }
+              },
+              "reconciliation": {
+                "changed": 1,
+                "delta": {
+                  "n": 49,
+                  "min": 0,
+                  "median": 0,
+                  "mean": 1.7346938775510203,
+                  "p95": 0,
+                  "max": 85
+                }
+              }
+            }
+          ],
+          "byPatternPack": {
+            "en/communication": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "en/content": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 8.55076923076923,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            },
+            "en/filler": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 4.06923076923077,
+                "p95": 33.3,
+                "max": 38.9
+              }
+            },
+            "en/language": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 8.35,
+                "mean": 9.833461538461538,
+                "p95": 27.8,
+                "max": 33.3
+              }
+            },
+            "en/structure": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 6.7,
+                "mean": 7.9423076923076925,
+                "p95": 20,
+                "max": 20
+              }
+            },
+            "en/style": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 2.1923076923076925,
+                "p95": 14.3,
+                "max": 14.3
+              }
+            },
+            "en/viral-hook": {
+              "validRows": 26,
+              "missing": 0,
+              "score": {
+                "n": 26,
+                "min": 0,
+                "median": 0,
+                "mean": 3.213846153846154,
+                "p95": 11.1,
+                "max": 27.8
+              }
+            },
+            "ko/communication": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ko/content": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 2.8,
+                "mean": 9.500000000000002,
+                "p95": 27.8,
+                "max": 38.9
+              }
+            },
+            "ko/filler": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 5.6,
+                "mean": 6.029166666666668,
+                "p95": 22.2,
+                "max": 22.2
+              }
+            },
+            "ko/language": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 11.1,
+                "mean": 13.654166666666669,
+                "p95": 33.3,
+                "max": 33.3
+              }
+            },
+            "ko/structure": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 16.65,
+                "mean": 16.94583333333333,
+                "p95": 46.7,
+                "max": 46.7
+              }
+            },
+            "ko/style": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 7.1,
+                "mean": 13.987499999999997,
+                "p95": 42.9,
+                "max": 42.9
+              }
+            },
+            "ko/viral-hook": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 1.6291666666666667,
+                "p95": 5.6,
+                "max": 11.1
+              }
+            },
+            "zh/communication": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "zh/content": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 10.415833333333333,
+                "p95": 38.9,
+                "max": 38.9
+              }
+            },
+            "zh/filler": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 9.49125,
+                "p95": 38.9,
+                "max": 44.4
+              }
+            },
+            "zh/language": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 2.78,
+                "mean": 21.4525,
+                "p95": 63,
+                "max": 66.7
+              }
+            },
+            "zh/structure": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 3.335,
+                "mean": 10.832083333333335,
+                "p95": 33.3,
+                "max": 40
+              }
+            },
+            "zh/style": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 10.420833333333333,
+                "p95": 28.6,
+                "max": 28.6
+              }
+            },
+            "zh/viral-hook": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 2.78375,
+                "p95": 11.1,
+                "max": 11.11
+              }
+            },
+            "ja/communication": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            },
+            "ja/content": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 17.595000000000002,
+                "p95": 61.1,
+                "max": 61.1
+              }
+            },
+            "ja/filler": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 10.18,
+                "p95": 44.4,
+                "max": 50
+              }
+            },
+            "ja/language": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 13.899999999999999,
+                "mean": 17.598333333333333,
+                "p95": 50,
+                "max": 50
+              }
+            },
+            "ja/structure": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 10,
+                "mean": 15.56125,
+                "p95": 46.7,
+                "max": 46.7
+              }
+            },
+            "ja/style": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 5.652916666666666,
+                "p95": 14.3,
+                "max": 21.4
+              }
+            },
+            "ja/viral-hook": {
+              "validRows": 24,
+              "missing": 0,
+              "score": {
+                "n": 24,
+                "min": 0,
+                "median": 0,
+                "mean": 3.012083333333333,
+                "p95": 22.2,
+                "max": 22.22
+              }
+            }
+          },
+          "pairedRepeatAbsoluteDifference": {
+            "pairs": 49,
+            "scores": {
+              "overall": {
+                "n": 49,
+                "min": 0,
+                "median": 0.9000000000000004,
+                "mean": 1.8897959183673472,
+                "p95": 6.300000000000001,
+                "max": 17.7
+              },
+              "rawLLM": {
+                "n": 49,
+                "min": 0,
+                "median": 1,
+                "mean": 1.9775510204081634,
+                "p95": 6.300000000000001,
+                "max": 17.7
+              },
+              "deterministic": {
+                "n": 49,
+                "min": 0,
+                "median": 0,
+                "mean": 0,
+                "p95": 0,
+                "max": 0
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks/live-scorer-20260905.md
+++ b/docs/benchmarks/live-scorer-20260905.md
@@ -1,0 +1,599 @@
+# Live scorer diagnostics — September 5, 2026
+
+930/931 valid rows across 6 completed matrices, 11 observed model identifiers, and 49 unique regression fixtures.
+
+Partial evidence for #412. The fixture diagnostic deliverable is complete; do not claim its rebaseline scope is complete.
+
+The production `src/scoring.js` `scoreText` path was used by the opt-in collector. This publication reads completed artifacts offline. It makes no provider calls.
+
+## Reading the results
+
+- **overall:** Recorded production scoreText overall, after deterministic reconciliation; valid rows only.
+- **rawLLM:** Receipt-validated raw_overall; equals llm_overall on valid rows. Invalid schema values are excluded.
+- **deterministic:** Recorded deterministic_overall on all observed rows, including scorer errors. No recomputation from hash-only resolved inputs.
+- **patternPack:** Recorded category.score; omissions counted, never filled with zero. A pack score is not an individual pattern accuracy.
+- **distribution:** Finite values only; median averages the middle pair; p95 is nearest-rank ceil(0.95*n); unrounded JSON statistics.
+
+Scores range from 0 to 100; larger values mean more detected writing patterns. A candidate mean is not a measure of scorer quality.
+
+The JSON companion preserves full-precision distributions, per-repeat and fixture-control slices, paired repeat differences, original protocol IDs, and source/receipt integrity commitments. All model names below are observed OpenCodex identifiers.
+
+## Validity and score distributions
+
+| Cohort | Candidate | Valid / expected | Errors | Overall median / mean | Raw LLM median / mean | Deterministic n / mean | Adjusted rows |
+|---|---|---:|---:|---:|---:|---:|---:|
+| A/scorer-openai | openai-astra | 49/49 | 0 | 0.44 / 6.57 | 0.44 / 4.67 | 49 / 53.06 | 1 |
+| A/scorer-openai | openai-sol | 49/49 | 0 | 3.70 / 11.18 | 3.70 / 9.42 | 49 / 53.06 | 1 |
+| A/scorer-openai | openai-terra | 49/49 | 0 | 2.00 / 7.99 | 2.00 / 6.04 | 49 / 53.06 | 1 |
+| A/scorer-openai | openai-luna | 48/49 | 1 | 2.41 / 7.30 | 2.41 / 5.35 | 49 / 53.06 | 1 |
+| A/scorer-openai | openai-5.5 | 49/49 | 0 | 6.00 / 11.60 | 6.00 / 9.84 | 49 / 53.06 | 1 |
+| A/scorer-openai | openai-mini | 49/49 | 0 | 1.00 / 5.27 | 1.00 / 3.28 | 49 / 53.06 | 1 |
+| A/scorer-gemini | gemini-pro | 49/49 | 0 | 3.55 / 10.70 | 3.55 / 8.86 | 49 / 53.06 | 1 |
+| A/scorer-gemini | gemini-3.7 | 49/49 | 0 | 0.00 / 5.09 | 0.00 / 3.21 | 49 / 53.06 | 1 |
+| A/scorer-gemini | gemini-3.8-low | 49/49 | 0 | 0.00 / 6.55 | 0.00 / 4.75 | 49 / 53.06 | 1 |
+| A/scorer-gemini | gemini-3.8-medium | 49/49 | 0 | 0.00 / 5.34 | 0.00 / 3.50 | 49 / 53.06 | 1 |
+| A/scorer-gemini | gemini-3.8-high | 49/49 | 0 | 0.00 / 5.36 | 0.00 / 3.51 | 49 / 53.06 | 1 |
+| A/scorer-gemini-low-confirm | gemini-3.8-low | 98/98 | 0 | 0.00 / 5.28 | 0.00 / 3.44 | 98 / 53.06 | 2 |
+| A/scorer-gemini-pro-confirm | gemini-pro | 98/98 | 0 | 3.04 / 10.81 | 3.04 / 9.00 | 98 / 53.06 | 2 |
+| C/scorer-openai-terra-confirm | openai-terra | 98/98 | 0 | 2.00 / 7.92 | 2.00 / 5.95 | 98 / 53.06 | 2 |
+| C/scorer-openai-5.5-confirm | openai-5.5 | 98/98 | 0 | 4.20 / 10.83 | 4.20 / 9.05 | 98 / 53.06 | 2 |
+
+## Errors and arithmetic diagnostics
+
+Validity uses the original collector schema. The arithmetic checks count category scores differing from `100 × sum / max`, and overall scores differing from the sum of category weights, by more than 0.11 points. They do not reclassify valid rows. These are diagnostic counts, not model rankings.
+
+| Cohort | Schema-failed rows | Transport-failed rows | Category arithmetic mismatches | Overall weighted-sum mismatches |
+|---|---:|---:|---:|---:|
+| scorer-openai | 1 | 0 | 2 | 0 |
+| scorer-gemini | 0 | 0 | 4 | 1 |
+| scorer-gemini-low-confirm | 0 | 0 | 0 | 0 |
+| scorer-gemini-pro-confirm | 0 | 0 | 32 | 7 |
+| scorer-openai-terra-confirm | 0 | 0 | 0 | 0 |
+| scorer-openai-5.5-confirm | 0 | 0 | 0 | 0 |
+
+## Language distributions
+
+| Cohort / candidate | Language | Valid / observed | Overall n / mean / median / p95 | Raw LLM n / mean / median / p95 | Deterministic n / mean / median / p95 |
+|---|---|---:|---:|---:|---:|
+| scorer-openai/openai-astra | en | 13/13 | 13 / 8.25 / 0.00 / 100.00 | 13 / 1.08 / 0.00 / 6.76 | 13 / 53.85 / 100.00 / 100.00 |
+| scorer-openai/openai-astra | ko | 12/12 | 12 / 3.87 / 1.50 / 12.02 | 12 / 3.87 / 1.50 / 12.02 | 12 / 58.33 / 100.00 / 100.00 |
+| scorer-openai/openai-astra | zh | 12/12 | 12 / 7.35 / 0.56 / 29.81 | 12 / 7.35 / 0.56 / 29.81 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-openai/openai-astra | ja | 12/12 | 12 / 6.68 / 0.50 / 25.24 | 12 / 6.68 / 0.50 / 25.24 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-openai/openai-sol | en | 13/13 | 13 / 12.25 / 2.40 / 100.00 | 13 / 5.64 / 2.40 / 19.30 | 13 / 53.85 / 100.00 / 100.00 |
+| scorer-openai/openai-sol | ko | 12/12 | 12 / 10.37 / 10.10 / 29.10 | 12 / 10.37 / 10.10 / 29.10 | 12 / 58.33 / 100.00 / 100.00 |
+| scorer-openai/openai-sol | zh | 12/12 | 12 / 11.83 / 5.85 / 33.40 | 12 / 11.83 / 5.85 / 33.40 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-openai/openai-sol | ja | 12/12 | 12 / 10.18 / 2.50 / 35.50 | 12 / 10.18 / 2.50 / 35.50 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-openai/openai-terra | en | 13/13 | 13 / 9.95 / 1.70 / 100.00 | 13 / 2.59 / 1.70 / 7.90 | 13 / 53.85 / 100.00 / 100.00 |
+| scorer-openai/openai-terra | ko | 12/12 | 12 / 5.67 / 3.00 / 20.60 | 12 / 5.67 / 3.00 / 20.60 | 12 / 58.33 / 100.00 / 100.00 |
+| scorer-openai/openai-terra | zh | 12/12 | 12 / 7.30 / 1.83 / 24.90 | 12 / 7.30 / 1.83 / 24.90 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-openai/openai-terra | ja | 12/12 | 12 / 8.90 / 2.00 / 29.90 | 12 / 8.90 / 2.00 / 29.90 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-openai/openai-luna | en | 13/13 | 13 / 10.67 / 3.30 / 100.00 | 13 / 3.49 / 3.30 / 11.30 | 13 / 53.85 / 100.00 / 100.00 |
+| scorer-openai/openai-luna | ko | 11/12 | 11 / 4.36 / 2.11 / 18.48 | 11 / 4.36 / 2.11 / 18.48 | 12 / 58.33 / 100.00 / 100.00 |
+| scorer-openai/openai-luna | zh | 12/12 | 12 / 6.46 / 1.79 / 22.30 | 12 / 6.46 / 1.79 / 22.30 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-openai/openai-luna | ja | 12/12 | 12 / 7.18 / 3.20 / 21.90 | 12 / 7.18 / 3.20 / 21.90 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-openai/openai-5.5 | en | 13/13 | 13 / 13.95 / 5.90 / 100.00 | 13 / 7.34 / 5.90 / 23.80 | 13 / 53.85 / 100.00 / 100.00 |
+| scorer-openai/openai-5.5 | ko | 12/12 | 12 / 12.06 / 8.87 / 34.50 | 12 / 12.06 / 8.87 / 34.50 | 12 / 58.33 / 100.00 / 100.00 |
+| scorer-openai/openai-5.5 | zh | 12/12 | 12 / 10.54 / 4.10 / 37.10 | 12 / 10.54 / 4.10 / 37.10 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-openai/openai-5.5 | ja | 12/12 | 12 / 9.63 / 4.50 / 31.60 | 12 / 9.63 / 4.50 / 31.60 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-openai/openai-mini | en | 13/13 | 13 / 9.54 / 1.11 / 100.00 | 13 / 2.04 / 1.11 / 7.40 | 13 / 53.85 / 100.00 / 100.00 |
+| scorer-openai/openai-mini | ko | 12/12 | 12 / 4.42 / 4.14 / 17.30 | 12 / 4.42 / 4.14 / 17.30 | 12 / 58.33 / 100.00 / 100.00 |
+| scorer-openai/openai-mini | zh | 12/12 | 12 / 4.61 / 0.50 / 18.60 | 12 / 4.61 / 0.50 / 18.60 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-openai/openai-mini | ja | 12/12 | 12 / 2.17 / 0.00 / 9.90 | 12 / 2.17 / 0.00 / 9.90 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-gemini/gemini-pro | en | 13/13 | 13 / 10.82 / 0.00 / 100.00 | 13 / 3.88 / 0.00 / 18.00 | 13 / 53.85 / 100.00 / 100.00 |
+| scorer-gemini/gemini-pro | ko | 12/12 | 12 / 9.33 / 4.88 / 31.81 | 12 / 9.33 / 4.88 / 31.81 | 12 / 58.33 / 100.00 / 100.00 |
+| scorer-gemini/gemini-pro | zh | 12/12 | 12 / 13.29 / 5.07 / 40.58 | 12 / 13.29 / 5.07 / 40.58 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-gemini/gemini-pro | ja | 12/12 | 12 / 9.35 / 4.70 / 35.24 | 12 / 9.35 / 4.70 / 35.24 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-gemini/gemini-3.7 | en | 13/13 | 13 / 7.91 / 0.00 / 100.00 | 13 / 0.83 / 0.00 / 7.86 | 13 / 53.85 / 100.00 / 100.00 |
+| scorer-gemini/gemini-3.7 | ko | 12/12 | 12 / 2.68 / 0.00 / 13.01 | 12 / 2.68 / 0.00 / 13.01 | 12 / 58.33 / 100.00 / 100.00 |
+| scorer-gemini/gemini-3.7 | zh | 12/12 | 12 / 5.15 / 0.00 / 21.92 | 12 / 5.15 / 0.00 / 21.92 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-gemini/gemini-3.7 | ja | 12/12 | 12 / 4.40 / 0.00 / 15.93 | 12 / 4.40 / 0.00 / 15.93 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-gemini/gemini-3.8-low | en | 13/13 | 13 / 7.79 / 0.00 / 100.00 | 13 / 1.01 / 0.00 / 11.74 | 13 / 53.85 / 100.00 / 100.00 |
+| scorer-gemini/gemini-3.8-low | ko | 12/12 | 12 / 2.92 / 0.00 / 12.50 | 12 / 2.92 / 0.00 / 12.50 | 12 / 58.33 / 100.00 / 100.00 |
+| scorer-gemini/gemini-3.8-low | zh | 12/12 | 12 / 9.11 / 0.28 / 38.04 | 12 / 9.11 / 0.28 / 38.04 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-gemini/gemini-3.8-low | ja | 12/12 | 12 / 6.26 / 0.00 / 31.35 | 12 / 6.26 / 0.00 / 31.35 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-gemini/gemini-3.8-medium | en | 13/13 | 13 / 8.00 / 0.00 / 100.00 | 13 / 1.08 / 0.00 / 10.08 | 13 / 53.85 / 100.00 / 100.00 |
+| scorer-gemini/gemini-3.8-medium | ko | 12/12 | 12 / 2.68 / 0.00 / 9.60 | 12 / 2.68 / 0.00 / 9.60 | 12 / 58.33 / 100.00 / 100.00 |
+| scorer-gemini/gemini-3.8-medium | zh | 12/12 | 12 / 5.46 / 0.00 / 27.47 | 12 / 5.46 / 0.00 / 27.47 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-gemini/gemini-3.8-medium | ja | 12/12 | 12 / 4.98 / 0.00 / 21.79 | 12 / 4.98 / 0.00 / 21.79 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-gemini/gemini-3.8-high | en | 13/13 | 13 / 7.83 / 0.00 / 100.00 | 13 / 0.83 / 0.00 / 9.00 | 13 / 53.85 / 100.00 / 100.00 |
+| scorer-gemini/gemini-3.8-high | ko | 12/12 | 12 / 2.96 / 0.00 / 11.00 | 12 / 2.96 / 0.00 / 11.00 | 12 / 58.33 / 100.00 / 100.00 |
+| scorer-gemini/gemini-3.8-high | zh | 12/12 | 12 / 4.94 / 0.00 / 20.48 | 12 / 4.94 / 0.00 / 20.48 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-gemini/gemini-3.8-high | ja | 12/12 | 12 / 5.53 / 0.00 / 24.46 | 12 / 5.53 / 0.00 / 24.46 | 12 / 50.00 / 50.00 / 100.00 |
+| scorer-gemini-low-confirm/gemini-3.8-low | en | 26/26 | 26 / 7.74 / 0.00 / 100.00 | 26 / 0.78 / 0.00 / 7.86 | 26 / 53.85 / 100.00 / 100.00 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ko | 24/24 | 24 / 2.73 / 0.00 / 9.01 | 24 / 2.73 / 0.00 / 9.01 | 24 / 58.33 / 100.00 / 100.00 |
+| scorer-gemini-low-confirm/gemini-3.8-low | zh | 24/24 | 24 / 5.31 / 0.00 / 25.36 | 24 / 5.31 / 0.00 / 25.36 | 24 / 50.00 / 50.00 / 100.00 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ja | 24/24 | 24 / 5.14 / 0.00 / 20.00 | 24 / 5.14 / 0.00 / 20.00 | 24 / 50.00 / 50.00 / 100.00 |
+| scorer-gemini-pro-confirm/gemini-pro | en | 26/26 | 26 / 11.17 / 2.38 / 100.00 | 26 / 4.36 / 2.38 / 16.00 | 26 / 53.85 / 100.00 / 100.00 |
+| scorer-gemini-pro-confirm/gemini-pro | ko | 24/24 | 24 / 8.41 / 6.07 / 21.81 | 24 / 8.41 / 6.07 / 21.81 | 24 / 58.33 / 100.00 / 100.00 |
+| scorer-gemini-pro-confirm/gemini-pro | zh | 24/24 | 24 / 13.07 / 1.65 / 41.83 | 24 / 13.07 / 1.65 / 41.83 | 24 / 50.00 / 50.00 / 100.00 |
+| scorer-gemini-pro-confirm/gemini-pro | ja | 24/24 | 24 / 10.55 / 3.65 / 36.25 | 24 / 10.55 / 3.65 / 36.25 | 24 / 50.00 / 50.00 / 100.00 |
+| scorer-openai-terra-confirm/openai-terra | en | 26/26 | 26 / 10.27 / 2.40 / 100.00 | 26 / 2.84 / 2.40 / 8.44 | 26 / 53.85 / 100.00 / 100.00 |
+| scorer-openai-terra-confirm/openai-terra | ko | 24/24 | 24 / 5.26 / 2.00 / 17.30 | 24 / 5.26 / 2.00 / 17.30 | 24 / 58.33 / 100.00 / 100.00 |
+| scorer-openai-terra-confirm/openai-terra | zh | 24/24 | 24 / 8.51 / 1.60 / 30.25 | 24 / 8.51 / 1.60 / 30.25 | 24 / 50.00 / 50.00 / 100.00 |
+| scorer-openai-terra-confirm/openai-terra | ja | 24/24 | 24 / 7.44 / 1.50 / 26.40 | 24 / 7.44 / 1.50 / 26.40 | 24 / 50.00 / 50.00 / 100.00 |
+| scorer-openai-5.5-confirm/openai-5.5 | en | 26/26 | 26 / 12.26 / 3.65 / 100.00 | 26 / 5.56 / 3.65 / 15.00 | 26 / 53.85 / 100.00 / 100.00 |
+| scorer-openai-5.5-confirm/openai-5.5 | ko | 24/24 | 24 / 9.88 / 7.15 / 27.50 | 24 / 9.88 / 7.15 / 27.50 | 24 / 58.33 / 100.00 / 100.00 |
+| scorer-openai-5.5-confirm/openai-5.5 | zh | 24/24 | 24 / 10.27 / 1.55 / 31.80 | 24 / 10.27 / 1.55 / 31.80 | 24 / 50.00 / 50.00 / 100.00 |
+| scorer-openai-5.5-confirm/openai-5.5 | ja | 24/24 | 24 / 10.80 / 4.65 / 31.10 | 24 / 10.80 / 4.65 / 31.10 | 24 / 50.00 / 50.00 / 100.00 |
+
+## Pattern-pack distributions
+
+Each value is the category score from a valid response. Missing packs remain missing. Repeated rows do not increase the unique fixture count.
+
+| Cohort / candidate | Language / pack | n / valid rows | Missing | Min | Median | Mean | p95 | Max |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| scorer-openai/openai-astra | en/communication | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-astra | en/content | 13/13 | 0 | 0.00 | 0.00 | 1.71 | 11.11 | 11.11 |
+| scorer-openai/openai-astra | en/filler | 13/13 | 0 | 0.00 | 0.00 | 1.71 | 16.67 | 16.67 |
+| scorer-openai/openai-astra | en/language | 13/13 | 0 | 0.00 | 0.00 | 1.28 | 11.11 | 11.11 |
+| scorer-openai/openai-astra | en/structure | 13/13 | 0 | 0.00 | 0.00 | 1.03 | 6.67 | 6.67 |
+| scorer-openai/openai-astra | en/style | 13/13 | 0 | 0.00 | 0.00 | 0.55 | 7.14 | 7.14 |
+| scorer-openai/openai-astra | en/viral-hook | 13/13 | 0 | 0.00 | 0.00 | 1.28 | 11.11 | 11.11 |
+| scorer-openai/openai-astra | ko/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-astra | ko/content | 12/12 | 0 | 0.00 | 0.00 | 3.24 | 11.11 | 11.11 |
+| scorer-openai/openai-astra | ko/filler | 12/12 | 0 | 0.00 | 0.00 | 1.39 | 5.56 | 5.56 |
+| scorer-openai/openai-astra | ko/language | 12/12 | 0 | 0.00 | 0.00 | 4.17 | 11.11 | 11.11 |
+| scorer-openai/openai-astra | ko/structure | 12/12 | 0 | 0.00 | 0.00 | 8.33 | 33.33 | 33.33 |
+| scorer-openai/openai-astra | ko/style | 12/12 | 0 | 0.00 | 0.00 | 6.55 | 21.43 | 21.43 |
+| scorer-openai/openai-astra | ko/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-astra | zh/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-astra | zh/content | 12/12 | 0 | 0.00 | 0.00 | 10.19 | 55.56 | 55.56 |
+| scorer-openai/openai-astra | zh/filler | 12/12 | 0 | 0.00 | 0.00 | 12.04 | 50.00 | 50.00 |
+| scorer-openai/openai-astra | zh/language | 12/12 | 0 | 0.00 | 0.00 | 13.43 | 50.00 | 50.00 |
+| scorer-openai/openai-astra | zh/structure | 12/12 | 0 | 0.00 | 0.00 | 3.33 | 20.00 | 20.00 |
+| scorer-openai/openai-astra | zh/style | 12/12 | 0 | 0.00 | 0.00 | 8.33 | 28.57 | 28.57 |
+| scorer-openai/openai-astra | zh/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 1.39 | 11.11 | 11.11 |
+| scorer-openai/openai-astra | ja/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-astra | ja/content | 12/12 | 0 | 0.00 | 0.00 | 16.67 | 61.11 | 61.11 |
+| scorer-openai/openai-astra | ja/filler | 12/12 | 0 | 0.00 | 0.00 | 8.80 | 44.44 | 44.44 |
+| scorer-openai/openai-astra | ja/language | 12/12 | 0 | 0.00 | 0.00 | 6.48 | 44.44 | 44.44 |
+| scorer-openai/openai-astra | ja/structure | 12/12 | 0 | 0.00 | 3.33 | 7.78 | 33.33 | 33.33 |
+| scorer-openai/openai-astra | ja/style | 12/12 | 0 | 0.00 | 0.00 | 3.57 | 14.29 | 14.29 |
+| scorer-openai/openai-astra | ja/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-sol | en/communication | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-sol | en/content | 13/13 | 0 | 0.00 | 0.00 | 7.70 | 33.30 | 33.30 |
+| scorer-openai/openai-sol | en/filler | 13/13 | 0 | 0.00 | 5.60 | 7.70 | 44.40 | 44.40 |
+| scorer-openai/openai-sol | en/language | 13/13 | 0 | 0.00 | 5.60 | 8.13 | 27.80 | 27.80 |
+| scorer-openai/openai-sol | en/structure | 13/13 | 0 | 0.00 | 13.30 | 12.30 | 46.70 | 46.70 |
+| scorer-openai/openai-sol | en/style | 13/13 | 0 | 0.00 | 0.00 | 1.65 | 14.30 | 14.30 |
+| scorer-openai/openai-sol | en/viral-hook | 13/13 | 0 | 0.00 | 0.00 | 3.00 | 11.10 | 11.10 |
+| scorer-openai/openai-sol | ko/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-sol | ko/content | 12/12 | 0 | 0.00 | 5.55 | 9.72 | 38.90 | 38.90 |
+| scorer-openai/openai-sol | ko/filler | 12/12 | 0 | 0.00 | 0.00 | 5.55 | 33.30 | 33.30 |
+| scorer-openai/openai-sol | ko/language | 12/12 | 0 | 0.00 | 8.35 | 13.42 | 44.40 | 44.40 |
+| scorer-openai/openai-sol | ko/structure | 12/12 | 0 | 0.00 | 16.65 | 18.32 | 53.30 | 53.30 |
+| scorer-openai/openai-sol | ko/style | 12/12 | 0 | 0.00 | 10.70 | 14.88 | 42.90 | 42.90 |
+| scorer-openai/openai-sol | ko/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 3.25 | 11.10 | 11.10 |
+| scorer-openai/openai-sol | zh/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-sol | zh/content | 12/12 | 0 | 0.00 | 0.00 | 12.96 | 44.40 | 44.40 |
+| scorer-openai/openai-sol | zh/filler | 12/12 | 0 | 0.00 | 0.00 | 14.35 | 61.10 | 61.10 |
+| scorer-openai/openai-sol | zh/language | 12/12 | 0 | 0.00 | 11.15 | 20.83 | 61.10 | 61.10 |
+| scorer-openai/openai-sol | zh/structure | 12/12 | 0 | 0.00 | 6.65 | 14.43 | 53.30 | 53.30 |
+| scorer-openai/openai-sol | zh/style | 12/12 | 0 | 0.00 | 7.15 | 11.92 | 28.60 | 28.60 |
+| scorer-openai/openai-sol | zh/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 2.78 | 11.10 | 11.10 |
+| scorer-openai/openai-sol | ja/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-sol | ja/content | 12/12 | 0 | 0.00 | 0.00 | 15.74 | 72.20 | 72.20 |
+| scorer-openai/openai-sol | ja/filler | 12/12 | 0 | 0.00 | 0.00 | 12.04 | 55.60 | 55.60 |
+| scorer-openai/openai-sol | ja/language | 12/12 | 0 | 0.00 | 5.60 | 13.42 | 44.40 | 44.40 |
+| scorer-openai/openai-sol | ja/structure | 12/12 | 0 | 0.00 | 10.00 | 15.00 | 46.70 | 46.70 |
+| scorer-openai/openai-sol | ja/style | 12/12 | 0 | 0.00 | 0.00 | 5.96 | 28.60 | 28.60 |
+| scorer-openai/openai-sol | ja/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 6.47 | 33.30 | 33.30 |
+| scorer-openai/openai-terra | en/communication | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-terra | en/content | 13/13 | 0 | 0.00 | 0.00 | 2.58 | 11.10 | 11.10 |
+| scorer-openai/openai-terra | en/filler | 13/13 | 0 | 0.00 | 0.00 | 3.42 | 33.30 | 33.30 |
+| scorer-openai/openai-terra | en/language | 13/13 | 0 | 0.00 | 5.60 | 5.15 | 22.20 | 22.20 |
+| scorer-openai/openai-terra | en/structure | 13/13 | 0 | 0.00 | 0.00 | 6.15 | 20.00 | 20.00 |
+| scorer-openai/openai-terra | en/style | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-terra | en/viral-hook | 13/13 | 0 | 0.00 | 0.00 | 1.72 | 11.10 | 11.10 |
+| scorer-openai/openai-terra | ko/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-terra | ko/content | 12/12 | 0 | 0.00 | 0.00 | 5.57 | 16.70 | 16.70 |
+| scorer-openai/openai-terra | ko/filler | 12/12 | 0 | 0.00 | 0.00 | 2.32 | 16.70 | 16.70 |
+| scorer-openai/openai-terra | ko/language | 12/12 | 0 | 0.00 | 2.80 | 6.48 | 22.20 | 22.20 |
+| scorer-openai/openai-terra | ko/structure | 12/12 | 0 | 0.00 | 3.35 | 10.00 | 33.30 | 33.30 |
+| scorer-openai/openai-terra | ko/style | 12/12 | 0 | 0.00 | 0.00 | 9.53 | 42.90 | 42.90 |
+| scorer-openai/openai-terra | ko/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 0.93 | 5.60 | 5.60 |
+| scorer-openai/openai-terra | zh/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-terra | zh/content | 12/12 | 0 | 0.00 | 0.00 | 9.26 | 50.00 | 50.00 |
+| scorer-openai/openai-terra | zh/filler | 12/12 | 0 | 0.00 | 0.00 | 5.55 | 22.20 | 22.20 |
+| scorer-openai/openai-terra | zh/language | 12/12 | 0 | 0.00 | 0.00 | 12.50 | 44.44 | 44.44 |
+| scorer-openai/openai-terra | zh/structure | 12/12 | 0 | 0.00 | 0.00 | 6.11 | 26.70 | 26.70 |
+| scorer-openai/openai-terra | zh/style | 12/12 | 0 | 0.00 | 7.14 | 10.72 | 28.60 | 28.60 |
+| scorer-openai/openai-terra | zh/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 0.92 | 11.10 | 11.10 |
+| scorer-openai/openai-terra | ja/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-terra | ja/content | 12/12 | 0 | 0.00 | 0.00 | 15.74 | 66.67 | 66.67 |
+| scorer-openai/openai-terra | ja/filler | 12/12 | 0 | 0.00 | 0.00 | 9.26 | 38.89 | 38.89 |
+| scorer-openai/openai-terra | ja/language | 12/12 | 0 | 0.00 | 2.80 | 11.12 | 55.60 | 55.60 |
+| scorer-openai/openai-terra | ja/structure | 12/12 | 0 | 0.00 | 3.35 | 10.56 | 40.00 | 40.00 |
+| scorer-openai/openai-terra | ja/style | 12/12 | 0 | 0.00 | 0.00 | 7.15 | 28.60 | 28.60 |
+| scorer-openai/openai-terra | ja/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 4.63 | 22.22 | 22.22 |
+| scorer-openai/openai-luna | en/communication | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-luna | en/content | 13/13 | 0 | 0.00 | 0.00 | 5.56 | 33.30 | 33.30 |
+| scorer-openai/openai-luna | en/filler | 13/13 | 0 | 0.00 | 5.56 | 4.29 | 22.20 | 22.20 |
+| scorer-openai/openai-luna | en/language | 13/13 | 0 | 0.00 | 3.70 | 4.98 | 22.20 | 22.20 |
+| scorer-openai/openai-luna | en/structure | 13/13 | 0 | 0.00 | 0.00 | 4.63 | 26.70 | 26.70 |
+| scorer-openai/openai-luna | en/style | 13/13 | 0 | 0.00 | 0.00 | 2.01 | 9.50 | 9.50 |
+| scorer-openai/openai-luna | en/viral-hook | 13/13 | 0 | 0.00 | 0.00 | 1.85 | 11.10 | 11.10 |
+| scorer-openai/openai-luna | ko/communication | 11/11 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-luna | ko/content | 11/11 | 0 | 0.00 | 0.00 | 3.54 | 16.70 | 16.70 |
+| scorer-openai/openai-luna | ko/filler | 11/11 | 0 | 0.00 | 5.56 | 4.55 | 16.67 | 16.67 |
+| scorer-openai/openai-luna | ko/language | 11/11 | 0 | 0.00 | 3.70 | 5.90 | 33.33 | 33.33 |
+| scorer-openai/openai-luna | ko/structure | 11/11 | 0 | 0.00 | 0.00 | 8.48 | 33.33 | 33.33 |
+| scorer-openai/openai-luna | ko/style | 11/11 | 0 | 0.00 | 0.00 | 5.19 | 28.57 | 28.57 |
+| scorer-openai/openai-luna | ko/viral-hook | 11/11 | 0 | 0.00 | 0.00 | 0.85 | 5.60 | 5.60 |
+| scorer-openai/openai-luna | zh/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-luna | zh/content | 12/12 | 0 | 0.00 | 0.00 | 6.48 | 38.90 | 38.90 |
+| scorer-openai/openai-luna | zh/filler | 12/12 | 0 | 0.00 | 0.00 | 5.56 | 27.80 | 27.80 |
+| scorer-openai/openai-luna | zh/language | 12/12 | 0 | 0.00 | 0.00 | 10.18 | 44.44 | 44.44 |
+| scorer-openai/openai-luna | zh/structure | 12/12 | 0 | 0.00 | 3.33 | 7.78 | 26.70 | 26.70 |
+| scorer-openai/openai-luna | zh/style | 12/12 | 0 | 0.00 | 3.57 | 9.53 | 28.60 | 28.60 |
+| scorer-openai/openai-luna | zh/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 1.39 | 11.11 | 11.11 |
+| scorer-openai/openai-luna | ja/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-luna | ja/content | 12/12 | 0 | 0.00 | 0.00 | 12.03 | 44.40 | 44.40 |
+| scorer-openai/openai-luna | ja/filler | 12/12 | 0 | 0.00 | 0.00 | 8.80 | 33.33 | 33.33 |
+| scorer-openai/openai-luna | ja/language | 12/12 | 0 | 0.00 | 5.60 | 12.50 | 33.30 | 33.30 |
+| scorer-openai/openai-luna | ja/structure | 12/12 | 0 | 0.00 | 3.33 | 8.88 | 33.30 | 33.30 |
+| scorer-openai/openai-luna | ja/style | 12/12 | 0 | 0.00 | 0.00 | 3.57 | 14.30 | 14.30 |
+| scorer-openai/openai-luna | ja/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 1.39 | 11.10 | 11.10 |
+| scorer-openai/openai-5.5 | en/communication | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-5.5 | en/content | 13/13 | 0 | 0.00 | 5.60 | 10.28 | 50.00 | 50.00 |
+| scorer-openai/openai-5.5 | en/filler | 13/13 | 0 | 0.00 | 5.56 | 5.99 | 22.20 | 22.20 |
+| scorer-openai/openai-5.5 | en/language | 13/13 | 0 | 0.00 | 11.10 | 11.12 | 38.90 | 38.90 |
+| scorer-openai/openai-5.5 | en/structure | 13/13 | 0 | 0.00 | 6.70 | 11.80 | 46.70 | 46.70 |
+| scorer-openai/openai-5.5 | en/style | 13/13 | 0 | 0.00 | 0.00 | 4.38 | 21.40 | 21.40 |
+| scorer-openai/openai-5.5 | en/viral-hook | 13/13 | 0 | 0.00 | 5.56 | 5.14 | 16.70 | 16.70 |
+| scorer-openai/openai-5.5 | ko/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-5.5 | ko/content | 12/12 | 0 | 0.00 | 2.80 | 14.82 | 50.00 | 50.00 |
+| scorer-openai/openai-5.5 | ko/filler | 12/12 | 0 | 0.00 | 5.60 | 8.81 | 27.80 | 27.80 |
+| scorer-openai/openai-5.5 | ko/language | 12/12 | 0 | 0.00 | 11.11 | 14.35 | 38.90 | 38.90 |
+| scorer-openai/openai-5.5 | ko/structure | 12/12 | 0 | 0.00 | 16.65 | 20.55 | 60.00 | 60.00 |
+| scorer-openai/openai-5.5 | ko/style | 12/12 | 0 | 0.00 | 10.71 | 16.08 | 42.90 | 42.90 |
+| scorer-openai/openai-5.5 | ko/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 1.40 | 5.60 | 5.60 |
+| scorer-openai/openai-5.5 | zh/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-5.5 | zh/content | 12/12 | 0 | 0.00 | 0.00 | 10.18 | 44.40 | 44.40 |
+| scorer-openai/openai-5.5 | zh/filler | 12/12 | 0 | 0.00 | 0.00 | 12.50 | 55.60 | 55.60 |
+| scorer-openai/openai-5.5 | zh/language | 12/12 | 0 | 0.00 | 8.35 | 19.91 | 77.80 | 77.80 |
+| scorer-openai/openai-5.5 | zh/structure | 12/12 | 0 | 0.00 | 6.65 | 12.78 | 40.00 | 40.00 |
+| scorer-openai/openai-5.5 | zh/style | 12/12 | 0 | 0.00 | 7.15 | 10.72 | 28.60 | 28.60 |
+| scorer-openai/openai-5.5 | zh/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 2.78 | 11.10 | 11.10 |
+| scorer-openai/openai-5.5 | ja/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-5.5 | ja/content | 12/12 | 0 | 0.00 | 0.00 | 16.20 | 66.70 | 66.70 |
+| scorer-openai/openai-5.5 | ja/filler | 12/12 | 0 | 0.00 | 0.00 | 9.72 | 38.90 | 38.90 |
+| scorer-openai/openai-5.5 | ja/language | 12/12 | 0 | 0.00 | 8.35 | 15.28 | 55.60 | 55.60 |
+| scorer-openai/openai-5.5 | ja/structure | 12/12 | 0 | 0.00 | 6.65 | 13.33 | 33.30 | 33.30 |
+| scorer-openai/openai-5.5 | ja/style | 12/12 | 0 | 0.00 | 0.00 | 4.75 | 21.40 | 21.40 |
+| scorer-openai/openai-5.5 | ja/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 3.25 | 16.70 | 16.70 |
+| scorer-openai/openai-mini | en/communication | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-mini | en/content | 13/13 | 0 | 0.00 | 0.00 | 2.57 | 22.22 | 22.22 |
+| scorer-openai/openai-mini | en/filler | 13/13 | 0 | 0.00 | 0.00 | 2.56 | 16.67 | 16.67 |
+| scorer-openai/openai-mini | en/language | 13/13 | 0 | 0.00 | 0.00 | 5.56 | 27.80 | 27.80 |
+| scorer-openai/openai-mini | en/structure | 13/13 | 0 | 0.00 | 0.00 | 2.05 | 13.30 | 13.30 |
+| scorer-openai/openai-mini | en/style | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-mini | en/viral-hook | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-mini | ko/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-mini | ko/content | 12/12 | 0 | 0.00 | 0.00 | 1.86 | 11.11 | 11.11 |
+| scorer-openai/openai-mini | ko/filler | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-mini | ko/language | 12/12 | 0 | 0.00 | 5.56 | 7.40 | 22.20 | 22.20 |
+| scorer-openai/openai-mini | ko/structure | 12/12 | 0 | 0.00 | 9.98 | 8.33 | 20.00 | 20.00 |
+| scorer-openai/openai-mini | ko/style | 12/12 | 0 | 0.00 | 0.00 | 8.33 | 57.10 | 57.10 |
+| scorer-openai/openai-mini | ko/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-mini | zh/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-mini | zh/content | 12/12 | 0 | 0.00 | 0.00 | 5.09 | 27.80 | 27.80 |
+| scorer-openai/openai-mini | zh/filler | 12/12 | 0 | 0.00 | 0.00 | 4.63 | 22.22 | 22.22 |
+| scorer-openai/openai-mini | zh/language | 12/12 | 0 | 0.00 | 0.00 | 7.86 | 33.30 | 33.30 |
+| scorer-openai/openai-mini | zh/structure | 12/12 | 0 | 0.00 | 0.00 | 5.56 | 20.00 | 20.00 |
+| scorer-openai/openai-mini | zh/style | 12/12 | 0 | 0.00 | 0.00 | 5.95 | 23.80 | 23.80 |
+| scorer-openai/openai-mini | zh/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-mini | ja/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai/openai-mini | ja/content | 12/12 | 0 | 0.00 | 0.00 | 4.64 | 22.22 | 22.22 |
+| scorer-openai/openai-mini | ja/filler | 12/12 | 0 | 0.00 | 0.00 | 4.63 | 22.20 | 22.20 |
+| scorer-openai/openai-mini | ja/language | 12/12 | 0 | 0.00 | 0.00 | 2.32 | 11.11 | 11.11 |
+| scorer-openai/openai-mini | ja/structure | 12/12 | 0 | 0.00 | 0.00 | 2.23 | 13.30 | 13.30 |
+| scorer-openai/openai-mini | ja/style | 12/12 | 0 | 0.00 | 0.00 | 1.19 | 14.29 | 14.29 |
+| scorer-openai/openai-mini | ja/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-pro | en/communication | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-pro | en/content | 13/13 | 0 | 0.00 | 0.00 | 4.27 | 38.89 | 38.89 |
+| scorer-gemini/gemini-pro | en/filler | 13/13 | 0 | 0.00 | 0.00 | 3.42 | 16.67 | 16.67 |
+| scorer-gemini/gemini-pro | en/language | 13/13 | 0 | 0.00 | 0.00 | 8.12 | 27.78 | 27.78 |
+| scorer-gemini/gemini-pro | en/structure | 13/13 | 0 | 0.00 | 0.00 | 8.20 | 33.33 | 33.33 |
+| scorer-gemini/gemini-pro | en/style | 13/13 | 0 | 0.00 | 0.00 | 1.10 | 14.29 | 14.29 |
+| scorer-gemini/gemini-pro | en/viral-hook | 13/13 | 0 | 0.00 | 0.00 | 0.85 | 11.11 | 11.11 |
+| scorer-gemini/gemini-pro | ko/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-pro | ko/content | 12/12 | 0 | 0.00 | 0.00 | 6.95 | 44.44 | 44.44 |
+| scorer-gemini/gemini-pro | ko/filler | 12/12 | 0 | 0.00 | 2.78 | 9.26 | 44.44 | 44.44 |
+| scorer-gemini/gemini-pro | ko/language | 12/12 | 0 | 0.00 | 0.11 | 8.04 | 33.33 | 33.33 |
+| scorer-gemini/gemini-pro | ko/structure | 12/12 | 0 | 0.00 | 3.63 | 16.72 | 53.33 | 53.33 |
+| scorer-gemini/gemini-pro | ko/style | 12/12 | 0 | 0.00 | 7.14 | 9.52 | 28.57 | 28.57 |
+| scorer-gemini/gemini-pro | ko/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 4.18 | 22.22 | 22.22 |
+| scorer-gemini/gemini-pro | zh/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-pro | zh/content | 12/12 | 0 | 0.00 | 0.00 | 11.11 | 50.00 | 50.00 |
+| scorer-gemini/gemini-pro | zh/filler | 12/12 | 0 | 0.00 | 0.00 | 16.67 | 77.78 | 77.78 |
+| scorer-gemini/gemini-pro | zh/language | 12/12 | 0 | 0.00 | 5.55 | 22.69 | 66.67 | 66.67 |
+| scorer-gemini/gemini-pro | zh/structure | 12/12 | 0 | 0.00 | 16.66 | 20.55 | 53.33 | 53.33 |
+| scorer-gemini/gemini-pro | zh/style | 12/12 | 0 | 0.00 | 7.14 | 11.91 | 42.86 | 42.86 |
+| scorer-gemini/gemini-pro | zh/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 6.48 | 22.22 | 22.22 |
+| scorer-gemini/gemini-pro | ja/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-pro | ja/content | 12/12 | 0 | 0.00 | 0.00 | 14.35 | 66.67 | 66.67 |
+| scorer-gemini/gemini-pro | ja/filler | 12/12 | 0 | 0.00 | 0.00 | 11.57 | 44.44 | 44.44 |
+| scorer-gemini/gemini-pro | ja/language | 12/12 | 0 | 0.00 | 2.78 | 11.11 | 44.44 | 44.44 |
+| scorer-gemini/gemini-pro | ja/structure | 12/12 | 0 | 0.00 | 10.00 | 16.11 | 53.33 | 53.33 |
+| scorer-gemini/gemini-pro | ja/style | 12/12 | 0 | 0.00 | 0.00 | 5.36 | 14.30 | 14.30 |
+| scorer-gemini/gemini-pro | ja/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 4.63 | 11.11 | 11.11 |
+| scorer-gemini/gemini-3.7 | en/communication | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.7 | en/content | 13/13 | 0 | 0.00 | 0.00 | 0.43 | 5.56 | 5.56 |
+| scorer-gemini/gemini-3.7 | en/filler | 13/13 | 0 | 0.00 | 0.00 | 0.85 | 11.11 | 11.11 |
+| scorer-gemini/gemini-3.7 | en/language | 13/13 | 0 | 0.00 | 0.00 | 1.28 | 11.11 | 11.11 |
+| scorer-gemini/gemini-3.7 | en/structure | 13/13 | 0 | 0.00 | 0.00 | 1.54 | 13.33 | 13.33 |
+| scorer-gemini/gemini-3.7 | en/style | 13/13 | 0 | 0.00 | 0.00 | 1.10 | 14.29 | 14.29 |
+| scorer-gemini/gemini-3.7 | en/viral-hook | 13/13 | 0 | 0.00 | 0.00 | 0.43 | 5.56 | 5.56 |
+| scorer-gemini/gemini-3.7 | ko/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.7 | ko/content | 12/12 | 0 | 0.00 | 0.00 | 2.78 | 22.22 | 22.22 |
+| scorer-gemini/gemini-3.7 | ko/filler | 12/12 | 0 | 0.00 | 0.00 | 0.93 | 5.60 | 5.60 |
+| scorer-gemini/gemini-3.7 | ko/language | 12/12 | 0 | 0.00 | 0.00 | 3.24 | 16.70 | 16.70 |
+| scorer-gemini/gemini-3.7 | ko/structure | 12/12 | 0 | 0.00 | 0.00 | 4.44 | 20.00 | 20.00 |
+| scorer-gemini/gemini-3.7 | ko/style | 12/12 | 0 | 0.00 | 0.00 | 4.76 | 14.30 | 14.30 |
+| scorer-gemini/gemini-3.7 | ko/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.7 | zh/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.7 | zh/content | 12/12 | 0 | 0.00 | 0.00 | 4.63 | 22.22 | 22.22 |
+| scorer-gemini/gemini-3.7 | zh/filler | 12/12 | 0 | 0.00 | 0.00 | 7.41 | 33.33 | 33.33 |
+| scorer-gemini/gemini-3.7 | zh/language | 12/12 | 0 | 0.00 | 0.00 | 8.33 | 33.33 | 33.33 |
+| scorer-gemini/gemini-3.7 | zh/structure | 12/12 | 0 | 0.00 | 0.00 | 6.11 | 26.67 | 26.67 |
+| scorer-gemini/gemini-3.7 | zh/style | 12/12 | 0 | 0.00 | 0.00 | 5.95 | 28.57 | 28.57 |
+| scorer-gemini/gemini-3.7 | zh/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 2.31 | 11.11 | 11.11 |
+| scorer-gemini/gemini-3.7 | ja/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.7 | ja/content | 12/12 | 0 | 0.00 | 0.00 | 7.41 | 33.33 | 33.33 |
+| scorer-gemini/gemini-3.7 | ja/filler | 12/12 | 0 | 0.00 | 0.00 | 6.94 | 38.89 | 38.89 |
+| scorer-gemini/gemini-3.7 | ja/language | 12/12 | 0 | 0.00 | 0.00 | 5.09 | 22.22 | 22.22 |
+| scorer-gemini/gemini-3.7 | ja/structure | 12/12 | 0 | 0.00 | 0.00 | 5.55 | 26.67 | 26.67 |
+| scorer-gemini/gemini-3.7 | ja/style | 12/12 | 0 | 0.00 | 0.00 | 3.17 | 14.29 | 14.29 |
+| scorer-gemini/gemini-3.7 | ja/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 1.85 | 11.11 | 11.11 |
+| scorer-gemini/gemini-3.8-low | en/communication | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-low | en/content | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-low | en/filler | 13/13 | 0 | 0.00 | 0.00 | 1.28 | 16.67 | 16.67 |
+| scorer-gemini/gemini-3.8-low | en/language | 13/13 | 0 | 0.00 | 0.00 | 1.71 | 22.22 | 22.22 |
+| scorer-gemini/gemini-3.8-low | en/structure | 13/13 | 0 | 0.00 | 0.00 | 2.56 | 20.00 | 20.00 |
+| scorer-gemini/gemini-3.8-low | en/style | 13/13 | 0 | 0.00 | 0.00 | 1.10 | 14.29 | 14.29 |
+| scorer-gemini/gemini-3.8-low | en/viral-hook | 13/13 | 0 | 0.00 | 0.00 | 0.85 | 11.11 | 11.11 |
+| scorer-gemini/gemini-3.8-low | ko/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-low | ko/content | 12/12 | 0 | 0.00 | 0.00 | 2.31 | 22.20 | 22.20 |
+| scorer-gemini/gemini-3.8-low | ko/filler | 12/12 | 0 | 0.00 | 0.00 | 1.85 | 11.10 | 11.10 |
+| scorer-gemini/gemini-3.8-low | ko/language | 12/12 | 0 | 0.00 | 0.00 | 2.78 | 11.11 | 11.11 |
+| scorer-gemini/gemini-3.8-low | ko/structure | 12/12 | 0 | 0.00 | 0.00 | 6.67 | 20.00 | 20.00 |
+| scorer-gemini/gemini-3.8-low | ko/style | 12/12 | 0 | 0.00 | 0.00 | 4.76 | 14.30 | 14.30 |
+| scorer-gemini/gemini-3.8-low | ko/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-low | zh/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-low | zh/content | 12/12 | 0 | 0.00 | 0.00 | 10.19 | 38.89 | 38.89 |
+| scorer-gemini/gemini-3.8-low | zh/filler | 12/12 | 0 | 0.00 | 0.00 | 11.58 | 55.56 | 55.56 |
+| scorer-gemini/gemini-3.8-low | zh/language | 12/12 | 0 | 0.00 | 0.00 | 14.35 | 61.11 | 61.11 |
+| scorer-gemini/gemini-3.8-low | zh/structure | 12/12 | 0 | 0.00 | 0.00 | 12.22 | 53.33 | 53.33 |
+| scorer-gemini/gemini-3.8-low | zh/style | 12/12 | 0 | 0.00 | 0.00 | 8.93 | 42.86 | 42.86 |
+| scorer-gemini/gemini-3.8-low | zh/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 3.24 | 22.22 | 22.22 |
+| scorer-gemini/gemini-3.8-low | ja/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-low | ja/content | 12/12 | 0 | 0.00 | 0.00 | 10.19 | 55.56 | 55.56 |
+| scorer-gemini/gemini-3.8-low | ja/filler | 12/12 | 0 | 0.00 | 0.00 | 10.18 | 44.44 | 44.44 |
+| scorer-gemini/gemini-3.8-low | ja/language | 12/12 | 0 | 0.00 | 0.00 | 9.26 | 38.89 | 38.89 |
+| scorer-gemini/gemini-3.8-low | ja/structure | 12/12 | 0 | 0.00 | 0.00 | 8.89 | 40.00 | 40.00 |
+| scorer-gemini/gemini-3.8-low | ja/style | 12/12 | 0 | 0.00 | 0.00 | 2.38 | 14.29 | 14.29 |
+| scorer-gemini/gemini-3.8-low | ja/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 1.85 | 22.22 | 22.22 |
+| scorer-gemini/gemini-3.8-medium | en/communication | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-medium | en/content | 13/13 | 0 | 0.00 | 0.00 | 0.85 | 11.11 | 11.11 |
+| scorer-gemini/gemini-3.8-medium | en/filler | 13/13 | 0 | 0.00 | 0.00 | 1.28 | 11.11 | 11.11 |
+| scorer-gemini/gemini-3.8-medium | en/language | 13/13 | 0 | 0.00 | 0.00 | 1.28 | 16.67 | 16.67 |
+| scorer-gemini/gemini-3.8-medium | en/structure | 13/13 | 0 | 0.00 | 0.00 | 2.05 | 13.33 | 13.33 |
+| scorer-gemini/gemini-3.8-medium | en/style | 13/13 | 0 | 0.00 | 0.00 | 1.10 | 14.29 | 14.29 |
+| scorer-gemini/gemini-3.8-medium | en/viral-hook | 13/13 | 0 | 0.00 | 0.00 | 1.28 | 16.67 | 16.67 |
+| scorer-gemini/gemini-3.8-medium | ko/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-medium | ko/content | 12/12 | 0 | 0.00 | 0.00 | 1.85 | 11.11 | 11.11 |
+| scorer-gemini/gemini-3.8-medium | ko/filler | 12/12 | 0 | 0.00 | 0.00 | 0.93 | 5.60 | 5.60 |
+| scorer-gemini/gemini-3.8-medium | ko/language | 12/12 | 0 | 0.00 | 0.00 | 2.78 | 11.11 | 11.11 |
+| scorer-gemini/gemini-3.8-medium | ko/structure | 12/12 | 0 | 0.00 | 0.00 | 6.11 | 20.00 | 20.00 |
+| scorer-gemini/gemini-3.8-medium | ko/style | 12/12 | 0 | 0.00 | 0.00 | 4.77 | 14.30 | 14.30 |
+| scorer-gemini/gemini-3.8-medium | ko/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-medium | zh/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-medium | zh/content | 12/12 | 0 | 0.00 | 0.00 | 5.55 | 44.44 | 44.44 |
+| scorer-gemini/gemini-3.8-medium | zh/filler | 12/12 | 0 | 0.00 | 0.00 | 7.41 | 33.33 | 33.33 |
+| scorer-gemini/gemini-3.8-medium | zh/language | 12/12 | 0 | 0.00 | 0.00 | 7.87 | 44.44 | 44.44 |
+| scorer-gemini/gemini-3.8-medium | zh/structure | 12/12 | 0 | 0.00 | 0.00 | 7.22 | 26.67 | 26.67 |
+| scorer-gemini/gemini-3.8-medium | zh/style | 12/12 | 0 | 0.00 | 0.00 | 6.55 | 28.57 | 28.57 |
+| scorer-gemini/gemini-3.8-medium | zh/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 1.85 | 11.11 | 11.11 |
+| scorer-gemini/gemini-3.8-medium | ja/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-medium | ja/content | 12/12 | 0 | 0.00 | 0.00 | 9.72 | 38.89 | 38.89 |
+| scorer-gemini/gemini-3.8-medium | ja/filler | 12/12 | 0 | 0.00 | 0.00 | 8.79 | 44.40 | 44.40 |
+| scorer-gemini/gemini-3.8-medium | ja/language | 12/12 | 0 | 0.00 | 0.00 | 5.55 | 33.30 | 33.30 |
+| scorer-gemini/gemini-3.8-medium | ja/structure | 12/12 | 0 | 0.00 | 0.00 | 6.67 | 26.70 | 26.70 |
+| scorer-gemini/gemini-3.8-medium | ja/style | 12/12 | 0 | 0.00 | 0.00 | 2.38 | 14.30 | 14.30 |
+| scorer-gemini/gemini-3.8-medium | ja/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 0.93 | 11.11 | 11.11 |
+| scorer-gemini/gemini-3.8-high | en/communication | 13/13 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-high | en/content | 13/13 | 0 | 0.00 | 0.00 | 0.43 | 5.56 | 5.56 |
+| scorer-gemini/gemini-3.8-high | en/filler | 13/13 | 0 | 0.00 | 0.00 | 0.85 | 11.10 | 11.10 |
+| scorer-gemini/gemini-3.8-high | en/language | 13/13 | 0 | 0.00 | 0.00 | 1.28 | 16.70 | 16.70 |
+| scorer-gemini/gemini-3.8-high | en/structure | 13/13 | 0 | 0.00 | 0.00 | 1.54 | 13.30 | 13.30 |
+| scorer-gemini/gemini-3.8-high | en/style | 13/13 | 0 | 0.00 | 0.00 | 1.10 | 14.30 | 14.30 |
+| scorer-gemini/gemini-3.8-high | en/viral-hook | 13/13 | 0 | 0.00 | 0.00 | 0.43 | 5.60 | 5.60 |
+| scorer-gemini/gemini-3.8-high | ko/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-high | ko/content | 12/12 | 0 | 0.00 | 0.00 | 1.85 | 22.20 | 22.20 |
+| scorer-gemini/gemini-3.8-high | ko/filler | 12/12 | 0 | 0.00 | 0.00 | 2.32 | 16.70 | 16.70 |
+| scorer-gemini/gemini-3.8-high | ko/language | 12/12 | 0 | 0.00 | 0.00 | 3.24 | 11.11 | 11.11 |
+| scorer-gemini/gemini-3.8-high | ko/structure | 12/12 | 0 | 0.00 | 0.00 | 6.66 | 33.30 | 33.30 |
+| scorer-gemini/gemini-3.8-high | ko/style | 12/12 | 0 | 0.00 | 0.00 | 4.76 | 14.30 | 14.30 |
+| scorer-gemini/gemini-3.8-high | ko/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-high | zh/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-high | zh/content | 12/12 | 0 | 0.00 | 0.00 | 5.55 | 22.22 | 22.22 |
+| scorer-gemini/gemini-3.8-high | zh/filler | 12/12 | 0 | 0.00 | 0.00 | 6.48 | 27.78 | 27.78 |
+| scorer-gemini/gemini-3.8-high | zh/language | 12/12 | 0 | 0.00 | 0.00 | 6.94 | 33.33 | 33.33 |
+| scorer-gemini/gemini-3.8-high | zh/structure | 12/12 | 0 | 0.00 | 0.00 | 6.11 | 26.67 | 26.67 |
+| scorer-gemini/gemini-3.8-high | zh/style | 12/12 | 0 | 0.00 | 0.00 | 5.95 | 28.57 | 28.57 |
+| scorer-gemini/gemini-3.8-high | zh/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 1.85 | 5.56 | 5.56 |
+| scorer-gemini/gemini-3.8-high | ja/communication | 12/12 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini/gemini-3.8-high | ja/content | 12/12 | 0 | 0.00 | 0.00 | 9.72 | 38.90 | 38.90 |
+| scorer-gemini/gemini-3.8-high | ja/filler | 12/12 | 0 | 0.00 | 0.00 | 7.87 | 33.30 | 33.30 |
+| scorer-gemini/gemini-3.8-high | ja/language | 12/12 | 0 | 0.00 | 0.00 | 7.10 | 38.89 | 38.89 |
+| scorer-gemini/gemini-3.8-high | ja/structure | 12/12 | 0 | 0.00 | 0.00 | 7.22 | 26.70 | 26.70 |
+| scorer-gemini/gemini-3.8-high | ja/style | 12/12 | 0 | 0.00 | 0.00 | 3.57 | 14.30 | 14.30 |
+| scorer-gemini/gemini-3.8-high | ja/viral-hook | 12/12 | 0 | 0.00 | 0.00 | 1.39 | 16.67 | 16.67 |
+| scorer-gemini-low-confirm/gemini-3.8-low | en/communication | 26/26 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini-low-confirm/gemini-3.8-low | en/content | 26/26 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini-low-confirm/gemini-3.8-low | en/filler | 26/26 | 0 | 0.00 | 0.00 | 1.07 | 11.11 | 16.67 |
+| scorer-gemini-low-confirm/gemini-3.8-low | en/language | 26/26 | 0 | 0.00 | 0.00 | 1.28 | 11.11 | 22.22 |
+| scorer-gemini-low-confirm/gemini-3.8-low | en/structure | 26/26 | 0 | 0.00 | 0.00 | 1.54 | 13.33 | 13.33 |
+| scorer-gemini-low-confirm/gemini-3.8-low | en/style | 26/26 | 0 | 0.00 | 0.00 | 1.10 | 14.29 | 14.29 |
+| scorer-gemini-low-confirm/gemini-3.8-low | en/viral-hook | 26/26 | 0 | 0.00 | 0.00 | 0.64 | 5.56 | 11.11 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ko/communication | 24/24 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ko/content | 24/24 | 0 | 0.00 | 0.00 | 2.08 | 11.11 | 11.11 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ko/filler | 24/24 | 0 | 0.00 | 0.00 | 0.93 | 5.56 | 5.60 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ko/language | 24/24 | 0 | 0.00 | 0.00 | 3.47 | 11.11 | 16.67 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ko/structure | 24/24 | 0 | 0.00 | 0.00 | 5.00 | 13.33 | 26.67 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ko/style | 24/24 | 0 | 0.00 | 0.00 | 5.06 | 14.30 | 21.43 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ko/viral-hook | 24/24 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini-low-confirm/gemini-3.8-low | zh/communication | 24/24 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini-low-confirm/gemini-3.8-low | zh/content | 24/24 | 0 | 0.00 | 0.00 | 5.32 | 27.78 | 33.33 |
+| scorer-gemini-low-confirm/gemini-3.8-low | zh/filler | 24/24 | 0 | 0.00 | 0.00 | 9.03 | 38.89 | 50.00 |
+| scorer-gemini-low-confirm/gemini-3.8-low | zh/language | 24/24 | 0 | 0.00 | 0.00 | 8.80 | 38.89 | 55.56 |
+| scorer-gemini-low-confirm/gemini-3.8-low | zh/structure | 24/24 | 0 | 0.00 | 0.00 | 5.83 | 33.33 | 33.33 |
+| scorer-gemini-low-confirm/gemini-3.8-low | zh/style | 24/24 | 0 | 0.00 | 0.00 | 5.36 | 28.57 | 28.57 |
+| scorer-gemini-low-confirm/gemini-3.8-low | zh/viral-hook | 24/24 | 0 | 0.00 | 0.00 | 2.08 | 11.11 | 11.11 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ja/communication | 24/24 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ja/content | 24/24 | 0 | 0.00 | 0.00 | 9.26 | 44.44 | 44.44 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ja/filler | 24/24 | 0 | 0.00 | 0.00 | 8.10 | 38.89 | 50.00 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ja/language | 24/24 | 0 | 0.00 | 0.00 | 7.64 | 33.33 | 33.33 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ja/structure | 24/24 | 0 | 0.00 | 0.00 | 7.50 | 26.67 | 26.67 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ja/style | 24/24 | 0 | 0.00 | 0.00 | 1.79 | 14.29 | 14.29 |
+| scorer-gemini-low-confirm/gemini-3.8-low | ja/viral-hook | 24/24 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini-pro-confirm/gemini-pro | en/communication | 26/26 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini-pro-confirm/gemini-pro | en/content | 26/26 | 0 | 0.00 | 0.00 | 3.42 | 27.78 | 33.33 |
+| scorer-gemini-pro-confirm/gemini-pro | en/filler | 26/26 | 0 | 0.00 | 0.00 | 4.27 | 27.78 | 27.78 |
+| scorer-gemini-pro-confirm/gemini-pro | en/language | 26/26 | 0 | 0.00 | 2.84 | 9.41 | 33.33 | 33.33 |
+| scorer-gemini-pro-confirm/gemini-pro | en/structure | 26/26 | 0 | 0.00 | 0.00 | 8.21 | 33.33 | 46.67 |
+| scorer-gemini-pro-confirm/gemini-pro | en/style | 26/26 | 0 | 0.00 | 0.00 | 1.37 | 14.29 | 14.29 |
+| scorer-gemini-pro-confirm/gemini-pro | en/viral-hook | 26/26 | 0 | 0.00 | 0.00 | 1.92 | 16.67 | 22.22 |
+| scorer-gemini-pro-confirm/gemini-pro | ko/communication | 24/24 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini-pro-confirm/gemini-pro | ko/content | 24/24 | 0 | 0.00 | 0.00 | 5.10 | 27.78 | 27.78 |
+| scorer-gemini-pro-confirm/gemini-pro | ko/filler | 24/24 | 0 | 0.00 | 0.00 | 6.72 | 33.33 | 38.89 |
+| scorer-gemini-pro-confirm/gemini-pro | ko/language | 24/24 | 0 | 0.00 | 0.14 | 7.65 | 27.78 | 33.33 |
+| scorer-gemini-pro-confirm/gemini-pro | ko/structure | 24/24 | 0 | 0.00 | 6.67 | 18.08 | 53.33 | 60.00 |
+| scorer-gemini-pro-confirm/gemini-pro | ko/style | 24/24 | 0 | 0.00 | 3.69 | 8.65 | 28.57 | 28.57 |
+| scorer-gemini-pro-confirm/gemini-pro | ko/viral-hook | 24/24 | 0 | 0.00 | 0.00 | 2.32 | 11.11 | 11.11 |
+| scorer-gemini-pro-confirm/gemini-pro | zh/communication | 24/24 | 0 | 0.00 | 0.00 | 1.04 | 0.00 | 25.00 |
+| scorer-gemini-pro-confirm/gemini-pro | zh/content | 24/24 | 0 | 0.00 | 0.00 | 10.66 | 50.00 | 61.11 |
+| scorer-gemini-pro-confirm/gemini-pro | zh/filler | 24/24 | 0 | 0.00 | 0.00 | 15.31 | 66.67 | 83.33 |
+| scorer-gemini-pro-confirm/gemini-pro | zh/language | 24/24 | 0 | 0.00 | 0.06 | 19.24 | 61.11 | 66.67 |
+| scorer-gemini-pro-confirm/gemini-pro | zh/structure | 24/24 | 0 | 0.00 | 0.17 | 16.69 | 60.00 | 66.67 |
+| scorer-gemini-pro-confirm/gemini-pro | zh/style | 24/24 | 0 | 0.00 | 0.07 | 9.24 | 28.57 | 28.57 |
+| scorer-gemini-pro-confirm/gemini-pro | zh/viral-hook | 24/24 | 0 | 0.00 | 0.00 | 4.87 | 22.22 | 22.22 |
+| scorer-gemini-pro-confirm/gemini-pro | ja/communication | 24/24 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-gemini-pro-confirm/gemini-pro | ja/content | 24/24 | 0 | 0.00 | 0.00 | 13.23 | 66.67 | 66.67 |
+| scorer-gemini-pro-confirm/gemini-pro | ja/filler | 24/24 | 0 | 0.00 | 0.00 | 9.97 | 50.00 | 50.00 |
+| scorer-gemini-pro-confirm/gemini-pro | ja/language | 24/24 | 0 | 0.00 | 0.03 | 11.13 | 44.44 | 50.00 |
+| scorer-gemini-pro-confirm/gemini-pro | ja/structure | 24/24 | 0 | 0.00 | 0.17 | 13.92 | 40.00 | 60.00 |
+| scorer-gemini-pro-confirm/gemini-pro | ja/style | 24/24 | 0 | 0.00 | 0.04 | 5.97 | 28.57 | 28.57 |
+| scorer-gemini-pro-confirm/gemini-pro | ja/viral-hook | 24/24 | 0 | 0.00 | 0.00 | 2.79 | 11.11 | 11.11 |
+| scorer-openai-terra-confirm/openai-terra | en/communication | 26/26 | 0 | 0.00 | 0.00 | 0.96 | 8.30 | 16.70 |
+| scorer-openai-terra-confirm/openai-terra | en/content | 26/26 | 0 | 0.00 | 0.00 | 3.21 | 16.67 | 27.80 |
+| scorer-openai-terra-confirm/openai-terra | en/filler | 26/26 | 0 | 0.00 | 0.00 | 2.57 | 16.70 | 27.80 |
+| scorer-openai-terra-confirm/openai-terra | en/language | 26/26 | 0 | 0.00 | 5.60 | 4.93 | 16.67 | 16.67 |
+| scorer-openai-terra-confirm/openai-terra | en/structure | 26/26 | 0 | 0.00 | 0.00 | 5.12 | 20.00 | 20.00 |
+| scorer-openai-terra-confirm/openai-terra | en/style | 26/26 | 0 | 0.00 | 0.00 | 0.55 | 7.10 | 7.14 |
+| scorer-openai-terra-confirm/openai-terra | en/viral-hook | 26/26 | 0 | 0.00 | 0.00 | 2.79 | 11.11 | 11.11 |
+| scorer-openai-terra-confirm/openai-terra | ko/communication | 24/24 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai-terra-confirm/openai-terra | ko/content | 24/24 | 0 | 0.00 | 0.00 | 6.03 | 16.70 | 22.22 |
+| scorer-openai-terra-confirm/openai-terra | ko/filler | 24/24 | 0 | 0.00 | 0.00 | 2.09 | 11.10 | 11.10 |
+| scorer-openai-terra-confirm/openai-terra | ko/language | 24/24 | 0 | 0.00 | 5.58 | 4.64 | 16.70 | 16.70 |
+| scorer-openai-terra-confirm/openai-terra | ko/structure | 24/24 | 0 | 0.00 | 3.35 | 10.55 | 40.00 | 53.30 |
+| scorer-openai-terra-confirm/openai-terra | ko/style | 24/24 | 0 | 0.00 | 0.00 | 8.33 | 28.60 | 42.90 |
+| scorer-openai-terra-confirm/openai-terra | ko/viral-hook | 24/24 | 0 | 0.00 | 0.00 | 0.93 | 5.60 | 11.10 |
+| scorer-openai-terra-confirm/openai-terra | zh/communication | 24/24 | 0 | 0.00 | 0.00 | 0.70 | 0.00 | 16.70 |
+| scorer-openai-terra-confirm/openai-terra | zh/content | 24/24 | 0 | 0.00 | 0.00 | 9.26 | 33.33 | 44.40 |
+| scorer-openai-terra-confirm/openai-terra | zh/filler | 24/24 | 0 | 0.00 | 0.00 | 8.10 | 33.33 | 38.89 |
+| scorer-openai-terra-confirm/openai-terra | zh/language | 24/24 | 0 | 0.00 | 2.78 | 15.97 | 61.10 | 61.11 |
+| scorer-openai-terra-confirm/openai-terra | zh/structure | 24/24 | 0 | 0.00 | 0.00 | 9.16 | 33.33 | 46.67 |
+| scorer-openai-terra-confirm/openai-terra | zh/style | 24/24 | 0 | 0.00 | 0.00 | 9.53 | 28.60 | 28.60 |
+| scorer-openai-terra-confirm/openai-terra | zh/viral-hook | 24/24 | 0 | 0.00 | 0.00 | 1.39 | 11.10 | 11.11 |
+| scorer-openai-terra-confirm/openai-terra | ja/communication | 24/24 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai-terra-confirm/openai-terra | ja/content | 24/24 | 0 | 0.00 | 0.00 | 13.20 | 50.00 | 55.60 |
+| scorer-openai-terra-confirm/openai-terra | ja/filler | 24/24 | 0 | 0.00 | 0.00 | 6.72 | 27.80 | 38.90 |
+| scorer-openai-terra-confirm/openai-terra | ja/language | 24/24 | 0 | 0.00 | 2.80 | 10.27 | 38.90 | 50.00 |
+| scorer-openai-terra-confirm/openai-terra | ja/structure | 24/24 | 0 | 0.00 | 0.00 | 8.89 | 33.30 | 40.00 |
+| scorer-openai-terra-confirm/openai-terra | ja/style | 24/24 | 0 | 0.00 | 0.00 | 6.85 | 28.60 | 28.60 |
+| scorer-openai-terra-confirm/openai-terra | ja/viral-hook | 24/24 | 0 | 0.00 | 0.00 | 1.16 | 11.10 | 11.10 |
+| scorer-openai-5.5-confirm/openai-5.5 | en/communication | 26/26 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai-5.5-confirm/openai-5.5 | en/content | 26/26 | 0 | 0.00 | 0.00 | 8.55 | 33.30 | 33.30 |
+| scorer-openai-5.5-confirm/openai-5.5 | en/filler | 26/26 | 0 | 0.00 | 0.00 | 4.07 | 33.30 | 38.90 |
+| scorer-openai-5.5-confirm/openai-5.5 | en/language | 26/26 | 0 | 0.00 | 8.35 | 9.83 | 27.80 | 33.30 |
+| scorer-openai-5.5-confirm/openai-5.5 | en/structure | 26/26 | 0 | 0.00 | 6.70 | 7.94 | 20.00 | 20.00 |
+| scorer-openai-5.5-confirm/openai-5.5 | en/style | 26/26 | 0 | 0.00 | 0.00 | 2.19 | 14.30 | 14.30 |
+| scorer-openai-5.5-confirm/openai-5.5 | en/viral-hook | 26/26 | 0 | 0.00 | 0.00 | 3.21 | 11.10 | 27.80 |
+| scorer-openai-5.5-confirm/openai-5.5 | ko/communication | 24/24 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai-5.5-confirm/openai-5.5 | ko/content | 24/24 | 0 | 0.00 | 2.80 | 9.50 | 27.80 | 38.90 |
+| scorer-openai-5.5-confirm/openai-5.5 | ko/filler | 24/24 | 0 | 0.00 | 5.60 | 6.03 | 22.20 | 22.20 |
+| scorer-openai-5.5-confirm/openai-5.5 | ko/language | 24/24 | 0 | 0.00 | 11.10 | 13.65 | 33.30 | 33.30 |
+| scorer-openai-5.5-confirm/openai-5.5 | ko/structure | 24/24 | 0 | 0.00 | 16.65 | 16.95 | 46.70 | 46.70 |
+| scorer-openai-5.5-confirm/openai-5.5 | ko/style | 24/24 | 0 | 0.00 | 7.10 | 13.99 | 42.90 | 42.90 |
+| scorer-openai-5.5-confirm/openai-5.5 | ko/viral-hook | 24/24 | 0 | 0.00 | 0.00 | 1.63 | 5.60 | 11.10 |
+| scorer-openai-5.5-confirm/openai-5.5 | zh/communication | 24/24 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai-5.5-confirm/openai-5.5 | zh/content | 24/24 | 0 | 0.00 | 0.00 | 10.42 | 38.90 | 38.90 |
+| scorer-openai-5.5-confirm/openai-5.5 | zh/filler | 24/24 | 0 | 0.00 | 0.00 | 9.49 | 38.90 | 44.40 |
+| scorer-openai-5.5-confirm/openai-5.5 | zh/language | 24/24 | 0 | 0.00 | 2.78 | 21.45 | 63.00 | 66.70 |
+| scorer-openai-5.5-confirm/openai-5.5 | zh/structure | 24/24 | 0 | 0.00 | 3.33 | 10.83 | 33.30 | 40.00 |
+| scorer-openai-5.5-confirm/openai-5.5 | zh/style | 24/24 | 0 | 0.00 | 0.00 | 10.42 | 28.60 | 28.60 |
+| scorer-openai-5.5-confirm/openai-5.5 | zh/viral-hook | 24/24 | 0 | 0.00 | 0.00 | 2.78 | 11.10 | 11.11 |
+| scorer-openai-5.5-confirm/openai-5.5 | ja/communication | 24/24 | 0 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scorer-openai-5.5-confirm/openai-5.5 | ja/content | 24/24 | 0 | 0.00 | 0.00 | 17.60 | 61.10 | 61.10 |
+| scorer-openai-5.5-confirm/openai-5.5 | ja/filler | 24/24 | 0 | 0.00 | 0.00 | 10.18 | 44.40 | 50.00 |
+| scorer-openai-5.5-confirm/openai-5.5 | ja/language | 24/24 | 0 | 0.00 | 13.90 | 17.60 | 50.00 | 50.00 |
+| scorer-openai-5.5-confirm/openai-5.5 | ja/structure | 24/24 | 0 | 0.00 | 10.00 | 15.56 | 46.70 | 46.70 |
+| scorer-openai-5.5-confirm/openai-5.5 | ja/style | 24/24 | 0 | 0.00 | 0.00 | 5.65 | 14.30 | 21.40 |
+| scorer-openai-5.5-confirm/openai-5.5 | ja/viral-hook | 24/24 | 0 | 0.00 | 0.00 | 3.01 | 22.20 | 22.22 |
+
+## Evidence and identity
+
+| Cohort | Source commit | Original protocol | Rows / calls / transport attempts |
+|---|---|---|---:|
+| A/scorer-openai | `66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c` | `7c79c2edf1b86407a5279eff9dc0f14d02e1e8e24e75b73f1f2a4e3dbc60706a` | 294 / 294 / 294 |
+| A/scorer-gemini | `66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c` | `c175a0f7e1c3495d4b95c0a5f6bd5efb81ceb794c5dda95a58b55ceed1023d2c` | 245 / 245 / 245 |
+| A/scorer-gemini-low-confirm | `66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c` | `94dbaa1798640081212148bbdd484436ffc17eb74dd969eb530c7e3940144755` | 98 / 98 / 98 |
+| A/scorer-gemini-pro-confirm | `66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c` | `980a3d6501f47cafb02a12a3c0c94f1aaf7d5ca3c8583a25207ec9ccef516fda` | 98 / 98 / 98 |
+| C/scorer-openai-terra-confirm | `7de2d0b6d78d905804e8e863392df11d3048265e` | `583b9f6ac3f7e1d7effd6da0ab99abad065cc7f91271bc893f46eccb818936a3` | 98 / 98 / 98 |
+| C/scorer-openai-5.5-confirm | `7de2d0b6d78d905804e8e863392df11d3048265e` | `f07aff116b48a289aa3acaa16934ac4f643a84c94318fd504e37a3f27c0aa502` | 98 / 98 / 98 |
+
+| Candidate | Exact requested and returned model | Transport | Requested reasoning effort |
+|---|---|---|---|
+| openai-astra | `gpt-6-astra` | opencodex | low |
+| openai-sol | `gpt-5.6-sol` | opencodex | low |
+| openai-terra | `gpt-5.6-terra` | opencodex | low |
+| openai-luna | `gpt-5.6-luna` | opencodex | low |
+| openai-5.5 | `gpt-5.5` | opencodex | low |
+| openai-mini | `gpt-5.4-mini` | opencodex | low |
+| gemini-pro | `google-antigravity/gemini-3.1-pro` | opencodex | unspecified |
+| gemini-3.7 | `google-antigravity/gemini-3.7-flash` | opencodex | unspecified |
+| gemini-3.8-low | `google-antigravity/gemini-3.8-flash-low` | opencodex | unspecified |
+| gemini-3.8-medium | `google-antigravity/gemini-3.8-flash-medium` | opencodex | unspecified |
+| gemini-3.8-high | `google-antigravity/gemini-3.8-flash-high` | opencodex | unspecified |
+
+Hashes in the JSON companion cover the source rows, semantics, summary, original protocol document, terminal job record, and private receipt set. Source and fixture bytes were checked against the two pinned commits. A uses legacy directories without `study-protocol.json`; C has that binding. Neither source directory is modified.
+
+The earlier audit (2026-09-05T01:09:19.300Z; SHA-256 `4a0b6c81d8b9195e417571d123164c806b07129924d02d4a36f85d373e061190`) agrees for scorer-openai, scorer-gemini, scorer-gemini-low-confirm. The other matrices were checked independently for this publication.
+
+## Limits and remaining work
+
+- The 49 suspect-zones inputs are curated regression controls (26 expected_hot, 23 expected_not_hot), not authenticated real-world human-vs-AI truth or human preference ratings.
+- No rebaseline corpus was collected in these six datasets. Its runner support is not evidence of a completed rebaseline experiment.
+- A and C retain separate protocol and effective-input hashes. Lexicon fingerprints include absolute paths; different hashes alone do not prove different lexical content. Repeats are the same 49 inputs, not additional independent samples.
+- Resolved configuration and complete deterministic analyses were not archived, only hashed. Protocol IDs are preserved and cross-bound to rows/receipts; they cannot be fully recomputed here. Prompt hashes bind requests but do not independently reconstruct prompt text.
+- Overall and deterministic scalars are source-bound collector observations, not independently replayed production outputs. Receipt schema, raw scores, categories, model metadata, matrix membership, and committed source/fixture bytes are independently checked.
+- Original raw-score validation permits partial packs and does not enforce arithmetic consistency. Reported arithmetic diagnostics do not change original validity or repair model outputs.
+- Model names are exact requested/returned OpenCodex identifiers observed in these calls. Metadata equality does not authenticate upstream model weights, current catalog availability, reasoning execution, or provider-wide reliability.
+- Serial call timing, one initial pass and selected two-repeat cohorts cannot establish a winner, calibrated threshold, or default model. No live score CI gate, cost estimate, rewrite-quality claim, or human label is introduced.
+- Only the six explicitly selected terminal A/C matrices are included. Other study lanes are outside this completed comparison.
+
+## Reproduce offline
+
+From a checkout containing the assembler, with read-only access to the pinned A and C worktrees:
+
+```sh
+node scripts/research/publish-scorer-report.mjs \
+  --source-a /path/to/frozen-A --source-c /path/to/frozen-C \
+  --audit /path/to/patina-model-journal-audit-20260905.json --check
+```
+
+Use `--write` to regenerate only this Markdown file and its JSON companion. Without either flag, the assembler prints a compact validation summary. Bounds reject unexpected matrices, nonterminal receipts, model mismatches, changed sources, symlinks, and oversized input. No provider credentials are read.
+
+The existing opt-in runner is `tests/quality/live-scorer-benchmark.mjs` (`npm run benchmark:scorer:live -- --help`). Its `--manifest`/`--texts` path can collect a separately authorized rebaseline study. This report does not start or imply that study.

--- a/scripts/research/publish-scorer-report.mjs
+++ b/scripts/research/publish-scorer-report.mjs
@@ -1,0 +1,514 @@
+#!/usr/bin/env node
+// Offline, bounded publication of the six completed A/C scorer matrices (#412).
+// Never imports a study runner, transport, credential loader, or live scorer.
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+import { parseStrictJson } from '../../src/json-response.js';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const REPORT = 'docs/benchmarks/live-scorer-20260905';
+const PROTOCOL = 'docs/research/model-evaluation-20260904.json';
+const LANGUAGES = ['en', 'ko', 'zh', 'ja'];
+const PACKS = ['communication', 'content', 'filler', 'language', 'structure', 'style', 'viral-hook'];
+const METRICS = { overall: 'overall', rawLLM: 'raw_overall', deterministic: 'deterministic_overall' };
+const HASH = /^[a-f0-9]{64}$/;
+const MAX_FILE = 8 * 1024 * 1024;
+const MAX_SOURCE = 64 * 1024 * 1024;
+const COMMITS = { A: '66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c', C: '7de2d0b6d78d905804e8e863392df11d3048265e' };
+const SOURCE_FILES = new Set(['.patina.default.yaml', 'package.json',
+  'scripts/research/model-evaluation-transport.mjs', 'scripts/research/model-rewrite-benchmark.mjs',
+  'scripts/research/study-inputs.mjs', 'scripts/research/study-job.mjs', 'scripts/research/study-journal.mjs',
+  'scripts/research/study-validation.mjs', 'tests/quality/live-quality.mjs', 'tests/quality/live-scorer-benchmark.mjs']);
+const MODELS = {
+  'openai-astra': 'gpt-6-astra', 'openai-sol': 'gpt-5.6-sol', 'openai-terra': 'gpt-5.6-terra',
+  'openai-luna': 'gpt-5.6-luna', 'openai-5.5': 'gpt-5.5', 'openai-mini': 'gpt-5.4-mini',
+  'gemini-pro': 'google-antigravity/gemini-3.1-pro', 'gemini-3.7': 'google-antigravity/gemini-3.7-flash',
+  'gemini-3.8-low': 'google-antigravity/gemini-3.8-flash-low',
+  'gemini-3.8-medium': 'google-antigravity/gemini-3.8-flash-medium',
+  'gemini-3.8-high': 'google-antigravity/gemini-3.8-flash-high',
+};
+export const DATASETS = [
+  { source: 'A', id: 'scorer-openai', candidates: Object.keys(MODELS).slice(0, 6), repeat: 1, protocolHash: '7c79c2edf1b86407a5279eff9dc0f14d02e1e8e24e75b73f1f2a4e3dbc60706a' },
+  { source: 'A', id: 'scorer-gemini', candidates: Object.keys(MODELS).slice(6), repeat: 1, protocolHash: 'c175a0f7e1c3495d4b95c0a5f6bd5efb81ceb794c5dda95a58b55ceed1023d2c' },
+  { source: 'A', id: 'scorer-gemini-low-confirm', candidates: ['gemini-3.8-low'], repeat: 2, protocolHash: '94dbaa1798640081212148bbdd484436ffc17eb74dd969eb530c7e3940144755' },
+  { source: 'A', id: 'scorer-gemini-pro-confirm', candidates: ['gemini-pro'], repeat: 2, protocolHash: '980a3d6501f47cafb02a12a3c0c94f1aaf7d5ca3c8583a25207ec9ccef516fda' },
+  { source: 'C', id: 'scorer-openai-terra-confirm', candidates: ['openai-terra'], repeat: 2, protocolHash: '583b9f6ac3f7e1d7effd6da0ab99abad065cc7f91271bc893f46eccb818936a3' },
+  { source: 'C', id: 'scorer-openai-5.5-confirm', candidates: ['openai-5.5'], repeat: 2, protocolHash: 'f07aff116b48a289aa3acaa16934ac4f643a84c94318fd504e37a3f27c0aa502' },
+];
+
+export const sha256 = (value) => createHash('sha256').update(typeof value === 'string' || Buffer.isBuffer(value) ? value : JSON.stringify(value)).digest('hex');
+function requireEvidence(condition, code) { if (!condition) throw new Error(`scorer-report: ${code}`); }
+const object = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+const number = (value, max = 100) => typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= max;
+const integer = (value, max = Number.MAX_SAFE_INTEGER) => Number.isSafeInteger(value) && number(value, max);
+const same = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+const sorted = (values) => [...values].sort();
+const rowKey = (row) => `${row.candidate_id}/${row.fixture_id}/${row.repeat}`;
+const timestamp = (value) => typeof value === 'string' && /^2026-09-0[45]T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value) && Number.isFinite(Date.parse(value));
+
+function readJson(bytes) {
+  try { return JSON.parse(bytes.toString('utf8')); }
+  catch { throw new Error('scorer-report: invalid JSON'); }
+}
+
+// Do not follow symlinks or allow any path supplied by a receipt to escape its root.
+export function createReader(directory) {
+  const root = realpathSync(directory);
+  const cache = new Map();
+  let size = 0;
+  const locate = (path) => {
+    requireEvidence(typeof path === 'string' && /^[a-zA-Z0-9._/-]+$/.test(path)
+      && !path.startsWith('/') && path.split('/').every((part) => part && part !== '.' && part !== '..'), 'unsafe source path');
+    let full = root;
+    for (const part of path.split('/')) {
+      full = resolve(full, part);
+      requireEvidence(!lstatSync(full).isSymbolicLink(), 'source symlink');
+    }
+    return full;
+  };
+  const bytes = (path) => {
+    if (cache.has(path)) return cache.get(path);
+    const full = locate(path); const stat = lstatSync(full);
+    requireEvidence(stat.isFile() && stat.size <= MAX_FILE && size + stat.size <= MAX_SOURCE, 'source size bound');
+    const value = readFileSync(full);
+    requireEvidence(value.length === stat.size, 'source changed during read');
+    size += value.length; cache.set(path, value); return value;
+  };
+  return { root, bytes, json: (path) => readJson(bytes(path)),
+    list: (path) => {
+      const entries = readdirSync(locate(path));
+      requireEvidence(entries.length <= 1000, 'directory entry bound'); return entries.sort();
+    },
+    exists: (path) => existsSync(resolve(root, path)),
+    verifyUnchanged() {
+      for (const [path, value] of cache) {
+        const full = locate(path);
+        requireEvidence(lstatSync(full).size === value.length && sha256(readFileSync(full)) === sha256(value), 'source changed during publication');
+      }
+    },
+  };
+}
+
+function committedFiles(reader, commit, paths) {
+  requireEvidence(execFileSync('git', ['rev-parse', 'HEAD'], { cwd: reader.root, encoding: 'utf8' }).trim() === commit, 'source commit differs');
+  const output = execFileSync('git', ['cat-file', '--batch'], {
+    cwd: reader.root, input: paths.map((path) => `${commit}:${path}\n`).join(''), maxBuffer: MAX_SOURCE,
+  });
+  let position = 0;
+  for (const path of paths) {
+    const end = output.indexOf(10, position);
+    const header = output.subarray(position, end).toString('utf8').match(/^[a-f0-9]{40} blob ([0-9]+)$/);
+    requireEvidence(header, 'missing committed source');
+    const length = Number(header[1]);
+    const content = output.subarray(end + 1, end + 1 + length);
+    requireEvidence(sha256(content) === sha256(reader.bytes(path)), 'source differs from commit');
+    position = end + length + 2;
+  }
+  requireEvidence(position === output.length, 'invalid git source evidence');
+}
+
+function frontmatter(bytes) {
+  const match = bytes.toString('utf8').match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+  requireEvidence(match, 'missing source frontmatter');
+  try { return { meta: yaml.load(match[1]), text: match[2].trim() }; }
+  catch { throw new Error('scorer-report: invalid source frontmatter'); }
+}
+
+function verifySource(reader, spec, semantics) {
+  const files = semantics.semantics;
+  requireEvidence(object(files) && Object.keys(files).length >= 150 && Object.keys(files).length <= 250, 'source manifest bound');
+  for (const [path, hash] of Object.entries(files)) {
+    requireEvidence(SOURCE_FILES.has(path) || /^(src|patterns|core|document-types|lexicon|personas)\/[a-zA-Z0-9/_-]+\.(js|md|json)$/.test(path), 'unexpected source file');
+    requireEvidence(HASH.test(hash) && sha256(reader.bytes(path)) === hash, 'source semantics hash differs');
+  }
+  requireEvidence(files['src/json-response.js'] === sha256(readFileSync(resolve(ROOT, 'src/json-response.js'))), 'response parser semantics differ');
+  requireEvidence(semantics.fixtures?.length === 49, 'fixture matrix bound');
+  const seen = new Set();
+  for (const fixture of semantics.fixtures) {
+    requireEvidence(LANGUAGES.includes(fixture.language) && ['ai', 'natural'].includes(fixture.class)
+      && typeof fixture.expected_hot === 'boolean' && HASH.test(fixture.text_hash)
+      && typeof fixture.id === 'string' && /^[a-z0-9-]+$/.test(fixture.id) && !seen.has(fixture.id)
+      && fixture.source?.startsWith(`tests/fixtures/suspect-zones/${fixture.language}/${fixture.class}/`), 'invalid fixture identity');
+    const source = frontmatter(reader.bytes(fixture.source));
+    requireEvidence(source.meta.fixture_id === fixture.id && source.meta.language === fixture.language
+      && source.meta.expected_hot === fixture.expected_hot && sha256(source.text) === fixture.text_hash, 'fixture provenance differs');
+    seen.add(fixture.id);
+  }
+  committedFiles(reader, COMMITS[spec.source], [...Object.keys(files), PROTOCOL, ...semantics.fixtures.map((fixture) => fixture.source)]);
+  const packs = {};
+  for (const language of LANGUAGES) {
+    const loaded = Object.keys(files).filter((path) => path.startsWith(`patterns/${language}-`) && path.endsWith('.md')).sort().map((path) => {
+      const { meta, text } = frontmatter(reader.bytes(path));
+      return { file: path.slice('patterns/'.length), frontmatter: meta, body: text, isStructure: meta.phase === 'structure', isScoreOnly: meta.score_only === true };
+    });
+    requireEvidence(sha256(loaded) === semantics.effectiveInputs?.patterns?.[language], 'effective pattern catalog differs');
+    packs[language] = Object.fromEntries(loaded.map((pack) => [pack.frontmatter.pack.replace(/^[a-z]{2}-/, ''), Number(pack.frontmatter.patterns)]));
+    requireEvidence(same(sorted(Object.keys(packs[language])), PACKS) && Object.values(packs[language]).every((n) => integer(n, 100) && n > 0), 'unexpected pattern catalog');
+  }
+  const effective = semantics.effectiveInputs;
+  requireEvidence(HASH.test(effective.configuration) && effective.sourceVoice === false, 'invalid effective configuration fingerprint');
+  for (const lang of LANGUAGES) requireEvidence(HASH.test(effective.lexicons?.[lang])
+    && effective.structuralModels?.[lang]?.status === 'absent' && effective.structuralModels[lang].contentHash === null, 'unexpected effective input');
+  return packs;
+}
+
+// Match the collector's original schema without silently strengthening it or
+// accepting an invalid row as a zero. Arithmetic consistency is a separate diagnostic.
+export function checkRawScore(text, packs) {
+  let value;
+  try { value = parseStrictJson(text); } catch { return { valid: false, reason: 'invalid-json' }; }
+  if (!number(value.overall) || !object(value.categories) || !Object.keys(value.categories).length) return { valid: false, reason: 'invalid-score-schema' };
+  for (const [name, category] of Object.entries(value.categories)) {
+    if (!Object.hasOwn(packs, name) || !object(category) || !integer(category.detected, packs[name])
+      || !number(category.sum, Number.MAX_SAFE_INTEGER) || !number(category.max, Number.MAX_SAFE_INTEGER) || category.max === 0 || category.sum > category.max
+      || !number(category.score) || !number(category.weighted)) return { valid: false, reason: 'invalid-score-category' };
+  }
+  return { valid: true, value };
+}
+
+export function distribution(values) {
+  const ordered = values.filter(Number.isFinite).sort((a, b) => a - b);
+  if (!ordered.length) return { n: 0, min: null, median: null, mean: null, p95: null, max: null };
+  const mid = Math.floor(ordered.length / 2);
+  return { n: ordered.length, min: ordered[0], median: ordered.length % 2 ? ordered[mid] : (ordered[mid - 1] + ordered[mid]) / 2,
+    mean: ordered.reduce((sum, value) => sum + value, 0) / ordered.length,
+    p95: ordered[Math.ceil(ordered.length * .95) - 1], max: ordered.at(-1) };
+}
+
+export function summarizeRows(rows) {
+  const valid = rows.filter((row) => row.status === 'ok');
+  return { observed: rows.length, uniqueFixtures: new Set(rows.map((row) => row.fixture_id)).size,
+    valid: valid.length, errors: rows.length - valid.length,
+    availability: { validNumerator: valid.length, observedDenominator: rows.length },
+    scores: Object.fromEntries(Object.entries(METRICS).map(([name, field]) => [name, distribution((name === 'deterministic' ? rows : valid).map((row) => row[field]))])),
+    reconciliation: { changed: valid.filter((row) => row.overall !== row.raw_overall).length, delta: distribution(valid.map((row) => row.overall - row.raw_overall)) },
+  };
+}
+
+function candidateSummary(rows, repeat) {
+  const valid = rows.filter((row) => row.status === 'ok');
+  const byPatternPack = {};
+  for (const language of LANGUAGES) for (const pack of PACKS) {
+    const selected = valid.filter((row) => row.language === language);
+    const values = selected.map((row) => row.categories[pack]?.score).filter(Number.isFinite);
+    byPatternPack[`${language}/${pack}`] = { validRows: selected.length, missing: selected.length - values.length, score: distribution(values) };
+  }
+  const pairs = [];
+  if (repeat === 2) for (const first of rows.filter((row) => row.repeat === 0 && row.status === 'ok')) {
+    const second = rows.find((row) => row.fixture_id === first.fixture_id && row.repeat === 1 && row.status === 'ok');
+    if (second) pairs.push([first, second]);
+  }
+  return { ...summarizeRows(rows), expected: 49 * repeat,
+    byLanguage: Object.fromEntries(LANGUAGES.map((lang) => [lang, summarizeRows(rows.filter((row) => row.language === lang))])),
+    byFixtureControl: Object.fromEntries([true, false].map((expected) => [expected ? 'expected_hot' : 'expected_not_hot', summarizeRows(rows.filter((row) => row.expected_hot === expected))])),
+    byRepeat: Array.from({ length: repeat }, (_, iteration) => ({ repeat: iteration, ...summarizeRows(rows.filter((row) => row.repeat === iteration)) })),
+    byPatternPack,
+    pairedRepeatAbsoluteDifference: repeat === 2 ? { pairs: pairs.length,
+      scores: Object.fromEntries(Object.entries(METRICS).map(([name, field]) => [name, distribution(pairs.map(([a, b]) => Math.abs(a[field] - b[field])))])) } : null,
+  };
+}
+
+function checkCandidate(candidate, id) {
+  requireEvidence(candidate?.id === id && candidate.model === MODELS[id]
+    && candidate.provider === (id.startsWith('openai-') ? 'openai' : 'gemini') && candidate.transport === 'opencodex'
+    && candidate.baseURL === 'http://127.0.0.1:10100/v1' && !candidate.apiKeyEnv
+    && (id.startsWith('openai-') ? candidate.extraBody?.reasoning_effort === 'low' : candidate.extraBody === undefined), 'candidate identity or route differs');
+}
+
+export function verifyMatrix(rows, expectedKeys, fixtures, spec) {
+  requireEvidence(Array.isArray(rows) && rows.length <= 400 && fixtures.length === 49, 'matrix size bound');
+  const expected = spec.candidates.flatMap((id) => Array.from({ length: spec.repeat }, (_, iteration) => fixtures.map((fixture) => `${id}/${fixture.id}/${iteration}`)).flat());
+  requireEvidence(Array.isArray(expectedKeys) && same(sorted(expectedKeys), sorted(expected)), 'declared matrix differs');
+  requireEvidence(same(sorted(rows.map(rowKey)), sorted(expected)), 'missing, duplicate, or unexpected row');
+  for (const row of rows) {
+    const fixture = fixtures.find((item) => item.id === row.fixture_id);
+    requireEvidence(row.schemaVersion === 1 && row.protocol_hash === spec.protocolHash && row.requested_model === MODELS[row.candidate_id]
+      && row.provider === (row.candidate_id.startsWith('openai-') ? 'openai' : 'gemini') && row.transport === 'opencodex'
+      && ['ok', 'error'].includes(row.status) && integer(row.repeat, spec.repeat - 1), 'row identity or protocol differs');
+    for (const field of ['text_hash', 'language', 'class', 'expected_hot', 'source', 'register']) requireEvidence(row[field] === fixture[field], 'row fixture identity differs');
+    requireEvidence(number(row.deterministic_overall) || row.deterministic_overall === null, 'invalid deterministic score');
+    requireEvidence(Array.isArray(row.calls) && row.calls.length >= 1 && row.calls.length <= 2, 'call count bound');
+    if (row.status === 'ok') requireEvidence(number(row.overall) && number(row.raw_overall) && row.raw_overall === row.llm_overall && row.error === null
+      && row.overall >= row.raw_overall && row.overall <= Math.max(row.raw_overall, row.deterministic_overall ?? row.raw_overall), 'invalid successful score');
+    else requireEvidence(row.overall === null && row.raw_overall === null && object(row.categories) && !Object.keys(row.categories).length, 'error score must remain missing');
+  }
+}
+
+export function verifyReceipt(receipt, call, { candidate, logicalId, index, packs }) {
+  requireEvidence(receipt.schemaVersion === 1 && ['completed', 'error'].includes(receipt.state)
+    && HASH.test(receipt.promptHash) && HASH.test(receipt.requestHash) && number(receipt.temperature, 2), 'nonterminal or invalid receipt');
+  const request = { logicalId, index, candidate, promptHash: receipt.promptHash, temperature: receipt.temperature, responseFormat: null, extraBody: null };
+  requireEvidence(sha256(request) === receipt.requestHash, 'receipt request binding differs');
+  requireEvidence(call.temperature === receipt.temperature && call.temperature_control === 'requested', 'temperature evidence differs');
+  requireEvidence(Array.isArray(receipt.transportAttempts) && receipt.transportAttempts.length <= 8, 'transport attempt bound');
+  const attempts = receipt.transportAttempts;
+  requireEvidence(call.attempts === attempts.length && call.transportAttempts?.length === attempts.length && !call.notStarted, 'attempt denominator differs');
+  for (let i = 0; i < attempts.length; i++) {
+    const attempt = attempts[i];
+    requireEvidence(attempt.attemptIndex === i + 1 && attempt.requestedModel === candidate.model
+      && ['success', 'error'].includes(attempt.outcome) && attempt.outcome === call.transportAttempts[i].outcome, 'attempt metadata differs');
+    if (attempt.outcome === 'success') requireEvidence(attempt.effectiveModel === candidate.model, 'attempt model identity differs');
+  }
+  if (receipt.state === 'error') {
+    requireEvidence(call.status === 'error' && call.schema_valid === null, 'transport failure metadata differs');
+    return { valid: false, reason: 'transport-error', attempts: attempts.length };
+  }
+  const response = receipt.response;
+  requireEvidence(object(response) && typeof response.text === 'string' && response.text.length <= 200_000
+    && Array.isArray(response.effectiveModels) && response.effectiveModels.length > 0
+    && response.effectiveModels.every((model) => model === candidate.model)
+    && same(call.effectiveModels, response.effectiveModels) && call.modelIdentityVerified === true && call.mixedOrUnexpectedModel === false
+    && call.status === 'ok' && response.attempts === attempts.length && call.durationMs === response.durationMs
+    && number(response.durationMs, 3_600_000), 'response model identity or metadata differs');
+  const checked = checkRawScore(response.text, packs);
+  requireEvidence(receipt.schemaValid === checked.valid && call.schema_valid === checked.valid, 'receipt schema evidence differs');
+  return { ...checked, attempts: attempts.length };
+}
+
+export function verifyDataset(reader, spec) {
+  const base = `artifacts/model-evaluation-${spec.source === 'A' ? '20260904' : '20260905'}/validated`;
+  const directory = `${base}/${spec.id}`;
+  requireEvidence(!reader.exists(`${directory}/.writer.lock`), 'dataset writer is active');
+  const summary = reader.json(`${directory}/scorer-summary.json`);
+  const semantics = reader.json(`${directory}/semantics.json`);
+  const job = reader.json(`${base}/jobs/${spec.id}/job.json`);
+  requireEvidence(summary.protocolHash === spec.protocolHash && semantics.protocolHash === spec.protocolHash, 'original protocol differs');
+  requireEvidence(job.schemaVersion === 1 && job.state === 'completed' && job.exitCode === 0 && job.signal === null
+    && timestamp(job.startedAt) && timestamp(job.endedAt) && Date.parse(job.endedAt) >= Date.parse(job.startedAt), 'job is not terminal');
+  const args = job.args;
+  requireEvidence(Array.isArray(args) && args.length <= 12 && args.includes('--live')
+    && args[args.indexOf('--candidates') + 1] === PROTOCOL && args[args.indexOf('--output') + 1] === directory
+    && (spec.repeat === 2 ? args[args.indexOf('--repeat') + 1] === '2' && args[args.indexOf('--candidate') + 1] === spec.candidates[0]
+      : args[args.indexOf('--provider') + 1] === (spec.id === 'scorer-openai' ? 'openai' : 'gemini'))
+    && !args.includes('--manifest') && !args.includes('--texts') && !args.includes('--limit'), 'terminal job selection differs');
+  const packs = verifySource(reader, spec, semantics);
+  const protocol = reader.json(PROTOCOL);
+  requireEvidence(protocol.study === 'patina-model-evaluation-20260904', 'study identifier differs');
+  const candidates = spec.candidates.map((id) => {
+    const matching = protocol.candidates.filter((row) => row.id === id);
+    requireEvidence(matching.length === 1, 'candidate is missing or duplicated');
+    checkCandidate(matching[0], id); return matching[0];
+  });
+  let rows;
+  try { rows = reader.bytes(`${directory}/scorer-rows.jsonl`).toString('utf8').split(/\r?\n/).filter((line) => line.trim()).map(JSON.parse); }
+  catch { throw new Error('scorer-report: invalid row JSON'); }
+  verifyMatrix(rows, summary.expectedKeys, semantics.fixtures, spec);
+  const bound = reader.exists(`${directory}/study-protocol.json`);
+  if (bound) {
+    const binding = reader.json(`${directory}/study-protocol.json`);
+    requireEvidence(binding.schemaVersion === 1 && binding.protocolHash === spec.protocolHash, 'directory protocol binding differs');
+  }
+  requireEvidence(spec.source !== 'C' || bound, 'missing C directory protocol binding');
+  const groups = rows.map((row) => sha256(`${spec.protocolHash}/${rowKey(row)}/score`));
+  requireEvidence(same(sorted(groups), reader.list(`${directory}/calls`)), 'receipt group matrix differs');
+  const receiptManifest = [];
+  const errorCounts = { 'invalid-json': 0, 'invalid-score-schema': 0, 'invalid-score-category': 0, 'transport-error': 0 };
+  let transportAttempts = 0; let schemaFailures = 0; let identityVerified = 0;
+  let arithmeticMismatches = 0; let weightedSumMismatches = 0;
+  for (const row of rows) {
+    const logicalId = `${spec.protocolHash}/${rowKey(row)}/score`;
+    const group = sha256(logicalId);
+    const names = Array.from({ length: row.calls.length }, (_, i) => `${i + 1}.private.json`);
+    requireEvidence(same(reader.list(`${directory}/calls/${group}`), names), 'receipt sequence differs');
+    const candidate = candidates.find((item) => item.id === row.candidate_id);
+    const checked = [];
+    for (let i = 0; i < names.length; i++) {
+      const path = `${directory}/calls/${group}/${names[i]}`;
+      const receipt = reader.json(path);
+      requireEvidence(timestamp(receipt.startedAt) && timestamp(receipt.endedAt) && timestamp(row.recorded_at)
+        && Date.parse(receipt.startedAt) >= Date.parse(job.startedAt)
+        && Date.parse(receipt.endedAt) >= Date.parse(receipt.startedAt)
+        && Date.parse(row.recorded_at) >= Date.parse(receipt.endedAt)
+        && Date.parse(row.recorded_at) <= Date.parse(job.endedAt), 'receipt time bounds differ');
+      const result = verifyReceipt(receipt, row.calls[i], { candidate, logicalId, index: i + 1, packs: packs[row.language] });
+      checked.push(result); transportAttempts += result.attempts;
+      if (receipt.state === 'completed') identityVerified++;
+      if (receipt.schemaValid === false) schemaFailures++;
+      receiptManifest.push({ group, index: i + 1, sha256: sha256(reader.bytes(path)), requestHash: receipt.requestHash, promptHash: receipt.promptHash });
+    }
+    requireEvidence(number(row.duration_ms, 7_200_000) && row.duration_ms === row.calls.reduce((sum, call) => sum + call.durationMs, 0), 'row duration differs from receipts');
+    const last = checked.at(-1);
+    requireEvidence(row.schema_failures === row.calls.filter((call) => call.schema_valid === false).length, 'schema failure count differs');
+    requireEvidence(row.status === (last.valid ? 'ok' : 'error'), 'row validity differs from receipts');
+    if (!last.valid) { errorCounts[last.reason]++; continue; }
+    requireEvidence(row.raw_overall === last.value.overall, 'raw score differs from receipt');
+    requireEvidence(same(sorted(Object.keys(row.categories)), sorted(Object.keys(last.value.categories))), 'category keys differ from receipt');
+    for (const [pack, category] of Object.entries(last.value.categories)) {
+      for (const field of ['detected', 'sum', 'max', 'score', 'weighted']) requireEvidence(row.categories[pack][field] === category[field], 'category score differs from receipt');
+      if (Math.abs(category.score - 100 * category.sum / category.max) > .11) arithmeticMismatches++;
+    }
+    if (Math.abs(Object.values(last.value.categories).reduce((sum, category) => sum + category.weighted, 0) - row.raw_overall) > .11) weightedSumMismatches++;
+  }
+  receiptManifest.sort((a, b) => a.group.localeCompare(b.group) || a.index - b.index);
+  for (const candidate of candidates) {
+    const selected = rows.filter((row) => row.candidate_id === candidate.id);
+    const actual = summarizeRows(selected); const prior = summary.summary?.[candidate.id];
+    requireEvidence(prior?.total === actual.observed && prior?.valid === actual.valid && prior?.errors === actual.errors
+      && same(prior.overall, actual.scores.overall), 'collector summary differs from rows');
+  }
+  const artifactPaths = [`${directory}/scorer-rows.jsonl`, `${directory}/scorer-summary.json`, `${directory}/semantics.json`, `${base}/jobs/${spec.id}/job.json`, PROTOCOL];
+  if (bound) artifactPaths.push(`${directory}/study-protocol.json`);
+  return { id: spec.id, source: spec.source, sourceCommit: COMMITS[spec.source], study: protocol.study,
+    protocolHash: spec.protocolHash, repeat: spec.repeat, uniqueFixtures: 49,
+    collection: { state: 'completed', startedAt: job.startedAt, endedAt: job.endedAt,
+      expected: summary.expectedKeys.length, observed: rows.length, valid: rows.filter((row) => row.status === 'ok').length,
+      errors: rows.filter((row) => row.status === 'error').length, missing: 0, calls: receiptManifest.length, transportAttempts, identityVerifiedResponses: identityVerified, schemaFailures, errorCounts },
+    provenance: { artifacts: Object.fromEntries(artifactPaths.map((path) => [path, sha256(reader.bytes(path))])),
+      semanticsSha256: sha256(semantics.semantics), effectiveInputs: {
+        configuration: semantics.effectiveInputs.configuration, sourceVoice: false,
+        patterns: Object.fromEntries(LANGUAGES.map((lang) => [lang, semantics.effectiveInputs.patterns[lang]])),
+        lexicons: Object.fromEntries(LANGUAGES.map((lang) => [lang, semantics.effectiveInputs.lexicons[lang]])),
+        structuralModels: Object.fromEntries(LANGUAGES.map((lang) => [lang, { status: 'absent', contentHash: null }])),
+      },
+      fixtureIdentitySha256: sha256(semantics.fixtures), expectedKeysSha256: sha256(summary.expectedKeys),
+      receiptManifestSha256: sha256(receiptManifest), receiptCount: receiptManifest.length,
+      requestHashesSha256: sha256(sorted(receiptManifest.map((receipt) => receipt.requestHash))),
+      promptHashesSha256: sha256(sorted(receiptManifest.map((receipt) => receipt.promptHash))),
+      sourceFilesVerifiedAgainstCommit: Object.keys(semantics.semantics).length,
+      scorerSha256: semantics.semantics['src/scoring.js'], parserSha256: semantics.semantics['src/json-response.js'],
+      patternCatalog: packs, directoryProtocolBinding: bound ? 'present' : 'legacy-absent',
+      protocolRecomputed: false, fullScorerReplay: false },
+    diagnostics: { categoryArithmeticMismatches: arithmeticMismatches, overallWeightedSumMismatches: weightedSumMismatches, arithmeticTolerance: .11 },
+    candidates: candidates.map((candidate) => ({ id: candidate.id, provider: candidate.provider, transport: candidate.transport,
+      requestedModel: candidate.model, responseModel: candidate.model, identityEvidence: 'OpenCodex response metadata; not upstream attestation',
+      requestedReasoningEffort: candidate.extraBody?.reasoning_effort ?? null,
+      ...candidateSummary(rows.filter((row) => row.candidate_id === candidate.id), spec.repeat) })),
+  };
+}
+
+export function assembleReport({ sourceA, sourceC, audit }) {
+  const readers = { A: createReader(sourceA), C: createReader(sourceC) };
+  const datasets = DATASETS.map((spec) => verifyDataset(readers[spec.source], spec));
+  const fixtureHash = datasets[0].provenance.fixtureIdentitySha256;
+  requireEvidence(datasets.every((dataset) => dataset.provenance.fixtureIdentitySha256 === fixtureHash), 'cross-cohort fixture identities differ');
+  let priorAudit = null;
+  if (audit) {
+    const reader = createReader(dirname(resolve(audit)));
+    const path = resolve(audit).slice(reader.root.length + 1);
+    const bytes = reader.bytes(path); const value = readJson(bytes);
+    requireEvidence(value.sourceCommit === COMMITS.A && timestamp(value.checkedAt), 'prior audit identity differs');
+    const covered = datasets.filter((dataset) => value.datasets?.some((entry) => entry.dataset === dataset.id));
+    for (const dataset of covered) {
+      const entry = value.datasets.find((item) => item.dataset === dataset.id);
+      requireEvidence(entry.protocolHash === dataset.protocolHash && entry.rows === dataset.collection.observed
+        && entry.receipts === dataset.collection.calls && entry.recordedTransportAttempts === dataset.collection.transportAttempts
+        && entry.receiptAudit === 'passed' && Array.isArray(entry.anomalies) && entry.anomalies.length === 0, 'prior audit contradicts independent checks');
+    }
+    priorAudit = { sha256: sha256(bytes), checkedAt: value.checkedAt, sourceCommit: value.sourceCommit, coveredDatasets: covered.map((dataset) => dataset.id) };
+    reader.verifyUnchanged();
+  }
+  for (const reader of Object.values(readers)) reader.verifyUnchanged();
+  return { schemaVersion: 1, reportDate: '2026-09-05', timezone: 'Asia/Seoul', issue: 412,
+    status: 'completed-fixture-diagnostics; rebaseline-evidence-missing',
+    scope: 'src/scoring.js scoreText AI-likeness diagnostics; not rewrite quality or authenticated authorship accuracy',
+    totals: { datasets: datasets.length, candidates: new Set(datasets.flatMap((dataset) => dataset.candidates.map((candidate) => candidate.id))).size,
+      uniqueFixtures: 49, observed: datasets.reduce((n, dataset) => n + dataset.collection.observed, 0),
+      valid: datasets.reduce((n, dataset) => n + dataset.collection.valid, 0), errors: datasets.reduce((n, dataset) => n + dataset.collection.errors, 0) },
+    metricDefinitions: { overall: 'Recorded production scoreText overall, after deterministic reconciliation; valid rows only.',
+      rawLLM: 'Receipt-validated raw_overall; equals llm_overall on valid rows. Invalid schema values are excluded.',
+      deterministic: 'Recorded deterministic_overall on all observed rows, including scorer errors. No recomputation from hash-only resolved inputs.',
+      patternPack: 'Recorded category.score; omissions counted, never filled with zero. A pack score is not an individual pattern accuracy.',
+      distribution: 'Finite values only; median averages the middle pair; p95 is nearest-rank ceil(0.95*n); unrounded JSON statistics.',
+      receiptManifest: 'SHA-256 of JSON.stringify(sorted [{group,index,sha256,requestHash,promptHash}]); group = SHA-256(originalProtocol/candidate/fixture/repeat/score). File sha256 covers original bytes. Sort by group then index. Request/prompt commitments hash sorted original hash arrays, including duplicates.' },
+    limitations: [
+      'The 49 suspect-zones inputs are curated regression controls (26 expected_hot, 23 expected_not_hot), not authenticated real-world human-vs-AI truth or human preference ratings.',
+      'No rebaseline corpus was collected in these six datasets. Its runner support is not evidence of a completed rebaseline experiment.',
+      'A and C retain separate protocol and effective-input hashes. Lexicon fingerprints include absolute paths; different hashes alone do not prove different lexical content. Repeats are the same 49 inputs, not additional independent samples.',
+      'Resolved configuration and complete deterministic analyses were not archived, only hashed. Protocol IDs are preserved and cross-bound to rows/receipts; they cannot be fully recomputed here. Prompt hashes bind requests but do not independently reconstruct prompt text.',
+      'Overall and deterministic scalars are source-bound collector observations, not independently replayed production outputs. Receipt schema, raw scores, categories, model metadata, matrix membership, and committed source/fixture bytes are independently checked.',
+      'Original raw-score validation permits partial packs and does not enforce arithmetic consistency. Reported arithmetic diagnostics do not change original validity or repair model outputs.',
+      'Model names are exact requested/returned OpenCodex identifiers observed in these calls. Metadata equality does not authenticate upstream model weights, current catalog availability, reasoning execution, or provider-wide reliability.',
+      'Serial call timing, one initial pass and selected two-repeat cohorts cannot establish a winner, calibrated threshold, or default model. No live score CI gate, cost estimate, rewrite-quality claim, or human label is introduced.',
+      'Only the six explicitly selected terminal A/C matrices are included. Other study lanes are outside this completed comparison.',
+    ],
+    acceptance: { supported: ['opt-in production scorer fixture collection', 'per-language and per-pattern-pack distributions', 'explicit validity and availability denominators', 'diagnostics without a CI score gate'],
+      gaps: ['completed rebaseline corpus measurements', 'resolved configuration and deterministic analysis snapshots for full offline replay'],
+      closure: 'Partial evidence for #412. The fixture diagnostic deliverable is complete; do not claim its rebaseline scope is complete.' },
+    priorAudit, datasets };
+}
+
+const format = (value) => Number.isFinite(value) ? value.toFixed(2) : 'N/A';
+export function renderReport(report) {
+  const lines = ['# Live scorer diagnostics — September 5, 2026', '',
+    `${report.totals.valid}/${report.totals.observed} valid rows across ${report.totals.datasets} completed matrices, ${report.totals.candidates} observed model identifiers, and 49 unique regression fixtures.`, '',
+    report.acceptance.closure, '',
+    'The production `src/scoring.js` `scoreText` path was used by the opt-in collector. This publication reads completed artifacts offline. It makes no provider calls.', '',
+    '## Reading the results', '',
+    ...Object.entries(report.metricDefinitions).filter(([key]) => key !== 'receiptManifest').map(([key, value]) => `- **${key}:** ${value}`), '',
+    'Scores range from 0 to 100; larger values mean more detected writing patterns. A candidate mean is not a measure of scorer quality.', '',
+    'The JSON companion preserves full-precision distributions, per-repeat and fixture-control slices, paired repeat differences, original protocol IDs, and source/receipt integrity commitments. All model names below are observed OpenCodex identifiers.', '',
+    '## Validity and score distributions', '',
+    '| Cohort | Candidate | Valid / expected | Errors | Overall median / mean | Raw LLM median / mean | Deterministic n / mean | Adjusted rows |',
+    '|---|---|---:|---:|---:|---:|---:|---:|'];
+  for (const dataset of report.datasets) for (const candidate of dataset.candidates) {
+    const scores = candidate.scores;
+    lines.push(`| ${dataset.source}/${dataset.id} | ${candidate.id} | ${candidate.valid}/${candidate.expected} | ${candidate.errors} | ${format(scores.overall.median)} / ${format(scores.overall.mean)} | ${format(scores.rawLLM.median)} / ${format(scores.rawLLM.mean)} | ${scores.deterministic.n} / ${format(scores.deterministic.mean)} | ${candidate.reconciliation.changed} |`);
+  }
+  lines.push('', '## Errors and arithmetic diagnostics', '',
+    'Validity uses the original collector schema. The arithmetic checks count category scores differing from `100 × sum / max`, and overall scores differing from the sum of category weights, by more than 0.11 points. They do not reclassify valid rows. These are diagnostic counts, not model rankings.', '',
+    '| Cohort | Schema-failed rows | Transport-failed rows | Category arithmetic mismatches | Overall weighted-sum mismatches |', '|---|---:|---:|---:|---:|');
+  for (const dataset of report.datasets) lines.push(`| ${dataset.id} | ${dataset.collection.errors - dataset.collection.errorCounts['transport-error']} | ${dataset.collection.errorCounts['transport-error']} | ${dataset.diagnostics.categoryArithmeticMismatches} | ${dataset.diagnostics.overallWeightedSumMismatches} |`);
+  lines.push('', '## Language distributions', '', '| Cohort / candidate | Language | Valid / observed | Overall n / mean / median / p95 | Raw LLM n / mean / median / p95 | Deterministic n / mean / median / p95 |', '|---|---|---:|---:|---:|---:|');
+  const compact = (d) => `${d.n} / ${format(d.mean)} / ${format(d.median)} / ${format(d.p95)}`;
+  for (const dataset of report.datasets) for (const candidate of dataset.candidates) for (const [lang, slice] of Object.entries(candidate.byLanguage)) {
+    lines.push(`| ${dataset.id}/${candidate.id} | ${lang} | ${slice.valid}/${slice.observed} | ${compact(slice.scores.overall)} | ${compact(slice.scores.rawLLM)} | ${compact(slice.scores.deterministic)} |`);
+  }
+  lines.push('', '## Pattern-pack distributions', '', 'Each value is the category score from a valid response. Missing packs remain missing. Repeated rows do not increase the unique fixture count.', '',
+    '| Cohort / candidate | Language / pack | n / valid rows | Missing | Min | Median | Mean | p95 | Max |', '|---|---|---:|---:|---:|---:|---:|---:|---:|');
+  for (const dataset of report.datasets) for (const candidate of dataset.candidates) for (const [pack, slice] of Object.entries(candidate.byPatternPack)) {
+    const d = slice.score;
+    lines.push(`| ${dataset.id}/${candidate.id} | ${pack} | ${d.n}/${slice.validRows} | ${slice.missing} | ${format(d.min)} | ${format(d.median)} | ${format(d.mean)} | ${format(d.p95)} | ${format(d.max)} |`);
+  }
+  lines.push('', '## Evidence and identity', '', '| Cohort | Source commit | Original protocol | Rows / calls / transport attempts |', '|---|---|---|---:|');
+  for (const dataset of report.datasets) lines.push(`| ${dataset.source}/${dataset.id} | \`${dataset.sourceCommit}\` | \`${dataset.protocolHash}\` | ${dataset.collection.observed} / ${dataset.collection.calls} / ${dataset.collection.transportAttempts} |`);
+  lines.push('', '| Candidate | Exact requested and returned model | Transport | Requested reasoning effort |', '|---|---|---|---|');
+  const seen = new Set();
+  for (const dataset of report.datasets) for (const candidate of dataset.candidates) if (!seen.has(candidate.id)) {
+    seen.add(candidate.id); lines.push(`| ${candidate.id} | \`${candidate.requestedModel}\` | ${candidate.transport} | ${candidate.requestedReasoningEffort ?? 'unspecified'} |`);
+  }
+  lines.push('', 'Hashes in the JSON companion cover the source rows, semantics, summary, original protocol document, terminal job record, and private receipt set. Source and fixture bytes were checked against the two pinned commits. A uses legacy directories without `study-protocol.json`; C has that binding. Neither source directory is modified.', '',
+    report.priorAudit ? `The earlier audit (${report.priorAudit.checkedAt}; SHA-256 \`${report.priorAudit.sha256}\`) agrees for ${report.priorAudit.coveredDatasets.join(', ')}. The other matrices were checked independently for this publication.` : 'No earlier external audit was supplied.', '',
+    '## Limits and remaining work', '', ...report.limitations.map((item) => `- ${item}`), '',
+    '## Reproduce offline', '', 'From a checkout containing the assembler, with read-only access to the pinned A and C worktrees:', '',
+    '```sh', 'node scripts/research/publish-scorer-report.mjs \\', '  --source-a /path/to/frozen-A --source-c /path/to/frozen-C \\', '  --audit /path/to/patina-model-journal-audit-20260905.json --check', '```', '',
+    'Use `--write` to regenerate only this Markdown file and its JSON companion. Without either flag, the assembler prints a compact validation summary. Bounds reject unexpected matrices, nonterminal receipts, model mismatches, changed sources, symlinks, and oversized input. No provider credentials are read.', '',
+    'The existing opt-in runner is `tests/quality/live-scorer-benchmark.mjs` (`npm run benchmark:scorer:live -- --help`). Its `--manifest`/`--texts` path can collect a separately authorized rebaseline study. This report does not start or imply that study.', '');
+  return lines.join('\n');
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const options = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help') { console.log('publish-scorer-report --source-a DIR --source-c DIR [--audit FILE] [--write | --check] (offline only)'); return; }
+    if (['--write', '--check'].includes(arg)) options[arg.slice(2)] = true;
+    else if (['--source-a', '--source-c', '--audit'].includes(arg) && argv[i + 1] && !argv[i + 1].startsWith('--')) options[arg.slice(2)] = argv[++i];
+    else throw new Error('scorer-report: invalid argument');
+  }
+  requireEvidence(options['source-a'] && options['source-c'] && !(options.write && options.check), 'required sources or conflicting mode');
+  const report = assembleReport({ sourceA: options['source-a'], sourceC: options['source-c'], audit: options.audit });
+  const outputs = { [`${REPORT}.json`]: `${JSON.stringify(report, null, 2)}\n`, [`${REPORT}.md`]: renderReport(report) };
+  for (const [path, content] of Object.entries(outputs)) {
+    const destination = resolve(ROOT, path);
+    if (options.check) requireEvidence(existsSync(destination) && readFileSync(destination, 'utf8') === content, 'published report differs');
+    if (options.write) {
+      createReader(ROOT).list('docs/benchmarks');
+      requireEvidence(!existsSync(destination) || !lstatSync(destination).isSymbolicLink(), 'output symlink');
+      mkdirSync(dirname(destination), { recursive: true }); writeFileSync(destination, content);
+    }
+  }
+  console.log(JSON.stringify({ status: report.status, ...report.totals, written: options.write === true, checked: options.check === true }));
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try { main(); }
+  catch (error) {
+    // Never echo a path, parser excerpt, receipt, or provider error to public logs.
+    console.error(error.message?.startsWith('scorer-report: ') ? error.message : 'scorer-report: input verification failed');
+    process.exitCode = 1;
+  }
+}

--- a/tests/unit/scorer-public-report.test.js
+++ b/tests/unit/scorer-public-report.test.js
@@ -1,0 +1,227 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, truncateSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DATASETS, checkRawScore, createReader, distribution, main, renderReport, sha256, summarizeRows, verifyMatrix, verifyReceipt } from '../../scripts/research/publish-scorer-report.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const publicJson = resolve(ROOT, 'docs/benchmarks/live-scorer-20260905.json');
+const publicMarkdown = resolve(ROOT, 'docs/benchmarks/live-scorer-20260905.md');
+const clone = (value) => JSON.parse(JSON.stringify(value));
+// Synthetic verification cases below are not experimental measurements.
+const candidate = { id: 'openai-astra', provider: 'openai', transport: 'opencodex',
+  baseURL: 'http://127.0.0.1:10100/v1', model: 'gpt-6-astra', extraBody: { reasoning_effort: 'low' } };
+const category = { detected: 0, sum: 0, max: 18, score: 0, weighted: 0 };
+const raw = { overall: 0, categories: { content: category }, interpretation: 'test-only' };
+
+function receiptCase(value = raw, valid = true) {
+  const binding = { candidate, logicalId: 'synthetic-test/fixture/0/score', index: 1, packs: { content: 6 } };
+  const receipt = { schemaVersion: 1, state: 'completed', promptHash: sha256('synthetic prompt'), temperature: .1,
+    transportAttempts: [{ attemptIndex: 1, requestedModel: candidate.model, effectiveModel: candidate.model, outcome: 'success' }],
+    response: { text: JSON.stringify(value), effectiveModels: [candidate.model], attempts: 1, durationMs: 10 }, schemaValid: valid };
+  receipt.requestHash = sha256({ logicalId: binding.logicalId, index: 1, candidate, promptHash: receipt.promptHash,
+    temperature: .1, responseFormat: null, extraBody: null });
+  const call = { temperature: .1, temperature_control: 'requested', attempts: 1, notStarted: false,
+    transportAttempts: [{ outcome: 'success' }], effectiveModels: [candidate.model], modelIdentityVerified: true,
+    mixedOrUnexpectedModel: false, status: 'ok', durationMs: 10, schema_valid: valid };
+  return { receipt, call, binding };
+}
+
+function matrixCase() {
+  const spec = { ...DATASETS[0], candidates: [candidate.id] };
+  const fixtures = Array.from({ length: 49 }, (_, i) => ({ id: `test-${i}`, text_hash: sha256(`fixture-${i}`), language: 'en',
+    class: i % 2 ? 'ai' : 'natural', expected_hot: Boolean(i % 2), source: `tests/fixtures/suspect-zones/en/test-${i}.md`, register: 'unspecified' }));
+  const rows = fixtures.map((fixture) => ({ ...fixture, fixture_id: fixture.id, schemaVersion: 1, protocol_hash: spec.protocolHash,
+    requested_model: candidate.model, candidate_id: candidate.id, provider: 'openai', transport: 'opencodex',
+    status: 'ok', repeat: 0, deterministic_overall: 25, overall: 0, raw_overall: 0, llm_overall: 0, error: null,
+    calls: [receiptCase().call], categories: { content: category } }));
+  const expected = rows.map((row) => `${row.candidate_id}/${row.fixture_id}/${row.repeat}`);
+  return { spec, fixtures, rows, expected };
+}
+
+test('statistics retain zero, exclude missing values, and use nearest-rank p95', () => {
+  assert.deepEqual(distribution([null, undefined, '0', NaN, Infinity]), { n: 0, min: null, median: null, mean: null, p95: null, max: null });
+  assert.deepEqual(distribution([0, 2, 4, 6, null]), { n: 4, min: 0, median: 3, mean: 3, p95: 6, max: 6 });
+  assert.equal(distribution(Array.from({ length: 20 }, (_, i) => i)).p95, 18);
+});
+
+test('schema failures are excluded from LLM distributions but retain deterministic observations', () => {
+  const rows = [
+    { fixture_id: 'one', status: 'ok', overall: 0, raw_overall: 0, deterministic_overall: 80, privateText: 'DO-NOT-PUBLISH' },
+    { fixture_id: 'two', status: 'error', overall: null, raw_overall: null, llm_overall: 6.6, deterministic_overall: 100, error: 'DO-NOT-PUBLISH' },
+  ];
+  const summary = summarizeRows(rows);
+  assert.equal(summary.valid, 1); assert.equal(summary.errors, 1);
+  assert.deepEqual(summary.availability, { validNumerator: 1, observedDenominator: 2 });
+  assert.equal(summary.scores.overall.mean, 0); assert.equal(summary.scores.rawLLM.n, 1);
+  assert.equal(summary.scores.deterministic.n, 2); assert.equal(summary.scores.deterministic.mean, 90);
+  assert.ok(!JSON.stringify(summary).includes('DO-NOT-PUBLISH'));
+});
+
+test('raw-score audit follows original category schema including partial packs', () => {
+  assert.equal(checkRawScore(JSON.stringify(raw), { content: 6, style: 7 }).valid, true);
+  for (const value of [{}, { ...raw, overall: '0' }, { ...raw, overall: null }, { ...raw, overall: 101 },
+    { ...raw, categories: {} }, { ...raw, categories: { secret: category } },
+    { ...raw, categories: { content: { ...category, detected: 7 } } },
+    { ...raw, categories: { content: { ...category, score: -1 } } },
+    { ...raw, categories: { content: { ...category, max: 0 } } },
+    { ...raw, categories: { content: { ...category, sum: 19 } } }]) {
+    assert.equal(checkRawScore(JSON.stringify(value), { content: 6 }).valid, false);
+  }
+  assert.deepEqual(checkRawScore('DO-NOT-PUBLISH invalid response', { content: 6 }), { valid: false, reason: 'invalid-json' });
+});
+
+test('valid receipt independently binds original logical ID, request, schema, and model', () => {
+  const { receipt, call, binding } = receiptCase();
+  const original = JSON.stringify(receipt);
+  const checked = verifyReceipt(receipt, call, binding);
+  assert.equal(checked.valid, true); assert.equal(checked.value.overall, 0); assert.equal(checked.attempts, 1);
+  assert.equal(JSON.stringify(receipt), original, 'audit must not rewrite receipts');
+});
+
+test('request substitution, nonterminal calls, and false model attestations fail closed', () => {
+  const changes = [
+    ({ receipt }) => { receipt.state = 'started'; },
+    ({ receipt }) => { receipt.promptHash = sha256('substituted'); },
+    ({ binding }) => { binding.logicalId = 'different-protocol'; },
+    ({ receipt }) => { receipt.response.effectiveModels = ['wrong-model']; },
+    ({ receipt, call }) => { receipt.response.effectiveModels = ['wrong-model']; call.effectiveModels = ['wrong-model']; },
+    ({ receipt }) => { receipt.transportAttempts[0].effectiveModel = 'wrong-model'; },
+    ({ receipt }) => { receipt.transportAttempts[0].requestedModel = 'wrong-model'; },
+    ({ call }) => { call.modelIdentityVerified = false; },
+    ({ call }) => { call.mixedOrUnexpectedModel = true; },
+    ({ call }) => { call.attempts = 0; },
+    ({ call }) => { call.schema_valid = false; },
+    ({ receipt }) => { receipt.schemaValid = false; },
+    ({ receipt }) => { receipt.response.attempts = 3; },
+  ];
+  for (const change of changes) {
+    const data = receiptCase(); change(data);
+    assert.throws(() => verifyReceipt(data.receipt, data.call, data.binding), /^Error: scorer-report:/);
+  }
+});
+
+test('terminal schema and transport errors remain classified failures, never valid zero scores', () => {
+  const invalid = receiptCase({ overall: 6.6 }, false);
+  const checked = verifyReceipt(invalid.receipt, invalid.call, invalid.binding);
+  assert.equal(checked.valid, false); assert.equal(checked.reason, 'invalid-score-schema');
+  const transport = receiptCase();
+  transport.receipt.state = 'error'; delete transport.receipt.response; delete transport.receipt.schemaValid;
+  transport.receipt.transportAttempts[0].outcome = 'error';
+  transport.call.transportAttempts[0].outcome = 'error'; transport.call.status = 'error'; transport.call.schema_valid = null;
+  assert.deepEqual(verifyReceipt(transport.receipt, transport.call, transport.binding), { valid: false, reason: 'transport-error', attempts: 1 });
+});
+
+test('matrix membership requires the full independent candidate × fixture × repeat product', () => {
+  const data = matrixCase();
+  assert.doesNotThrow(() => verifyMatrix(data.rows, data.expected, data.fixtures, data.spec));
+  const changes = [
+    (d) => { d.rows.pop(); },
+    (d) => { d.rows[1] = clone(d.rows[0]); },
+    (d) => { d.rows[0].repeat = 1; },
+    (d) => { d.rows[0].protocol_hash = sha256('different protocol'); },
+    (d) => { d.rows[0].text_hash = sha256('different input'); },
+    (d) => { d.rows[0].expected_hot = !d.rows[0].expected_hot; },
+    (d) => { d.rows[0].requested_model = 'invented-model'; },
+    (d) => { d.rows[0].transport = 'http'; },
+    (d) => { d.expected[0] = d.expected[1]; },
+    (d) => { d.rows[0].overall = 101; },
+    (d) => { d.rows[0].deterministic_overall = '25'; },
+    (d) => { d.rows[0].raw_overall = null; },
+    (d) => { d.rows[0].llm_overall = 5; },
+    (d) => { d.rows[0].status = 'error'; },
+    (d) => { d.rows[0].calls = []; },
+  ];
+  for (const change of changes) {
+    const changed = matrixCase(); change(changed);
+    assert.throws(() => verifyMatrix(changed.rows, changed.expected, changed.fixtures, changed.spec), /^Error: scorer-report:/);
+  }
+});
+
+test('bounded reader rejects traversal, symlinks, oversized input, and source mutations', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'scorer-public-reader-'));
+  try {
+    writeFileSync(join(directory, 'small.json'), '{}');
+    const reader = createReader(directory);
+    assert.deepEqual(reader.json('small.json'), {});
+    assert.throws(() => reader.bytes('../private.json'), /unsafe source path/);
+    assert.throws(() => reader.bytes('/private.json'), /unsafe source path/);
+    symlinkSync(join(directory, 'small.json'), join(directory, 'link.json'));
+    assert.throws(() => reader.bytes('link.json'), /source symlink/);
+    writeFileSync(join(directory, 'big.json'), ''); truncateSync(join(directory, 'big.json'), 8 * 1024 * 1024 + 1);
+    assert.throws(() => reader.bytes('big.json'), /source size bound/);
+    writeFileSync(join(directory, 'small.json'), '[]');
+    assert.throws(() => reader.verifyUnchanged(), /source changed during publication/);
+  } finally { rmSync(directory, { recursive: true, force: true }); }
+});
+
+test('CLI has an explicit offline interface and never echoes unknown argument contents', () => {
+  assert.throws(() => main(['--api-key', 'DO-NOT-PUBLISH']), (error) => error.message === 'scorer-report: invalid argument');
+  assert.throws(() => main(['--write', '--check']), /required sources or conflicting mode/);
+  const output = execFileSync(process.execPath, ['scripts/research/publish-scorer-report.mjs', '--help'], { cwd: ROOT, encoding: 'utf8' });
+  assert.match(output, /offline only/); assert.doesNotMatch(output, /--live|--api-key/);
+});
+
+test('public artifact reproduces Markdown and preserves scoped acceptance and original protocols', () => {
+  const report = JSON.parse(readFileSync(publicJson, 'utf8'));
+  assert.equal(renderReport(report), readFileSync(publicMarkdown, 'utf8'));
+  assert.deepEqual(report.totals, { datasets: 6, candidates: 11, uniqueFixtures: 49, observed: 931, valid: 930, errors: 1 });
+  assert.equal(report.datasets.length, DATASETS.length);
+  for (const spec of DATASETS) {
+    const dataset = report.datasets.find((item) => item.id === spec.id);
+    assert.equal(dataset.protocolHash, spec.protocolHash);
+    assert.equal(dataset.collection.expected, spec.candidates.length * 49 * spec.repeat);
+    assert.equal(dataset.collection.missing, 0);
+    assert.equal(dataset.collection.observed, dataset.collection.valid + dataset.collection.errors);
+    assert.equal(dataset.collection.calls, dataset.provenance.receiptCount);
+    assert.equal(dataset.collection.transportAttempts, dataset.collection.calls);
+    assert.equal(dataset.provenance.protocolRecomputed, false);
+    assert.equal(dataset.provenance.fullScorerReplay, false);
+    for (const field of ['receiptManifestSha256', 'requestHashesSha256', 'promptHashesSha256', 'fixtureIdentitySha256']) assert.match(dataset.provenance[field], /^[a-f0-9]{64}$/);
+    for (const hash of Object.values(dataset.provenance.artifacts)) assert.match(hash, /^[a-f0-9]{64}$/);
+  }
+  assert.match(report.acceptance.closure, /Partial evidence/);
+  assert.ok(report.acceptance.gaps.some((gap) => gap.includes('rebaseline')));
+  assert.ok(report.limitations.some((limit) => limit.includes('not authenticated real-world')));
+  assert.ok(report.limitations.some((limit) => limit.includes('not independently replayed')));
+});
+
+test('public distribution denominators balance by language, pack, control, and repeat', () => {
+  const report = JSON.parse(readFileSync(publicJson, 'utf8'));
+  for (const dataset of report.datasets) for (const candidate of dataset.candidates) {
+    assert.equal(candidate.scores.overall.n, candidate.valid);
+    assert.equal(candidate.scores.rawLLM.n, candidate.valid);
+    assert.equal(candidate.scores.deterministic.n, candidate.observed);
+    for (const grouping of [Object.values(candidate.byLanguage), Object.values(candidate.byFixtureControl), candidate.byRepeat]) {
+      assert.equal(grouping.reduce((n, slice) => n + slice.observed, 0), candidate.observed);
+      assert.equal(grouping.reduce((n, slice) => n + slice.valid, 0), candidate.valid);
+    }
+    assert.equal(Object.keys(candidate.byPatternPack).length, 28);
+    for (const [pack, slice] of Object.entries(candidate.byPatternPack)) {
+      assert.equal(slice.validRows, candidate.byLanguage[pack.split('/')[0]].valid);
+      assert.equal(slice.score.n + slice.missing, slice.validRows);
+    }
+    if (dataset.repeat === 2) assert.equal(candidate.pairedRepeatAbsoluteDifference.pairs, 49);
+    else assert.equal(candidate.pairedRepeatAbsoluteDifference, null);
+  }
+});
+
+test('published JSON is summaries and integrity commitments, without private row or receipt bodies', () => {
+  const source = readFileSync(publicJson, 'utf8');
+  const report = JSON.parse(source);
+  const forbiddenKeys = new Set(['text', 'prompt', 'response', 'raw', 'rationale', 'apiKey', 'apiKeyEnv', 'baseURL', 'usage', 'owner', 'pid', 'args', 'fixture_id', 'text_hash', 'requestHash', 'promptHash']);
+  function walk(value) {
+    if (Array.isArray(value)) { value.forEach(walk); return; }
+    if (!value || typeof value !== 'object') return;
+    for (const [key, nested] of Object.entries(value)) { assert.ok(!forbiddenKeys.has(key), key); walk(nested); }
+  }
+  walk(report);
+  assert.doesNotMatch(source, /\/home\/|\/tmp\/|Bearer |sk-[A-Za-z0-9]{10}|PRIVATE KEY/);
+  for (const dataset of report.datasets) {
+    assert.deepEqual(Object.keys(dataset.provenance.effectiveInputs).sort(), ['configuration', 'lexicons', 'patterns', 'sourceVoice', 'structuralModels']);
+    assert.ok(dataset.candidates.every((candidate) => ['openai', 'gemini'].includes(candidate.provider)));
+  }
+});


### PR DESCRIPTION
Publish receipt-bound live scorer diagnostics

Publishes diagnostics for 931 observations across six completed immutable A/C matrices; 930 valid, one error. Includes language/pack distributions, omission/error counts, repeat differences and source/receipt commitments. No raw text/keys, new model calls, CI gate or winner/default change.

Validation: 12 focused tests; full 1,897 passed, 2 skipped; lint/privacy checks; offline exact regeneration. Independent Astra/xhigh review matched 928 distributions and passed.

Supports #412; rebaseline measurements remain outstanding. Historical configuration replay limitations are explicit.
