### PR TITLE
research: revalidate frozen MPS screening evidence

### DIFF
--- a/docs/research/mps-validation-correction-20260905.json
+++ b/docs/research/mps-validation-correction-20260905.json
@@ -1,0 +1,923 @@
+{
+  "schemaVersion": 1,
+  "date": "2026-09-05",
+  "timezone": "Asia/Seoul",
+  "status": "completed-offline-screening-correction",
+  "derivationProtocolHash": "75dc405f5960b9a666ec56d0bf17a31863e029c8e308a3ba0c4e3367040602c9",
+  "protocol": {
+    "schemaVersion": 1,
+    "kind": "canonical-negation-mps-retrospective",
+    "correctionCommit": "5567e4a81fedd6f56cdd518507051c6c0db04f9d",
+    "validatorSha256": "3425c404615ca1fe53a586348c26d1dedd01b27888d8634a40b60038ca4e6e8b",
+    "canonicalSpecSha256": "0100887249e43eccb0d320dc9680d7ec3ade65d83bf24d724a742e222d81275d",
+    "validationSourceManifestHash": "07593ce748d927cbee43e7c8da7314fb9bba07690193e79de71403fd87615b94",
+    "derivationScriptSha256": "3bd298a7b5f6b3d8302ff25f8c2e74fa8ed82e6c4ef7dde1af8a4687900ce977",
+    "joinRuleSha256": "14262d469f3461ebb4531c2d8b807ae063a67183af25221a89b96afdff961a36",
+    "sourceManifests": {
+      "A": {
+        "commit": "66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c",
+        "sha256": "bf25bbb70b3c74c55a69e1f13b5cdec7a9124dcb254a2deb4a8848752b1ee478"
+      },
+      "D": {
+        "commit": "dca3aa1de00bd21594f39e5b3c83614f28f22b85",
+        "sha256": "4292debdb98ecebb143a8b5126c6340b6d81eb4c3692225eed67eb4cb73887cc"
+      },
+      "E": {
+        "commit": "8918cd015fc71b35d0b7855cfe7625eb7a050fcf",
+        "sha256": "de9c193ca706a50c6b7cd590ed9f3e63997ae68d3ea980f30423dda675ad2af7"
+      }
+    },
+    "planHashes": {
+      "openai": "d0dcbbdaa1a6f9af3570c89db2ce3f3a5ca8b9563e7bad9849fc3caf3b10af84",
+      "gemini": "4fd83be749fa2e4c48dec9518f2a27dc4bb8bcf1202e627bd754bac50af1cf20",
+      "claude": "925bf4aed683345b4669f79c200a41781f987f0757e5ae46c040f0e40869ec42"
+    },
+    "screens": [
+      {
+        "screen": "openai",
+        "provenance": {
+          "source": "A",
+          "sourceCommit": "66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c",
+          "originalParentProtocolHash": "c2779dde62beec49c198f3faa1be494565de48f147eaf511eacc785ae3b61ef5",
+          "parentSnapshotHash": "90a5395382fb803f4168ac66a243d8250851b9e2dab195ac1efbcd68efa045d2",
+          "generationFileHash": "ae5408c0ddd53b1274897dea9721cb9e34087dc113152c397254b4c3084aa562",
+          "privateGenerationFileHash": "0bbbbea1f689660f3bb43a74ecb6fd9be3918eefd9e699ba3c51f6d52d3cb274",
+          "generationReceiptCount": 72,
+          "generationReceiptManifestHash": "b53b36c06cd34aa562577d2e0725d746926aab89502f2274d6b1add9d91d405b",
+          "rebuiltGenerationPrompts": 72,
+          "baselineSummaryHash": "9ee8f28d2797097a2b2834c1f25311dec0347e3dd33d42d25dc93abbe424360f",
+          "judgments": [
+            {
+              "source": "A",
+              "sourceCommit": "66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c",
+              "judge": "gemini-3.7",
+              "requestedModel": "google-antigravity/gemini-3.7-flash",
+              "transport": "opencodex",
+              "originalProtocolHash": "c2779dde62beec49c198f3faa1be494565de48f147eaf511eacc785ae3b61ef5",
+              "publicFile": "artifacts/model-evaluation-20260904/validated/rewrite-openai/judge-gemini-3.7.jsonl",
+              "publicFileSha256": "efcf6548557d0dce23a99e479938d4b8afa35965be5da7cff9ae5da7e2327387",
+              "privateFile": "artifacts/model-evaluation-20260904/validated/rewrite-openai/judge-gemini-3.7.private.jsonl",
+              "privateFileSha256": "1872e3f606d08dc58a412b4836e6a5934ea7978ec93d5bbda27d584ab3d2d7be",
+              "rows": 72,
+              "originalValid": 72,
+              "receiptCount": 216,
+              "receiptManifestHash": "788d1c796f5db77cf9e536d644b3a6c676ea4be7ca95481669402b16cf8a4a88"
+            },
+            {
+              "source": "E",
+              "sourceCommit": "8918cd015fc71b35d0b7855cfe7625eb7a050fcf",
+              "judge": "anthropic-sonnet",
+              "requestedModel": "claude-sonnet-5",
+              "transport": "claude-cli",
+              "originalProtocolHash": "09bc9689f7b6ba4e872d667d6fead52f5e8c173c6aa1c6d42733b15de108cfc9",
+              "publicFile": "artifacts/evaluation-parent-20260905/claude-on-openai/judge-anthropic-sonnet.jsonl",
+              "publicFileSha256": "0c9160d1eb311b485206ff95e389af2fa2771303f56c3de9ea43836bbd51349e",
+              "privateFile": "artifacts/evaluation-parent-20260905/claude-on-openai/judge-anthropic-sonnet.private.jsonl",
+              "privateFileSha256": "2030fa22eb3df4cca8585f07a6c4f59bda66dcf3a660e3629521fc837ec86dce",
+              "rows": 72,
+              "originalValid": 68,
+              "receiptCount": 216,
+              "receiptManifestHash": "4eb1ce7f7854c76dff94f23bb47b4669cb5a8f728640887097b9c9f68423a30b",
+              "provenanceHash": "ebad9bf7e0f200e8f95c2b02bc0353cb456881d22604f0ec7721757bc2d0e55c",
+              "directoryBindingHash": "6349e473e4d37c3c06431204f2d164a72f39d483f4100eda68ef00ba8ab5c704"
+            }
+          ]
+        }
+      },
+      {
+        "screen": "gemini",
+        "provenance": {
+          "source": "A",
+          "sourceCommit": "66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c",
+          "originalParentProtocolHash": "60e90a2d1cb33f02c30bc6eaefcbe2ef8ee19ab862ae969356b44f46b6b5710f",
+          "parentSnapshotHash": "eda02129432097969f964c7915979776889f7c328d8ccc8dc11ccfa46adb792e",
+          "generationFileHash": "aeecd0e91305b6707dd0d0ab60488b673271267eb3dae705bc78e18e94d2b5e7",
+          "privateGenerationFileHash": "ce760096cab1f373e97d681aa58e1c296b4f61ca2cd22bb78b24770bf0b09926",
+          "generationReceiptCount": 60,
+          "generationReceiptManifestHash": "4322ab9857f2d2ad4483faa21d2a1303bac059f0c8f0f9e246612faa33e8a060",
+          "rebuiltGenerationPrompts": 60,
+          "baselineSummaryHash": "9958bb7d39dae39f9b6bcd777942c906c5668532e46949f71245ff61f92e5039",
+          "judgments": [
+            {
+              "source": "A",
+              "sourceCommit": "66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c",
+              "judge": "openai-5.5",
+              "requestedModel": "gpt-5.5",
+              "transport": "opencodex",
+              "originalProtocolHash": "60e90a2d1cb33f02c30bc6eaefcbe2ef8ee19ab862ae969356b44f46b6b5710f",
+              "publicFile": "artifacts/model-evaluation-20260904/validated/rewrite-gemini/judge-openai-5.5.jsonl",
+              "publicFileSha256": "1c5c6d02d7029fea616a0e8fcc1923d1741b73ecdf65e3d1e2c49b6657466d1b",
+              "privateFile": "artifacts/model-evaluation-20260904/validated/rewrite-gemini/judge-openai-5.5.private.jsonl",
+              "privateFileSha256": "9a08a838f76a52a2263c46789b89b260252fd4ce699b1a4ab02e490cfefd3d8d",
+              "rows": 60,
+              "originalValid": 58,
+              "receiptCount": 180,
+              "receiptManifestHash": "a578ddea7e0a419e5b1fa283b41c2b99769fe2475427a71955a755786cb6cad6"
+            },
+            {
+              "source": "E",
+              "sourceCommit": "8918cd015fc71b35d0b7855cfe7625eb7a050fcf",
+              "judge": "anthropic-sonnet",
+              "requestedModel": "claude-sonnet-5",
+              "transport": "claude-cli",
+              "originalProtocolHash": "6e0510eef4840768f6c0ee102d0a66c0114025c5102625deca4dfe6190340645",
+              "publicFile": "artifacts/evaluation-parent-20260905/claude-on-gemini/judge-anthropic-sonnet.jsonl",
+              "publicFileSha256": "f49eb5e1e862a59fb4e12667a8ebf1c2852eb75c01b1ace6a5ddf7bdbc1ad5ee",
+              "privateFile": "artifacts/evaluation-parent-20260905/claude-on-gemini/judge-anthropic-sonnet.private.jsonl",
+              "privateFileSha256": "ae0904b9ec86788277aecb7a5c95829dda5dfd167e064a89172a455194003a5b",
+              "rows": 60,
+              "originalValid": 56,
+              "receiptCount": 180,
+              "receiptManifestHash": "67a28fdd595cda623f980b52676daadf169101edcbdd1a6bdfa0b1b19c519f4c",
+              "provenanceHash": "ee80433db1b80774aa1619159840a14f96ec801e4ff93aee3348b3b45f16cb41",
+              "directoryBindingHash": "a596dda2921285a8dfcbad2f99bbf0b167c3e275ef32ea584ddbe55ccfb718e0"
+            }
+          ]
+        }
+      },
+      {
+        "screen": "claude",
+        "provenance": {
+          "source": "D",
+          "sourceCommit": "dca3aa1de00bd21594f39e5b3c83614f28f22b85",
+          "originalParentProtocolHash": "64399c90db9352c305ade1fb23419d30cd1f436a8bb0fff073f9b54765ed34e3",
+          "parentSnapshotHash": "1d8202d5ccdee04e7391398995594e2d9738412c11fcd53c7e1005427298872b",
+          "generationFileHash": "814081b95f65974b4cf69bc90a0341e3a452bcea5ddea7962da8e5ac88166d72",
+          "privateGenerationFileHash": "8a96b2c4506e765af9a16ee23e6c2cacc6a52862d767cdda299b9cfb962fbd92",
+          "generationReceiptCount": 60,
+          "generationReceiptManifestHash": "e621311a1d7bd23c4cd28794d6399a5883aac36c7c68d2b98d21a34ee741c6cc",
+          "rebuiltGenerationPrompts": 60,
+          "baselineSummaryHash": "4a01b28eb84fb1bebddf3075f776f690a73ab2f0ddf10d2a071df285475cbfa5",
+          "judgments": [
+            {
+              "source": "E",
+              "sourceCommit": "8918cd015fc71b35d0b7855cfe7625eb7a050fcf",
+              "judge": "openai-5.5",
+              "requestedModel": "gpt-5.5",
+              "transport": "opencodex",
+              "originalProtocolHash": "43045a18cafee832bc2f4679435ad3b147404932b73ae7bac22ebd794a31a185",
+              "publicFile": "artifacts/evaluation-parent-20260905/openai-on-claude/judge-openai-5.5.jsonl",
+              "publicFileSha256": "2807605575be998547a45341ac2a1149d3b0e8bb50fbd947d3a8d607b35f7b78",
+              "privateFile": "artifacts/evaluation-parent-20260905/openai-on-claude/judge-openai-5.5.private.jsonl",
+              "privateFileSha256": "e8bc43957678d21f0c5493e0895ae4818f275998239da3bccc8c508eef355ad5",
+              "rows": 60,
+              "originalValid": 59,
+              "receiptCount": 180,
+              "receiptManifestHash": "071607589fb0913124408572e806b832dc7c12a76fbaf176bbcd217c9762519d",
+              "provenanceHash": "73ec41aeb018c545099a427815be697bdc804803c81bd96c5ca566610b349d46",
+              "directoryBindingHash": "d2b7186742a76728d968914b04e506ab901f757c025368c7d942ee47e3b4a1d2"
+            },
+            {
+              "source": "E",
+              "sourceCommit": "8918cd015fc71b35d0b7855cfe7625eb7a050fcf",
+              "judge": "gemini-3.7",
+              "requestedModel": "google-antigravity/gemini-3.7-flash",
+              "transport": "opencodex",
+              "originalProtocolHash": "c50a50e534c177caf2dbb1d9739e80744179c4ffed2da9e5d33052bfc258fa04",
+              "publicFile": "artifacts/evaluation-parent-20260905/gemini-on-claude/judge-gemini-3.7.jsonl",
+              "publicFileSha256": "102cb50abcceec1100584e488a1b590a02dc3bc43c3b508e19febe83822ec69c",
+              "privateFile": "artifacts/evaluation-parent-20260905/gemini-on-claude/judge-gemini-3.7.private.jsonl",
+              "privateFileSha256": "039db0864dbb5e2c7c56161dde2405ec89951dc5b245d62401cf25c8013396c2",
+              "rows": 60,
+              "originalValid": 60,
+              "receiptCount": 180,
+              "receiptManifestHash": "b8edfaf5a3b7a8c8bbc66d21cb61192bd53fa007ea15cd310877faceb67f1dc0",
+              "provenanceHash": "3f686151d3735495a4bc7a0a59ed8f560beace4f89b3a006c45a471cf0ab5d3b",
+              "directoryBindingHash": "ef95a5596c72258394b1ad949944c2bdcbb22028359bf9e33693347c7109b27b"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "privateLedgerSha256": "e3c4613b00e90fc053b05c426420e28e76a429542108bbfb8e8a473db91045e5",
+  "totals": {
+    "generations": 192,
+    "judgments": 384,
+    "originalValid": 373,
+    "correctedValid": 363,
+    "statusTransitions": {
+      "valid->valid": 363,
+      "valid->invalid": 10,
+      "invalid->valid": 0,
+      "invalid->invalid": 11
+    },
+    "mpsResponses": 384,
+    "mpsTransitions": {
+      "valid->valid": 366,
+      "valid->invalid": 10,
+      "invalid->valid": 0,
+      "invalid->invalid": 8
+    },
+    "judgmentReceipts": 1152,
+    "generationReceipts": 192
+  },
+  "method": [
+    "Every judgment in the three declared screening joins is included, regardless of its original valid/invalid status. Public/private parity, full matrix membership, original snapshots/protocols, committed source/fixture bytes and terminal receipt metadata are checked before correction.",
+    "Generation prompts are rebuilt from frozen-source inputs and matched by hash; request identities and delivered rewrites are bound to original receipts. This does not claim recovery of every historical ambient configuration field.",
+    "Both historical and corrected judge pipelines receive only the original private receipt responses through an injected callback. Every MPS, fidelity and naturalness prompt/request hash and receipt ordinal must match. No source journal, lock, row, schema flag or protocol ID is rewritten.",
+    "The canonical polarity group includes polarity and negation anchors. The corrected validator checks the original self-reported pass counts, polarity counts and MPS. Inconsistent responses stay rejected; no counts or model scores are repaired.",
+    "The correction has its own protocol and private ledger. Historical rows/flags remain in original; corrected status and per-receipt flags are separate. Original protocol IDs stay attached to original observations."
+  ],
+  "rankingRule": "Within each screen: safe-output rate descending, model-rated naturalness median descending, generation latency median ascending, candidate ID ascending. Safety requires numeric proxy pass and two configured different-family valid judges with MPS/fidelity >=90 and zero hard failures. All generation attempts remain in the denominator.",
+  "limits": [
+    "Proxy response.model echoes the requested alias. Model identity here is only recorded response/assistant-message/profile evidence, not proof of upstream weights or independent upstream judge families.",
+    "These are one-pass screening results on 12 curated source fixtures per candidate. They do not establish a final winner, default model, human preference or authenticated authorship accuracy.",
+    "MPS arithmetic/schema consistency does not independently certify the truth of the model’s anchor extraction or verdicts. Naturalness remains model-rated.",
+    "Confirmation and other active D/E jobs are outside this derivation. Revalidate completed confirmation evidence under the fix and obtain missing confirmation evidence before any promotion; no paid rerun is performed here.",
+    "Public output contains allowlisted counts, ranks, recorded identifiers and integrity hashes. Source texts, anchors, rationales and raw response/receipt bodies remain private."
+  ],
+  "screens": [
+    {
+      "screen": "openai",
+      "provider": "openai",
+      "generations": 72,
+      "judgments": 144,
+      "originalValid": 140,
+      "correctedValid": 137,
+      "statusTransitions": {
+        "valid->valid": 137,
+        "valid->invalid": 3,
+        "invalid->valid": 0,
+        "invalid->invalid": 4
+      },
+      "mpsTransitions": {
+        "valid->valid": 138,
+        "valid->invalid": 3,
+        "invalid->valid": 0,
+        "invalid->invalid": 3
+      },
+      "oldTopTwo": [
+        "openai-astra",
+        "openai-terra"
+      ],
+      "newTopTwo": [
+        "openai-astra",
+        "openai-terra"
+      ],
+      "oldRanks": [
+        {
+          "rank": 1,
+          "id": "openai-astra",
+          "attempted": 12,
+          "safe": 10,
+          "safeRate": 0.8333333333333334,
+          "judgeErrors": 0,
+          "naturalnessMedian": 3,
+          "generationMedianMs": 11430.5
+        },
+        {
+          "rank": 2,
+          "id": "openai-terra",
+          "attempted": 12,
+          "safe": 8,
+          "safeRate": 0.6666666666666666,
+          "judgeErrors": 2,
+          "naturalnessMedian": 3.5,
+          "generationMedianMs": 5485
+        },
+        {
+          "rank": 3,
+          "id": "openai-5.5",
+          "attempted": 12,
+          "safe": 8,
+          "safeRate": 0.6666666666666666,
+          "judgeErrors": 0,
+          "naturalnessMedian": 3.25,
+          "generationMedianMs": 6176
+        },
+        {
+          "rank": 4,
+          "id": "openai-sol",
+          "attempted": 12,
+          "safe": 8,
+          "safeRate": 0.6666666666666666,
+          "judgeErrors": 1,
+          "naturalnessMedian": 2.5,
+          "generationMedianMs": 12791
+        },
+        {
+          "rank": 5,
+          "id": "openai-luna",
+          "attempted": 12,
+          "safe": 6,
+          "safeRate": 0.5,
+          "judgeErrors": 1,
+          "naturalnessMedian": 3,
+          "generationMedianMs": 6379
+        },
+        {
+          "rank": 6,
+          "id": "openai-mini",
+          "attempted": 12,
+          "safe": 5,
+          "safeRate": 0.4166666666666667,
+          "judgeErrors": 0,
+          "naturalnessMedian": 3.25,
+          "generationMedianMs": 4549
+        }
+      ],
+      "correctedRanks": [
+        {
+          "rank": 1,
+          "id": "openai-astra",
+          "attempted": 12,
+          "safe": 10,
+          "safeRate": 0.8333333333333334,
+          "judgeErrors": 0,
+          "naturalnessMedian": 3,
+          "generationMedianMs": 11430.5
+        },
+        {
+          "rank": 2,
+          "id": "openai-terra",
+          "attempted": 12,
+          "safe": 8,
+          "safeRate": 0.6666666666666666,
+          "judgeErrors": 2,
+          "naturalnessMedian": 3.5,
+          "generationMedianMs": 5485
+        },
+        {
+          "rank": 3,
+          "id": "openai-sol",
+          "attempted": 12,
+          "safe": 8,
+          "safeRate": 0.6666666666666666,
+          "judgeErrors": 1,
+          "naturalnessMedian": 2.5,
+          "generationMedianMs": 12791
+        },
+        {
+          "rank": 4,
+          "id": "openai-5.5",
+          "attempted": 12,
+          "safe": 7,
+          "safeRate": 0.5833333333333334,
+          "judgeErrors": 1,
+          "naturalnessMedian": 3,
+          "generationMedianMs": 6176
+        },
+        {
+          "rank": 5,
+          "id": "openai-luna",
+          "attempted": 12,
+          "safe": 6,
+          "safeRate": 0.5,
+          "judgeErrors": 2,
+          "naturalnessMedian": 3.25,
+          "generationMedianMs": 6379
+        },
+        {
+          "rank": 6,
+          "id": "openai-mini",
+          "attempted": 12,
+          "safe": 5,
+          "safeRate": 0.4166666666666667,
+          "judgeErrors": 1,
+          "naturalnessMedian": 3.5,
+          "generationMedianMs": 4549
+        }
+      ],
+      "changes": [
+        {
+          "id": "openai-sol",
+          "oldRank": 4,
+          "newRank": 3,
+          "oldSafe": 8,
+          "newSafe": 8,
+          "oldJudgeErrors": 1,
+          "newJudgeErrors": 1,
+          "enteredTopTwo": false,
+          "leftTopTwo": false
+        },
+        {
+          "id": "openai-5.5",
+          "oldRank": 3,
+          "newRank": 4,
+          "oldSafe": 8,
+          "newSafe": 7,
+          "oldJudgeErrors": 0,
+          "newJudgeErrors": 1,
+          "enteredTopTwo": false,
+          "leftTopTwo": false
+        },
+        {
+          "id": "openai-luna",
+          "oldRank": 5,
+          "newRank": 5,
+          "oldSafe": 6,
+          "newSafe": 6,
+          "oldJudgeErrors": 1,
+          "newJudgeErrors": 2,
+          "enteredTopTwo": false,
+          "leftTopTwo": false
+        },
+        {
+          "id": "openai-mini",
+          "oldRank": 6,
+          "newRank": 6,
+          "oldSafe": 5,
+          "newSafe": 5,
+          "oldJudgeErrors": 0,
+          "newJudgeErrors": 1,
+          "enteredTopTwo": false,
+          "leftTopTwo": false
+        }
+      ],
+      "requiresConfirmation": {
+        "promotedCandidates": [],
+        "correctedTopTwo": [
+          "openai-astra",
+          "openai-terra"
+        ],
+        "action": "Revalidate any completed confirmation receipts with the corrected validator before relying on them. Newly selected candidates require confirmation evidence. No active confirmation dataset was inspected and no paid rerun is authorized by this report."
+      },
+      "provenance": {
+        "source": "A",
+        "sourceCommit": "66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c",
+        "originalParentProtocolHash": "c2779dde62beec49c198f3faa1be494565de48f147eaf511eacc785ae3b61ef5",
+        "parentSnapshotHash": "90a5395382fb803f4168ac66a243d8250851b9e2dab195ac1efbcd68efa045d2",
+        "generationFileHash": "ae5408c0ddd53b1274897dea9721cb9e34087dc113152c397254b4c3084aa562",
+        "privateGenerationFileHash": "0bbbbea1f689660f3bb43a74ecb6fd9be3918eefd9e699ba3c51f6d52d3cb274",
+        "generationReceiptCount": 72,
+        "generationReceiptManifestHash": "b53b36c06cd34aa562577d2e0725d746926aab89502f2274d6b1add9d91d405b",
+        "rebuiltGenerationPrompts": 72,
+        "baselineSummaryHash": "9ee8f28d2797097a2b2834c1f25311dec0347e3dd33d42d25dc93abbe424360f",
+        "judgments": [
+          {
+            "source": "A",
+            "sourceCommit": "66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c",
+            "judge": "gemini-3.7",
+            "requestedModel": "google-antigravity/gemini-3.7-flash",
+            "transport": "opencodex",
+            "originalProtocolHash": "c2779dde62beec49c198f3faa1be494565de48f147eaf511eacc785ae3b61ef5",
+            "publicFile": "artifacts/model-evaluation-20260904/validated/rewrite-openai/judge-gemini-3.7.jsonl",
+            "publicFileSha256": "efcf6548557d0dce23a99e479938d4b8afa35965be5da7cff9ae5da7e2327387",
+            "privateFile": "artifacts/model-evaluation-20260904/validated/rewrite-openai/judge-gemini-3.7.private.jsonl",
+            "privateFileSha256": "1872e3f606d08dc58a412b4836e6a5934ea7978ec93d5bbda27d584ab3d2d7be",
+            "rows": 72,
+            "originalValid": 72,
+            "receiptCount": 216,
+            "receiptManifestHash": "788d1c796f5db77cf9e536d644b3a6c676ea4be7ca95481669402b16cf8a4a88"
+          },
+          {
+            "source": "E",
+            "sourceCommit": "8918cd015fc71b35d0b7855cfe7625eb7a050fcf",
+            "judge": "anthropic-sonnet",
+            "requestedModel": "claude-sonnet-5",
+            "transport": "claude-cli",
+            "originalProtocolHash": "09bc9689f7b6ba4e872d667d6fead52f5e8c173c6aa1c6d42733b15de108cfc9",
+            "publicFile": "artifacts/evaluation-parent-20260905/claude-on-openai/judge-anthropic-sonnet.jsonl",
+            "publicFileSha256": "0c9160d1eb311b485206ff95e389af2fa2771303f56c3de9ea43836bbd51349e",
+            "privateFile": "artifacts/evaluation-parent-20260905/claude-on-openai/judge-anthropic-sonnet.private.jsonl",
+            "privateFileSha256": "2030fa22eb3df4cca8585f07a6c4f59bda66dcf3a660e3629521fc837ec86dce",
+            "rows": 72,
+            "originalValid": 68,
+            "receiptCount": 216,
+            "receiptManifestHash": "4eb1ce7f7854c76dff94f23bb47b4669cb5a8f728640887097b9c9f68423a30b",
+            "provenanceHash": "ebad9bf7e0f200e8f95c2b02bc0353cb456881d22604f0ec7721757bc2d0e55c",
+            "directoryBindingHash": "6349e473e4d37c3c06431204f2d164a72f39d483f4100eda68ef00ba8ab5c704"
+          }
+        ]
+      }
+    },
+    {
+      "screen": "gemini",
+      "provider": "gemini",
+      "generations": 60,
+      "judgments": 120,
+      "originalValid": 114,
+      "correctedValid": 110,
+      "statusTransitions": {
+        "valid->valid": 110,
+        "valid->invalid": 4,
+        "invalid->valid": 0,
+        "invalid->invalid": 6
+      },
+      "mpsTransitions": {
+        "valid->valid": 112,
+        "valid->invalid": 4,
+        "invalid->valid": 0,
+        "invalid->invalid": 4
+      },
+      "oldTopTwo": [
+        "gemini-3.8-high",
+        "gemini-3.8-medium"
+      ],
+      "newTopTwo": [
+        "gemini-3.8-high",
+        "gemini-3.8-medium"
+      ],
+      "oldRanks": [
+        {
+          "rank": 1,
+          "id": "gemini-3.8-high",
+          "attempted": 12,
+          "safe": 7,
+          "safeRate": 0.5833333333333334,
+          "judgeErrors": 1,
+          "naturalnessMedian": 3,
+          "generationMedianMs": 9471
+        },
+        {
+          "rank": 2,
+          "id": "gemini-3.8-medium",
+          "attempted": 12,
+          "safe": 7,
+          "safeRate": 0.5833333333333334,
+          "judgeErrors": 0,
+          "naturalnessMedian": 3,
+          "generationMedianMs": 10744
+        },
+        {
+          "rank": 3,
+          "id": "gemini-3.7",
+          "attempted": 12,
+          "safe": 6,
+          "safeRate": 0.5,
+          "judgeErrors": 1,
+          "naturalnessMedian": 3,
+          "generationMedianMs": 6275
+        },
+        {
+          "rank": 4,
+          "id": "gemini-3.8-low",
+          "attempted": 12,
+          "safe": 4,
+          "safeRate": 0.3333333333333333,
+          "judgeErrors": 3,
+          "naturalnessMedian": 2.5,
+          "generationMedianMs": 9836
+        },
+        {
+          "rank": 5,
+          "id": "gemini-pro",
+          "attempted": 12,
+          "safe": 2,
+          "safeRate": 0.16666666666666666,
+          "judgeErrors": 1,
+          "naturalnessMedian": 3,
+          "generationMedianMs": 22035.5
+        }
+      ],
+      "correctedRanks": [
+        {
+          "rank": 1,
+          "id": "gemini-3.8-high",
+          "attempted": 12,
+          "safe": 7,
+          "safeRate": 0.5833333333333334,
+          "judgeErrors": 1,
+          "naturalnessMedian": 3,
+          "generationMedianMs": 9471
+        },
+        {
+          "rank": 2,
+          "id": "gemini-3.8-medium",
+          "attempted": 12,
+          "safe": 7,
+          "safeRate": 0.5833333333333334,
+          "judgeErrors": 0,
+          "naturalnessMedian": 3,
+          "generationMedianMs": 10744
+        },
+        {
+          "rank": 3,
+          "id": "gemini-3.7",
+          "attempted": 12,
+          "safe": 6,
+          "safeRate": 0.5,
+          "judgeErrors": 1,
+          "naturalnessMedian": 3,
+          "generationMedianMs": 6275
+        },
+        {
+          "rank": 4,
+          "id": "gemini-3.8-low",
+          "attempted": 12,
+          "safe": 3,
+          "safeRate": 0.25,
+          "judgeErrors": 4,
+          "naturalnessMedian": 2.5,
+          "generationMedianMs": 9836
+        },
+        {
+          "rank": 5,
+          "id": "gemini-pro",
+          "attempted": 12,
+          "safe": 2,
+          "safeRate": 0.16666666666666666,
+          "judgeErrors": 2,
+          "naturalnessMedian": 3,
+          "generationMedianMs": 22035.5
+        }
+      ],
+      "changes": [
+        {
+          "id": "gemini-3.8-low",
+          "oldRank": 4,
+          "newRank": 4,
+          "oldSafe": 4,
+          "newSafe": 3,
+          "oldJudgeErrors": 3,
+          "newJudgeErrors": 4,
+          "enteredTopTwo": false,
+          "leftTopTwo": false
+        },
+        {
+          "id": "gemini-pro",
+          "oldRank": 5,
+          "newRank": 5,
+          "oldSafe": 2,
+          "newSafe": 2,
+          "oldJudgeErrors": 1,
+          "newJudgeErrors": 2,
+          "enteredTopTwo": false,
+          "leftTopTwo": false
+        }
+      ],
+      "requiresConfirmation": {
+        "promotedCandidates": [],
+        "correctedTopTwo": [
+          "gemini-3.8-high",
+          "gemini-3.8-medium"
+        ],
+        "action": "Revalidate any completed confirmation receipts with the corrected validator before relying on them. Newly selected candidates require confirmation evidence. No active confirmation dataset was inspected and no paid rerun is authorized by this report."
+      },
+      "provenance": {
+        "source": "A",
+        "sourceCommit": "66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c",
+        "originalParentProtocolHash": "60e90a2d1cb33f02c30bc6eaefcbe2ef8ee19ab862ae969356b44f46b6b5710f",
+        "parentSnapshotHash": "eda02129432097969f964c7915979776889f7c328d8ccc8dc11ccfa46adb792e",
+        "generationFileHash": "aeecd0e91305b6707dd0d0ab60488b673271267eb3dae705bc78e18e94d2b5e7",
+        "privateGenerationFileHash": "ce760096cab1f373e97d681aa58e1c296b4f61ca2cd22bb78b24770bf0b09926",
+        "generationReceiptCount": 60,
+        "generationReceiptManifestHash": "4322ab9857f2d2ad4483faa21d2a1303bac059f0c8f0f9e246612faa33e8a060",
+        "rebuiltGenerationPrompts": 60,
+        "baselineSummaryHash": "9958bb7d39dae39f9b6bcd777942c906c5668532e46949f71245ff61f92e5039",
+        "judgments": [
+          {
+            "source": "A",
+            "sourceCommit": "66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c",
+            "judge": "openai-5.5",
+            "requestedModel": "gpt-5.5",
+            "transport": "opencodex",
+            "originalProtocolHash": "60e90a2d1cb33f02c30bc6eaefcbe2ef8ee19ab862ae969356b44f46b6b5710f",
+            "publicFile": "artifacts/model-evaluation-20260904/validated/rewrite-gemini/judge-openai-5.5.jsonl",
+            "publicFileSha256": "1c5c6d02d7029fea616a0e8fcc1923d1741b73ecdf65e3d1e2c49b6657466d1b",
+            "privateFile": "artifacts/model-evaluation-20260904/validated/rewrite-gemini/judge-openai-5.5.private.jsonl",
+            "privateFileSha256": "9a08a838f76a52a2263c46789b89b260252fd4ce699b1a4ab02e490cfefd3d8d",
+            "rows": 60,
+            "originalValid": 58,
+            "receiptCount": 180,
+            "receiptManifestHash": "a578ddea7e0a419e5b1fa283b41c2b99769fe2475427a71955a755786cb6cad6"
+          },
+          {
+            "source": "E",
+            "sourceCommit": "8918cd015fc71b35d0b7855cfe7625eb7a050fcf",
+            "judge": "anthropic-sonnet",
+            "requestedModel": "claude-sonnet-5",
+            "transport": "claude-cli",
+            "originalProtocolHash": "6e0510eef4840768f6c0ee102d0a66c0114025c5102625deca4dfe6190340645",
+            "publicFile": "artifacts/evaluation-parent-20260905/claude-on-gemini/judge-anthropic-sonnet.jsonl",
+            "publicFileSha256": "f49eb5e1e862a59fb4e12667a8ebf1c2852eb75c01b1ace6a5ddf7bdbc1ad5ee",
+            "privateFile": "artifacts/evaluation-parent-20260905/claude-on-gemini/judge-anthropic-sonnet.private.jsonl",
+            "privateFileSha256": "ae0904b9ec86788277aecb7a5c95829dda5dfd167e064a89172a455194003a5b",
+            "rows": 60,
+            "originalValid": 56,
+            "receiptCount": 180,
+            "receiptManifestHash": "67a28fdd595cda623f980b52676daadf169101edcbdd1a6bdfa0b1b19c519f4c",
+            "provenanceHash": "ee80433db1b80774aa1619159840a14f96ec801e4ff93aee3348b3b45f16cb41",
+            "directoryBindingHash": "a596dda2921285a8dfcbad2f99bbf0b167c3e275ef32ea584ddbe55ccfb718e0"
+          }
+        ]
+      }
+    },
+    {
+      "screen": "claude",
+      "provider": "anthropic",
+      "generations": 60,
+      "judgments": 120,
+      "originalValid": 119,
+      "correctedValid": 116,
+      "statusTransitions": {
+        "valid->valid": 116,
+        "valid->invalid": 3,
+        "invalid->valid": 0,
+        "invalid->invalid": 1
+      },
+      "mpsTransitions": {
+        "valid->valid": 116,
+        "valid->invalid": 3,
+        "invalid->valid": 0,
+        "invalid->invalid": 1
+      },
+      "oldTopTwo": [
+        "anthropic-sonnet",
+        "anthropic-fable"
+      ],
+      "newTopTwo": [
+        "anthropic-sonnet",
+        "anthropic-fable"
+      ],
+      "oldRanks": [
+        {
+          "rank": 1,
+          "id": "anthropic-sonnet",
+          "attempted": 12,
+          "safe": 8,
+          "safeRate": 0.6666666666666666,
+          "judgeErrors": 0,
+          "naturalnessMedian": 3.5,
+          "generationMedianMs": 8366
+        },
+        {
+          "rank": 2,
+          "id": "anthropic-fable",
+          "attempted": 12,
+          "safe": 8,
+          "safeRate": 0.6666666666666666,
+          "judgeErrors": 0,
+          "naturalnessMedian": 3.5,
+          "generationMedianMs": 16877
+        },
+        {
+          "rank": 3,
+          "id": "anthropic-haiku",
+          "attempted": 12,
+          "safe": 5,
+          "safeRate": 0.4166666666666667,
+          "judgeErrors": 1,
+          "naturalnessMedian": 3.5,
+          "generationMedianMs": 48565.5
+        },
+        {
+          "rank": 4,
+          "id": "anthropic-opus",
+          "attempted": 12,
+          "safe": 4,
+          "safeRate": 0.3333333333333333,
+          "judgeErrors": 0,
+          "naturalnessMedian": 3.5,
+          "generationMedianMs": 24263
+        },
+        {
+          "rank": 5,
+          "id": "anthropic-sonnet4.6",
+          "attempted": 12,
+          "safe": 3,
+          "safeRate": 0.25,
+          "judgeErrors": 0,
+          "naturalnessMedian": 3.5,
+          "generationMedianMs": 18205
+        }
+      ],
+      "correctedRanks": [
+        {
+          "rank": 1,
+          "id": "anthropic-sonnet",
+          "attempted": 12,
+          "safe": 8,
+          "safeRate": 0.6666666666666666,
+          "judgeErrors": 1,
+          "naturalnessMedian": 3.5,
+          "generationMedianMs": 8366
+        },
+        {
+          "rank": 2,
+          "id": "anthropic-fable",
+          "attempted": 12,
+          "safe": 8,
+          "safeRate": 0.6666666666666666,
+          "judgeErrors": 1,
+          "naturalnessMedian": 3.5,
+          "generationMedianMs": 16877
+        },
+        {
+          "rank": 3,
+          "id": "anthropic-haiku",
+          "attempted": 12,
+          "safe": 5,
+          "safeRate": 0.4166666666666667,
+          "judgeErrors": 1,
+          "naturalnessMedian": 3.5,
+          "generationMedianMs": 48565.5
+        },
+        {
+          "rank": 4,
+          "id": "anthropic-opus",
+          "attempted": 12,
+          "safe": 4,
+          "safeRate": 0.3333333333333333,
+          "judgeErrors": 1,
+          "naturalnessMedian": 3.5,
+          "generationMedianMs": 24263
+        },
+        {
+          "rank": 5,
+          "id": "anthropic-sonnet4.6",
+          "attempted": 12,
+          "safe": 3,
+          "safeRate": 0.25,
+          "judgeErrors": 0,
+          "naturalnessMedian": 3.5,
+          "generationMedianMs": 18205
+        }
+      ],
+      "changes": [
+        {
+          "id": "anthropic-sonnet",
+          "oldRank": 1,
+          "newRank": 1,
+          "oldSafe": 8,
+          "newSafe": 8,
+          "oldJudgeErrors": 0,
+          "newJudgeErrors": 1,
+          "enteredTopTwo": false,
+          "leftTopTwo": false
+        },
+        {
+          "id": "anthropic-fable",
+          "oldRank": 2,
+          "newRank": 2,
+          "oldSafe": 8,
+          "newSafe": 8,
+          "oldJudgeErrors": 0,
+          "newJudgeErrors": 1,
+          "enteredTopTwo": false,
+          "leftTopTwo": false
+        },
+        {
+          "id": "anthropic-opus",
+          "oldRank": 4,
+          "newRank": 4,
+          "oldSafe": 4,
+          "newSafe": 4,
+          "oldJudgeErrors": 0,
+          "newJudgeErrors": 1,
+          "enteredTopTwo": false,
+          "leftTopTwo": false
+        }
+      ],
+      "requiresConfirmation": {
+        "promotedCandidates": [],
+        "correctedTopTwo": [
+          "anthropic-sonnet",
+          "anthropic-fable"
+        ],
+        "action": "Revalidate any completed confirmation receipts with the corrected validator before relying on them. Newly selected candidates require confirmation evidence. No active confirmation dataset was inspected and no paid rerun is authorized by this report."
+      },
+      "provenance": {
+        "source": "D",
+        "sourceCommit": "dca3aa1de00bd21594f39e5b3c83614f28f22b85",
+        "originalParentProtocolHash": "64399c90db9352c305ade1fb23419d30cd1f436a8bb0fff073f9b54765ed34e3",
+        "parentSnapshotHash": "1d8202d5ccdee04e7391398995594e2d9738412c11fcd53c7e1005427298872b",
+        "generationFileHash": "814081b95f65974b4cf69bc90a0341e3a452bcea5ddea7962da8e5ac88166d72",
+        "privateGenerationFileHash": "8a96b2c4506e765af9a16ee23e6c2cacc6a52862d767cdda299b9cfb962fbd92",
+        "generationReceiptCount": 60,
+        "generationReceiptManifestHash": "e621311a1d7bd23c4cd28794d6399a5883aac36c7c68d2b98d21a34ee741c6cc",
+        "rebuiltGenerationPrompts": 60,
+        "baselineSummaryHash": "4a01b28eb84fb1bebddf3075f776f690a73ab2f0ddf10d2a071df285475cbfa5",
+        "judgments": [
+          {
+            "source": "E",
+            "sourceCommit": "8918cd015fc71b35d0b7855cfe7625eb7a050fcf",
+            "judge": "openai-5.5",
+            "requestedModel": "gpt-5.5",
+            "transport": "opencodex",
+            "originalProtocolHash": "43045a18cafee832bc2f4679435ad3b147404932b73ae7bac22ebd794a31a185",
+            "publicFile": "artifacts/evaluation-parent-20260905/openai-on-claude/judge-openai-5.5.jsonl",
+            "publicFileSha256": "2807605575be998547a45341ac2a1149d3b0e8bb50fbd947d3a8d607b35f7b78",
+            "privateFile": "artifacts/evaluation-parent-20260905/openai-on-claude/judge-openai-5.5.private.jsonl",
+            "privateFileSha256": "e8bc43957678d21f0c5493e0895ae4818f275998239da3bccc8c508eef355ad5",
+            "rows": 60,
+            "originalValid": 59,
+            "receiptCount": 180,
+            "receiptManifestHash": "071607589fb0913124408572e806b832dc7c12a76fbaf176bbcd217c9762519d",
+            "provenanceHash": "73ec41aeb018c545099a427815be697bdc804803c81bd96c5ca566610b349d46",
+            "directoryBindingHash": "d2b7186742a76728d968914b04e506ab901f757c025368c7d942ee47e3b4a1d2"
+          },
+          {
+            "source": "E",
+            "sourceCommit": "8918cd015fc71b35d0b7855cfe7625eb7a050fcf",
+            "judge": "gemini-3.7",
+            "requestedModel": "google-antigravity/gemini-3.7-flash",
+            "transport": "opencodex",
+            "originalProtocolHash": "c50a50e534c177caf2dbb1d9739e80744179c4ffed2da9e5d33052bfc258fa04",
+            "publicFile": "artifacts/evaluation-parent-20260905/gemini-on-claude/judge-gemini-3.7.jsonl",
+            "publicFileSha256": "102cb50abcceec1100584e488a1b590a02dc3bc43c3b508e19febe83822ec69c",
+            "privateFile": "artifacts/evaluation-parent-20260905/gemini-on-claude/judge-gemini-3.7.private.jsonl",
+            "privateFileSha256": "039db0864dbb5e2c7c56161dde2405ec89951dc5b245d62401cf25c8013396c2",
+            "rows": 60,
+            "originalValid": 60,
+            "receiptCount": 180,
+            "receiptManifestHash": "b8edfaf5a3b7a8c8bbc66d21cb61192bd53fa007ea15cd310877faceb67f1dc0",
+            "provenanceHash": "3f686151d3735495a4bc7a0a59ed8f560beace4f89b3a006c45a471cf0ab5d3b",
+            "directoryBindingHash": "ef95a5596c72258394b1ad949944c2bdcbb22028359bf9e33693347c7109b27b"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/research/mps-validation-correction-20260905.md
+++ b/docs/research/mps-validation-correction-20260905.md
@@ -1,0 +1,83 @@
+# MPS validation correction — September 5, 2026
+
+384 screening judgments over 192 generations were replayed offline. Valid judgments changed from 373 to 363.
+
+Correction commit: `5567e4a81fedd6f56cdd518507051c6c0db04f9d`. New derivation protocol: `75dc405f5960b9a666ec56d0bf17a31863e029c8e308a3ba0c4e3367040602c9`.
+
+Negation was omitted. The reviewed fix restores the Polarity + Negation group specified in `core/scoring.md` §16 and rejects the original response if its reported counts or score are inconsistent.
+
+## Validity transitions
+
+| Transition | MPS responses | Whole judgments |
+|---|---:|---:|
+| valid->valid | 366 | 363 |
+| valid->invalid | 10 | 10 |
+| invalid->valid | 0 | 0 |
+| invalid->invalid | 8 | 11 |
+
+## Screening top two
+
+| Screen | Original | Corrected | Newly selected; confirmation required |
+|---|---|---|---|
+| openai | openai-astra, openai-terra | openai-astra, openai-terra | None |
+| gemini | gemini-3.8-high, gemini-3.8-medium | gemini-3.8-high, gemini-3.8-medium | None |
+| claude | anthropic-sonnet, anthropic-fable | anthropic-sonnet, anthropic-fable | None |
+
+## Candidate ranks and safety
+
+| Screen | Candidate | Old rank → new | Safe before → after / attempted | Judge errors before → after | Corrected naturalness median | Generation median ms |
+|---|---|---:|---:|---:|---:|---:|
+| openai | openai-astra | 1 → 1 | 10 → 10 / 12 | 0 → 0 | 3.000 | 11430.500 |
+| openai | openai-terra | 2 → 2 | 8 → 8 / 12 | 2 → 2 | 3.500 | 5485.000 |
+| openai | openai-sol | 4 → 3 | 8 → 8 / 12 | 1 → 1 | 2.500 | 12791.000 |
+| openai | openai-5.5 | 3 → 4 | 8 → 7 / 12 | 0 → 1 | 3.000 | 6176.000 |
+| openai | openai-luna | 5 → 5 | 6 → 6 / 12 | 1 → 2 | 3.250 | 6379.000 |
+| openai | openai-mini | 6 → 6 | 5 → 5 / 12 | 0 → 1 | 3.500 | 4549.000 |
+| gemini | gemini-3.8-high | 1 → 1 | 7 → 7 / 12 | 1 → 1 | 3.000 | 9471.000 |
+| gemini | gemini-3.8-medium | 2 → 2 | 7 → 7 / 12 | 0 → 0 | 3.000 | 10744.000 |
+| gemini | gemini-3.7 | 3 → 3 | 6 → 6 / 12 | 1 → 1 | 3.000 | 6275.000 |
+| gemini | gemini-3.8-low | 4 → 4 | 4 → 3 / 12 | 3 → 4 | 2.500 | 9836.000 |
+| gemini | gemini-pro | 5 → 5 | 2 → 2 / 12 | 1 → 2 | 3.000 | 22035.500 |
+| claude | anthropic-sonnet | 1 → 1 | 8 → 8 / 12 | 0 → 1 | 3.500 | 8366.000 |
+| claude | anthropic-fable | 2 → 2 | 8 → 8 / 12 | 0 → 1 | 3.500 | 16877.000 |
+| claude | anthropic-haiku | 3 → 3 | 5 → 5 / 12 | 1 → 1 | 3.500 | 48565.500 |
+| claude | anthropic-opus | 4 → 4 | 4 → 4 / 12 | 0 → 1 | 3.500 | 24263.000 |
+| claude | anthropic-sonnet4.6 | 5 → 5 | 3 → 3 / 12 | 0 → 0 | 3.500 | 18205.000 |
+
+Within each screen: safe-output rate descending, model-rated naturalness median descending, generation latency median ascending, candidate ID ascending. Safety requires numeric proxy pass and two configured different-family valid judges with MPS/fidelity >=90 and zero hard failures. All generation attempts remain in the denominator.
+
+The corrected top two remain screening candidates. Existing completed confirmations need the same retrospective validation; newly selected candidates need confirmation evidence before promotion. No confirmation dataset was inspected here.
+
+## Evidence and derivation
+
+- Every judgment in the three declared screening joins is included, regardless of its original valid/invalid status. Public/private parity, full matrix membership, original snapshots/protocols, committed source/fixture bytes and terminal receipt metadata are checked before correction.
+- Generation prompts are rebuilt from frozen-source inputs and matched by hash; request identities and delivered rewrites are bound to original receipts. This does not claim recovery of every historical ambient configuration field.
+- Both historical and corrected judge pipelines receive only the original private receipt responses through an injected callback. Every MPS, fidelity and naturalness prompt/request hash and receipt ordinal must match. No source journal, lock, row, schema flag or protocol ID is rewritten.
+- The canonical polarity group includes polarity and negation anchors. The corrected validator checks the original self-reported pass counts, polarity counts and MPS. Inconsistent responses stay rejected; no counts or model scores are repaired.
+- The correction has its own protocol and private ledger. Historical rows/flags remain in original; corrected status and per-receipt flags are separate. Original protocol IDs stay attached to original observations.
+
+All 192 generation receipts and 1152 judgment receipts were bound. The private ledger SHA-256 is `e3c4613b00e90fc053b05c426420e28e76a429542108bbfb8e8a473db91045e5`. The JSON companion preserves original source/protocol/file/receipt commitments, status counts and rank changes.
+
+| Screen | Original parent protocol | Parent snapshot |
+|---|---|---|
+| openai | `c2779dde62beec49c198f3faa1be494565de48f147eaf511eacc785ae3b61ef5` | `90a5395382fb803f4168ac66a243d8250851b9e2dab195ac1efbcd68efa045d2` |
+| gemini | `60e90a2d1cb33f02c30bc6eaefcbe2ef8ee19ab862ae969356b44f46b6b5710f` | `eda02129432097969f964c7915979776889f7c328d8ccc8dc11ccfa46adb792e` |
+| claude | `64399c90db9352c305ade1fb23419d30cd1f436a8bb0fff073f9b54765ed34e3` | `1d8202d5ccdee04e7391398995594e2d9738412c11fcd53c7e1005427298872b` |
+
+## Limits
+
+- Proxy response.model echoes the requested alias. Model identity here is only recorded response/assistant-message/profile evidence, not proof of upstream weights or independent upstream judge families.
+- These are one-pass screening results on 12 curated source fixtures per candidate. They do not establish a final winner, default model, human preference or authenticated authorship accuracy.
+- MPS arithmetic/schema consistency does not independently certify the truth of the model’s anchor extraction or verdicts. Naturalness remains model-rated.
+- Confirmation and other active D/E jobs are outside this derivation. Revalidate completed confirmation evidence under the fix and obtain missing confirmation evidence before any promotion; no paid rerun is performed here.
+- Public output contains allowlisted counts, ranks, recorded identifiers and integrity hashes. Source texts, anchors, rationales and raw response/receipt bodies remain private.
+
+## Reproduce offline
+
+```sh
+node scripts/research/revalidate-mps-evidence.mjs --check
+```
+
+The default input plans are the three supplied `/tmp/patina-{openai,gemini,claude}-join-plan.json` files. The runner reads only their declared completed screening cohorts. `--write` writes the two public report files and a private, gitignored ledger under `/tmp/patina-mps-revalidation-20260905`; no source directory receives a lock or write. Source worktrees must remain at their pinned commits. No credentials are read and network requests are disabled.
+
+Validation code is selected separately. The plans locate the historical evaluator and protocol; `--validation-source DIR --validation-commit COMMIT` points to the reviewed correction, including the frozen G source without reading any of its study artifacts. For full joins, callers can pass the original runtime, corrected pipeline and validator to `replayBoundJudgment`. Those joins must declare their own complete matrix. The CLI is limited to these three screens.

--- a/scripts/research/revalidate-mps-evidence.mjs
+++ b/scripts/research/revalidate-mps-evidence.mjs
@@ -1,0 +1,529 @@
+#!/usr/bin/env node
+// Offline correction of the three completed screening joins. Never resume a study.
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import http from 'node:http';
+import https from 'node:https';
+import net from 'node:net';
+import yaml from 'js-yaml';
+import { parseStrictJson } from '../../src/json-response.js';
+import { validateRawMps } from './study-validation.mjs';
+import { judgeRewrite, summarizeRewrites } from './model-rewrite-benchmark.mjs';
+import { selectRewriteFinalists } from './join-model-evaluations.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const SCRIPT = 'scripts/research/revalidate-mps-evidence.mjs';
+const REPORT = 'docs/research/mps-validation-correction-20260905';
+const PRIVATE_OUTPUT = '/tmp/patina-mps-revalidation-20260905';
+const VALIDATION_SOURCE = resolve(ROOT, '../patina-corrected-judge-source-20260905');
+const FIX = '5567e4a81fedd6f56cdd518507051c6c0db04f9d';
+const HASH = /^[a-f0-9]{64}$/;
+const SEATS = ['openai-5.5', 'gemini-3.7', 'anthropic-sonnet'];
+const STAGES = ['mps', 'fidelity', 'naturalness'];
+const FIELDS = ['status', 'error', 'mps', 'fidelity', 'naturalness', 'hard_fail_count'];
+const COMMITS = {
+  A: '66a19b79e68e0e7df00d0c5da0aa94dac3c51e1c',
+  D: 'dca3aa1de00bd21594f39e5b3c83614f28f22b85',
+  E: '8918cd015fc71b35d0b7855cfe7625eb7a050fcf',
+  F: '6ef4ae0abe7f571dabd7648fbe9373ea16946616',
+};
+const SCREENS = {
+  openai: { source: 'A', provider: 'openai', generations: 72, parent: 'artifacts/model-evaluation-20260904/validated/rewrite-openai', evaluations: ['claude-on-openai'] },
+  gemini: { source: 'A', provider: 'gemini', generations: 60, parent: 'artifacts/model-evaluation-20260904/validated/rewrite-gemini', evaluations: ['claude-on-gemini'] },
+  claude: { source: 'D', provider: 'anthropic', generations: 60, parent: 'artifacts/model-evaluation-claude-isolated-20260905/validated/rewrite-screen', evaluations: ['openai-on-claude', 'gemini-on-claude'] },
+};
+const MAX_FILE = 16 * 1024 * 1024;
+const MAX_TOTAL = 128 * 1024 * 1024;
+const key = (row) => `${row.candidate_id}/${row.fixture_id}/${row.repeat}`;
+const canonical = (value) => Array.isArray(value) ? value.map(canonical) : value && typeof value === 'object'
+  ? Object.fromEntries(Object.keys(value).sort().map((name) => [name, canonical(value[name])])) : value;
+const same = (a, b) => JSON.stringify(canonical(a)) === JSON.stringify(canonical(b));
+export const sha256 = (value) => createHash('sha256').update(typeof value === 'string' || Buffer.isBuffer(value) ? value : JSON.stringify(value)).digest('hex');
+const digest = (value) => sha256(canonical(value));
+const sorted = (values) => [...values].sort();
+const insist = (condition, code) => { if (!condition) throw new Error(`mps-revalidation: ${code}`); };
+const snapshot = (row) => Object.fromEntries(FIELDS.map((field) => [field, row[field] ?? null]));
+const unresolved = (row) => [row.error, ...(row.calls || []).map((call) => call.error)].some((error) =>
+  ['study-cancelled', 'study-call-inflight', 'study-call-unobserved', 'study-journal-persistence-failed'].includes(error));
+
+function json(bytes) {
+  try { return JSON.parse(bytes.toString('utf8')); }
+  catch { throw new Error('mps-revalidation: invalid JSON'); }
+}
+
+export function createEvidenceReader(root) {
+  root = realpathSync(root);
+  const cache = new Map(); let total = 0;
+  const locate = (name) => {
+    insist(typeof name === 'string' && /^[a-zA-Z0-9._/-]+$/.test(name) && !name.startsWith('/')
+      && name.split('/').every((part) => part && !['.', '..'].includes(part)), 'unsafe evidence path');
+    let full = root;
+    for (const part of name.split('/')) { full = resolve(full, part); insist(!lstatSync(full).isSymbolicLink(), 'evidence symlink'); }
+    return full;
+  };
+  const bytes = (name) => {
+    if (cache.has(name)) return cache.get(name);
+    const full = locate(name), stat = lstatSync(full);
+    insist(stat.isFile() && stat.size <= MAX_FILE && total + stat.size <= MAX_TOTAL, 'evidence size bound');
+    const data = readFileSync(full); insist(data.length === stat.size, 'evidence changed during read');
+    total += data.length; cache.set(name, data); return data;
+  };
+  return { root, bytes, json: (name) => json(bytes(name)),
+    rows(name, rowKey = key) {
+      const rows = bytes(name).toString('utf8').split(/\r?\n/).filter((line) => line.trim()).map((line) => json(line));
+      insist(rows.length <= 500 && new Set(rows.map(rowKey)).size === rows.length, 'row bound or duplicate'); return rows;
+    },
+    list(name) { const entries = readdirSync(locate(name)); insist(entries.length <= 1500, 'directory bound'); return entries.sort(); },
+    exists: (name) => existsSync(resolve(root, name)),
+    hash: (name) => sha256(bytes(name)),
+    unchanged() {
+      for (const [name, data] of cache) {
+        const full = locate(name); insist(lstatSync(full).size === data.length && sha256(readFileSync(full)) === sha256(data), 'evidence changed during derivation');
+      }
+    },
+  };
+}
+
+function verifyCommitted(reader, commit, paths) {
+  insist(execFileSync('git', ['rev-parse', 'HEAD'], { cwd: reader.root, encoding: 'utf8' }).trim() === commit, 'frozen source commit differs');
+  const output = execFileSync('git', ['cat-file', '--batch'], { cwd: reader.root,
+    input: paths.map((path) => `${commit}:${path}\n`).join(''), maxBuffer: MAX_TOTAL });
+  let offset = 0;
+  for (const path of paths) {
+    const end = output.indexOf(10, offset);
+    const header = output.subarray(offset, end).toString('utf8').match(/^[a-f0-9]{40} blob ([0-9]+)$/);
+    insist(header, 'source file missing from commit');
+    const size = Number(header[1]);
+    insist(sha256(output.subarray(end + 1, end + size + 1)) === reader.hash(path), 'source bytes differ from commit');
+    offset = end + size + 2;
+  }
+  insist(offset === output.length, 'invalid committed source stream');
+}
+
+async function loadRuntime(reader, commit) {
+  const names = execFileSync('git', ['ls-tree', '-r', '--name-only', commit], { cwd: reader.root, encoding: 'utf8' }).trim().split('\n')
+    .filter((name) => /^(src|patterns|core|document-types|lexicon|personas)\//.test(name)
+      || /^tests\/fixtures\/(live-quality|suspect-zones)\//.test(name)
+      || ['.patina.default.yaml', 'package.json', 'tests/quality/live-quality.mjs', 'tests/quality/live-scorer-benchmark.mjs'].includes(name)
+      || /^scripts\/research\/[a-z0-9-]+\.mjs$/.test(name)
+      || /^docs\/research\/model-evaluation.*\.json$/.test(name));
+  verifyCommitted(reader, commit, names);
+  const module = (name) => import(pathToFileURL(resolve(reader.root, name)).href);
+  const [rewrite, journal, validation, live, loader, numbers] = await Promise.all([
+    module('scripts/research/model-rewrite-benchmark.mjs'), module('scripts/research/study-journal.mjs'),
+    module('scripts/research/study-validation.mjs'), module('tests/quality/live-quality.mjs'),
+    module('src/loader.js'), module('src/features/meaning-proxy.js'),
+  ]);
+  return { rewrite, journal, validation, live, loader, numbers,
+    sourceHashes: Object.fromEntries(names.map((name) => [name, reader.hash(name)])) };
+}
+
+export function checkParity(publicRows, privateRows, privateField) {
+  insist(publicRows.length === privateRows.length && new Set(publicRows.map(key)).size === publicRows.length
+    && new Set(privateRows.map(key)).size === privateRows.length, 'public/private matrix differs');
+  const byKey = new Map(privateRows.map((row) => [key(row), row]));
+  for (const row of publicRows) {
+    const stored = byKey.get(key(row)); insist(stored, 'missing private row');
+    const { [privateField]: _private, ...publicPart } = stored;
+    insist(same(row, publicPart), 'public/private row differs');
+  }
+  return byKey;
+}
+
+export function bindReceipt(receipt, { logicalId, index, candidate, promptHash, temperature, responseFormat = null, extraBody = null }) {
+  const identity = { logicalId, index, candidate, promptHash, temperature, responseFormat, extraBody };
+  insist(receipt.schemaVersion === 1 && ['completed', 'error'].includes(receipt.state), 'receipt is not terminal');
+  insist(HASH.test(promptHash) && receipt.promptHash === promptHash && receipt.requestHash === sha256(identity), 'request/prompt binding differs');
+  insist(!['study-call-inflight', 'study-call-unobserved', 'study-cancelled', 'study-journal-persistence-failed'].includes(receipt.error), 'unresolved receipt');
+}
+
+function errorCode(error) {
+  return ['invalid-mps-schema', 'invalid-anchor', 'inconsistent-mps-counts', 'inconsistent-mps-score'].includes(error?.message) ? error.message : 'invalid-mps-json';
+}
+
+// No counts or MPS values are changed. Validators receive the original text.
+export function classifyMps(text, originalSchemaValid, legacyValidator, correctedValidator = validateRawMps) {
+  let oldValid = false, newValid = false, reason = null, parsed = null;
+  try { legacyValidator(text); oldValid = true; } catch { /* A historical rejection is evidence too. */ }
+  insist(originalSchemaValid === oldValid, 'historical MPS flag differs from original validator');
+  try { correctedValidator(text); newValid = true; } catch (error) { reason = errorCode(error); }
+  try { parsed = parseStrictJson(text); } catch { /* Preserve unparsable input as a rejection. */ }
+  const fields = ['pass_count', 'total_count', 'polarity_pass_count', 'polarity_total_count', 'mps'];
+  return { originalSchemaValid: oldValid, correctedSchemaValid: newValid,
+    transition: `${oldValid ? 'valid' : 'invalid'}->${newValid ? 'valid' : 'invalid'}`, rejection: reason,
+    selfReported: Object.fromEntries(fields.map((field) => [field, Number.isFinite(parsed?.[field]) ? parsed[field] : null])),
+    negationAnchors: Array.isArray(parsed?.anchors) ? parsed.anchors.filter((anchor) => anchor?.type === 'negation').length : null,
+    acceptedMps: newValid ? parsed.mps : null };
+}
+
+function receiptSequence(reader, directory, logicalId, row, candidate, runtime) {
+  insist(!unresolved(row) && Array.isArray(row.calls) && row.calls.length > 0 && row.calls.length <= 6, 'unresolved row or call bound');
+  const group = sha256(logicalId), names = Array.from({ length: row.calls.length }, (_, i) => `${i + 1}.private.json`);
+  insist(same(reader.list(`${directory}/calls/${group}`), names), 'receipt sequence differs');
+  return names.map((name, i) => {
+    const path = `${directory}/calls/${group}/${name}`, receipt = reader.json(path), call = row.calls[i];
+    insist(['completed', 'error'].includes(receipt.state) && !unresolved(receipt), 'nonterminal receipt');
+    const safe = runtime.journal.safeCallRecord(receipt, candidate);
+    const { stage: _stage, ...originalCall } = call;
+    insist(same(safe, originalCall), 'original receipt/call metadata differs');
+    insist(safe.modelIdentityVerified === true || safe.profileIdentityVerified === true, 'missing recorded identity evidence');
+    insist(!safe.mixedOrUnexpectedModel && receipt.response?.effectiveModels?.every((model) => model === candidate.model), 'mixed or unexpected recorded model');
+    return { receipt, path, sha256: reader.hash(path), group, index: i + 1 };
+  });
+}
+
+export async function replayBoundJudgment({ row, stored, fixture, generation, judge, entries, originalRuntime,
+  correctedRun = judgeRewrite, correctedValidator = validateRawMps }) {
+  const logicalId = `${row.protocol_hash}/${key(row)}/judge/${judge.id}`;
+  const run = async (evaluate) => {
+    let ordinal = 0, bindingFailure = null;
+    const replay = await evaluate(fixture, generation, judge, { logicalId,
+      complete: async (requested, prompt, options) => {
+        const entry = entries[ordinal++];
+        try {
+          insist(entry && same(requested, judge), 'unrecorded replay call or candidate');
+          bindReceipt(entry.receipt, { logicalId, index: ordinal, candidate: requested, promptHash: sha256(prompt),
+            temperature: options.temperature ?? .2, responseFormat: options.responseFormat ?? null, extraBody: options.extraBody ?? null });
+        } catch (error) { bindingFailure = error; throw error; }
+        for (const attempt of entry.receipt.transportAttempts || []) options.onAttempt?.(attempt);
+        if (entry.receipt.state !== 'completed') throw new Error(entry.receipt.error);
+        return globalThis.structuredClone(entry.receipt.response);
+      } });
+    if (bindingFailure) throw bindingFailure;
+    insist(ordinal === entries.length, 'replay did not consume exact receipt sequence');
+    return replay;
+  };
+  const historical = await run(originalRuntime.rewrite.judgeRewrite);
+  insist(same(snapshot(historical), snapshot(row)), 'original judgment outcome differs from receipts');
+  insist(same(historical.private_details, stored.private_details), 'original private judgment details differ');
+  for (let i = 0; i < entries.length; i++) insist(historical.calls[i].stage === row.calls[i].stage
+    && historical.calls[i].schema_valid === row.calls[i].schema_valid, 'original stage binding differs');
+  const corrected = await run(correctedRun);
+  insist(corrected.calls.length === row.calls.length, 'correction changed call sequence');
+  const mpsResponses = [];
+  for (let i = 0; i < entries.length; i++) {
+    const oldCall = row.calls[i], nextCall = corrected.calls[i];
+    insist(STAGES.includes(oldCall.stage) && oldCall.stage === nextCall.stage, 'correction changed stage');
+    if (oldCall.stage === 'mps' && entries[i].receipt.state === 'completed') {
+      const result = classifyMps(entries[i].receipt.response.text, oldCall.schema_valid, originalRuntime.validation.validateRawMps, correctedValidator);
+      insist(nextCall.schema_valid === result.correctedSchemaValid, 'corrected MPS replay differs');
+      mpsResponses.push({ ordinal: i + 1, responseSha256: sha256(entries[i].receipt.response.text), ...result });
+    } else insist(oldCall.schema_valid === nextCall.schema_valid, 'non-MPS validation changed');
+  }
+  // Validation may change status and derived hard-failure availability, not a
+  // model's numerical MPS, fidelity, or naturalness response.
+  for (const field of ['mps', 'fidelity', 'naturalness']) insist((corrected[field] ?? null) === (historical[field] ?? null), 'correction repaired a model score');
+  return { corrected, mpsResponses };
+}
+
+export function rankSummary(summary) {
+  const rows = Object.entries(summary).map(([id, value]) => ({ id, ...value }));
+  insist(rows.every((row) => row.pending_judgments === 0), 'pending judgments prevent ranking');
+  return rows.sort((a, b) => b.safe_rate - a.safe_rate
+    || (b.naturalness.median ?? -Infinity) - (a.naturalness.median ?? -Infinity)
+    || (a.generation_latency_ms.median ?? Infinity) - (b.generation_latency_ms.median ?? Infinity)
+    || a.id.localeCompare(b.id)).map((row, i) => ({ rank: i + 1, id: row.id, attempted: row.attempted,
+      safe: row.safe, safeRate: row.safe_rate, judgeErrors: row.judge_errors, naturalnessMedian: row.naturalness.median,
+      generationMedianMs: row.generation_latency_ms.median }));
+}
+
+function transitions(values) {
+  return Object.fromEntries(['valid->valid', 'valid->invalid', 'invalid->valid', 'invalid->invalid'].map((value) => [value, values.filter((item) => item === value).length]));
+}
+
+function validatePlan(plan, screen) {
+  const spec = SCREENS[screen];
+  insist(spec && plan.parentProvider === spec.provider && !plan.parentCandidate && (plan.repeat ?? 1) === 1
+    && (plan.suite ?? 'screening') === 'screening', 'plan scope differs');
+  insist(resolve(plan.parent) === resolve(plan.parentRoot, spec.parent), 'parent is outside selected screening cohort');
+  const evaluations = spec.evaluations.map((name) => resolve(plan.evaluationSourceRoot, 'artifacts/evaluation-parent-20260905', name));
+  insist(same(sorted(plan.evaluations.map((path) => resolve(path))), sorted(evaluations)), 'evaluation scope differs');
+  const parentProtocol = spec.source === 'A' ? 'docs/research/model-evaluation-20260904.json' : 'docs/research/model-evaluation-claude-isolated-20260905.json';
+  insist(resolve(plan.parentCandidates) === resolve(plan.parentRoot, parentProtocol)
+    && resolve(plan.candidates) === resolve(plan.evaluationSourceRoot, 'docs/research/model-evaluation-claude-isolated-20260905.json'), 'protocol source differs');
+  insist(plan.output === `/tmp/patina-${screen}-rewrite-screen-summary`, 'baseline summary scope differs');
+  return { spec, parentProtocol };
+}
+
+async function auditScreen(screen, plan, readers, runtimes, correctedRuntime) {
+  const { spec, parentProtocol } = validatePlan(plan, screen);
+  const parentReader = readers[spec.source], parentRuntime = runtimes[spec.source], evaluator = readers.E;
+  const directory = spec.parent;
+  insist(!parentReader.exists(`${directory}/.writer.lock`), 'selected parent writer active');
+  const protocol = parentReader.json(parentProtocol), evaluationProtocol = evaluator.json('docs/research/model-evaluation-claude-isolated-20260905.json');
+  const fixtures = parentRuntime.rewrite.rewriteFixtures('screening', parentReader.root);
+  insist(fixtures.length === 12 && new Set(fixtures.map((f) => f.fixture_id)).size === 12, 'fixture matrix differs');
+  const candidates = protocol.candidates.filter((candidate) => candidate.provider === spec.provider);
+  const generations = parentReader.rows(`${directory}/rewrite-rows.jsonl`), privateRows = parentReader.rows(`${directory}/rewrites.private.jsonl`);
+  const originals = checkParity(generations, privateRows, 'rewrite');
+  const expected = candidates.flatMap((candidate) => fixtures.map((fixture) => `${candidate.id}/${fixture.fixture_id}/0`));
+  insist(generations.length === spec.generations && same(sorted(generations.map(key)), sorted(expected)), 'generation matrix incomplete or unexpected');
+  const config = yaml.load(parentReader.bytes('.patina.default.yaml').toString('utf8'));
+  config.documentType = config['document-type'] || 'default'; delete config['document-type']; config.persona = null; config.register = null;
+  const prompts = new Map();
+  for (const fixture of fixtures) prompts.set(fixture.fixture_id, await parentRuntime.live.buildPatinaRewritePrompt(fixture, {
+    repoRoot: parentReader.root, promptMode: 'minimal', config, patterns: parentRuntime.loader.loadPatterns(parentReader.root, fixture.language),
+  }));
+  const generationEvidence = [], expectedParentGroups = [];
+  for (const row of generations) {
+    const original = originals.get(key(row)), fixture = fixtures.find((f) => f.fixture_id === row.fixture_id), candidate = candidates.find((c) => c.id === row.candidate_id);
+    insist(row.schemaVersion === 1 && row.status === 'ok' && !unresolved(row) && HASH.test(row.protocol_hash)
+      && row.repeat === 0 && row.text_hash === fixture.text_hash && row.language === fixture.language
+      && row.provider === candidate.provider && row.requested_model === candidate.model && row.transport === candidate.transport
+      && row.prompt_hash === sha256(prompts.get(fixture.fixture_id)) && sha256(original.rewrite) === row.rewrite_hash, 'generation source/identity/prompt differs');
+    insist(row.number_safety?.ok === parentRuntime.numbers.evaluateNumberSafety(fixture.text, original.rewrite, fixture.language).ok, 'original numeric safety differs');
+    const logicalId = `${row.protocol_hash}/${key(row)}/rewrite`;
+    const entries = receiptSequence(parentReader, directory, logicalId, row, candidate, parentRuntime);
+    for (const entry of entries) bindReceipt(entry.receipt, { logicalId, index: entry.index, candidate, promptHash: row.prompt_hash, temperature: .2 });
+    insist(parentRuntime.live.deliveredRewrite(entries.at(-1).receipt.response.text) === original.rewrite, 'delivered generation differs from receipt');
+    generationEvidence.push(...entries); expectedParentGroups.push(sha256(logicalId));
+  }
+  const parentProtocols = [...new Set(generations.map((row) => row.protocol_hash))];
+  insist(parentProtocols.length === 1, 'mixed parent protocols');
+  if (parentReader.exists(`${directory}/study-protocol.json`)) insist(parentReader.json(`${directory}/study-protocol.json`).protocolHash === parentProtocols[0], 'parent protocol directory binding differs');
+  else insist(plan.allowLegacyParent === true, 'unbound parent not authorized');
+
+  const datasets = [];
+  for (const id of SEATS) if (parentReader.exists(`${directory}/judge-${id}.jsonl`)) datasets.push({ reader: parentReader, runtime: parentRuntime,
+    directory, id, protocol, parent: true, source: spec.source });
+  const evaluationSemantics = runtimes.E.validation.studySemantics(evaluator.root);
+  const parentInputHashes = new Map(); let parentSnapshotHash = null;
+  for (const name of spec.evaluations) {
+    const path = `artifacts/evaluation-parent-20260905/${name}`;
+    insist(!evaluator.exists(`${path}/.writer.lock`), 'selected evaluation writer active');
+    const provenance = evaluator.json(`${path}/provenance.json`);
+    const base = Object.fromEntries(['schemaVersion', 'bindingMode', 'parentProtocolHashes', 'inputHashes', 'scope', 'fixtures'].map((field) => [field, provenance[field]]));
+    insist(sha256(base) === provenance.parentSnapshotHash && same(base.parentProtocolHashes, parentProtocols)
+      && same(base.scope, { provider: spec.provider, candidateId: null, repeat: 1 })
+      && same(base.fixtures, fixtures.map(parentRuntime.validation.fixtureIdentity)), 'parent snapshot provenance differs');
+    for (const [file, hash] of Object.entries(base.inputHashes)) {
+      insist(file === 'protocol' || /^(rewrite-rows\.jsonl|rewrites\.private\.jsonl|study-protocol\.json|judge-[a-z0-9.-]+(?:\.private)?\.jsonl|calls\/[a-f0-9]{64}\/[1-6]\.private\.json)$/.test(file), 'unexpected parent snapshot member');
+      insist(HASH.test(hash) && (file === 'protocol' ? parentReader.hash(parentProtocol) : parentReader.hash(`${directory}/${file}`)) === hash, 'parent snapshot bytes differ');
+    }
+    if (parentSnapshotHash) insist(parentSnapshotHash === provenance.parentSnapshotHash, 'evaluations use different parent snapshots');
+    parentSnapshotHash = provenance.parentSnapshotHash;
+    parentInputHashes.set(name, base.inputHashes);
+    const id = provenance.judge?.id, judge = evaluationProtocol.candidates.find((candidate) => candidate.id === id);
+    insist(judge && SEATS.includes(id) && same(provenance.judge, { id, provider: judge.provider, model: judge.model, transport: judge.transport, effort: judge.effort ?? null }), 'evaluation judge identity differs');
+    const expectedProtocol = sha256({ protocol: evaluationProtocol, judge: id, parentSnapshotHash, semantics: evaluationSemantics });
+    insist(provenance.evaluationProtocolHash === expectedProtocol && evaluator.json(`${path}/study-protocol.json`).protocolHash === expectedProtocol, 'evaluation protocol differs');
+    datasets.push({ reader: evaluator, runtime: runtimes.E, directory: path, id, protocol: evaluationProtocol,
+      parent: false, protocolHash: expectedProtocol, source: 'E' });
+  }
+  const allOriginal = [], allCorrected = [], ledger = [], datasetEvidence = [];
+  for (const dataset of datasets) {
+    const { reader, runtime, directory: path, id } = dataset;
+    const publicFile = `${path}/judge-${id}.jsonl`, privateFile = `${path}/judge-${id}.private.jsonl`;
+    const rows = reader.rows(publicFile), stored = checkParity(rows, reader.rows(privateFile), 'private_details');
+    insist(rows.length === generations.length && same(sorted(rows.map(key)), sorted(expected)), 'judge matrix incomplete or unexpected');
+    const judge = dataset.protocol.candidates.find((candidate) => candidate.id === id);
+    const entriesManifest = [], groups = [];
+    for (const row of rows) {
+      const generation = originals.get(key(row)), fixture = fixtures.find((f) => f.fixture_id === row.fixture_id), generator = candidates.find((c) => c.id === row.candidate_id);
+      insist(row.schemaVersion === 1 && ['ok', 'error'].includes(row.status) && !unresolved(row)
+        && row.text_hash === generation.text_hash && row.rewrite_hash === generation.rewrite_hash
+        && row.judge_id === id && row.judge_model === judge.model && row.judge_provider === judge.provider && row.judge_transport === judge.transport
+        && runtime.rewrite.judgeCandidates(generator, dataset.protocol).some((seat) => seat.id === id)
+        && row.protocol_hash === (dataset.parent ? generation.protocol_hash : dataset.protocolHash), 'judgment identity or protocol differs');
+      if (!dataset.parent) insist(row.parent_protocol_hash === generation.protocol_hash && row.parent_snapshot_hash === parentSnapshotHash, 'judgment parent binding differs');
+      const logicalId = `${row.protocol_hash}/${key(row)}/judge/${id}`;
+      const entries = receiptSequence(reader, path, logicalId, row, judge, runtime);
+      const result = await replayBoundJudgment({ row, stored: stored.get(key(row)), fixture, generation, judge, entries, originalRuntime: runtime,
+        correctedRun: correctedRuntime.rewrite.judgeRewrite, correctedValidator: correctedRuntime.validation.validateRawMps });
+      const corrected = { ...row, ...snapshot(result.corrected) };
+      allOriginal.push(row); allCorrected.push(corrected); groups.push(sha256(logicalId));
+      const receiptBindings = entries.map((entry, i) => ({ path: entry.path, sha256: entry.sha256, ordinal: entry.index,
+        requestHash: entry.receipt.requestHash, promptHash: entry.receipt.promptHash, responseSha256: entry.receipt.response ? sha256(entry.receipt.response.text) : null,
+        originalSchemaValid: entry.receipt.schemaValid ?? null, correctedSchemaValid: result.corrected.calls[i].schema_valid,
+        stage: row.calls[i].stage, identityEvidence: row.calls[i].identityEvidence ?? 'response-metadata' }));
+      entriesManifest.push(...receiptBindings);
+      ledger.push({ schemaVersion: 1, screen, source: dataset.source, sourceCommit: COMMITS[dataset.source],
+        sourcePublicFile: publicFile, sourcePrivateFile: privateFile,
+        originalPublicRowHash: sha256(row), originalPrivateRowHash: sha256(stored.get(key(row))),
+        original: globalThis.structuredClone(row), corrected: snapshot(result.corrected),
+        statusTransition: `${row.status === 'ok' ? 'valid' : 'invalid'}->${corrected.status === 'ok' ? 'valid' : 'invalid'}`,
+        mpsResponses: result.mpsResponses, receiptBindings });
+    }
+    if (dataset.parent) expectedParentGroups.push(...groups);
+    else insist(same(reader.list(`${path}/calls`), sorted(groups)), 'unexpected evaluation receipt group');
+    datasetEvidence.push({ source: dataset.source, sourceCommit: COMMITS[dataset.source], judge: id,
+      requestedModel: judge.model, transport: judge.transport, originalProtocolHash: rows[0].protocol_hash,
+      publicFile, publicFileSha256: reader.hash(publicFile), privateFile, privateFileSha256: reader.hash(privateFile),
+      rows: rows.length, originalValid: rows.filter((row) => row.status === 'ok').length,
+      receiptCount: entriesManifest.length, receiptManifestHash: digest(entriesManifest),
+      ...(!dataset.parent ? { provenanceHash: reader.hash(`${path}/provenance.json`), directoryBindingHash: reader.hash(`${path}/study-protocol.json`) } : {}) });
+  }
+  insist(same(parentReader.list(`${directory}/calls`), sorted(expectedParentGroups)), 'unexpected parent receipt group');
+  insist(allOriginal.length === generations.length * 2, 'missing screening judge seats');
+  // Coverage must match the original snapshot exactly, not a convenient subset.
+  for (const hashes of parentInputHashes.values()) {
+    const files = ['protocol', 'rewrite-rows.jsonl', 'rewrites.private.jsonl'];
+    if (parentReader.exists(`${directory}/study-protocol.json`)) files.push('study-protocol.json');
+    for (const dataset of datasets.filter((dataset) => dataset.parent)) files.push(`judge-${dataset.id}.jsonl`, `judge-${dataset.id}.private.jsonl`);
+    for (const group of expectedParentGroups) for (const file of parentReader.list(`${directory}/calls/${group}`)) files.push(`calls/${group}/${file}`);
+    insist(same(sorted(Object.keys(hashes)), sorted(files)), 'parent snapshot membership differs');
+  }
+  const before = summarizeRewrites(generations, allOriginal), after = summarizeRewrites(generations, allCorrected);
+  const oldRank = rankSummary(before), newRank = rankSummary(after), oldTopTwo = oldRank.slice(0, 2).map((row) => row.id), newTopTwo = newRank.slice(0, 2).map((row) => row.id);
+  insist(same(selectRewriteFinalists(before)[spec.provider], oldTopTwo) && same(selectRewriteFinalists(after)[spec.provider], newTopTwo), 'ranking differs from join rule');
+  const baselineReader = createEvidenceReader(plan.output), baseline = baselineReader.json('rewrite-summary.json');
+  insist(same(baseline.summary, before) && same(baseline.finalists[spec.provider], oldTopTwo), 'original F screening summary differs');
+  baselineReader.unchanged();
+  const changes = newRank.map((next) => {
+    const prior = oldRank.find((row) => row.id === next.id);
+    return { id: next.id, oldRank: prior.rank, newRank: next.rank, oldSafe: prior.safe, newSafe: next.safe,
+      oldJudgeErrors: prior.judgeErrors, newJudgeErrors: next.judgeErrors,
+      enteredTopTwo: newTopTwo.includes(next.id) && !oldTopTwo.includes(next.id),
+      leftTopTwo: oldTopTwo.includes(next.id) && !newTopTwo.includes(next.id) };
+  }).filter((row) => row.oldRank !== row.newRank || row.oldSafe !== row.newSafe || row.oldJudgeErrors !== row.newJudgeErrors);
+  const mps = ledger.flatMap((row) => row.mpsResponses);
+  for (const path of [directory]) insist(!parentReader.exists(`${path}/.writer.lock`), 'parent writer appeared');
+  for (const name of spec.evaluations) insist(!evaluator.exists(`artifacts/evaluation-parent-20260905/${name}/.writer.lock`), 'evaluation writer appeared');
+  return { ledger, report: { screen, provider: spec.provider, generations: generations.length, judgments: ledger.length,
+    originalValid: allOriginal.filter((row) => row.status === 'ok').length, correctedValid: allCorrected.filter((row) => row.status === 'ok').length,
+    statusTransitions: transitions(ledger.map((row) => row.statusTransition)), mpsTransitions: transitions(mps.map((row) => row.transition)),
+    oldTopTwo, newTopTwo, oldRanks: oldRank, correctedRanks: newRank, changes,
+    requiresConfirmation: { promotedCandidates: newTopTwo.filter((id) => !oldTopTwo.includes(id)),
+      correctedTopTwo: newTopTwo, action: 'Revalidate any completed confirmation receipts with the corrected validator before relying on them. Newly selected candidates require confirmation evidence. No active confirmation dataset was inspected and no paid rerun is authorized by this report.' },
+    provenance: { source: spec.source, sourceCommit: COMMITS[spec.source], originalParentProtocolHash: parentProtocols[0], parentSnapshotHash,
+      generationFileHash: parentReader.hash(`${directory}/rewrite-rows.jsonl`), privateGenerationFileHash: parentReader.hash(`${directory}/rewrites.private.jsonl`),
+      generationReceiptCount: generationEvidence.length,
+      generationReceiptManifestHash: digest(generationEvidence.map((entry) => ({ path: entry.path, sha256: entry.sha256, requestHash: entry.receipt.requestHash, promptHash: entry.receipt.promptHash }))),
+      rebuiltGenerationPrompts: generations.length, baselineSummaryHash: baselineReader.hash('rewrite-summary.json'), judgments: datasetEvidence } } };
+}
+
+export async function deriveCorrection(plans, { joinSourceRoot = '/home/devswha/workspace/patina-model-results',
+  validationSourceRoot = VALIDATION_SOURCE, validationCommit = FIX } = {}) {
+  insist(/^[a-f0-9]{40}$/.test(validationCommit), 'invalid validation commit');
+  insist(same(sorted(Object.keys(plans)), ['claude', 'gemini', 'openai']), 'exactly three screening plans required');
+  for (const [name, plan] of Object.entries(plans)) validatePlan(plan, name);
+  insist(plans.openai.parentRoot === plans.gemini.parentRoot
+    && Object.values(plans).every((plan) => plan.evaluationSourceRoot === plans.openai.evaluationSourceRoot), 'source roots differ');
+  const readers = { A: createEvidenceReader(plans.openai.parentRoot), D: createEvidenceReader(plans.claude.parentRoot), E: createEvidenceReader(plans.openai.evaluationSourceRoot) };
+  const runtimes = {};
+  for (const name of Object.keys(readers)) runtimes[name] = await loadRuntime(readers[name], COMMITS[name]);
+  const validationReader = createEvidenceReader(validationSourceRoot);
+  // This source is independent of each original evaluator's root and protocol.
+  // Only code/fixtures are read here, never a validation source's study outputs.
+  const correctedRuntime = await loadRuntime(validationReader, validationCommit);
+  const joinReader = createEvidenceReader(joinSourceRoot);
+  verifyCommitted(joinReader, COMMITS.F, ['scripts/research/join-model-evaluations.mjs', 'scripts/research/model-rewrite-benchmark.mjs']);
+  insist(joinReader.hash('scripts/research/join-model-evaluations.mjs') === sha256(readFileSync(resolve(ROOT, 'scripts/research/join-model-evaluations.mjs'))), 'join ranking source differs');
+  insist(correctedRuntime.validation.validateRawMps.toString().includes("['polarity', 'negation']"), 'canonical negation grouping absent');
+  const correctionSource = validationReader.bytes('scripts/research/study-validation.mjs');
+  for (const reader of Object.values(readers)) for (const file of ['src/scoring.js', 'src/json-response.js']) insist(reader.hash(file) === validationReader.hash(file), 'production scorer/parser changed');
+  const screens = [], ledger = [];
+  for (const screen of ['openai', 'gemini', 'claude']) { const result = await auditScreen(screen, plans[screen], readers, runtimes, correctedRuntime); screens.push(result.report); ledger.push(...result.ledger); }
+  for (const reader of [...Object.values(readers), joinReader, validationReader]) reader.unchanged();
+  const inputs = { schemaVersion: 1, kind: 'canonical-negation-mps-retrospective', correctionCommit: validationCommit,
+    validatorSha256: sha256(correctionSource), canonicalSpecSha256: validationReader.hash('core/scoring.md'),
+    validationSourceManifestHash: digest(correctedRuntime.sourceHashes),
+    derivationScriptSha256: sha256(readFileSync(resolve(ROOT, SCRIPT))),
+    joinRuleSha256: joinReader.hash('scripts/research/join-model-evaluations.mjs'),
+    sourceManifests: Object.fromEntries(Object.entries(runtimes).map(([name, runtime]) => [name, { commit: COMMITS[name], sha256: digest(runtime.sourceHashes) }])),
+    planHashes: Object.fromEntries(Object.entries(plans).map(([name, plan]) => [name, digest(plan)])),
+    screens: screens.map((screen) => ({ screen: screen.screen, provenance: screen.provenance })) };
+  const protocolHash = digest(inputs);
+  const derivedLedger = ledger.map((row) => ({ ...row, derivationProtocolHash: protocolHash }));
+  const ledgerBytes = derivedLedger.map((row) => JSON.stringify(row)).join('\n') + '\n';
+  const allMps = ledger.flatMap((row) => row.mpsResponses);
+  const report = { schemaVersion: 1, date: '2026-09-05', timezone: 'Asia/Seoul', status: 'completed-offline-screening-correction',
+    derivationProtocolHash: protocolHash, protocol: inputs, privateLedgerSha256: sha256(ledgerBytes),
+    totals: { generations: screens.reduce((n, screen) => n + screen.generations, 0), judgments: ledger.length,
+      originalValid: screens.reduce((n, screen) => n + screen.originalValid, 0), correctedValid: screens.reduce((n, screen) => n + screen.correctedValid, 0),
+      statusTransitions: transitions(ledger.map((row) => row.statusTransition)), mpsResponses: allMps.length,
+      mpsTransitions: transitions(allMps.map((row) => row.transition)),
+      judgmentReceipts: ledger.reduce((n, row) => n + row.receiptBindings.length, 0),
+      generationReceipts: screens.reduce((n, screen) => n + screen.provenance.generationReceiptCount, 0) },
+    method: [
+      'Every judgment in the three declared screening joins is included, regardless of its original valid/invalid status. Public/private parity, full matrix membership, original snapshots/protocols, committed source/fixture bytes and terminal receipt metadata are checked before correction.',
+      'Generation prompts are rebuilt from frozen-source inputs and matched by hash; request identities and delivered rewrites are bound to original receipts. This does not claim recovery of every historical ambient configuration field.',
+      'Both historical and corrected judge pipelines receive only the original private receipt responses through an injected callback. Every MPS, fidelity and naturalness prompt/request hash and receipt ordinal must match. No source journal, lock, row, schema flag or protocol ID is rewritten.',
+      'The canonical polarity group includes polarity and negation anchors. The corrected validator checks the original self-reported pass counts, polarity counts and MPS. Inconsistent responses stay rejected; no counts or model scores are repaired.',
+      'The correction has its own protocol and private ledger. Historical rows/flags remain in original; corrected status and per-receipt flags are separate. Original protocol IDs stay attached to original observations.',
+    ],
+    rankingRule: 'Within each screen: safe-output rate descending, model-rated naturalness median descending, generation latency median ascending, candidate ID ascending. Safety requires numeric proxy pass and two configured different-family valid judges with MPS/fidelity >=90 and zero hard failures. All generation attempts remain in the denominator.',
+    limits: [
+      'Proxy response.model echoes the requested alias. Model identity here is only recorded response/assistant-message/profile evidence, not proof of upstream weights or independent upstream judge families.',
+      'These are one-pass screening results on 12 curated source fixtures per candidate. They do not establish a final winner, default model, human preference or authenticated authorship accuracy.',
+      'MPS arithmetic/schema consistency does not independently certify the truth of the model’s anchor extraction or verdicts. Naturalness remains model-rated.',
+      'Confirmation and other active D/E jobs are outside this derivation. Revalidate completed confirmation evidence under the fix and obtain missing confirmation evidence before any promotion; no paid rerun is performed here.',
+      'Public output contains allowlisted counts, ranks, recorded identifiers and integrity hashes. Source texts, anchors, rationales and raw response/receipt bodies remain private.',
+    ], screens };
+  return { report, ledgerBytes };
+}
+
+const format = (value) => Number.isFinite(value) ? value.toFixed(3) : 'N/A';
+export function renderCorrection(report) {
+  const t = report.totals;
+  const lines = ['# MPS validation correction — September 5, 2026', '',
+    `${t.judgments} screening judgments over ${t.generations} generations were replayed offline. Valid judgments changed from ${t.originalValid} to ${t.correctedValid}.`, '',
+    `Correction commit: \`${report.protocol.correctionCommit}\`. New derivation protocol: \`${report.derivationProtocolHash}\`.`, '',
+    'Negation was omitted. The reviewed fix restores the Polarity + Negation group specified in `core/scoring.md` §16 and rejects the original response if its reported counts or score are inconsistent.', '',
+    '## Validity transitions', '', '| Transition | MPS responses | Whole judgments |', '|---|---:|---:|'];
+  for (const name of Object.keys(t.statusTransitions)) lines.push(`| ${name} | ${t.mpsTransitions[name]} | ${t.statusTransitions[name]} |`);
+  lines.push('', '## Screening top two', '', '| Screen | Original | Corrected | Newly selected; confirmation required |', '|---|---|---|---|');
+  for (const screen of report.screens) lines.push(`| ${screen.screen} | ${screen.oldTopTwo.join(', ')} | ${screen.newTopTwo.join(', ')} | ${screen.requiresConfirmation.promotedCandidates.join(', ') || 'None'} |`);
+  lines.push('', '## Candidate ranks and safety', '', '| Screen | Candidate | Old rank → new | Safe before → after / attempted | Judge errors before → after | Corrected naturalness median | Generation median ms |', '|---|---|---:|---:|---:|---:|---:|');
+  for (const screen of report.screens) for (const next of screen.correctedRanks) {
+    const prior = screen.oldRanks.find((row) => row.id === next.id);
+    lines.push(`| ${screen.screen} | ${next.id} | ${prior.rank} → ${next.rank} | ${prior.safe} → ${next.safe} / ${next.attempted} | ${prior.judgeErrors} → ${next.judgeErrors} | ${format(next.naturalnessMedian)} | ${format(next.generationMedianMs)} |`);
+  }
+  lines.push('', report.rankingRule, '', 'The corrected top two remain screening candidates. Existing completed confirmations need the same retrospective validation; newly selected candidates need confirmation evidence before promotion. No confirmation dataset was inspected here.', '',
+    '## Evidence and derivation', '', ...report.method.map((value) => `- ${value}`), '',
+    `All ${t.generationReceipts} generation receipts and ${t.judgmentReceipts} judgment receipts were bound. The private ledger SHA-256 is \`${report.privateLedgerSha256}\`. The JSON companion preserves original source/protocol/file/receipt commitments, status counts and rank changes.`, '',
+    '| Screen | Original parent protocol | Parent snapshot |', '|---|---|---|');
+  for (const screen of report.screens) lines.push(`| ${screen.screen} | \`${screen.provenance.originalParentProtocolHash}\` | \`${screen.provenance.parentSnapshotHash}\` |`);
+  lines.push('', '## Limits', '', ...report.limits.map((value) => `- ${value}`), '', '## Reproduce offline', '',
+    '```sh', 'node scripts/research/revalidate-mps-evidence.mjs --check', '```', '',
+    'The default input plans are the three supplied `/tmp/patina-{openai,gemini,claude}-join-plan.json` files. The runner reads only their declared completed screening cohorts. `--write` writes the two public report files and a private, gitignored ledger under `/tmp/patina-mps-revalidation-20260905`; no source directory receives a lock or write. Source worktrees must remain at their pinned commits. No credentials are read and network requests are disabled.', '',
+    'Validation code is selected separately. The plans locate the historical evaluator and protocol; `--validation-source DIR --validation-commit COMMIT` points to the reviewed correction, including the frozen G source without reading any of its study artifacts. For full joins, callers can pass the original runtime, corrected pipeline and validator to `replayBoundJudgment`. Those joins must declare their own complete matrix. The CLI is limited to these three screens.', '');
+  return lines.join('\n');
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help') { console.log('revalidate-mps-evidence [--write | --check] [--plans-dir DIR] [--join-source DIR] [--validation-source DIR --validation-commit COMMIT] (offline only)'); return; }
+    if (['--write', '--check'].includes(arg)) options[arg.slice(2)] = true;
+    else if (['--plans-dir', '--join-source', '--validation-source', '--validation-commit'].includes(arg) && argv[i + 1] && !argv[i + 1].startsWith('--')) options[arg.slice(2)] = argv[++i];
+    else throw new Error('mps-revalidation: invalid argument');
+  }
+  insist(!(options.write && options.check), 'conflicting output modes');
+  const block = () => { throw new Error('mps-revalidation: network disabled'); };
+  globalThis.fetch = block; http.request = block; http.get = block; https.request = block; https.get = block; net.Socket.prototype.connect = block;
+  const planReader = createEvidenceReader(options['plans-dir'] || '/tmp');
+  const plans = Object.fromEntries(Object.keys(SCREENS).map((name) => [name, planReader.json(`patina-${name}-join-plan.json`)]));
+  const result = await deriveCorrection(plans, { joinSourceRoot: options['join-source'], validationSourceRoot: options['validation-source'], validationCommit: options['validation-commit'] });
+  planReader.unchanged();
+  const output = { [`${REPORT}.json`]: `${JSON.stringify(result.report, null, 2)}\n`, [`${REPORT}.md`]: renderCorrection(result.report) };
+  if (options.check) {
+    for (const [path, bytes] of Object.entries(output)) insist(readFileSync(resolve(ROOT, path), 'utf8') === bytes, 'public report differs');
+    insist(readFileSync(resolve(PRIVATE_OUTPUT, 'correction-ledger.private.jsonl'), 'utf8') === result.ledgerBytes, 'private ledger differs');
+  }
+  if (options.write) {
+    insist(!existsSync(PRIVATE_OUTPUT) || !lstatSync(PRIVATE_OUTPUT).isSymbolicLink(), 'private output symlink');
+    mkdirSync(PRIVATE_OUTPUT, { recursive: true, mode: 0o700 });
+    for (const [name, bytes] of Object.entries({ '.gitignore': '*\n', 'correction-ledger.private.jsonl': result.ledgerBytes,
+      'derivation-protocol.json': `${JSON.stringify(result.report.protocol, null, 2)}\n` })) {
+      const path = resolve(PRIVATE_OUTPUT, name);
+      insist(!existsSync(path) || !lstatSync(path).isSymbolicLink(), 'private artifact symlink');
+      writeFileSync(path, bytes, { mode: 0o600 });
+    }
+    for (const [path, bytes] of Object.entries(output)) {
+      const target = resolve(ROOT, path); insist(!existsSync(target) || !lstatSync(target).isSymbolicLink(), 'public output symlink');
+      writeFileSync(target, bytes);
+    }
+  }
+  console.log(JSON.stringify({ protocolHash: result.report.derivationProtocolHash, ...result.report.totals,
+    topTwo: Object.fromEntries(result.report.screens.map((screen) => [screen.screen, screen.newTopTwo])) }));
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main().catch((error) => {
+  console.error(error.message?.startsWith('mps-revalidation: ') ? error.message : 'mps-revalidation: evidence validation failed');
+  process.exitCode = 1;
+});

--- a/tests/unit/mps-revalidation.test.js
+++ b/tests/unit/mps-revalidation.test.js
@@ -1,0 +1,215 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, truncateSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validateRawMps } from '../../scripts/research/study-validation.mjs';
+import { bindReceipt, checkParity, classifyMps, createEvidenceReader, rankSummary, renderCorrection, replayBoundJudgment, sha256 } from '../../scripts/research/revalidate-mps-evidence.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const clone = (value) => JSON.parse(JSON.stringify(value));
+// Synthetic legacy cases describe the old bug, not new empirical observations.
+function legacyValidator(text) {
+  const row = JSON.parse(text), anchors = row.anchors;
+  const passed = anchors.filter((anchor) => anchor.verdict === 'PASS').length;
+  const polarity = anchors.filter((anchor) => anchor.type === 'polarity');
+  const polarityPass = polarity.filter((anchor) => anchor.verdict === 'PASS').length;
+  if (row.pass_count !== passed || row.total_count !== anchors.length || row.polarity_pass_count !== polarityPass
+    || row.polarity_total_count !== polarity.length) throw new Error('inconsistent-mps-counts');
+  const passRate = anchors.length ? passed / anchors.length : 1;
+  const expected = polarity.length ? (passRate * .6 + polarityPass / polarity.length * .4) * 100 : passRate * 100;
+  if (Math.abs(row.mps - expected) > .11) throw new Error('inconsistent-mps-score');
+  return { ...row, hard_fail_count: anchors.filter((anchor) => anchor.verdict === 'HARD_FAIL').length };
+}
+
+const claim = { anchors: [{ type: 'claim', content: 'Synthetic fact', verdict: 'PASS' }], pass_count: 1,
+  total_count: 1, polarity_pass_count: 0, polarity_total_count: 0, mps: 100 };
+const oldOnly = { ...claim, anchors: [{ type: 'negation', content: 'Synthetic negative claim', verdict: 'PASS' }] };
+const canonicalOnly = { ...oldOnly, polarity_pass_count: 1, polarity_total_count: 1 };
+const invalidBoth = { ...canonicalOnly, total_count: 2 };
+
+test('all four transitions are checked, including previously rejected canonical responses', () => {
+  for (const [raw, oldValid, transition] of [
+    [claim, true, 'valid->valid'], [oldOnly, true, 'valid->invalid'],
+    [canonicalOnly, false, 'invalid->valid'], [invalidBoth, false, 'invalid->invalid'],
+  ]) {
+    const text = JSON.stringify(raw);
+    const result = classifyMps(text, oldValid, legacyValidator);
+    assert.equal(result.transition, transition);
+    assert.equal(result.selfReported.mps, raw.mps);
+    assert.equal(result.selfReported.polarity_total_count, raw.polarity_total_count);
+    assert.equal(result.acceptedMps, result.correctedSchemaValid ? 100 : null);
+    assert.equal(text, JSON.stringify(raw));
+  }
+  assert.throws(() => classifyMps(JSON.stringify(oldOnly), false, legacyValidator), /historical MPS flag differs/);
+});
+
+test('corrected validator never repairs reported scores or counts', () => {
+  const brokenScore = { anchors: [claim.anchors[0], { type: 'negation', content: 'Synthetic prohibition', verdict: 'HARD_FAIL' }],
+    pass_count: 1, total_count: 2, polarity_pass_count: 0, polarity_total_count: 1, mps: 50 };
+  const bytes = JSON.stringify(brokenScore);
+  let seen;
+  const result = classifyMps(bytes, false, legacyValidator, (text) => { seen = text; return validateRawMps(text); });
+  assert.equal(seen, bytes);
+  assert.equal(result.rejection, 'inconsistent-mps-score');
+  assert.equal(result.acceptedMps, null);
+  assert.equal(result.selfReported.mps, 50, 'canonical arithmetic would be 30, but must not replace the response');
+  assert.equal(classifyMps(JSON.stringify(oldOnly), true, legacyValidator).rejection, 'inconsistent-mps-counts');
+});
+
+function synthetic(raw = oldOnly) {
+  const fixture = { fixture_id: 'synthetic-fixture', text: 'Synthetic source.', language: 'en' };
+  const generation = { candidate_id: 'synthetic-generator', fixture_id: fixture.fixture_id, repeat: 0, rewrite: 'Synthetic rewrite.' };
+  const judge = { id: 'synthetic-judge', model: 'test-model', provider: 'test-provider', transport: 'opencodex' };
+  const protocol = sha256('synthetic-protocol');
+  const logicalId = `${protocol}/${generation.candidate_id}/${fixture.fixture_id}/0/judge/${judge.id}`;
+  const stages = ['mps', 'fidelity', 'naturalness'];
+  const texts = [JSON.stringify(raw), '{"claims_preserved":3,"no_fabrication":3,"audience_register_match":3}', '{"naturalness":3}'];
+  const flag = (validator) => { try { validator(texts[0]); return true; } catch { return false; } };
+  const make = (validator) => {
+    const valid = flag(validator);
+    return { status: valid ? 'ok' : 'error', error: valid ? null : 'judge-schema-failure', mps: raw.mps,
+      fidelity: 100, naturalness: 3, hard_fail_count: valid ? 0 : null,
+      private_details: { anchors: raw.anchors },
+      calls: stages.map((stage) => ({ stage, schema_valid: stage === 'mps' ? valid : true })) };
+  };
+  const historical = make(legacyValidator);
+  const row = { ...generation, protocol_hash: protocol, judge_id: judge.id, ...historical };
+  delete row.private_details;
+  const entries = texts.map((text, i) => {
+    const identity = { logicalId, index: i + 1, candidate: judge, promptHash: sha256(`synthetic-${stages[i]}-prompt`),
+      temperature: .1, responseFormat: null, extraBody: null };
+    return { receipt: { schemaVersion: 1, state: 'completed', promptHash: identity.promptHash, requestHash: sha256(identity),
+      temperature: .1, schemaValid: historical.calls[i].schema_valid, transportAttempts: [], response: { text } } };
+  });
+  const runner = (validator) => async (_fixture, _generation, candidate, { complete }) => {
+    for (const stage of stages) await complete(candidate, `synthetic-${stage}-prompt`, { temperature: .1 });
+    return make(validator);
+  };
+  return { row, stored: { ...row, private_details: historical.private_details }, fixture, generation, judge, entries,
+    originalRuntime: { rewrite: { judgeRewrite: runner(legacyValidator) }, validation: { validateRawMps: legacyValidator } },
+    correctedRun: runner(validateRawMps), correctedValidator: validateRawMps };
+}
+
+test('paired replay preserves source evidence while deriving both directions of change', async () => {
+  for (const [raw, status] of [[oldOnly, 'error'], [canonicalOnly, 'ok']]) {
+    const data = synthetic(raw), original = JSON.stringify(data.entries), oldRow = JSON.stringify(data.row);
+    const result = await replayBoundJudgment(data);
+    assert.equal(result.corrected.status, status);
+    assert.equal(result.corrected.mps, 100);
+    assert.equal(result.mpsResponses.length, 1);
+    assert.equal(JSON.stringify(data.entries), original);
+    assert.equal(JSON.stringify(data.row), oldRow);
+  }
+});
+
+test('replay rejects prompt, request, stage, outcome, and non-MPS substitutions', async () => {
+  const changes = [
+    (data) => { data.entries[0].receipt.promptHash = sha256('wrong prompt'); },
+    (data) => { data.entries[0].receipt.requestHash = sha256('wrong request'); },
+    (data) => { data.entries[1].receipt.state = 'started'; },
+    (data) => { data.entries.pop(); },
+    (data) => { data.row.calls[0].stage = 'fidelity'; },
+    (data) => { data.row.mps = 99; },
+    (data) => { data.stored.private_details = {}; },
+    (data) => {
+      const original = data.correctedRun;
+      data.correctedRun = async (...args) => { const value = await original(...args); value.calls[1].schema_valid = false; return value; };
+    },
+    (data) => {
+      const original = data.correctedRun;
+      data.correctedRun = async (...args) => { const value = await original(...args); value.mps = 30; return value; };
+    },
+  ];
+  for (const change of changes) {
+    const data = synthetic(); change(data);
+    await assert.rejects(replayBoundJudgment(data), /^Error: mps-revalidation:/);
+  }
+});
+
+test('receipt identity retains original protocol, ordinal, candidate, and request options', () => {
+  const data = synthetic(), receipt = data.entries[0].receipt;
+  const binding = { logicalId: `${data.row.protocol_hash}/synthetic-generator/synthetic-fixture/0/judge/synthetic-judge`,
+    index: 1, candidate: data.judge, promptHash: receipt.promptHash, temperature: .1 };
+  assert.doesNotThrow(() => bindReceipt(receipt, binding));
+  for (const patch of [{ logicalId: 'new-derived-protocol' }, { index: 2 }, { temperature: 0 },
+    { candidate: { ...data.judge, model: 'different-model' } }, { extraBody: { reasoning_effort: 'high' } }]) {
+    assert.throws(() => bindReceipt(receipt, { ...binding, ...patch }), /request\/prompt binding differs/);
+  }
+});
+
+test('public/private parity checks rejected rows too, with exact membership', () => {
+  const rows = [synthetic().row, { ...synthetic(canonicalOnly).row, fixture_id: 'second' }];
+  const privateRows = rows.map((row) => ({ ...clone(row), private_details: { secret: 'not-public' } }));
+  assert.equal(checkParity(rows, privateRows, 'private_details').size, 2);
+  privateRows[0].mps = 20;
+  assert.throws(() => checkParity(rows, privateRows, 'private_details'), /row differs/);
+  assert.throws(() => checkParity(rows, [privateRows[1], privateRows[1]], 'private_details'), /matrix differs/);
+});
+
+test('rank comparison retains safety/naturalness/latency ordering and blocks incomplete joins', () => {
+  const row = (rate, naturalness, latency) => ({ attempted: 12, safe: rate * 12, safe_rate: rate,
+    judge_errors: 0, pending_judgments: 0, naturalness: { median: naturalness }, generation_latency_ms: { median: latency } });
+  const summary = { a: row(.5, 3, 10), b: row(.75, 2, 20), c: row(.5, 4, 30), d: row(.5, 4, 20) };
+  assert.deepEqual(rankSummary(summary).map((row) => row.id), ['b', 'd', 'c', 'a']);
+  summary.a.pending_judgments = 1;
+  assert.throws(() => rankSummary(summary), /pending judgments/);
+});
+
+test('read-only evidence reader bounds input and rejects source changes or symlink escapes', () => {
+  const root = mkdtempSync(join(tmpdir(), 'mps-revalidation-'));
+  try {
+    writeFileSync(join(root, 'data.json'), '{}'); const reader = createEvidenceReader(root);
+    assert.deepEqual(reader.json('data.json'), {});
+    assert.throws(() => reader.bytes('../secret'), /unsafe evidence path/);
+    symlinkSync(join(root, 'data.json'), join(root, 'link.json'));
+    assert.throws(() => reader.bytes('link.json'), /evidence symlink/);
+    writeFileSync(join(root, 'huge.json'), ''); truncateSync(join(root, 'huge.json'), 16 * 1024 * 1024 + 1);
+    assert.throws(() => reader.bytes('huge.json'), /evidence size bound/);
+    writeFileSync(join(root, 'data.json'), '[]');
+    assert.throws(() => reader.unchanged(), /evidence changed/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('CLI exposes independent corrected source and cannot start a live run', () => {
+  const help = execFileSync(process.execPath, ['scripts/research/revalidate-mps-evidence.mjs', '--help'], { cwd: ROOT, encoding: 'utf8' });
+  assert.match(help, /--validation-source DIR --validation-commit COMMIT/);
+  assert.match(help, /offline only/); assert.doesNotMatch(help, /--live/);
+  assert.throws(() => execFileSync(process.execPath, ['scripts/research/revalidate-mps-evidence.mjs', '--api-key', 'do-not-echo'], { cwd: ROOT, encoding: 'utf8', stdio: 'pipe' }),
+    (error) => error.stderr.trim() === 'mps-revalidation: invalid argument');
+});
+
+test('public correction balances all observations and reproduces its Markdown', () => {
+  const report = JSON.parse(readFileSync(resolve(ROOT, 'docs/research/mps-validation-correction-20260905.json')));
+  assert.equal(renderCorrection(report), readFileSync(resolve(ROOT, 'docs/research/mps-validation-correction-20260905.md'), 'utf8'));
+  assert.equal(report.totals.generations, 192); assert.equal(report.totals.judgments, 384);
+  assert.equal(report.totals.judgmentReceipts, 1152); assert.equal(report.totals.generationReceipts, 192);
+  assert.equal(Object.values(report.totals.statusTransitions).reduce((a, b) => a + b), 384);
+  assert.equal(report.totals.statusTransitions['valid->valid'] + report.totals.statusTransitions['valid->invalid'], report.totals.originalValid);
+  assert.equal(report.totals.statusTransitions['valid->valid'] + report.totals.statusTransitions['invalid->valid'], report.totals.correctedValid);
+  assert.match(report.derivationProtocolHash, /^[a-f0-9]{64}$/); assert.match(report.privateLedgerSha256, /^[a-f0-9]{64}$/);
+  for (const screen of report.screens) {
+    assert.equal(screen.judgments, screen.generations * 2);
+    assert.equal(screen.correctedRanks.reduce((n, row) => n + row.attempted, 0), screen.generations);
+    assert.deepEqual(screen.newTopTwo, screen.correctedRanks.slice(0, 2).map((row) => row.id));
+    assert.ok(screen.provenance.judgments.every((dataset) => /^[a-f0-9]{64}$/.test(dataset.originalProtocolHash)));
+  }
+});
+
+test('public report excludes bodies, private rows, and claims of upstream authentication', () => {
+  const bytes = readFileSync(resolve(ROOT, 'docs/research/mps-validation-correction-20260905.json'), 'utf8');
+  const report = JSON.parse(bytes);
+  const forbidden = new Set(['text', 'rewrite', 'anchors', 'rationale', 'private_details', 'response', 'calls', 'apiKey', 'authorization', 'original']);
+  function walk(value) {
+    if (Array.isArray(value)) { value.forEach(walk); return; }
+    if (!value || typeof value !== 'object') return;
+    for (const [key, child] of Object.entries(value)) { assert.ok(!forbidden.has(key), key); walk(child); }
+  }
+  walk(report);
+  assert.doesNotMatch(bytes, /\/home\/|Bearer |PRIVATE KEY/);
+  assert.ok(report.limits.some((value) => value.includes('echoes the requested alias')));
+  assert.ok(report.limits.some((value) => value.includes('not proof of upstream')));
+  assert.ok(report.limits.some((value) => value.includes('active D/E jobs')));
+});


### PR DESCRIPTION
Derives canonical MPS validation from all384 frozen screening judgments without changing original rows, counters, model scores, receipt flags or protocol IDs. Both previously valid and invalid responses are replayed with exact source/prompt/request/receipt-order checks.

Whole-judgment validity changes373 to363; ten prior valid judgments become invalid. Screening top-two pairs remain Astra/Terra, Gemini high/medium, and Sonnet/Fable; Sol and GPT-5.5 swap third/fourth. These are screening results, not final promotion or human-quality claims.

Validation:11 focused tests; full1,900 passed,2 skipped; lint/privacy checks; exact post-commit reproduction. Independent Astra/xhigh review recalculated all384 MPS classifications and1152 judgment receipts, and verified192 generation receipts. No live calls.

Full confirmation cohorts are handled separately after completion.
