### PR TITLE
fix: enforce upstream judge families across study entry points

### DIFF
--- a/scripts/research/evaluate-existing-rewrites.mjs
+++ b/scripts/research/evaluate-existing-rewrites.mjs
@@ -8,6 +8,7 @@ import { judgeCandidates, judgeRewrite, renderRewriteReport, rewriteFixtures, su
 import { acceptedStudyIdentity, acquireStudyWriter, bindStudyProtocol, readUniqueRows } from './study-journal.mjs';
 import { assertStudyActive, installStudySignals, safeStudyError, validateTransport } from './model-evaluation-transport.mjs';
 import { fixtureIdentity, studySemantics } from './study-validation.mjs';
+import { resolveStudyFamily, generationFamily, independentJudgeMetadata, validateJudgmentFamilies } from './study-family.mjs';
 import { auditParentReceipts } from './parent-cohort-audit.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
@@ -29,7 +30,7 @@ export async function loadParentCohort({ directory, protocolFile, fixtures, prov
     const protocol = JSON.parse(protocolBytes);
     const candidates = protocol.candidates.filter((candidate) => candidate.provider === provider && (!candidateId || candidate.id === candidateId));
     if (!candidates.length || candidates.some((candidate) => !/^[a-z0-9.-]{1,80}$/i.test(candidate.id))) throw new Error('Invalid parent candidate scope');
-    for (const candidate of candidates) validateTransport(candidate);
+    for (const candidate of candidates) { validateTransport(candidate); resolveStudyFamily(candidate); }
     const hashes = { protocol: textHash(protocolBytes) };
     const read = (name) => {
       const path = resolve(directory, name); const bytes = readFileSync(path, 'utf8'); hashes[name] = textHash(bytes);
@@ -46,6 +47,7 @@ export async function loadParentCohort({ directory, protocolFile, fixtures, prov
       if (!same(row, publicPart)) throw new Error('Parent public/private generation metadata differs');
       const fixture = fixtures.find((fixture) => fixture.fixture_id === row.fixture_id);
       const candidate = candidates.find((candidate) => candidate.id === row.candidate_id);
+      generationFamily(row, candidate);
       if (!/^[a-f0-9]{64}$/.test(row.protocol_hash) || row.text_hash !== fixture.text_hash || row.language !== fixture.language
         || row.provider !== candidate.provider || row.requested_model !== candidate.model || row.transport !== candidate.transport || unresolved(row)) throw new Error('Unbound parent generation');
       protocols.add(row.protocol_hash);
@@ -86,6 +88,7 @@ export async function loadParentCohort({ directory, protocolFile, fixtures, prov
         if (!generation || row.judge_id !== id || row.judge_model !== judge.model || row.judge_provider !== judge.provider || row.judge_transport !== judge.transport
           || row.protocol_hash !== generation.protocol_hash || row.text_hash !== generation.text_hash || row.rewrite_hash !== generation.rewrite_hash
           || !judgeCandidates(candidate, protocol).some((seat) => seat.id === id) || unresolved(row)) throw new Error('Unbound parent judgment');
+        validateJudgmentFamilies(generation, row, { candidate, judge });
         if (row.status === 'ok' && !['mps', 'fidelity', 'naturalness'].every((stage) => {
           const call = row.calls?.filter((call) => call.stage === stage).at(-1);
           return call?.schema_valid === true && acceptedStudyIdentity(call, judge);
@@ -105,6 +108,9 @@ function validateJudgment(row, parent, judge, protocolHash) {
   if (!generation || row.protocol_hash !== protocolHash || row.parent_snapshot_hash !== parent.snapshotHash
     || row.parent_protocol_hash !== generation.protocol_hash || row.text_hash !== generation.text_hash || row.rewrite_hash !== generation.rewrite_hash
     || row.judge_id !== judge.id || row.judge_model !== judge.model || row.judge_provider !== judge.provider || row.judge_transport !== judge.transport) throw new Error('Unbound evaluation row');
+  const candidate = parent.candidates.find((candidate) => candidate.id === generation.candidate_id);
+  if (!candidate) throw new Error('Unknown evaluation generator');
+  validateJudgmentFamilies(generation, row, { candidate, judge });
   if (!['ok', 'error'].includes(row.status)) throw new Error('Unknown evaluation status');
   if (row.status === 'ok' && (!Number.isFinite(row.mps) || row.mps < 0 || row.mps > 100
     || !Number.isFinite(row.fidelity) || row.fidelity < 0 || row.fidelity > 100
@@ -119,11 +125,18 @@ function validateJudgment(row, parent, judge, protocolHash) {
 export async function evaluateExisting({ parent, judge, output, protocolHash, live = false, report = false, evaluate = judgeRewrite }) {
   if (parent.judgments.some((row) => row.judge_id === judge.id)) throw new Error('Selected seat already has parent observations; do not silently re-evaluate it');
   validateTransport(judge);
-  for (const candidate of parent.candidates) if (candidate.provider === judge.provider) throw new Error('A judge cannot evaluate its own family');
+  for (const candidate of parent.candidates) {
+    if (resolveStudyFamily(candidate).upstreamFamily === resolveStudyFamily(judge).upstreamFamily) throw new Error('A judge cannot evaluate its own family');
+  }
+  for (const generation of [...parent.generations, ...parent.privateRows]) {
+    const candidate = parent.candidates.find((candidate) => candidate.id === generation.candidate_id);
+    if (!candidate) throw new Error('Unknown evaluation generator');
+    independentJudgeMetadata(generation, judge, candidate);
+  }
   const release = acquireStudyWriter(output, `judge-${judge.id}`);
   try {
     bindStudyProtocol(output, protocolHash);
-    const judgeIdentity = { id: judge.id, provider: judge.provider, model: judge.model, transport: judge.transport, effort: judge.effort ?? null };
+    const judgeIdentity = { id: judge.id, provider: judge.provider, model: judge.model, transport: judge.transport, effort: judge.effort ?? null, ...resolveStudyFamily(judge) };
     writeFileSync(resolve(output, 'provenance.json'), `${JSON.stringify({ ...parent.provenance, parentSnapshotHash: parent.snapshotHash, evaluationProtocolHash: protocolHash, judge: judgeIdentity }, null, 2)}\n`);
     const publicPath = resolve(output, `judge-${judge.id}.jsonl`), privatePath = resolve(output, `judge-${judge.id}.private.jsonl`);
     const rows = readUniqueRows(publicPath, key), done = new Set(rows.map(key));
@@ -142,8 +155,12 @@ export async function evaluateExisting({ parent, judge, output, protocolHash, li
     if (live && !report) for (const generation of parent.privateRows) {
       assertStudyActive(); if (generation.status !== 'ok' || done.has(key(generation))) continue;
       const fixture = parent.fixtures.find((fixture) => fixture.fixture_id === generation.fixture_id);
-      const row = { ...await evaluate(fixture, generation, judge, { journalDirectory: output,
-        logicalId: `${protocolHash}/${key(generation)}/judge/${judge.id}` }),
+      const evaluated = await evaluate(fixture, generation, judge, { journalDirectory: output,
+        logicalId: `${protocolHash}/${key(generation)}/judge/${judge.id}` });
+      // Validate supplied metadata before adding the new row's explicit family
+      // fields. Existing first-party evaluators may still omit those fields.
+      validateJudgmentFamilies(generation, evaluated, { judge });
+      const row = { ...evaluated, ...independentJudgeMetadata(generation, judge),
         protocol_hash: protocolHash, parent_protocol_hash: generation.protocol_hash, parent_snapshot_hash: parent.snapshotHash, recorded_at: new Date().toISOString() };
       validateJudgment(row, parent, judge, protocolHash);
       append(privatePath, row); const { private_details: _details, ...safe } = row; append(publicPath, safe); rows.push(safe); done.add(key(row));

--- a/scripts/research/evaluate-existing-rewrites.mjs
+++ b/scripts/research/evaluate-existing-rewrites.mjs
@@ -133,6 +133,9 @@ export async function evaluateExisting({ parent, judge, output, protocolHash, li
     if (!candidate) throw new Error('Unknown evaluation generator');
     independentJudgeMetadata(generation, judge, candidate);
   }
+  // Apply the report's binding and family checks to every saved judgment before
+  // acquiring an output writer or allowing any new evaluator calls.
+  summarizeRewrites(parent.generations, parent.judgments);
   const release = acquireStudyWriter(output, `judge-${judge.id}`);
   try {
     bindStudyProtocol(output, protocolHash);

--- a/scripts/research/join-model-evaluations.mjs
+++ b/scripts/research/join-model-evaluations.mjs
@@ -8,6 +8,7 @@ import { loadParentCohort } from './evaluate-existing-rewrites.mjs';
 import { auditParentReceipts } from './parent-cohort-audit.mjs';
 import { judgeCandidates, renderRewriteReport, rewriteFixtures, summarizeRewrites } from './model-rewrite-benchmark.mjs';
 import { studySemantics } from './study-validation.mjs';
+import { resolveStudyFamily, generationFamily, validateJudgmentFamilies } from './study-family.mjs';
 
 const key = (row) => `${row.candidate_id}/${row.fixture_id}/${row.repeat}`;
 const canonical = (value) => Array.isArray(value) ? value.map(canonical) : value && typeof value === 'object'
@@ -15,6 +16,19 @@ const canonical = (value) => Array.isArray(value) ? value.map(canonical) : value
 const same = (a, b) => JSON.stringify(canonical(a)) === JSON.stringify(canonical(b));
 
 export async function joinEvaluations({ parent, fixtures, directories, protocol, evaluationSemantics }) {
+  for (const candidate of parent.candidates) judgeCandidates(candidate, protocol);
+  for (const generation of parent.generations) {
+    const candidate = parent.candidates.find((candidate) => candidate.id === generation.candidate_id);
+    if (!candidate) throw new Error('Unknown joined generator');
+    generationFamily(generation, candidate);
+  }
+  for (const row of parent.judgments) {
+    const generation = parent.generations.find((generation) => key(generation) === key(row));
+    const candidate = parent.candidates.find((candidate) => candidate.id === generation?.candidate_id);
+    const judge = protocol.candidates.find((candidate) => candidate.id === row.judge_id);
+    if (!generation || !judge || !judgeCandidates(candidate, protocol).some((seat) => seat.id === judge.id)) throw new Error('Unbound or same-family parent judgment');
+    validateJudgmentFamilies(generation, row, { candidate, judge });
+  }
   const judgments = [...parent.judgments], evidence = [];
   for (const directory of [...new Set(directories.map((path) => resolve(path)))].sort()) {
     const release = acquireStudyWriter(directory, 'analysis-snapshot');
@@ -23,6 +37,9 @@ export async function joinEvaluations({ parent, fixtures, directories, protocol,
       const provenance = JSON.parse(provenanceBytes);
       const judge = protocol.candidates.find((candidate) => candidate.id === provenance.judge?.id);
       if (!judge || provenance.parentSnapshotHash !== parent.snapshotHash) throw new Error('Evaluation belongs to another parent snapshot');
+      if (['provider', 'model', 'transport'].some((field) => provenance.judge[field] !== judge[field])
+        || resolveStudyFamily(provenance.judge, { legacy: true }).upstreamFamily !== resolveStudyFamily(judge).upstreamFamily
+        || (Object.hasOwn(provenance.judge, 'familyEvidence') && provenance.judge.familyEvidence !== resolveStudyFamily(judge).familyEvidence)) throw new Error('Evaluation judge family differs from admitted definition');
       const expected = textHash(JSON.stringify({ protocol, judge: judge.id, parentSnapshotHash: parent.snapshotHash, semantics: evaluationSemantics }));
       const binding = JSON.parse(readFileSync(resolve(directory, 'study-protocol.json'), 'utf8'));
       if (binding.schemaVersion !== 1 || binding.protocolHash !== expected || provenance.evaluationProtocolHash !== expected) throw new Error('Evaluation source/protocol binding differs');
@@ -41,6 +58,7 @@ export async function joinEvaluations({ parent, fixtures, directories, protocol,
           || row.parent_snapshot_hash !== parent.snapshotHash || row.text_hash !== generation.text_hash || row.rewrite_hash !== generation.rewrite_hash
           || row.judge_id !== judge.id || row.judge_model !== judge.model || row.judge_provider !== judge.provider || row.judge_transport !== judge.transport
           || !judgeCandidates(candidate, protocol).some((seat) => seat.id === judge.id)) throw new Error('Unbound evaluation judgment');
+        validateJudgmentFamilies(generation, row, { candidate, judge });
       }
       await auditParentReceipts({ directory, generations: parent.generations, privateRows: parent.privateRows, judgments: rows,
         candidates: parent.candidates, protocol, fixtures, hashes, includeGenerations: false, judgmentProtocolHash: expected, judgeIds: [judge.id] });
@@ -78,7 +96,8 @@ async function main() {
   if ([plan.parent, ...plan.evaluations].some((path) => resolve(path) === output)) throw new Error('Analysis output must be separate from input cohorts');
   mkdirSync(output, { recursive: true });
   const provenance = { parent: parent.provenance, parentSnapshotHash: parent.snapshotHash, evaluations: result.evidence,
-    analysisScriptHash: textHash(readFileSync(fileURLToPath(import.meta.url))) };
+    analysisScriptHash: textHash(readFileSync(fileURLToPath(import.meta.url))),
+    analysisFamilyPolicyHash: textHash(readFileSync(new URL('./study-family.mjs', import.meta.url))) };
   writeFileSync(resolve(output, 'provenance.json'), `${JSON.stringify(provenance, null, 2)}\n`);
   writeFileSync(resolve(output, 'rewrite-report.md'), `Parent and evaluation protocols are preserved in provenance.json.\n\n${result.report}`);
   writeFileSync(resolve(output, 'rewrite-summary.json'), `${JSON.stringify({ summary: result.summary, finalists: selectRewriteFinalists(result.summary) }, null, 2)}\n`);

--- a/scripts/research/join-model-evaluations.mjs
+++ b/scripts/research/join-model-evaluations.mjs
@@ -17,10 +17,20 @@ const same = (a, b) => JSON.stringify(canonical(a)) === JSON.stringify(canonical
 
 export async function joinEvaluations({ parent, fixtures, directories, protocol, evaluationSemantics }) {
   for (const candidate of parent.candidates) judgeCandidates(candidate, protocol);
+  const privateByKey = new Map(parent.privateRows.map((row) => [key(row), row]));
+  if (parent.privateRows.length !== parent.generations.length || privateByKey.size !== parent.privateRows.length
+    || new Set(parent.generations.map(key)).size !== parent.generations.length) throw new Error('Parent public/private generation matrix differs');
   for (const generation of parent.generations) {
     const candidate = parent.candidates.find((candidate) => candidate.id === generation.candidate_id);
     if (!candidate) throw new Error('Unknown joined generator');
     generationFamily(generation, candidate);
+    const original = privateByKey.get(key(generation));
+    if (!original) throw new Error('Missing private parent generation');
+    generationFamily(original, candidate);
+    if (original.transport !== candidate.transport) throw new Error('Parent generation transport differs from admitted definition');
+    const { rewrite: _rewrite, ...publicPart } = original;
+    if (!same(generation, publicPart)) throw new Error('Parent public/private generation metadata differs');
+    if (generation.status === 'ok' && (typeof original.rewrite !== 'string' || textHash(original.rewrite) !== generation.rewrite_hash)) throw new Error('Parent rewrite content/hash mismatch');
   }
   for (const row of parent.judgments) {
     const generation = parent.generations.find((generation) => key(generation) === key(row));

--- a/scripts/research/model-rewrite-benchmark.mjs
+++ b/scripts/research/model-rewrite-benchmark.mjs
@@ -10,6 +10,7 @@ import { assertStudyActive, installStudySignals, studyCompletion, safeStudyError
 import { acceptedStudyIdentity, acquireStudyWriter, bindStudyProtocol, createCallJournal, readUniqueRows } from './study-journal.mjs';
 import { fixtureIdentity, studySemantics, validateRawFidelity, validateRawMps } from './study-validation.mjs';
 import { createStudyInputs } from './study-inputs.mjs';
+import { resolveStudyFamily, generationFamily, independentJudgeMetadata, validateJudgmentFamilies } from './study-family.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const LOG = { warn() {}, info() {}, debug() {} };
@@ -37,8 +38,10 @@ export function rewriteFixtures(suite = 'screening', repoRoot = ROOT) {
 export function judgeCandidates(candidate, protocol) {
   const seats = ['openai-5.5', 'gemini-3.7', 'anthropic-sonnet'].map((id) => protocol.candidates.find((row) => row.id === id));
   if (seats.some((seat) => !seat)) throw new Error('Protocol is missing a fixed judge seat');
-  const chosen = seats.filter((seat) => seat.provider !== candidate.provider).slice(0, 2);
-  if (chosen.length !== 2 || new Set(chosen.map((seat) => seat.provider)).size !== 2) throw new Error('Two independent judge families are required');
+  const family = resolveStudyFamily(candidate).upstreamFamily;
+  const families = new Map(seats.map((seat) => [seat, resolveStudyFamily(seat).upstreamFamily]));
+  const chosen = seats.filter((seat) => families.get(seat) !== family).slice(0, 2);
+  if (chosen.length !== 2 || new Set(chosen.map((seat) => families.get(seat))).size !== 2) throw new Error('Two independent judge families are required');
   return chosen;
 }
 
@@ -60,7 +63,9 @@ export function parseNaturalness(text) {
 }
 
 export async function generateRewrite(fixture, candidate, prompt, { complete = studyCompletion, envFile, timeoutMs = 180_000, journalDirectory, logicalId } = {}) {
+  const family = resolveStudyFamily(candidate);
   const base = { schemaVersion: 1, candidate_id: candidate.id, provider: candidate.provider, requested_model: candidate.model,
+    upstream_family: family.upstreamFamily, family_evidence: family.familyEvidence,
     transport: candidate.transport, fixture_id: fixture.fixture_id, language: fixture.language,
     register: fixture.register, document_type: fixture.documentType || 'default', text_hash: fixture.text_hash,
     prompt_hash: textHash(prompt) };
@@ -86,6 +91,7 @@ export async function generateRewrite(fixture, candidate, prompt, { complete = s
 }
 
 export async function judgeRewrite(fixture, generation, judge, { complete = studyCompletion, envFile, timeoutMs = 180_000, journalDirectory, logicalId } = {}) {
+  const families = independentJudgeMetadata(generation, judge);
   const calls = [];
   const deadline = Date.now() + timeoutMs;
   let stage = 'mps';
@@ -96,7 +102,7 @@ export async function judgeRewrite(fixture, generation, judge, { complete = stud
     record: (call, raw) => { calls.push({ ...call, stage }); rawStages[stage] = raw; } });
   const base = { schemaVersion: 1, candidate_id: generation.candidate_id, fixture_id: fixture.fixture_id,
     repeat: generation.repeat, text_hash: fixture.text_hash, rewrite_hash: generation.rewrite_hash,
-    judge_id: judge.id, judge_provider: judge.provider, judge_model: judge.model, judge_transport: judge.transport };
+    judge_id: judge.id, judge_provider: judge.provider, judge_model: judge.model, judge_transport: judge.transport, ...families };
   try {
     // The production evaluators remain separate from the naturalness rubric.
     // Sequential calls preserve the one-request-per-judge execution budget.
@@ -123,21 +129,26 @@ export function summarizeRewrites(generations, judgments) {
   const byGeneration = new Map();
   for (const row of judgments) {
     const key = rowKey(row);
+    if (!generations.some((generation) => rowKey(generation) === key)) throw new Error('Unbound judgment has no generation');
     const list = byGeneration.get(key) || [];
     if (list.some((previous) => previous.judge_id === row.judge_id)) throw new Error('Duplicate judge result');
     list.push(row); byGeneration.set(key, list);
   }
   const groups = {};
   for (const row of generations) {
+    generationFamily(row);
     const judges = byGeneration.get(rowKey(row)) || [];
-    if (judges.some((judge) => judge.text_hash !== row.text_hash || judge.rewrite_hash !== row.rewrite_hash || judge.judge_provider === row.provider)) throw new Error('Unbound or same-family judgment');
-    const independent = judges.length === 2 && new Set(judges.map((judge) => judge.judge_provider)).size === 2;
+    if (judges.some((judge) => judge.text_hash !== row.text_hash || judge.rewrite_hash !== row.rewrite_hash)) throw new Error('Unbound judgment');
+    const families = judges.map((judge) => validateJudgmentFamilies(row, judge));
+    const independent = judges.length === 2 && new Set(families).size === 2;
     const judged = independent && judges.every((judge) => judge.status === 'ok' && validJudgeScores(judge));
     const safe = row.status === 'ok' && row.number_safety?.ok === true && judged && judges.every((judge) => judge.mps >= 90 && judge.fidelity >= 90 && judge.hard_fail_count === 0);
+    const prior = groups[row.candidate_id]?.[0]?.row;
+    if (prior && (prior.provider !== row.provider || generationFamily(prior).upstreamFamily !== generationFamily(row).upstreamFamily)) throw new Error('Mixed host/family identity for one candidate');
     (groups[row.candidate_id] ||= []).push({ row, judges, judged, safe, pending: row.status === 'ok' && !independent });
   }
   return Object.fromEntries(Object.entries(groups).map(([id, items]) => [id, {
-    provider: items[0].row.provider, attempted: items.length,
+    provider: items[0].row.provider, upstream_family: generationFamily(items[0].row).upstreamFamily, attempted: items.length,
     generation_errors: items.filter((item) => item.row.status !== 'ok').length,
     pending_judgments: items.filter((item) => item.pending).length,
     judge_errors: items.filter((item) => item.row.status === 'ok' && !item.pending && !item.judged).length,
@@ -192,7 +203,16 @@ export async function main(argv = process.argv.slice(2)) {
   const protocol = JSON.parse(readFileSync(options.candidates, 'utf8'));
   const candidates = protocol.candidates.filter((row) => (!options.provider || row.provider === options.provider) && (!options.candidate || row.id === options.candidate));
   if (!candidates.length) throw new Error('No candidates selected');
-  for (const candidate of candidates) validateTransport(candidate);
+  // Validate the entire selected matrix before the first generation, not only
+  // when a later candidate happens to reach its paid judge pass.
+  const seats = ['openai-5.5', 'gemini-3.7', 'anthropic-sonnet'].map((id) => protocol.candidates.find((candidate) => candidate.id === id)).filter(Boolean);
+  for (const seat of seats) resolveStudyFamily(seat);
+  for (const candidate of candidates) {
+    validateTransport(candidate); resolveStudyFamily(candidate);
+    // Generation-only protocols may contain a single fixed-seat model. A full
+    // panel is validated now; judging/reporting always requires all seats.
+    if (options.phase !== 'rewrite' || seats.length === 3) judgeCandidates(candidate, protocol);
+  }
   const fixtures = rewriteFixtures(options.suite);
   const inputs = createStudyInputs(ROOT, { sourceVoice: true });
   const prompts = new Map();
@@ -212,7 +232,12 @@ export async function main(argv = process.argv.slice(2)) {
   const privatePath = resolve(output, 'rewrites.private.jsonl');
   const generated = readRows(generatedPath);
   const privateRows = readRows(privatePath);
-  for (const row of [...generated, ...privateRows]) if (row.protocol_hash !== protocolHash) throw new Error('Output belongs to a different rewrite protocol');
+  for (const row of [...generated, ...privateRows]) {
+    if (row.protocol_hash !== protocolHash) throw new Error('Output belongs to a different rewrite protocol');
+    const candidate = candidates.find((candidate) => candidate.id === row.candidate_id);
+    if (!candidate) throw new Error('Unknown generation candidate');
+    generationFamily(row, candidate);
+  }
   const done = new Set(generated.map(rowKey));
   // Recover a paid completion written before an interruption between the two
   // journal appends, rather than invoking the model again.
@@ -244,15 +269,26 @@ export async function main(argv = process.argv.slice(2)) {
     const seen = new Set(rows.map(rowKey));
     for (const row of options.phase === 'judge' ? readRows(resolve(output, `judge-${judgeId}.private.jsonl`)) : []) {
       if (row.protocol_hash !== protocolHash || row.judge_id !== judgeId) throw new Error('Unbound private judge journal');
-      if (seen.has(rowKey(row))) continue;
       const generation = generated.find((item) => rowKey(item) === rowKey(row));
       if (!generation || row.text_hash !== generation.text_hash || row.rewrite_hash !== generation.rewrite_hash) throw new Error('Private judge hash mismatch');
+      const candidate = candidates.find((candidate) => candidate.id === generation.candidate_id);
+      const judge = protocol.candidates.find((candidate) => candidate.id === judgeId);
+      if (!judge || !judgeCandidates(candidate, protocol).some((seat) => seat.id === judgeId)) throw new Error('Unbound private judge family');
+      validateJudgmentFamilies(generation, row, { candidate, judge });
+      if (seen.has(rowKey(row))) continue;
       const { private_details: _details, ...safe } = row;
       append(path, safe); rows.push(safe); seen.add(rowKey(row));
     }
     judgments.push(...rows);
   }
-  for (const row of judgments) if (row.protocol_hash !== protocolHash) throw new Error('Judge output belongs to a different protocol');
+  for (const row of judgments) {
+    if (row.protocol_hash !== protocolHash) throw new Error('Judge output belongs to a different protocol');
+    const generation = generated.find((generation) => rowKey(generation) === rowKey(row));
+    const candidate = candidates.find((candidate) => candidate.id === generation?.candidate_id);
+    const judge = protocol.candidates.find((candidate) => candidate.id === row.judge_id);
+    if (!generation || !judge || !judgeCandidates(candidate, protocol).some((seat) => seat.id === judge.id)) throw new Error('Unbound judge family');
+    validateJudgmentFamilies(generation, row, { candidate, judge });
+  }
   if (options.phase === 'judge') {
     if (!options.judge) throw new Error('--judge selects one fixed writer/seat');
     const judge = protocol.candidates.find((row) => row.id === options.judge);

--- a/scripts/research/parent-cohort-audit.mjs
+++ b/scripts/research/parent-cohort-audit.mjs
@@ -4,6 +4,7 @@ import { textHash } from '../../tests/quality/live-scorer-benchmark.mjs';
 import { deliveredRewrite } from '../../tests/quality/live-quality.mjs';
 import { judgeCandidates, judgeRewrite } from './model-rewrite-benchmark.mjs';
 import { safeCallRecord } from './study-journal.mjs';
+import { generationFamily, validateJudgmentFamilies } from './study-family.mjs';
 
 const key = (row) => `${row.candidate_id}/${row.fixture_id}/${row.repeat}`;
 
@@ -16,8 +17,22 @@ function bindRequest(receipt, logicalId, index, candidate, promptHash, options =
 export async function auditParentReceipts({ directory, generations, privateRows, judgments, candidates, protocol, fixtures, hashes,
   includeGenerations = true, judgmentProtocolHash, judgeIds }) {
   const expectedGroups = new Map();
+  // This exported audit is also called directly by joins. Reject every supplied
+  // judgment up front, including seats the expected-group loop would omit.
+  for (const row of judgments) {
+    const generation = generations.find((generation) => key(generation) === key(row));
+    const candidate = candidates.find((candidate) => candidate.id === generation?.candidate_id);
+    const judge = protocol.candidates.find((candidate) => candidate.id === row.judge_id);
+    if (!generation || !candidate || !judge || !judgeCandidates(candidate, protocol).some((seat) => seat.id === judge.id)) throw new Error('Unbound or same-family parent judgment');
+    validateJudgmentFamilies(generation, row, { candidate, judge });
+  }
   for (const generation of generations) {
     const candidate = candidates.find((candidate) => candidate.id === generation.candidate_id);
+    if (!candidate) throw new Error('Unknown parent generator');
+    generationFamily(generation, candidate);
+    const original = privateRows.find((row) => key(row) === key(generation));
+    if (!original) throw new Error('Missing private parent generation');
+    generationFamily(original, candidate);
     const logical = `${generation.protocol_hash}/${key(generation)}`;
     if (includeGenerations) expectedGroups.set(textHash(`${logical}/rewrite`), { row: generation, candidate, generation, logicalId: `${logical}/rewrite` });
     for (const judge of judgeCandidates(candidate, protocol).filter((judge) => !judgeIds || judgeIds.includes(judge.id))) {

--- a/scripts/research/study-family.mjs
+++ b/scripts/research/study-family.mjs
@@ -1,0 +1,86 @@
+// Study admission policy, not model availability or quality evidence. Provider
+// remains the host/billing identity; never rewrite it to select judge seats.
+const FAMILIES = new Set(['openai', 'google', 'anthropic', 'deepseek', 'moonshot', 'minimax', 'qwen', 'meta', 'glm']);
+const ALIASES = { gemini: 'google', kimi: 'moonshot', alibaba: 'qwen', llama: 'meta', zai: 'glm' };
+const FIRST_PARTY = { openai: 'openai', google: 'google', gemini: 'google', anthropic: 'anthropic',
+  deepseek: 'deepseek', kimi: 'moonshot', moonshot: 'moonshot', minimax: 'minimax', 'minimax-cn': 'minimax' };
+const EVIDENCE = new Set(['declared', 'model-id', 'legacy-first-party']);
+const own = (value, field) => Object.hasOwn(value, field);
+
+function normalize(value) {
+  if (typeof value !== 'string' || value !== value.trim()) throw new Error('Invalid upstream family');
+  const name = value.toLowerCase(), family = ALIASES[name] || name;
+  if (!FAMILIES.has(family)) throw new Error('Unknown upstream family; explicit reviewed family policy is required');
+  return family;
+}
+
+function modelFamily(model) {
+  if (typeof model !== 'string') return null;
+  const rules = [
+    ['openai', /^(?:openai\/)?(?:gpt-|o[1-9](?:-|$))/i],
+    ['google', /^(?:(?:google|google-antigravity)\/)?gemini-/i],
+    ['anthropic', /^(?:anthropic\/)?claude-/i],
+    ['deepseek', /^(?:deepseek-ai\/)?deepseek-/i],
+    ['moonshot', /^(?:moonshotai\/)?kimi-|^kimi-code\//i],
+    ['minimax', /^(?:minimaxai\/)?minimax-/i],
+    ['qwen', /^qwen\/|^qwen[0-9-]/i],
+    ['meta', /^(?:meta-llama\/)?llama-/i],
+    ['glm', /^(?:(?:zai-org|z-ai)\/)?glm-/i],
+  ];
+  return rules.find(([, pattern]) => pattern.test(model))?.[0] ?? null;
+}
+
+/** Resolve only declared families or recognized identities, never a host name. */
+export function resolveStudyFamily(definition, { legacy = false } = {}) {
+  if (!definition || typeof definition.provider !== 'string' || !definition.provider) throw new Error('Missing study provider/family identity');
+  const providerFamily = own(FIRST_PARTY, definition.provider) ? FIRST_PARTY[definition.provider] : null;
+  const inferred = modelFamily(definition.model);
+  const declared = own(definition, 'upstreamFamily') ? normalize(definition.upstreamFamily) : null;
+  if ((providerFamily && inferred && providerFamily !== inferred)
+    || (declared && [providerFamily, inferred].some((family) => family && family !== declared))) {
+    throw new Error('Contradictory upstream family in admitted definition');
+  }
+  if (declared) return { upstreamFamily: declared, familyEvidence: 'declared' };
+  if (inferred) return { upstreamFamily: inferred, familyEvidence: 'model-id' };
+  if (legacy && providerFamily) return { upstreamFamily: providerFamily, familyEvidence: 'legacy-first-party' };
+  throw new Error('Missing upstream family; declare upstreamFamily for an opaque hosted model');
+}
+
+function rowFamily(row, judge = false, admitted) {
+  const provider = row[judge ? 'judge_provider' : 'provider'];
+  const model = row[judge ? 'judge_model' : 'requested_model'];
+  const field = judge ? 'judge_upstream_family' : 'upstream_family';
+  const evidenceField = judge ? 'judge_family_evidence' : 'family_evidence';
+  if (!own(FIRST_PARTY, provider) && (!own(row, field) || !own(row, evidenceField))) throw new Error('Missing hosted row upstream family/evidence');
+  if (own(row, evidenceField) && !EVIDENCE.has(row[evidenceField])) throw new Error('Invalid row family evidence');
+  if (row[evidenceField] === 'legacy-first-party' && !own(FIRST_PARTY, provider)) throw new Error('Hosted rows cannot claim legacy first-party evidence');
+  const identity = { provider, model, ...(own(row, field) ? { upstreamFamily: row[field] } : {}) };
+  const resolved = resolveStudyFamily(identity, { legacy: true });
+  if (admitted) {
+    const expected = resolveStudyFamily(admitted);
+    if (provider !== admitted.provider || model !== admitted.model || resolved.upstreamFamily !== expected.upstreamFamily
+      || (own(row, evidenceField) && row[evidenceField] !== expected.familyEvidence)) throw new Error('Row upstream family differs from admitted definition');
+  }
+  return { ...resolved, familyEvidence: row[evidenceField] ?? (own(row, field) ? resolved.familyEvidence : 'legacy-first-party') };
+}
+
+export function generationFamily(row, admitted) { return rowFamily(row, false, admitted); }
+
+/** Guard direct judge calls too, before journals or paid evaluators are opened. */
+export function independentJudgeMetadata(generation, judge, admittedGenerator) {
+  const producer = generationFamily(generation, admittedGenerator), evaluator = resolveStudyFamily(judge);
+  if (producer.upstreamFamily === evaluator.upstreamFamily) throw new Error('A judge cannot evaluate its own family (same-family judgment)');
+  return { generator_upstream_family: producer.upstreamFamily, generator_family_evidence: producer.familyEvidence,
+    judge_upstream_family: evaluator.upstreamFamily, judge_family_evidence: evaluator.familyEvidence };
+}
+
+/** Validate saved results without adding fields to historical rows/protocols. */
+export function validateJudgmentFamilies(generation, judgment, { candidate, judge } = {}) {
+  const producer = generationFamily(generation, candidate), evaluator = rowFamily(judgment, true, judge);
+  if ((!own(FIRST_PARTY, generation.provider) && !own(judgment, 'generator_upstream_family'))
+    || (own(judgment, 'generator_upstream_family') && normalize(judgment.generator_upstream_family) !== producer.upstreamFamily)
+    || (own(judgment, 'generator_family_evidence') && (!EVIDENCE.has(judgment.generator_family_evidence)
+      || judgment.generator_family_evidence !== producer.familyEvidence))) throw new Error('Judgment generator family differs from its source');
+  if (producer.upstreamFamily === evaluator.upstreamFamily) throw new Error('A judge cannot evaluate its own family (same-family judgment)');
+  return evaluator.upstreamFamily;
+}

--- a/scripts/research/study-family.mjs
+++ b/scripts/research/study-family.mjs
@@ -56,6 +56,7 @@ function rowFamily(row, judge = false, admitted) {
   if (row[evidenceField] === 'legacy-first-party' && !own(FIRST_PARTY, provider)) throw new Error('Hosted rows cannot claim legacy first-party evidence');
   const identity = { provider, model, ...(own(row, field) ? { upstreamFamily: row[field] } : {}) };
   const resolved = resolveStudyFamily(identity, { legacy: true });
+  if (row[evidenceField] === 'model-id' && modelFamily(model) !== resolved.upstreamFamily) throw new Error('Row model-id family evidence requires a recognized model identity');
   if (admitted) {
     const expected = resolveStudyFamily(admitted);
     if (provider !== admitted.provider || model !== admitted.model || resolved.upstreamFamily !== expected.upstreamFamily

--- a/scripts/research/study-validation.mjs
+++ b/scripts/research/study-validation.mjs
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parseStrictJson } from '../../src/json-response.js';
 import { createHash } from 'node:crypto';
@@ -52,6 +52,10 @@ export function studySemantics(repoRoot) {
     'scripts/research/model-rewrite-benchmark.mjs', 'scripts/research/model-evaluation-transport.mjs', 'scripts/research/kimi-study-transport.mjs', 'scripts/research/claude-study-stream.mjs', 'scripts/research/evaluate-existing-rewrites.mjs', 'scripts/research/parent-cohort-audit.mjs',
     'scripts/research/study-validation.mjs', 'scripts/research/study-journal.mjs', 'scripts/research/study-job.mjs', 'scripts/research/study-inputs.mjs'];
   const paths = [...fixed];
+  // Historical source snapshots predate family admission. Keep their original
+  // semantics maps intact; every new snapshot binds the family policy bytes.
+  const familyPolicy = 'scripts/research/study-family.mjs';
+  if (existsSync(resolve(repoRoot, familyPolicy))) paths.push(familyPolicy);
   for (const directory of ['src', 'patterns', 'core', 'document-types', 'lexicon', 'personas']) {
     const walk = (path) => {
       for (const item of readdirSync(resolve(repoRoot, path), { withFileTypes: true })) {

--- a/tests/unit/model-evaluation-join.test.js
+++ b/tests/unit/model-evaluation-join.test.js
@@ -8,10 +8,12 @@ import { generateRewrite, judgeRewrite } from '../../scripts/research/model-rewr
 import { loadParentCohort, evaluateExisting } from '../../scripts/research/evaluate-existing-rewrites.mjs';
 import { joinEvaluations, selectRewriteFinalists } from '../../scripts/research/join-model-evaluations.mjs';
 
-async function fixture(t) {
+async function fixture(t, hosted = false) {
   const root = mkdtempSync(join(tmpdir(), 'patina-evaluation-join-')); t.after(() => rmSync(root, { recursive: true, force: true }));
-  const generator = { id: 'generator', provider: 'openai', model: 'gpt-test', transport: 'opencodex', baseURL: 'http://127.0.0.1:10100/v1' };
-  const gemini = { id: 'gemini-3.7', provider: 'gemini', model: 'google-antigravity/gemini-test', transport: 'opencodex', baseURL: generator.baseURL };
+  const generator = hosted
+    ? { id: 'generator', provider: 'together', model: 'openai/gpt-oss-120b', upstreamFamily: 'openai', transport: 'http', baseURL: 'https://api.together.ai/v1' }
+    : { id: 'generator', provider: 'openai', model: 'gpt-test', transport: 'opencodex', baseURL: 'http://127.0.0.1:10100/v1' };
+  const gemini = { id: 'gemini-3.7', provider: 'gemini', model: 'google-antigravity/gemini-test', transport: 'opencodex', baseURL: 'http://127.0.0.1:10100/v1' };
   const claude = { id: 'anthropic-sonnet', provider: 'anthropic', model: 'claude-sonnet-5', transport: 'claude-cli' };
   const protocol = { candidates: [generator, { ...generator, id: 'openai-5.5' }, gemini, claude] };
   const source = { fixture_id: 'one', text: 'We shipped 12 fixes.', language: 'en', text_hash: textHash('We shipped 12 fixes.') };
@@ -23,7 +25,7 @@ async function fixture(t) {
   const { rewrite: _text, ...publicGeneration } = generation;
   writeFileSync(join(root, 'rewrite-rows.jsonl'), JSON.stringify(publicGeneration) + '\n');
   writeFileSync(join(root, 'rewrites.private.jsonl'), JSON.stringify(generation) + '\n');
-  const parent = await loadParentCohort({ directory: root, protocolFile, fixtures: [source], provider: 'openai', candidateId: generator.id });
+  const parent = await loadParentCohort({ directory: root, protocolFile, fixtures: [source], provider: generator.provider, candidateId: generator.id });
   const directories = [];
   for (const judge of [gemini, claude]) {
     const output = join(root, judge.id); directories.push(output);
@@ -42,6 +44,25 @@ test('two independently bound evaluation directories join without relabeling par
   assert.match(result.report, /complete: \*\*yes/);
   assert.equal(args.parent.generations[0].protocol_hash, 'a'.repeat(64));
   await assert.rejects(joinEvaluations({ ...args, directories: [args.directories[0]] }), /missing or unresolved/);
+});
+
+test('hosted OpenAI cohort joins using different upstream judges and keeps the billing host', async (t) => {
+  const args = await fixture(t, true);
+  const before = readFileSync(join(args.root, 'protocol.json'), 'utf8');
+  const result = await joinEvaluations(args);
+  assert.equal(result.summary.generator.safe, 1);
+  assert.equal(result.summary.generator.provider, 'together');
+  assert.equal(result.summary.generator.upstream_family, 'openai');
+  const rowPath = join(args.directories[0], 'judge-gemini-3.7.jsonl');
+  const row = JSON.parse(readFileSync(rowPath, 'utf8'));
+  assert.equal(row.generator_upstream_family, 'openai'); assert.equal(row.judge_upstream_family, 'google');
+  assert.equal(args.parent.generations[0].protocol_hash, 'a'.repeat(64));
+  assert.equal(readFileSync(join(args.root, 'protocol.json'), 'utf8'), before);
+  for (const suffix of ['jsonl', 'private.jsonl']) {
+    const path = join(args.directories[0], `judge-gemini-3.7.${suffix}`), stored = JSON.parse(readFileSync(path, 'utf8'));
+    stored.generator_upstream_family = 'qwen'; writeFileSync(path, JSON.stringify(stored) + '\n');
+  }
+  await assert.rejects(joinEvaluations(args), /generator family/);
 });
 
 test('wrong snapshots and altered public/private scores cannot certify joined results', async (t) => {

--- a/tests/unit/model-evaluation-join.test.js
+++ b/tests/unit/model-evaluation-join.test.js
@@ -65,6 +65,43 @@ test('hosted OpenAI cohort joins using different upstream judges and keeps the b
   await assert.rejects(joinEvaluations(args), /generator family/);
 });
 
+test('joins without evaluation directories still validate every private generation', async (t) => {
+  const args = await fixture(t, true);
+  const judgments = args.directories.map((directory) => {
+    const judge = JSON.parse(readFileSync(join(directory, 'provenance.json'), 'utf8')).judge;
+    return JSON.parse(readFileSync(join(directory, `judge-${judge.id}.jsonl`), 'utf8'));
+  });
+  const parent = { ...args.parent, judgments }, original = parent.privateRows[0];
+  const before = JSON.stringify(parent);
+  const result = await joinEvaluations({ ...args, parent, directories: [] });
+  assert.equal(result.summary.generator.safe, 1); assert.match(result.report, /complete: \*\*yes/);
+  const cases = [
+    ['contradictory-family', [{ ...original, upstream_family: 'qwen' }], /Contradictory/],
+    ['evidence', [{ ...original, family_evidence: 'model-id' }], /admitted definition/],
+    ['model', [{ ...original, requested_model: 'openai/gpt-oss-20b' }], /admitted definition/],
+    ['host', [{ ...original, provider: 'groq' }], /admitted definition/],
+    ['missing', [], /private.*generation/],
+    ['extra', [original, { ...original, fixture_id: 'extra' }], /private.*generation/],
+    ['unbound', [{ ...original, fixture_id: 'missing' }], /private.*generation/],
+    ['metadata-parity', [{ ...original, text_hash: textHash('other source') }], /metadata differs/],
+    ['rewrite-binding', [{ ...original, rewrite: 'We shipped 13 fixes.' }], /rewrite.*hash/],
+  ];
+  for (const [name, privateRows, error] of cases) await t.test(name, async () => {
+    await assert.rejects(joinEvaluations({ ...args, parent: { ...parent, privateRows }, directories: [] }), error);
+  });
+  await t.test('duplicate private keys cannot replace a missing generation', async () => {
+    const second = { ...parent.generations[0], repeat: 1 };
+    await assert.rejects(joinEvaluations({ ...args, parent: { ...parent,
+      generations: [...parent.generations, second], privateRows: [original, original] }, directories: [] }), /private.*generation/);
+  });
+  await t.test('matching public/private transport still must bind to the definition', async () => {
+    await assert.rejects(joinEvaluations({ ...args, parent: { ...parent,
+      generations: [{ ...parent.generations[0], transport: 'opencodex' }],
+      privateRows: [{ ...original, transport: 'opencodex' }] }, directories: [] }), /generation.*definition/);
+  });
+  assert.equal(JSON.stringify(parent), before);
+});
+
 test('wrong snapshots and altered public/private scores cannot certify joined results', async (t) => {
   const args = await fixture(t);
   const provenancePath = join(args.directories[0], 'provenance.json'), original = readFileSync(provenancePath, 'utf8');

--- a/tests/unit/model-rewrite-benchmark.test.js
+++ b/tests/unit/model-rewrite-benchmark.test.js
@@ -55,7 +55,7 @@ test('naturalness rubric is model-blind and rejects non-numeric or out-of-range 
 });
 
 test('judging exercises production MPS and fidelity separately from naturalness', async () => {
-  const generation = { candidate_id: candidate.id, repeat: 0, rewrite: text, rewrite_hash: textHash(text) };
+  const generation = { candidate_id: candidate.id, provider: candidate.provider, requested_model: candidate.model, repeat: 0, rewrite: text, rewrite_hash: textHash(text) };
   const prompts = [];
   const result = await judgeRewrite(fixture, generation, judgeCandidates(candidate, protocol)[0], { complete: async (judge, prompt) => {
     prompts.push(prompt);

--- a/tests/unit/study-family.test.js
+++ b/tests/unit/study-family.test.js
@@ -1,0 +1,160 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveStudyFamily, generationFamily, independentJudgeMetadata, validateJudgmentFamilies } from '../../scripts/research/study-family.mjs';
+import { generateRewrite, judgeCandidates, judgeRewrite, main, summarizeRewrites } from '../../scripts/research/model-rewrite-benchmark.mjs';
+import { evaluateExisting } from '../../scripts/research/evaluate-existing-rewrites.mjs';
+import { auditParentReceipts } from '../../scripts/research/parent-cohort-audit.mjs';
+import { joinEvaluations } from '../../scripts/research/join-model-evaluations.mjs';
+import { studySemantics } from '../../scripts/research/study-validation.mjs';
+import { textHash } from '../quality/live-scorer-benchmark.mjs';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const openai = { id: 'openai-5.5', provider: 'openai', model: 'gpt-test', transport: 'opencodex', baseURL: 'http://127.0.0.1:10100/v1' };
+const google = { id: 'gemini-3.7', provider: 'gemini', model: 'google-antigravity/gemini-test', transport: 'opencodex', baseURL: openai.baseURL };
+const anthropic = { id: 'anthropic-sonnet', provider: 'anthropic', model: 'claude-test', transport: 'claude-cli' };
+const protocol = { candidates: [openai, google, anthropic] };
+// Synthetic transport results below are tests, never provider observations.
+const hosted = { id: 'hosted-test', provider: 'groq', model: 'openai/gpt-oss-120b', transport: 'http', baseURL: 'https://api.groq.com/openai/v1' };
+const text = 'We shipped 12 fixes.';
+const fixture = { fixture_id: 'synthetic', text, text_hash: textHash(text), language: 'en' };
+function generation(candidate = hosted) {
+  const family = resolveStudyFamily(candidate);
+  return { candidate_id: candidate.id, fixture_id: fixture.fixture_id, repeat: 0, provider: candidate.provider,
+    requested_model: candidate.model, transport: candidate.transport, upstream_family: family.upstreamFamily, family_evidence: family.familyEvidence,
+    text_hash: fixture.text_hash, rewrite_hash: fixture.text_hash, rewrite: text, status: 'ok', number_safety: { ok: true }, language: 'en', duration_ms: 1 };
+}
+function judgment(source, judge) {
+  return { candidate_id: source.candidate_id, fixture_id: source.fixture_id, repeat: source.repeat,
+    text_hash: source.text_hash, rewrite_hash: source.rewrite_hash, judge_id: judge.id, judge_provider: judge.provider,
+    judge_model: judge.model, judge_transport: judge.transport, ...independentJudgeMetadata(source, judge),
+    status: 'ok', mps: 100, fidelity: 100, hard_fail_count: 0, naturalness: 3 };
+}
+
+test('hosted OpenAI identifiers resolve their upstream family without changing host or billing inputs', () => {
+  for (const provider of ['groq', 'together']) {
+    for (const model of ['openai/gpt-oss-120b', 'openai/gpt-oss-20b']) {
+      const candidate = { ...hosted, provider, model, apiKeyEnv: 'SYNTHETIC_KEY_NAME' }, before = JSON.stringify(candidate);
+      assert.deepEqual(resolveStudyFamily(candidate), { upstreamFamily: 'openai', familyEvidence: 'model-id' });
+      assert.deepEqual(judgeCandidates(candidate, protocol).map((seat) => seat.id), ['gemini-3.7', 'anthropic-sonnet']);
+      assert.equal(JSON.stringify(candidate), before);
+    }
+  }
+});
+
+test('opaque hosted models need an explicit recognized family; contradictory and unknown declarations fail', () => {
+  const opaque = { ...hosted, model: 'private-deployment-id' };
+  assert.throws(() => resolveStudyFamily(opaque), /Missing upstream family/);
+  assert.deepEqual(resolveStudyFamily({ ...opaque, upstreamFamily: 'openai' }), { upstreamFamily: 'openai', familyEvidence: 'declared' });
+  for (const upstreamFamily of ['groq', 'together', 'unknown', 'new-independent-family', '', null, 1, ' openai']) {
+    assert.throws(() => resolveStudyFamily({ ...opaque, upstreamFamily }));
+  }
+  for (const upstreamFamily of ['google', 'qwen', 'anthropic']) assert.throws(() => resolveStudyFamily({ ...hosted, upstreamFamily }), /Contradictory/);
+  assert.throws(() => resolveStudyFamily({ ...openai, model: 'Qwen/Qwen3.5-9B' }), /Contradictory/);
+  assert.throws(() => resolveStudyFamily({ ...openai, upstreamFamily: 'qwen' }), /Contradictory/);
+  assert.equal(resolveStudyFamily({ ...google, upstreamFamily: 'gemini' }).upstreamFamily, 'google');
+});
+
+test('all original admitted first-party protocols keep their seats and remain byte-for-byte unchanged', () => {
+  for (const name of ['model-evaluation-20260904.json', 'model-evaluation-kimi-code-20260905.json', 'model-evaluation-claude-isolated-20260905.json']) {
+    const path = join(ROOT, 'docs/research', name), bytes = readFileSync(path, 'utf8'), original = JSON.parse(bytes);
+    const before = JSON.stringify(original);
+    for (const candidate of original.candidates) {
+      const family = resolveStudyFamily(candidate).upstreamFamily, judges = judgeCandidates(candidate, original);
+      assert.ok(judges.every((judge) => resolveStudyFamily(judge).upstreamFamily !== family));
+    }
+    assert.equal(JSON.stringify(original), before); assert.equal(readFileSync(path, 'utf8'), bytes);
+  }
+  assert.deepEqual(generationFamily({ provider: 'openai' }), { upstreamFamily: 'openai', familyEvidence: 'legacy-first-party' });
+  assert.throws(() => generationFamily({ provider: 'together', requested_model: hosted.model }), /Missing hosted row/);
+});
+
+test('cross-host duplicate judge families cannot supply independence', () => {
+  const producer = { ...hosted, model: 'Qwen/Qwen3.5-9B' };
+  const panel = { candidates: [openai, { ...hosted, id: google.id }, anthropic] };
+  assert.throws(() => judgeCandidates(producer, panel), /independent judge families/);
+  const source = generation(producer), judges = [judgment(source, openai), judgment(source, { ...hosted, id: 'hosted-openai-judge' })];
+  const summary = summarizeRewrites([source], judges)[source.candidate_id];
+  assert.equal(summary.safe, 0); assert.equal(summary.pending_judgments, 1);
+});
+
+test('new rows record upstream family and preserve host, requested model and usage', async () => {
+  const candidate = { ...hosted, upstreamFamily: 'openai' };
+  const row = await generateRewrite(fixture, candidate, 'Synthetic prompt', { complete: async () => ({
+    text, effectiveModels: [candidate.model], durationMs: 1, attempts: 1, usage: { prompt_tokens: 4, completion_tokens: 5 } }) });
+  assert.equal(row.provider, 'groq'); assert.equal(row.requested_model, candidate.model);
+  assert.equal(row.upstream_family, 'openai'); assert.equal(row.family_evidence, 'declared');
+  assert.equal(row.usage.prompt_tokens, 4);
+  let calls = 0;
+  const result = await judgeRewrite(fixture, row, google, { complete: async (judge, prompt) => {
+    calls++;
+    const value = prompt.includes('Meaning Preservation evaluator')
+      ? '{"anchors":[],"pass_count":0,"total_count":0,"polarity_pass_count":0,"polarity_total_count":0,"mps":100}'
+      : prompt.includes('Fidelity evaluator') ? '{"claims_preserved":3,"no_fabrication":3,"audience_register_match":3}' : '{"naturalness":3}';
+    return { text: value, effectiveModels: [judge.model], durationMs: 1, attempts: 1 };
+  } });
+  assert.equal(calls, 3); assert.equal(result.status, 'ok');
+  assert.equal(result.generator_upstream_family, 'openai'); assert.equal(result.judge_upstream_family, 'google');
+  assert.equal(result.judge_provider, 'gemini');
+});
+
+test('direct generation and judging reject unknown, missing and self-family identities before calls', async () => {
+  let calls = 0; const complete = async () => { calls++; throw new Error('must not call'); };
+  await assert.rejects(generateRewrite(fixture, { ...hosted, model: 'opaque' }, 'prompt', { complete }), /Missing upstream family/);
+  await assert.rejects(generateRewrite(fixture, { ...hosted, upstreamFamily: 'qwen' }, 'prompt', { complete }), /Contradictory/);
+  await assert.rejects(judgeRewrite(fixture, generation(), openai, { complete }), /own family/);
+  await assert.rejects(judgeRewrite(fixture, { ...generation(), upstream_family: 'qwen' }, google, { complete }), /Contradictory/);
+  const missing = generation(); delete missing.upstream_family;
+  await assert.rejects(judgeRewrite(fixture, missing, google, { complete }), /Missing hosted row/);
+  assert.equal(calls, 0);
+});
+
+test('summary guards reject self-family and contradictory generator/judge metadata; legacy first-party rows still work', () => {
+  const source = generation(), good = judgment(source, google);
+  assert.throws(() => summarizeRewrites([source], [{ ...good, judge_provider: 'openai', judge_model: 'gpt-test', judge_upstream_family: 'openai' }]), /same-family/);
+  assert.throws(() => validateJudgmentFamilies(source, { ...good, generator_upstream_family: 'qwen' }), /generator family/);
+  assert.throws(() => validateJudgmentFamilies(source, { ...good, judge_upstream_family: 'openai' }), /Contradictory/);
+  const legacy = { ...generation(openai) }; delete legacy.upstream_family; delete legacy.family_evidence;
+  const judges = [google, anthropic].map((judge) => {
+    const row = judgment(legacy, judge);
+    for (const key of ['generator_upstream_family', 'generator_family_evidence', 'judge_upstream_family', 'judge_family_evidence']) delete row[key];
+    return row;
+  });
+  assert.equal(summarizeRewrites([legacy], judges)[openai.id].safe, 1);
+  assert.equal(summarizeRewrites([source], [good, judgment(source, anthropic)])[hosted.id].provider, 'groq');
+});
+
+test('existing evaluation rejects hosted self-family and unresolved definitions before opening an output', async (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'patina-family-eval-')); t.after(() => rmSync(root, { recursive: true, force: true }));
+  let calls = 0; const evaluate = async () => { calls++; };
+  const parent = { candidates: [hosted], generations: [generation()], privateRows: [generation()], judgments: [] };
+  await assert.rejects(evaluateExisting({ parent, judge: openai, output: join(root, 'blocked'), live: true, evaluate }), /own family/);
+  await assert.rejects(evaluateExisting({ parent: { ...parent, candidates: [{ ...hosted, model: 'opaque' }] }, judge: google,
+    output: join(root, 'blocked'), live: true, evaluate }), /Missing upstream family/);
+  assert.equal(calls, 0); assert.equal(existsSync(join(root, 'blocked')), false);
+});
+
+test('exported receipt audit and join reject self-family parent rows even without evaluation directories', async () => {
+  const source = generation();
+  const bad = { ...judgment(source, google), judge_id: openai.id, judge_provider: openai.provider, judge_model: openai.model,
+    judge_upstream_family: 'openai' };
+  const parent = { generations: [source], privateRows: [source], candidates: [hosted], judgments: [bad] };
+  await assert.rejects(auditParentReceipts({ ...parent, protocol, fixtures: [fixture], directory: '/unused', hashes: {} }), /same-family/);
+  await assert.rejects(joinEvaluations({ parent, protocol, fixtures: [fixture], directories: [], evaluationSemantics: {} }), /same-family/);
+});
+
+test('benchmark preflight rejects a later unknown family before the first candidate is called', async (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'patina-family-preflight-')); t.after(() => rmSync(root, { recursive: true, force: true }));
+  const path = join(root, 'protocol.json'), output = join(root, 'output');
+  writeFileSync(path, JSON.stringify({ candidates: [...protocol.candidates, { ...hosted, model: 'opaque' }] }));
+  await assert.rejects(main(['--live', '--candidates', path, '--output', output]), /Missing upstream family/);
+  assert.equal(existsSync(output), false);
+});
+
+test('new study semantics hash the family helper', () => {
+  const path = 'scripts/research/study-family.mjs';
+  assert.equal(studySemantics(ROOT)[path], textHash(readFileSync(join(ROOT, path))));
+});

--- a/tests/unit/study-family.test.js
+++ b/tests/unit/study-family.test.js
@@ -58,6 +58,29 @@ test('opaque hosted models need an explicit recognized family; contradictory and
   assert.equal(resolveStudyFamily({ ...google, upstreamFamily: 'gemini' }).upstreamFamily, 'google');
 });
 
+test('opaque generation evidence stays declared without an admitted definition', async (t) => {
+  const candidate = { ...hosted, model: 'private-deployment-id', upstreamFamily: 'qwen' };
+  const source = generation(candidate), forged = { ...source, family_evidence: 'model-id' };
+  assert.deepEqual(generationFamily(source), { upstreamFamily: 'qwen', familyEvidence: 'declared' });
+  assert.equal(summarizeRewrites([source], [judgment(source, openai), judgment(source, google)])[candidate.id].safe, 1);
+  assert.throws(() => generationFamily(forged), /model-id.*evidence/);
+  assert.throws(() => summarizeRewrites([forged], []), /model-id.*evidence/);
+  const root = mkdtempSync(join(tmpdir(), 'patina-family-evidence-')); t.after(() => rmSync(root, { recursive: true, force: true }));
+  let calls = 0;
+  const output = join(root, 'blocked');
+  await assert.rejects(judgeRewrite(fixture, forged, openai, { journalDirectory: output,
+    complete: async () => { calls++; throw new Error('Injected evaluator reached'); } }), /model-id.*evidence/);
+  assert.equal(calls, 0); assert.equal(existsSync(output), false);
+});
+
+test('opaque judge evidence cannot claim model-id in saved results', () => {
+  const source = generation(), judge = { ...hosted, id: 'opaque-judge', model: 'private-deployment-id', upstreamFamily: 'qwen' };
+  const good = judgment(source, judge), forged = { ...good, judge_family_evidence: 'model-id' };
+  assert.equal(validateJudgmentFamilies(source, good), 'qwen');
+  assert.throws(() => validateJudgmentFamilies(source, forged), /model-id.*evidence/);
+  assert.throws(() => summarizeRewrites([source], [judgment(source, google), forged]), /model-id.*evidence/);
+});
+
 test('all original admitted first-party protocols keep their seats and remain byte-for-byte unchanged', () => {
   for (const name of ['model-evaluation-20260904.json', 'model-evaluation-kimi-code-20260905.json', 'model-evaluation-claude-isolated-20260905.json']) {
     const path = join(ROOT, 'docs/research', name), bytes = readFileSync(path, 'utf8'), original = JSON.parse(bytes);
@@ -137,11 +160,39 @@ test('existing evaluation rejects hosted self-family and unresolved definitions 
   assert.equal(calls, 0); assert.equal(existsSync(join(root, 'blocked')), false);
 });
 
+test('existing evaluation validates every saved judgment before output or injected evaluator calls', async (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'patina-family-parent-')); t.after(() => rmSync(root, { recursive: true, force: true }));
+  const source = { ...generation(), protocol_hash: textHash('parent-protocol') };
+  const { rewrite: _rewrite, ...publicSource } = source;
+  const good = judgment(source, anthropic);
+  const bad = { ...good, judge_id: openai.id, judge_provider: openai.provider, judge_model: openai.model,
+    judge_transport: openai.transport, judge_upstream_family: 'openai' };
+  const cases = [
+    ['same-family', [good, bad], /same-family/],
+    ['generator-family', [{ ...good, generator_upstream_family: 'qwen' }], /generator family/],
+    ['judge-family', [{ ...good, judge_upstream_family: 'qwen' }], /Contradictory/],
+    ['opaque-evidence', [{ ...good, judge_provider: 'together', judge_model: 'opaque', judge_upstream_family: 'qwen' }], /model-id.*evidence/],
+    ['source-hash', [{ ...good, rewrite_hash: textHash('different rewrite') }], /Unbound/],
+    ['orphan', [{ ...good, fixture_id: 'missing' }], /Unbound/],
+    ['duplicate', [good, good], /Duplicate/],
+  ];
+  for (const [name, judgments, error] of cases) await t.test(name, async () => {
+    let calls = 0;
+    const output = join(root, name), parent = { candidates: [hosted], generations: [publicSource], privateRows: [source], judgments,
+      fixtures: [fixture], snapshotHash: textHash('parent-snapshot'), provenance: { parentProtocolHashes: [source.protocol_hash] },
+      expectedKeys: [`${hosted.id}/${fixture.fixture_id}/0`] };
+    await assert.rejects(evaluateExisting({ parent, judge: google, output, protocolHash: textHash('evaluation-protocol'), live: true,
+      evaluate: async () => { calls++; throw new Error('Injected evaluator reached'); } }), error);
+    assert.equal(calls, 0); assert.equal(existsSync(output), false);
+  });
+});
+
 test('exported receipt audit and join reject self-family parent rows even without evaluation directories', async () => {
   const source = generation();
+  const { rewrite: _rewrite, ...publicSource } = source;
   const bad = { ...judgment(source, google), judge_id: openai.id, judge_provider: openai.provider, judge_model: openai.model,
     judge_upstream_family: 'openai' };
-  const parent = { generations: [source], privateRows: [source], candidates: [hosted], judgments: [bad] };
+  const parent = { generations: [publicSource], privateRows: [source], candidates: [hosted], judgments: [bad] };
   await assert.rejects(auditParentReceipts({ ...parent, protocol, fixtures: [fixture], directory: '/unused', hashes: {} }), /same-family/);
   await assert.rejects(joinEvaluations({ parent, protocol, fixtures: [fixture], directories: [], evaluationSemantics: {} }), /same-family/);
 });

--- a/tests/unit/study-validation.test.js
+++ b/tests/unit/study-validation.test.js
@@ -58,7 +58,7 @@ test('MPS anchor/count/score consistency and raw fidelity ranges are mandatory',
 test('a clamped fidelity and fabricated MPS cannot certify a successful judgment', async () => {
   const text = 'We shipped 12 updates.';
   const fixture = { fixture_id: 'test', language: 'en', text, text_hash: textHash(text) };
-  const generation = { candidate_id: candidate.id, repeat: 0, rewrite: text, rewrite_hash: textHash(text) };
+  const generation = { candidate_id: candidate.id, provider: candidate.provider, requested_model: candidate.model, repeat: 0, rewrite: text, rewrite_hash: textHash(text) };
   const judge = judgeCandidates(candidate, protocol)[0];
   const row = await judgeRewrite(fixture, generation, judge, { complete: async (_candidate, prompt) => {
     if (prompt.includes('Meaning Preservation evaluator')) return response('{"anchors":[{"type":"claim","content":"12","verdict":"HARD_FAIL"}],"pass_count":1,"total_count":1,"polarity_pass_count":0,"polarity_total_count":0,"mps":100}', judge.model);
@@ -105,6 +105,11 @@ test('semantic identity binds configuration, pattern contents, language and labe
   try {
     for (const path of Object.keys(original)) { const target = join(dir, path); mkdirSync(dirname(target), { recursive: true }); writeFileSync(target, readFileSync(join(ROOT, path))); }
     assert.deepEqual(studySemantics(dir), original);
+    const familyPolicy = 'scripts/research/study-family.mjs';
+    rmSync(join(dir, familyPolicy));
+    const legacy = { ...original }; delete legacy[familyPolicy];
+    assert.deepEqual(studySemantics(dir), legacy, 'historical snapshots without the helper retain their semantics shape');
+    writeFileSync(join(dir, familyPolicy), readFileSync(join(ROOT, familyPolicy)));
     writeFileSync(join(dir, '.patina.default.yaml'), '# changed configuration');
     assert.notEqual(studySemantics(dir)['.patina.default.yaml'], original['.patina.default.yaml']);
     const pattern = Object.keys(original).find((path) => path.startsWith('patterns/'));


### PR DESCRIPTION
Study judges now compare upstream model families while preserving hosting-provider and billing identity. Hosted OpenAI models cannot use an OpenAI judge merely because the API host differs. Unknown or contradictory family declarations fail before evaluation.

The guards cover selection, direct judging, existing parent judgments, private generations, empty-directory joins, and audits. Opaque identifiers cannot claim model-ID evidence. New rows record family evidence and protocol semantics include the helper hash; known first-party legacy cohorts remain supported.

Validation: 62 focused tests; full1,935 passed,2 skipped; lint clean. Independent Astra/xhigh review passed all three reproduced API-edge fixes and confirmed canonical MPS validation unchanged. No live calls, model admissions, CLI defaults or frozen studies changed.
