### PR TITLE
fix: include negation in MPS polarity validation

### DIFF
--- a/scripts/research/study-validation.mjs
+++ b/scripts/research/study-validation.mjs
@@ -29,7 +29,8 @@ export function validateRawMps(text) {
     if (!object(anchor) || !types.has(anchor.type) || !verdicts.has(anchor.verdict) || typeof anchor.content !== 'string' || !anchor.content.trim()) throw new Error('invalid-anchor');
   }
   const passed = value.anchors.filter((anchor) => anchor.verdict === 'PASS').length;
-  const polarity = value.anchors.filter((anchor) => anchor.type === 'polarity');
+  // core/scoring.md defines the weighted polarity group as Polarity + Negation.
+  const polarity = value.anchors.filter((anchor) => ['polarity', 'negation'].includes(anchor.type));
   const polarityPassed = polarity.filter((anchor) => anchor.verdict === 'PASS').length;
   if (value.pass_count !== passed || value.total_count !== value.anchors.length
     || value.polarity_pass_count !== polarityPassed || value.polarity_total_count !== polarity.length) throw new Error('inconsistent-mps-counts');

--- a/tests/unit/mps-negation-validation.test.js
+++ b/tests/unit/mps-negation-validation.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateRawMps } from '../../scripts/research/study-validation.mjs';
+
+test('MPS polarity counters include preserved negation anchors', () => {
+  const value = { anchors: [
+    { type: 'claim', content: 'The report arrives Friday.', verdict: 'PASS' },
+    { type: 'claim', content: 'The team approved it.', verdict: 'SOFT_FAIL' },
+    { type: 'negation', content: 'There is no fee.', verdict: 'PASS' },
+  ], pass_count: 2, total_count: 3, polarity_pass_count: 1, polarity_total_count: 1, mps: 80 };
+  assert.equal(validateRawMps(JSON.stringify(value)).mps, 80);
+  assert.throws(() => validateRawMps(JSON.stringify({ ...value, polarity_pass_count: 0, polarity_total_count: 0, mps: 66.7 })), /counts/);
+});
+
+test('failed negation carries the documented polarity weight and remains a hard failure', () => {
+  const value = { anchors: [
+    { type: 'claim', content: 'The report arrives Friday.', verdict: 'PASS' },
+    { type: 'negation', content: 'There is no fee.', verdict: 'HARD_FAIL' },
+  ], pass_count: 1, total_count: 2, polarity_pass_count: 0, polarity_total_count: 1, mps: 30 };
+  assert.equal(validateRawMps(JSON.stringify(value)).hard_fail_count, 1);
+  assert.throws(() => validateRawMps(JSON.stringify({ ...value, mps: 50 })), /score/);
+});
+
+test('polarity and negation are counted together without inventing polarity for ordinary claims', () => {
+  const value = { anchors: [
+    { type: 'polarity', content: 'The team opposes the change.', verdict: 'PASS' },
+    { type: 'negation', content: 'There is no fee.', verdict: 'SOFT_FAIL' },
+  ], pass_count: 1, total_count: 2, polarity_pass_count: 1, polarity_total_count: 2, mps: 50 };
+  assert.equal(validateRawMps(JSON.stringify(value)).mps, 50);
+  assert.throws(() => validateRawMps(JSON.stringify({ ...value, polarity_total_count: 1, mps: 70 })), /counts/);
+  assert.equal(validateRawMps(JSON.stringify({ anchors: [{ type: 'claim', content: 'It arrives Friday.', verdict: 'PASS' }], pass_count: 1, total_count: 1, polarity_pass_count: 0, polarity_total_count: 0, mps: 100 })).mps, 100);
+});


### PR DESCRIPTION
The study validator omitted negation anchors from the weighted polarity group, although core/scoring.md explicitly defines the group as Polarity + Negation. This could both reject valid judge responses and accept inconsistent counters. Include both types without changing the canonical formula or ordinary-claim fallback.

Validation: three regressions; full1,889 tests passed,2 skipped; lint clean; independent Astra/xhigh review passed. Frozen studies and their original receipt flags remain unchanged. A separate offline derivation will revalidate all prior judgments, including previously valid rows; model rankings are not final until that correction is complete.
