### PR TITLE
research: collect approval-bound unlabelled rebaseline scores

### DIFF
--- a/docs/research/rebaseline-score-collection-20260905.md
+++ b/docs/research/rebaseline-score-collection-20260905.md
@@ -30,10 +30,33 @@ including inactive fields, before dispatch.
 **Admission and bounds**
 
 Supply an existing candidate protocol, its exact file SHA-256, and one candidate
-ID. The selected definition is copied unchanged. Supply a separate approval file
-whose header binds the intake and candidate, and whose decisions bind exact text
-hashes and inherited origin evidence. Approved entries require all fields below.
-These placeholders illustrate the schema; they grant no processing permission.
+ID. The selected definition is copied unchanged. Two approval schemas are supported.
+
+The parent approval dated September 5 is consumed directly through `--approvals`;
+no rewritten approval file is needed. Its `parentApproved`, scope, exact Gemini 3.7
+OpenCodex candidate, `reviewPath`/`reviewHash`, `approvedTextHashes`, one repeat,
+and logical-observation limit must agree. Every approved hash must have an
+`approve` decision, verified bindings, and unchanged provenance in the bound
+review. The reviewed bundle's three exact file hashes and semantic hashes are
+checked too. Duplicate, deferred, substituted, or missing hashes reject the run.
+The parent-selected order is retained, so this grant fixes one pass of 85 targets.
+
+The original approval and review bytes and their SHA-256 values are stored in
+`approvalSource` inside the private snapshot. The review's pending status is left
+unchanged; the separate parent approval supplies the execution gate. Its authority,
+unknowns, payload restriction, and exclusions are preserved verbatim. This does
+not certify publication rights, human authorship, or quality. Both source files
+remain untouched, and replay reads their frozen copies without rereading them.
+
+The supplied approval was validated read-only: approval SHA-256
+`8f31c1b5cbcf43af58a254cbc27f03b1ebab7378582fffe3614afdad3bb67c00`,
+review SHA-256
+`24d3403dc3f422291d5c087b9a19241ed828f774175dbdf337edfd62b3596f89`,
+and all 85 approved hashes matched. No live calls were made.
+
+The earlier per-text decision schema is also supported. Approved entries require
+all fields below. These placeholders illustrate its schema and grant no processing
+permission.
 
 ```json
 {
@@ -116,6 +139,21 @@ frozen code, and feeds recorded completions through the scorer. It verifies exac
 prompts, request hashes, call sequence, schema outcome, the full production score
 object, and observed collector fields. It writes nothing and has no live fallback.
 Only a complete observed matrix can return `fullObservedReplay: true`.
+
+**Outbound payload boundary**
+
+The HTTP body contains the selected model, one user message, and supported scoring
+request controls. The message is derived only from the exact approved text and
+necessary scoring instructions: weights, severity rules, pack counts, and pattern
+catalog. The intake, source index, source URLs, generator/quality labels, previous
+prompts or receipts, and full source documents stay in the private snapshot.
+Unrelated config fields are not included. Tests intercept the outbound body and
+check these boundaries using distinct metadata markers.
+
+If production fencing would alter the approved text, preparation stops. There is
+no silent edit or replacement text. Scores do not trigger a replacement run:
+only the existing bounded JSON-parse retry is permitted, within the fixed call
+budget. The worker has not executed the parent's approved live pass.
 
 **Private evidence**
 

--- a/docs/research/rebaseline-score-collection-20260905.md
+++ b/docs/research/rebaseline-score-collection-20260905.md
@@ -201,6 +201,31 @@ scorer execution, not an independently reconstructed upstream inference.
 
 **Interruption and reporting**
 
+Each HTTP request links its private controller to the read-only study cancellation
+signal. `abortStudy()`, SIGTERM, and SIGINT therefore interrupt the active fetch
+and stop later texts. An already-cancelled study is checked before dispatch and
+again after listener registration to close the missed-event race. The global
+listener, deadline timer, and response-reader lock are cleaned up on every exit.
+
+Cancellation cause is explicit in private error metadata:
+
+| Cause | Recorded error | Collection behavior |
+| --- | --- | --- |
+| Study-wide cancellation | `study-cancelled`; interruption `operator-cancelled` | Stop further work; retain the call receipt and reservation |
+| Per-request deadline | `request-timeout`; interruption `deadline` | Persist a missing-score/error row and continue within the bound |
+| Network abort without either control firing | `study-call-failed`; interruption `network` | Persist an error row and continue within the bound |
+
+The name `AbortError` alone never establishes operator cancellation. The deadline
+controller is separate from study-wide cancellation, so a timed-out request does
+not cancel the whole cohort. Regression tests exercise active-fetch programmatic
+cancellation, real SIGTERM, already-aborted/listener-installation races, listener
+cleanup, and deadline/network-error rows followed by a successful next text.
+
+The earlier zero-call preparation beginning `c6a599` must remain unchanged. These
+collector/transport code changes require a new prepared snapshot after the fix
+commit, with the same approval bytes, exact texts, and candidate. Turing's
+independent re-review remains required before any live execution.
+
 Every evaluation is reserved before its first call. Completed receipts can recover
 a row that failed to persist, entirely offline. Missing, extra, altered, or started
 receipts stop resume. A missing parser-retry receipt cannot cause a replacement

--- a/docs/research/rebaseline-score-collection-20260905.md
+++ b/docs/research/rebaseline-score-collection-20260905.md
@@ -1,0 +1,171 @@
+# Private rebaseline score collection — September 5, 2026
+
+`collect-rebaseline-scores.mjs` prepares a bounded, single-candidate `scoreText`
+collection for issue #412. Execution requires `--live`. The existing frozen
+intake has 85 records; this implementation has made no provider calls on them.
+The parent owns processing-approval review and live execution.
+
+The collector uses `evaluateScorerFixture` with prepared inputs and its existing
+call journal. It has its own intake adapter because `loadScorerManifest` requires
+boolean labels. Unknown `expected_hot` stays `null`; source origin, rights,
+quality labels, register claims, and dependency links remain in the private
+snapshot. A model-generated origin does not assign a tell label, and a publisher
+page does not establish human authorship.
+
+The supplemental replay-gap audit showed why config fingerprints alone are
+insufficient: observed scores could be reproduced without recovering the full
+historical resolved config. This collector saves the actual serialized objects,
+including inactive fields, before dispatch.
+
+**Admission and bounds**
+
+Supply an existing candidate protocol, its exact file SHA-256, and one candidate
+ID. The selected definition is copied unchanged. Supply a separate approval file
+whose header binds the intake and candidate, and whose decisions bind exact text
+hashes and inherited origin evidence. Approved entries require all fields below.
+These placeholders illustrate the schema; they grant no processing permission.
+
+```json
+{
+  "schemaVersion": 1,
+  "intakeHash": "<canonical hash of the complete frozen intake object>",
+  "candidateHash": "<SHA-256 of JSON.stringify(selected candidate)>",
+  "decisions": [
+    {
+      "textHash": "<SHA-256 of exact text bytes>",
+      "sourceEvidenceHash": "<canonical hash of this record's origins array>",
+      "decision": "approved",
+      "reviewer": "<parent-recorded reviewer reference>",
+      "reviewedAt": "<ISO timestamp>",
+      "provider": "<selected provider>",
+      "transport": "<selected transport>",
+      "model": "<exact selected model>",
+      "permittedLocalAnalysis": true,
+      "permittedProviderProcessing": true,
+      "retention": "private-only",
+      "publication": "summary-only"
+    }
+  ]
+}
+```
+
+Canonical hashes recursively sort object keys and preserve array order before
+JSON serialization. The frozen bundle's `manifestHash` covers `intake.records`;
+its `intakeHash` covers the complete intake object. The collector verifies all
+content-addressed evidence blobs and inherited byte/hash bindings. The source
+index is also copied and hashed in the new snapshot.
+
+Missing decisions remain unknown. Explicit `blocked` and `unknown` decisions
+stay excluded. The approved matrix and the full intake denominator are fixed
+before calls; source rights and quality labels are never rewritten by approval.
+No collection runs with zero approved texts.
+
+There is one candidate and one evaluation per approved text. The caller supplies
+`--max-calls`, bounded by twice the approved count (at most 170). This counts
+reserved completion invocations, including errors; it is not a cash-cost figure.
+For native routes the bound covers CLI invocations; auxiliary usage and upstream
+request counts are known only where the transport reports them.
+The production parser may invoke the transport twice after malformed JSON. A
+valid JSON object that fails the stricter study schema remains a schema failure.
+Timeouts are explicit, from 1 to 180 seconds per logical evaluation.
+
+**Prepare, execute, and replay**
+
+Run from the committed collector checkout. All paths are explicit; the examples
+use placeholders and do not create or approve a real cohort.
+
+```sh
+node scripts/research/collect-rebaseline-scores.mjs \
+  --intake <frozen-intake-directory> \
+  --protocol <candidate-protocol.json> --protocol-sha256 <file-sha256> \
+  --candidate <candidate-id> --config <pinned-config.yaml> \
+  --approvals <processing-approvals.private.json> \
+  --output <new-private-directory> --max-calls <approved-bound> \
+  --timeout-ms 60000
+```
+
+This prepares the snapshot and dispatches no provider call. After the parent's
+review, the same bound directory can be executed with:
+
+```sh
+node scripts/research/collect-rebaseline-scores.mjs \
+  --output <prepared-private-directory> --resume --live
+```
+
+Resume uses the embedded approval, matrix, config, and candidate. It cannot take
+new input paths or enlarge the budget. A changed protocol requires a new output
+directory. Existing model cohorts are never selected implicitly.
+
+```sh
+node scripts/research/collect-rebaseline-scores.mjs \
+  --output <completed-private-directory> --replay
+```
+
+Replay reads snapshots and receipts only, checks current code hashes against the
+frozen code, and feeds recorded completions through the scorer. It verifies exact
+prompts, request hashes, call sequence, schema outcome, the full production score
+object, and observed collector fields. It writes nothing and has no live fallback.
+Only a complete observed matrix can return `fullObservedReplay: true`.
+
+**Private evidence**
+
+- `snapshot.private.json`: exact input records and provenance, decisions, fixed
+  matrix, candidate protocol bytes, config source bytes and resolved objects,
+  language-specific patterns and lexicons, per-text config and full deterministic
+  analyses, expected prompts, structural-model policy, bounds, and code hashes.
+- `wire/<logical-hash>/<ordinal>.private.json`: a started record written before
+  dispatch, with the exact private prompt and credential-free request; then the
+  terminal result or bounded error and available transport evidence.
+- `calls/<logical-hash>/<ordinal>.private.json`: the existing scorer journal,
+  including every returned text and schema-validity outcome.
+- `rows/<text-hash>.private.json`: observed collector output and the complete
+  production result reconstructed immediately from those same receipts.
+- `progress.private.json`: reservations, completed-row hashes, and hashes of each
+  evaluation's journal/wire receipt set. `study-protocol.json` binds the snapshot.
+
+Files are mode 0600 inside a private directory, with a local `*` ignore rule.
+Tracked output destinations, symlink paths, and changed permissions are rejected.
+Credential fields and recognized credential-like strings reject snapshots; they
+are not redacted and represented as complete evidence. A rejected response leaves
+an unresolved call requiring review. No raw text or provider error body goes to
+stdout or a tracked report.
+
+Pinned config is parsed directly, with documented `document-type` normalization
+and per-text language/document-type selection. No global or project config is
+merged. This bounded collector explicitly freezes structural models as absent;
+configured model paths are rejected, and incidental ambient model discovery is
+blocked during preparation. Loaded pattern/lexicon objects, including RegExp
+source/flags when present, are serialized in the private snapshot.
+
+HTTP/OpenCodex uses one fetch per parser invocation, without redirects, transport
+retries, temperature fallback, or provider fallback. Request and response bodies
+are retained privately; authorization headers are never serialized. Only the
+selected HTTP candidate's configured credential variable is read by the existing
+credential helper. There is no environment-file option or credential discovery.
+Gemini is restricted to the existing loopback OpenCodex route and cannot request
+a Gemini API key.
+
+Native CLI candidates use the existing study transport. Their exact collector
+arguments and returned metadata are retained; native upstream request bodies,
+server revision, effective effort, and thinking remain unverified when the
+transport does not disclose them. The replay claim concerns the finite observed
+scorer execution, not an independently reconstructed upstream inference.
+
+**Interruption and reporting**
+
+Every evaluation is reserved before its first call. Completed receipts can recover
+a row that failed to persist, entirely offline. Missing, extra, altered, or started
+receipts stop resume. A missing parser-retry receipt cannot cause a replacement
+paid call during recovery. Persistence failures stop subsequent work. Stale locks
+and pending writes require parent review; the collector does not erase them.
+
+Output contains score distributions, language/pack distributions, missing-pack
+counts, and separate error classes. Failed observations remain missing values.
+Distribution denominators use schema-valid observations; excluded texts remain in
+the intake denominator. Classification metrics and human-quality ratings remain
+null. No FNR, FPR, AUC, accuracy, winner, threshold, or default change is inferred.
+
+Validation uses synthetic inputs and mocked providers, plus a read-only integrity
+check of the 85-record bundle. Tests cover opt-in, approval binding, nullable
+labels, bounded parser retries, transport errors, immutable snapshots, offline
+replay, receipt loss, persistence failure, secret rejection, and Gemini routing.

--- a/docs/research/rebaseline-score-collection-20260905.md
+++ b/docs/research/rebaseline-score-collection-20260905.md
@@ -7,10 +7,20 @@ The parent owns processing-approval review and live execution.
 
 The collector uses `evaluateScorerFixture` with prepared inputs and its existing
 call journal. It has its own intake adapter because `loadScorerManifest` requires
-boolean labels. Unknown `expected_hot` stays `null`; source origin, rights,
-quality labels, register claims, and dependency links remain in the private
-snapshot. A model-generated origin does not assign a tell label, and a publisher
-page does not establish human authorship.
+boolean labels. Every collected target has `expected_hot: null` and `class: null`,
+even if source metadata contains a fixture label. Source origin, rights, quality
+labels, genre declarations, and dependency links remain in the private snapshot.
+A model-generated origin does not assign a tell label, and a publisher page does
+not establish human authorship.
+
+Intake `register` means dataset genre: `social`, `marketing`, or `chat-update`.
+It is retained as `datasetGenre`, with its declared review status. The scorer's
+`config.register` and observed row `register` use only the pinned delivery axis,
+`casual` or `professional` (or null). Genre is never copied into that setting.
+Document type comes from an explicit intake `documentType` declaration or the
+pinned config; the collector does not infer it from genre. Each row records which
+source supplied document type. Unreviewed declarations do not become human-verified
+labels, and original-fixture labels never become rewritten-text target labels.
 
 The supplemental replay-gap audit showed why config fingerprints alone are
 insufficient: observed scores could be reproduced without recovering the full

--- a/docs/research/rebaseline-score-collection-20260905.md
+++ b/docs/research/rebaseline-score-collection-20260905.md
@@ -213,6 +213,7 @@ Cancellation cause is explicit in private error metadata:
 | --- | --- | --- |
 | Study-wide cancellation | `study-cancelled`; interruption `operator-cancelled` | Stop further work; retain the call receipt and reservation |
 | Per-request deadline | `request-timeout`; interruption `deadline` | Persist a missing-score/error row and continue within the bound |
+| Logical deadline before dispatch | `request-timeout`; `notStarted: true`, zero attempts | Persist the row and continue; no wire or completion slot exists |
 | Network abort without either control firing | `study-call-failed`; interruption `network` | Persist an error row and continue within the bound |
 
 The name `AbortError` alone never establishes operator cancellation. The deadline
@@ -221,10 +222,26 @@ not cancel the whole cohort. Regression tests exercise active-fetch programmatic
 cancellation, real SIGTERM, already-aborted/listener-installation races, listener
 cleanup, and deadline/network-error rows followed by a successful next text.
 
-The earlier zero-call preparation beginning `c6a599` must remain unchanged. These
+The earlier zero-call preparations beginning `c6a599` and `2ea5edf` must remain
+unchanged. These
 collector/transport code changes require a new prepared snapshot after the fix
 commit, with the same approval bytes, exact texts, and candidate. Turing's
 independent re-review remains required before any live execution.
+
+A parser retry can exhaust its logical deadline after a malformed first response.
+The shared journal then writes a terminal `notStarted: true` receipt without
+calling the collector transport. This is valid zero-dispatch evidence. It must
+have the exact frozen request/prompt/ordinal binding, timeout state, null start,
+zero duration, empty transport-attempt list, and no response, owner, or wire.
+Wire counts therefore follow dispatched calls, not journal-ordinal counts.
+
+Offline replay consumes this receipt at its original ordinal and restores only
+its validated `notStarted` and zero-attempt flags. It creates no wire, completion
+slot, or provider request. Tests advance the logical clock around the real bounded
+HTTP wrapper: the first fixture has one mocked fetch, two journals, and one wire;
+its timeout row persists and the next fixture succeeds. Resume and replay retain
+the receipt set without replacement calls, including recovery after a row-write
+failure. Corrupted or falsely marked zero-dispatch receipts still stop recovery.
 
 Every evaluation is reserved before its first call. Completed receipts can recover
 a row that failed to persist, entirely offline. Missing, extra, altered, or started

--- a/scripts/research/collect-rebaseline-scores.mjs
+++ b/scripts/research/collect-rebaseline-scores.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+// Private, nullable-label scoreText collection. No live execution by default.
+import fs from 'node:fs';
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { syncBuiltinESMExports } from 'node:module';
+import { dirname, resolve, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+import { evaluateScorerFixture, distribution } from '../../tests/quality/live-scorer-benchmark.mjs';
+import { loadPatterns } from '../../src/loader.js';
+import { loadLexicon } from '../../src/features/lexicon.js';
+import { analyzeText } from '../../src/features/index.js';
+import { scoreDeterministicSignals, scoreText } from '../../src/scoring.js';
+import { studySemantics } from './study-validation.mjs';
+import { acquireStudyWriter, bindStudyProtocol, safeCallRecord } from './study-journal.mjs';
+import { replayPreparationRow } from './preparation-replay.mjs';
+import { studyCompletion, validateTransport, readCredential, safeStudyError, installStudySignals } from './model-evaluation-transport.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const SELF = 'scripts/research/collect-rebaseline-scores.mjs';
+const HEX = /^[a-f0-9]{64}$/;
+const LANGS = ['en', 'ko', 'zh', 'ja'];
+const clone = value => globalThis.structuredClone(value);
+export const hash = value => createHash('sha256').update(typeof value === 'string' || Buffer.isBuffer(value) ? value : JSON.stringify(value)).digest('hex');
+const encode = value => JSON.stringify(value, (_key, item) => item instanceof RegExp ? { $regexp: item.source, $flags: item.flags } : item);
+const decode = text => JSON.parse(text, (_key, item) => item && typeof item === 'object' && Object.keys(item).length === 2 && typeof item.$regexp === 'string' && typeof item.$flags === 'string' ? new RegExp(item.$regexp, item.$flags) : item);
+const sorted = value => Array.isArray(value) ? value.map(sorted) : value && typeof value === 'object' ? Object.fromEntries(Object.keys(value).sort().map(key => [key, sorted(value[key])])) : value;
+const canonicalHash = value => hash(JSON.stringify(sorted(value)));
+const fail = message => { throw new Error(`rebaseline: ${message}`); };
+
+// Refuse identifiable credentials; never replace bytes and call them a replay.
+export function assertSecretFree(value) {
+  const walk = (item, key = '') => {
+    if (item === null || item === undefined || item === '') return;
+    if (/^(?:api[-_]?key|authorization|proxy-authorization|password|passwd|client[-_]?secret|access[-_]?token|refresh[-_]?token|cookie|set-cookie|headers)$/i.test(key)) fail('secret-bearing snapshot field');
+    if (typeof item === 'string' && /\b(?:sk-[A-Za-z0-9_-]{20,}|AIza[A-Za-z0-9_-]{30,}|gh[pousr]_[A-Za-z0-9]{20,}|Bearer\s+[A-Za-z0-9._~+/-]{12,})|-----BEGIN (?:RSA |OPENSSH |EC )?PRIVATE KEY-----|(?:api[_-]?key|password|access[_-]?token)\s*[:=]\s*["']?[A-Za-z0-9_-]{16,}/i.test(item)) fail('credential-like bytes in snapshot');
+    if (typeof item === 'number' && !Number.isFinite(item)) fail('nonfinite snapshot value');
+    if (item && typeof item === 'object' && !Array.isArray(item) && !(item instanceof RegExp)
+      && ![Object.prototype, null].includes(Object.getPrototypeOf(item))) fail('unsupported snapshot object type');
+    if (Array.isArray(item)) item.forEach(child => walk(child));
+    else if (item && typeof item === 'object' && !(item instanceof RegExp)) Object.entries(item).forEach(([name, child]) => walk(child, name));
+  };
+  walk(value);
+}
+function noLinks(path) {
+  for (let part = resolve(path);; part = dirname(part)) {
+    if (fs.existsSync(part) && fs.lstatSync(part).isSymbolicLink()) fail('symlink path refused');
+    if (dirname(part) === part) break;
+  }
+}
+function readJson(path) { noLinks(path); try { return decode(fs.readFileSync(path, 'utf8')); } catch { fail('invalid or missing JSON artifact'); } }
+export function persistPrivate(path, value) {
+  assertSecretFree(value); noLinks(path);
+  fs.mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.pending`;
+  const fd = fs.openSync(temporary, 'wx', 0o600);
+  try { fs.writeFileSync(fd, `${encode(value)}\n`); fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+  fs.renameSync(temporary, path);
+}
+function filesBelow(root) {
+  if (!fs.existsSync(root)) return [];
+  return fs.readdirSync(root, { withFileTypes: true }).flatMap(entry => {
+    const path = resolve(root, entry.name); noLinks(path);
+    return entry.isDirectory() ? filesBelow(path) : [path];
+  });
+}
+
+export function loadNullableIntake(directory) {
+  const intake = readJson(resolve(directory, 'intake.private.json'));
+  const summary = readJson(resolve(directory, 'summary.json'));
+  const sourceIndex = readJson(resolve(directory, 'source-index.private.json'));
+  if (!Array.isArray(intake.records) || intake.records.length < 1 || intake.records.length > 85) fail('intake must contain 1..85 records');
+  if (canonicalHash(intake) !== summary.intakeHash || canonicalHash(intake.records) !== summary.manifestHash) fail('frozen intake/record-manifest hash mismatch');
+  const evidence = new Map();
+  for (const name of fs.readdirSync(resolve(directory, 'evidence'))) {
+    if (!HEX.test(name)) fail('invalid evidence filename');
+    const path = resolve(directory, 'evidence', name); noLinks(path);
+    const bytes = fs.readFileSync(path);
+    if (hash(bytes) !== name) fail('frozen evidence mismatch');
+    evidence.set(name, bytes.length);
+  }
+  const checkBindings = value => {
+    if (!value || typeof value !== 'object') return;
+    if (Object.hasOwn(value, 'sha256') && Object.hasOwn(value, 'bytes') && evidence.get(value.sha256) !== value.bytes) fail('missing inherited evidence');
+    Object.values(value).forEach(checkBindings);
+  };
+  checkBindings(intake);
+  for (const entry of Object.values(sourceIndex)) {
+    if (!HEX.test(entry?.sha256) || !Number.isSafeInteger(entry.bytes)) fail('invalid evidence binding');
+    const path = resolve(directory, 'evidence', entry.sha256); noLinks(path);
+    const bytes = fs.readFileSync(path);
+    if (bytes.length !== entry.bytes || hash(bytes) !== entry.sha256) fail('frozen evidence mismatch');
+  }
+  const ids = new Set(), hashes = new Set();
+  for (const record of intake.records) {
+    if (!record || typeof record.id !== 'string' || !record.id || ids.has(record.id) || hashes.has(record.textHash)
+      || typeof record.text !== 'string' || !record.text.trim() || record.text.length > 100000
+      || hash(record.text) !== record.textHash || !LANGS.includes(record.language)
+      || !Array.isArray(record.origins) || !record.origins.length || !record.labels || !record.rights
+      || (record.expected_hot !== undefined && record.expected_hot !== null && typeof record.expected_hot !== 'boolean')) fail('invalid nullable intake record');
+    ids.add(record.id); hashes.add(record.textHash);
+  }
+  assertSecretFree(intake);
+  return { intake, sourceIndex, intakeHash: summary.intakeHash, manifestHash: summary.manifestHash, sourceIndexHash: canonicalHash(sourceIndex) };
+}
+function selectCandidate(protocolFile, protocolSha256, candidateId) {
+  const bytes = fs.readFileSync(protocolFile);
+  if (!HEX.test(protocolSha256) || hash(bytes) !== protocolSha256) fail('explicit frozen candidate protocol hash required');
+  const protocol = readJson(protocolFile);
+  const matches = protocol.candidates?.filter(row => row.id === candidateId);
+  if (matches?.length !== 1) fail('one explicit candidate required');
+  const candidate = matches[0]; assertSecretFree(candidate); validateTransport(candidate);
+  const allowed = new Set(['id', 'provider', 'transport', 'baseURL', 'model', 'extraBody', 'apiKeyEnv', 'effort']);
+  if (Object.keys(candidate).some(key => !allowed.has(key))) fail('unsupported candidate field');
+  if (candidate.extraBody && Object.keys(candidate.extraBody).some(key => ['model', 'messages', 'stream', 'temperature', 'response_format', 'seed'].includes(key))) fail('candidate overrides collector request fields');
+  if (candidate.transport === 'http' && (!/^[A-Z][A-Z0-9_]*$/.test(candidate.apiKeyEnv) || /GEMINI|GOOGLE/.test(candidate.apiKeyEnv))) fail('invalid transport credential variable');
+  return { protocol, candidate };
+}
+export function validateApprovals(bundle, candidate, approvals) {
+  const records = new Map(bundle.intake.records.map(row => [row.textHash, row]));
+  if (approvals?.schemaVersion !== 1 || approvals.intakeHash !== bundle.intakeHash || approvals.candidateHash !== hash(candidate) || !Array.isArray(approvals.decisions)) fail('separate processing-approval manifest required');
+  const decisions = new Map();
+  for (const decision of approvals.decisions) {
+    if (!records.has(decision.textHash) || decisions.has(decision.textHash) || !['approved', 'blocked', 'unknown'].includes(decision.decision)) fail('invalid or duplicate approval decision');
+    if (decision.decision === 'approved' && (decision.sourceEvidenceHash !== canonicalHash(records.get(decision.textHash).origins)
+      || decision.permittedLocalAnalysis !== true || decision.permittedProviderProcessing !== true
+      || decision.provider !== candidate.provider || decision.transport !== candidate.transport || decision.model !== candidate.model
+      || typeof decision.reviewer !== 'string' || !decision.reviewer.trim() || !Number.isFinite(Date.parse(decision.reviewedAt))
+      || decision.retention !== 'private-only' || decision.publication !== 'summary-only')) fail('incomplete or route-mismatched processing approval');
+    decisions.set(decision.textHash, decision);
+  }
+  assertSecretFree(approvals);
+  return bundle.intake.records.map(record => ({ textHash: record.textHash, decision: decisions.get(record.textHash)?.decision ?? 'unknown' }));
+}
+
+// Synchronous, restored filesystem guard prevents incidental structural-model
+// discovery in scoreDeterministicSignals. This collector freezes absence; it
+// never reads ambient overrides or credentials during input preparation.
+function withoutAmbientModels(run) {
+  const read = fs.readFileSync, exists = fs.existsSync;
+  const allowed = path => typeof path === 'string' && resolve(path).startsWith(`${ROOT}${sep}`) && !/[\\/]\.patina(?:[\\/.]|$)|[\\/]\.env|[\\/]credentials[\\/]/.test(path);
+  fs.existsSync = path => allowed(path) && exists(path);
+  fs.readFileSync = (path, ...args) => { if (!allowed(path)) fail('ambient read refused'); return read(path, ...args); };
+  syncBuiltinESMExports();
+  try { return run(); } finally { fs.readFileSync = read; fs.existsSync = exists; syncBuiltinESMExports(); }
+}
+export function prepareInputs(records, configFile) {
+  const configBytes = fs.readFileSync(configFile, 'utf8');
+  let config; try { config = yaml.load(configBytes); } catch { fail('invalid pinned config'); }
+  if (!config || Array.isArray(config) || typeof config !== 'object') fail('config must be a mapping');
+  assertSecretFree(config);
+  if (['profile', 'tone', 'formality'].some(key => Object.hasOwn(config, key))) fail('retired configuration field');
+  if (config.stylometry?.structural_model?.path || config.stylometry?.classifier?.model_path || config.private_model?.path) fail('explicit structural model unsupported by this absence-frozen collector');
+  config.documentType = config['document-type'] || config.documentType || 'default'; delete config['document-type'];
+  const languages = [...new Set(records.map(row => row.language))];
+  const patterns = Object.fromEntries(languages.map(lang => [lang, loadPatterns(ROOT, lang)]));
+  const lexicons = Object.fromEntries(languages.map(lang => [lang, loadLexicon(lang, ROOT)]));
+  const prepared = {};
+  for (const record of records) {
+    const settings = clone(config); settings.language = record.language;
+    if (record.documentType) settings.documentType = record.documentType;
+    let analysis = null;
+    const deterministicScore = withoutAmbientModels(() => scoreDeterministicSignals({ text: record.text, config: settings, patterns: patterns[record.language], repoRoot: ROOT,
+      logger: { warn() {} }, analyzer: (text, options) => {
+        analysis = analyzeText(text, { ...options, structuralModel: null, lexicon: options.lexicon ?? clone(lexicons[record.language]) });
+        return analysis;
+      } }));
+    prepared[record.textHash] = { config: settings, patterns: clone(patterns[record.language]), deterministicScore, analysis };
+  }
+  const result = { configSource: { bytes: configBytes, sha256: hash(configBytes), layers: ['explicit-pinned-file'], ambientOverrides: false }, config, patterns, lexicons,
+    structuralModels: Object.fromEntries(languages.map(lang => [lang, { status: 'explicitly-absent', model: null }])), prepared };
+  assertSecretFree(result); return result;
+}
+function currentCodeHashes() { return { ...studySemantics(ROOT), [SELF]: hash(fs.readFileSync(resolve(ROOT, SELF))), 'scripts/research/preparation-replay.mjs': hash(fs.readFileSync(resolve(ROOT, 'scripts/research/preparation-replay.mjs'))) }; }
+function fixture(record) { return { fixture_id: record.id, text_hash: record.textHash, text: record.text, language: record.language, documentType: record.documentType,
+  register: record.register ?? null, class: record.class ?? null, expected_hot: record.expected_hot ?? null, source: null }; }
+const logical = (protocolHash, candidate, record) => `${protocolHash}/${candidate.id}/${record.id}/0/score`;
+function normalizedObservation(row) {
+  const value = clone(row); delete value.productionResult; value.calls.forEach(call => { delete call.recovered_from_journal; }); return value;
+}
+
+// Exact credential-free HTTP body, one fetch only: no automatic temperature
+// fallback, HTTP retry, redirect, alternate provider or environment-file lookup.
+export async function boundedCompletion(candidate, prompt, options, observe) {
+  if (['claude-cli', 'kimi-cli'].includes(candidate.transport)) {
+    try {
+      const result = await studyCompletion(candidate, prompt, { ...options, maxRetries: 0 });
+      observe({ scope: 'native-cli-observed-result', response: result, upstreamRequestVerified: false });
+      return result;
+    } catch (error) {
+      if (error.studyResult) observe({ scope: 'native-cli-error-metadata', errorMetadata: error.studyResult, upstreamRequestVerified: false });
+      throw error;
+    }
+  }
+  const apiKey = candidate.transport === 'opencodex' ? 'opencodex-local' : readCredential(candidate.apiKeyEnv);
+  if (!apiKey) throw new Error('Required transport credential unavailable');
+  const body = { ...(candidate.extraBody || {}), model: candidate.model, messages: [{ role: 'user', content: prompt }], temperature: options.temperature };
+  if (options.responseFormat) body.response_format = options.responseFormat;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+  const started = Date.now();
+  try {
+    const response = await fetch(`${candidate.baseURL}/chat/completions`, { method: 'POST', redirect: 'error', signal: controller.signal,
+      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+    let raw = '', size = 0;
+    const reader = response.body.getReader(); const decoder = new globalThis.TextDecoder();
+    for (let chunk = await reader.read(); !chunk.done; chunk = await reader.read()) {
+      size += chunk.value.byteLength; if (size > 4 * 1024 * 1024) { controller.abort(); throw new Error('Response size bound exceeded'); }
+      raw += decoder.decode(chunk.value, { stream: true });
+    }
+    raw += decoder.decode();
+    observe({ scope: 'http-body', requestBody: body, responseBody: raw, httpStatus: response.status });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    let data; try { data = JSON.parse(raw); } catch { throw new Error('Invalid provider JSON'); }
+    const text = data.choices?.[0]?.message?.content;
+    if (typeof text !== 'string' || !text.trim()) throw new Error('Empty response');
+    const result = { text, effectiveModels: typeof data.model === 'string' ? [data.model] : [], usage: data.usage ?? null, attempts: 1,
+      durationMs: Date.now() - started, requestedTemperature: options.temperature, effectiveTemperature: body.temperature };
+    options.onAttempt?.({ attemptIndex: 1, requestedModel: candidate.model, effectiveModel: data.model ?? null, usage: result.usage, outcome: 'success', retryReason: 'initial' });
+    return result;
+  } finally { clearTimeout(timer); }
+}
+function credentialFreeRequest(candidate, prompt, options) {
+  return { candidate, prompt, temperature: options.temperature ?? .2, responseFormat: options.responseFormat ?? null, extraBody: options.extraBody ?? null,
+    timeoutMs: options.timeoutMs, maxRetries: 0,
+    requestBody: ['http', 'opencodex'].includes(candidate.transport) ? { ...(candidate.extraBody || {}), model: candidate.model, messages: [{ role: 'user', content: prompt }], temperature: options.temperature ?? .2,
+      ...(options.responseFormat ? { response_format: options.responseFormat } : {}) } : null,
+    nativeBoundary: ['http', 'opencodex'].includes(candidate.transport) ? null : 'Exact collector arguments only; native effective upstream parameters remain unverified.' };
+}
+function verifyPrivateTree(output) {
+  for (const path of filesBelow(output)) {
+    if (path.endsWith('.pending')) fail('incomplete persistence artifact');
+    if ((fs.statSync(path).mode & 0o077) !== 0) fail('private file permissions must be 0600');
+  }
+}
+function savedSnapshot(output) {
+  verifyPrivateTree(output);
+  if (fs.readFileSync(resolve(output, '.gitignore'), 'utf8') !== '*\n') fail('private output ignore rule changed');
+  const snapshot = readJson(resolve(output, 'snapshot.private.json'));
+  const binding = readJson(resolve(output, 'study-protocol.json'));
+  if (hash(encode(snapshot)) !== binding.protocolHash) fail('snapshot/protocol mismatch');
+  if (JSON.stringify(snapshot.codeHashes) !== JSON.stringify(currentCodeHashes())) fail('collector source changed; replay requires the frozen code');
+  assertSecretFree(snapshot); validateTransport(snapshot.candidate);
+  if (hash(snapshot.candidateProtocolBytes) !== snapshot.candidateProtocolHash || encode(JSON.parse(snapshot.candidateProtocolBytes)) !== encode(snapshot.protocol)
+    || snapshot.protocol.candidates.filter(candidate => encode(candidate) === encode(snapshot.candidate)).length !== 1) fail('frozen candidate protocol mismatch');
+  const admission = validateApprovals({ intake: { records: snapshot.records }, intakeHash: snapshot.intakeHash }, snapshot.candidate, snapshot.approvals);
+  if (encode(admission.filter(row => row.decision === 'approved').map(row => row.textHash)) !== encode(snapshot.matrix)) fail('saved approval matrix mismatch');
+  return { snapshot, protocolHash: binding.protocolHash };
+}
+function evidenceHash(output, id) {
+  return hash(['calls', 'wire'].flatMap(kind => filesBelow(resolve(output, kind, hash(id)))).sort().map(path => [relative(output, path), hash(fs.readFileSync(path))]));
+}
+function checkWire(output, id, candidate, record, snapshot, protocolHash) {
+  const group = resolve(output, 'calls', hash(id));
+  const paths = filesBelow(group);
+  if (!paths.length) fail('started evaluation lacks recorded calls');
+  const receipts = paths.map((_, i) => readJson(resolve(group, `${i + 1}.private.json`)));
+  for (const [i, receipt] of receipts.entries()) {
+    if (!['completed', 'error'].includes(receipt.state)) fail('unresolved call; no paid replay');
+    const wire = readJson(resolve(output, 'wire', hash(id), `${i + 1}.private.json`));
+    if (wire.protocolHash !== protocolHash || wire.preparedHash !== hash(encode(snapshot.inputs.prepared[record.textHash])) || wire.request.prompt !== snapshot.prompts[record.textHash]
+      || !['completed', 'error'].includes(wire.state) || wire.requestHash !== receipt.requestHash || hash(wire.request.prompt) !== receipt.promptHash
+      || wire.textHash !== record.textHash || hash(wire.request.candidate) !== hash(candidate)) fail('wire/request binding mismatch or unresolved paid call');
+    if (receipt.state === 'completed' && encode(wire.response) !== encode(receipt.response)) fail('response receipt mismatch');
+    if (receipt.state === 'error' && (wire.error !== receipt.error || encode(wire.errorMetadata ?? null) !== encode(receipt.errorMetadata ?? null))) fail('error receipt mismatch');
+  }
+  if (filesBelow(resolve(output, 'wire', hash(id))).length !== receipts.length) fail('extra wire receipts');
+  return { calls: receipts.map(receipt => safeCallRecord(receipt, candidate)) };
+}
+async function replayOne(output, snapshot, protocolHash, record, stored) {
+  const id = logical(protocolHash, snapshot.candidate, record);
+  const receiptRow = checkWire(output, id, snapshot.candidate, record, snapshot, protocolHash);
+  let consumed = 0;
+  const replay = await replayPreparationRow({ directory: output, logicalId: id, row: stored || receiptRow, candidate: snapshot.candidate,
+    run: complete => evaluateScorerFixture(fixture(record), snapshot.candidate, {
+      complete: async (...args) => {
+        const ordinal = consumed++;
+        try { return await complete(...args); } catch (error) {
+          error.studyResult = { ...(error.studyResult || {}), durationMs: receiptRow.calls[ordinal]?.durationMs }; throw error;
+        }
+      }, preparedInputs: snapshot.inputs.prepared[record.textHash], logicalId: id, timeoutMs: snapshot.timeoutMs }) });
+  if (stored && encode(normalizedObservation(stored)) !== encode(normalizedObservation(replay))) fail('observed replay mismatch');
+  replay.productionResult = await replayPreparationRow({ directory: output, logicalId: id, row: receiptRow, candidate: snapshot.candidate,
+    run: complete => scoreText({ ...snapshot.inputs.prepared[record.textHash], text: record.text, model: snapshot.candidate.model, logger: { warn() {}, info() {}, debug() {} },
+      callLLM: async args => (await complete(snapshot.candidate, args.prompt, { temperature: args.temperature, responseFormat: args.responseFormat, extraBody: args.extraBody, onAttempt: args.onAttempt })).text }) });
+  if (stored && encode(stored.productionResult) !== encode(replay.productionResult)) fail('full production result replay mismatch');
+  return replay;
+}
+export function summarizeCollection(snapshot, observations) {
+  const scores = rows => ({ overall: distribution(rows.map(row => row.overall)), rawLlm: distribution(rows.map(row => row.raw_overall)), deterministic: distribution(rows.map(row => row.deterministic_overall)) });
+  const valid = observations.filter(row => row.status === 'ok');
+  return { schemaVersion: 1, scope: 'unlabelled-score-distributions-only', candidateId: snapshot.candidate.id,
+    denominator: snapshot.records.length, approved: snapshot.matrix.length, excluded: snapshot.records.length - snapshot.matrix.length,
+    attempted: observations.length, valid: valid.length, errors: observations.length - valid.length,
+    errorClasses: Object.fromEntries([...new Set(observations.filter(row => row.error).map(row => row.error))].map(error => [error, observations.filter(row => row.error === error).length])),
+    distributions: scores(valid),
+    languages: Object.fromEntries([...new Set(snapshot.records.map(row => row.language))].map(language => {
+      const rows = observations.filter(row => row.language === language), ok = rows.filter(row => row.status === 'ok');
+      const packs = snapshot.inputs.patterns[language] || [];
+      return [language, { attempted: rows.length, valid: ok.length, errors: rows.length - ok.length, ...scores(ok),
+        packs: Object.fromEntries(packs.map(pack => { const name = pack.frontmatter.pack.replace(/^[a-z]{2}-/, ''); const values = ok.map(row => row.categories?.[name]?.score);
+          return [name, { ...distribution(values), missing: ok.filter(row => !Number.isFinite(row.categories?.[name]?.score)).length }]; })) }];
+    })), classificationMetrics: null, humanQualityRatings: null };
+}
+function verifyProgress(output, snapshot, progress, protocolHash) {
+  if (progress.protocolHash !== protocolHash || !progress.entries || Object.keys(progress.entries).some(key => !snapshot.matrix.includes(key) || !['started', 'completed'].includes(progress.entries[key].state))) fail('progress binding mismatch');
+  const groups = new Set(Object.keys(progress.entries).map(textHash => hash(logical(protocolHash, snapshot.candidate, snapshot.records.find(row => row.textHash === textHash)))));
+  for (const kind of ['calls', 'wire']) {
+    const parent = resolve(output, kind);
+    if (fs.existsSync(parent) && fs.readdirSync(parent).some(name => !groups.has(name))) fail('orphan call evidence outside reserved evaluations');
+  }
+  const rows = resolve(output, 'rows');
+  if (fs.existsSync(rows) && fs.readdirSync(rows).some(name => !Object.hasOwn(progress.entries, name.replace(/\.private\.json$/, '')) || !/^[a-f0-9]{64}\.private\.json$/.test(name))) fail('unexpected observed row');
+}
+export async function replayCollection(output) {
+  const { snapshot, protocolHash } = savedSnapshot(output);
+  const progress = readJson(resolve(output, 'progress.private.json'));
+  verifyProgress(output, snapshot, progress, protocolHash);
+  const observations = [];
+  for (const textHash of snapshot.matrix) {
+    const record = snapshot.records.find(row => row.textHash === textHash);
+    const entry = progress.entries[textHash];
+    if (!entry || entry.state !== 'completed') fail('replay requires a complete observed matrix');
+    const path = resolve(output, 'rows', `${textHash}.private.json`);
+    if (hash(fs.readFileSync(path)) !== entry.rowHash) fail('missing or changed observed row');
+    const stored = readJson(path);
+    if (evidenceHash(output, logical(protocolHash, snapshot.candidate, record)) !== entry.evidenceHash) fail('receipt-set hash mismatch');
+    observations.push(await replayOne(output, snapshot, protocolHash, record, stored));
+  }
+  return { protocolHash, fullObservedReplay: true, ...summarizeCollection(snapshot, observations) };
+}
+
+export async function collectRebaselineScores(options, { complete = boundedCompletion, prepare = prepareInputs, persist = persistPrivate } = {}) {
+  const output = resolve(options.output); noLinks(output);
+  let fatal = null;
+  const save = (path, value) => { try { persist(path, value); } catch { fatal = new Error('rebaseline: persistence or secret rejection; stop without paid replay'); throw fatal; } };
+  const resume = options.resume === true;
+  if (fs.existsSync(output) && fs.readdirSync(output).length && !resume) fail('nonempty output requires bound resume');
+  if (!resume && fs.existsSync(resolve(output, 'snapshot.private.json'))) fail('snapshot already exists');
+  let snapshot, protocolHash;
+  if (resume) {
+    if (Object.keys(options).some(key => !['output', 'resume', 'live', 'candidateId'].includes(key))) fail('resume accepts only its bound output and opt-in');
+    ({ snapshot, protocolHash } = savedSnapshot(output));
+  }
+  else {
+    for (const path of [options.intake, options.protocol, options.config, options.approvals]) if (!path) fail('intake, protocol, config and separate approvals are required');
+    if ([resolve(options.intake, 'intake.private.json'), resolve(options.protocol), resolve(options.config)].includes(resolve(options.approvals))) fail('approval must be a separate manifest');
+    const bundle = loadNullableIntake(options.intake);
+    const { protocol, candidate } = selectCandidate(options.protocol, options.protocolSha256, options.candidateId);
+    const approvals = readJson(options.approvals), admission = validateApprovals(bundle, candidate, approvals);
+    const matrix = admission.filter(row => row.decision === 'approved').map(row => row.textHash);
+    if (!Number.isSafeInteger(options.maxCalls) || options.maxCalls < 0 || options.maxCalls > matrix.length * 2 || (matrix.length && !options.maxCalls)) fail('explicit call bound must be 1..2*approved (zero for empty admission)');
+    const timeoutMs = options.timeoutMs ?? 60000;
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1000 || timeoutMs > 180000) fail('timeout must be 1000..180000ms');
+    const inputs = await prepare(bundle.intake.records, options.config);
+    const prompts = {};
+    for (const record of bundle.intake.records) {
+      await scoreText({ ...inputs.prepared[record.textHash], text: record.text, model: candidate.model, logger: { warn() {}, info() {}, debug() {} },
+        callLLM: async args => { prompts[record.textHash] = args.prompt; throw new Error('prompt capture only'); } });
+      if (typeof prompts[record.textHash] !== 'string') fail('scorer prompt capture failed');
+    }
+    snapshot = { schemaVersion: 1, kind: 'nullable-rebaseline-score-collection', candidate, protocol, candidateProtocolHash: options.protocolSha256, candidateProtocolBytes: fs.readFileSync(options.protocol, 'utf8'),
+      intakeHash: bundle.intakeHash, manifestHash: bundle.manifestHash, sourceIndexHash: bundle.sourceIndexHash, sourceIndex: bundle.sourceIndex, records: bundle.intake.records,
+      approvals, admission, matrix, maxCalls: options.maxCalls, timeoutMs, repeats: 1, parserInvocationsPerText: 2, transportRetries: 0,
+      budgetUnit: ['http', 'opencodex'].includes(candidate.transport) ? 'HTTP-request' : 'CLI-invocation',
+      nativeUpstreamAttemptCountVerified: false, runtime: { node: process.version, platform: process.platform, arch: process.arch },
+      inputs, prompts, codeHashes: currentCodeHashes() };
+    assertSecretFree(snapshot); protocolHash = hash(encode(snapshot));
+  }
+  // Prevent writing even private artifacts into a tracked destination.
+  if (relative(ROOT, output).split(sep)[0] !== '..' && execFileSync('git', ['ls-files', '--', relative(ROOT, output)], { cwd: ROOT, encoding: 'utf8' }).trim()) fail('tracked output destination refused');
+  fs.mkdirSync(output, { recursive: true, mode: 0o700 });
+  if ((fs.statSync(output).mode & 0o077) !== 0) fail('private directory permissions must be 0700');
+  if (!resume) {
+    fs.writeFileSync(resolve(output, '.gitignore'), '*\n', { flag: 'wx', mode: 0o600 });
+    save(resolve(output, 'snapshot.private.json'), snapshot);
+    // Persist the same binding contract before opening the shared journal.
+    save(resolve(output, 'study-protocol.json'), { schemaVersion: 1, protocolHash });
+    save(resolve(output, 'progress.private.json'), { protocolHash, entries: {} });
+  }
+  const release = acquireStudyWriter(output, 'rebaseline-score-collection');
+  fs.chmodSync(resolve(output, '.writer.lock'), 0o600);
+  try {
+    bindStudyProtocol(output, protocolHash); verifyPrivateTree(output);
+    const progressPath = resolve(output, 'progress.private.json');
+    const progress = readJson(progressPath);
+    verifyProgress(output, snapshot, progress, protocolHash);
+    if (resume && options.candidateId && options.candidateId !== snapshot.candidate.id) fail('resume candidate changed');
+    const observations = [];
+    // Validate/recover every already reserved evaluation offline before a paid call.
+    for (const textHash of snapshot.matrix) {
+      const entry = progress.entries[textHash]; if (!entry) continue;
+      const record = snapshot.records.find(row => row.textHash === textHash), path = resolve(output, 'rows', `${textHash}.private.json`);
+      const stored = entry.state === 'completed' ? readJson(path) : null;
+      if (stored && (hash(fs.readFileSync(path)) !== entry.rowHash || evidenceHash(output, logical(protocolHash, snapshot.candidate, record)) !== entry.evidenceHash)) fail('observed row/receipt hash mismatch');
+      const observation = await replayOne(output, snapshot, protocolHash, record, stored);
+      if (!stored) { save(path, observation); progress.entries[textHash] = { state: 'completed', rowHash: hash(fs.readFileSync(path)), evidenceHash: evidenceHash(output, logical(protocolHash, snapshot.candidate, record)) }; save(progressPath, progress); }
+      observations.push(observation);
+    }
+    if (options.live !== true) return { protocolHash, state: 'prepared-no-live-calls', ...summarizeCollection(snapshot, observations) };
+    if (!snapshot.matrix.length) fail('no approved provider processing');
+    let invocations = filesBelow(resolve(output, 'wire')).length;
+    for (const textHash of snapshot.matrix) {
+      if (progress.entries[textHash]) continue;
+      if (fatal) throw fatal;
+      const record = snapshot.records.find(row => row.textHash === textHash), id = logical(protocolHash, snapshot.candidate, record);
+      progress.entries[textHash] = { state: 'started' }; save(progressPath, progress);
+      let ordinal = 0;
+      const observation = await evaluateScorerFixture(fixture(record), snapshot.candidate, { preparedInputs: snapshot.inputs.prepared[textHash], journalDirectory: output, logicalId: id, timeoutMs: snapshot.timeoutMs,
+        complete: async (candidate, prompt, args) => {
+          if (fatal) throw fatal;
+          if (++ordinal > 2 || invocations >= snapshot.maxCalls) { fatal = new Error('rebaseline: call budget exhausted'); throw fatal; }
+          invocations++;
+          if (prompt !== snapshot.prompts[textHash] || hash(candidate) !== hash(snapshot.candidate)) { fatal = new Error('rebaseline: frozen prompt/candidate changed'); throw fatal; }
+          const request = credentialFreeRequest(candidate, prompt, args);
+          const identity = { logicalId: id, index: ordinal, candidate, promptHash: hash(prompt), temperature: args.temperature ?? .2, responseFormat: args.responseFormat ?? null, extraBody: args.extraBody ?? null };
+          const wirePath = resolve(output, 'wire', hash(id), `${ordinal}.private.json`);
+          const wire = { schemaVersion: 1, protocolHash, textHash, preparedHash: hash(encode(snapshot.inputs.prepared[textHash])), requestHash: hash(identity), request,
+            state: 'started', startedAt: new Date().toISOString() };
+          save(wirePath, wire);
+          try {
+            const response = await complete(candidate, prompt, { ...args, maxRetries: 0 }, transport => { wire.transport = transport; save(wirePath, wire); });
+            if (fatal) throw fatal;
+            assertSecretFree(response);
+            wire.response = response; wire.state = 'completed'; wire.endedAt = new Date().toISOString(); save(wirePath, wire);
+            return response;
+          } catch (error) {
+            if (fatal || /secret|credential-like/.test(error.message)) { fatal ||= new Error('rebaseline: response rejected; unresolved paid observation'); throw fatal; }
+            if (error.studyResult) { assertSecretFree(error.studyResult); wire.errorMetadata = error.studyResult; }
+            wire.error = safeStudyError(error); wire.state = 'error'; wire.endedAt = new Date().toISOString(); save(wirePath, wire);
+            const failure = new Error(wire.error); if (wire.errorMetadata) failure.studyResult = wire.errorMetadata; throw failure;
+          }
+        } });
+      if (fatal) throw fatal;
+      if (observation.calls.some(call => ['study-journal-persistence-failed', 'study-call-unobserved', 'study-call-inflight', 'study-cancelled'].includes(call.error))) fail('unresolved journal; collection stopped');
+      const recovered = await replayOne(output, snapshot, protocolHash, record, null);
+      if (encode(normalizedObservation(observation)) !== encode(normalizedObservation(recovered))) fail('fresh receipt replay mismatch');
+      observation.productionResult = recovered.productionResult;
+      const rowPath = resolve(output, 'rows', `${textHash}.private.json`); save(rowPath, observation);
+      progress.entries[textHash] = { state: 'completed', rowHash: hash(fs.readFileSync(rowPath)), evidenceHash: evidenceHash(output, id) }; save(progressPath, progress);
+      observations.push(observation);
+    }
+    const report = { protocolHash, fullObservedReplay: false, ...summarizeCollection(snapshot, observations) };
+    save(resolve(output, 'summary.private.json'), report);
+    return report;
+  } finally { release(); }
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  if (argv.includes('--help')) { console.log('collect-rebaseline-scores --intake DIR --protocol FILE --protocol-sha256 HASH --candidate ID --config FILE --approvals FILE --output DIR --max-calls N [--timeout-ms N] [--live]\nResume: --output DIR --resume [--live]. Offline replay: --output DIR --replay.'); return; }
+  const options = {};
+  const names = { '--intake': 'intake', '--protocol': 'protocol', '--protocol-sha256': 'protocolSha256', '--candidate': 'candidateId', '--config': 'config', '--approvals': 'approvals', '--output': 'output', '--max-calls': 'maxCalls', '--timeout-ms': 'timeoutMs' };
+  for (let i = 0; i < argv.length; i++) {
+    if (['--live', '--resume', '--replay'].includes(argv[i])) options[argv[i].slice(2)] = true;
+    else if (names[argv[i]] && argv[i + 1] && !argv[i + 1].startsWith('--')) options[names[argv[i]]] = argv[++i];
+    else fail('unknown or missing command-line option');
+  }
+  if (!options.output || (options.replay && (options.live || options.resume))) fail('explicit output and separate replay mode required');
+  for (const key of ['maxCalls', 'timeoutMs']) if (options[key] !== undefined) options[key] = Number(options[key]);
+  if (options.live === true) installStudySignals();
+  const result = options.replay ? await replayCollection(resolve(options.output)) : await collectRebaselineScores(options);
+  console.log(JSON.stringify(result, null, 2));
+}
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main().catch(() => { console.error('rebaseline collection stopped; inspect private bindings/receipts before resuming'); process.exitCode = 1; });

--- a/scripts/research/collect-rebaseline-scores.mjs
+++ b/scripts/research/collect-rebaseline-scores.mjs
@@ -102,7 +102,13 @@ export function loadNullableIntake(directory) {
     ids.add(record.id); hashes.add(record.textHash);
   }
   assertSecretFree(intake);
-  return { intake, sourceIndex, intakeHash: summary.intakeHash, manifestHash: summary.manifestHash, sourceIndexHash: canonicalHash(sourceIndex) };
+  const originals = { 'intake.private.json': intake, 'summary.json': summary, 'source-index.private.json': sourceIndex };
+  const fileHashes = Object.fromEntries(Object.entries(originals).map(([name, value]) => {
+    const bytes = fs.readFileSync(resolve(directory, name));
+    if (encode(decode(bytes.toString('utf8'))) !== encode(value)) fail('bundle changed while reading');
+    return [name, hash(bytes)];
+  }));
+  return { intake, sourceIndex, fileHashes, intakeHash: summary.intakeHash, manifestHash: summary.manifestHash, sourceIndexHash: canonicalHash(sourceIndex) };
 }
 function selectCandidate(protocolFile, protocolSha256, candidateId) {
   const bytes = fs.readFileSync(protocolFile);
@@ -117,7 +123,63 @@ function selectCandidate(protocolFile, protocolSha256, candidateId) {
   if (candidate.transport === 'http' && (!/^[A-Z][A-Z0-9_]*$/.test(candidate.apiKeyEnv) || /GEMINI|GOOGLE/.test(candidate.apiKeyEnv))) fail('invalid transport credential variable');
   return { protocol, candidate };
 }
-export function validateApprovals(bundle, candidate, approvals) {
+export function loadProcessingApproval(path) {
+  noLinks(path);
+  const approvalBytes = fs.readFileSync(path, 'utf8');
+  let approvals; try { approvals = decode(approvalBytes); } catch { fail('invalid approval JSON'); }
+  const source = { approvalBytes, approvalSha256: hash(approvalBytes), reviewBytes: null, reviewSha256: null };
+  if (Object.hasOwn(approvals, 'parentApproved')) {
+    if (typeof approvals.reviewPath !== 'string' || !HEX.test(approvals.reviewHash)) fail('parent approval requires a bound review');
+    noLinks(approvals.reviewPath);
+    source.reviewBytes = fs.readFileSync(approvals.reviewPath, 'utf8'); source.reviewSha256 = hash(source.reviewBytes);
+    if (source.reviewSha256 !== approvals.reviewHash) fail('parent review hash mismatch');
+  }
+  assertSecretFree({ approvals, source });
+  return { approvals, source };
+}
+function validateParentApproval(bundle, candidate, approvals, source) {
+  const scope = 'private-benchmark-scoring-only';
+  if (approvals.schemaVersion !== 1 || approvals.status !== 'parent-approved-for-private-benchmark-scoring' || approvals.parentApproved !== true
+    || approvals.scope !== scope || approvals.repeats !== 1 || !Number.isFinite(Date.parse(approvals.approvedAt))
+    || canonicalHash(approvals.candidate) !== canonicalHash(candidate)
+    || candidate.id !== 'gemini-3.7' || candidate.provider !== 'gemini' || candidate.transport !== 'opencodex'
+    || candidate.model !== 'google-antigravity/gemini-3.7-flash') fail('parent approval candidate/scope mismatch');
+  validateTransport(candidate);
+  if (typeof source?.reviewBytes !== 'string' || hash(source.reviewBytes) !== approvals.reviewHash || source.reviewSha256 !== approvals.reviewHash) fail('parent review bytes/hash required');
+  let review; try { review = decode(source.reviewBytes); } catch { fail('invalid bound review'); }
+  const records = new Map(bundle.intake.records.map(record => [record.textHash, record]));
+  const hashes = approvals.approvedTextHashes;
+  if (!Array.isArray(hashes) || new Set(hashes).size !== hashes.length || hashes.length !== records.size
+    || approvals.logicalObservationLimit !== hashes.length || hashes.some(textHash => !records.has(textHash))) fail('parent-approved exact matrix mismatch');
+  if (review.schemaVersion !== 1 || review.scope?.id !== scope || review.scope.allowedCorpusSize !== records.size
+    || review.bundle?.intakeSemanticHash !== bundle.intakeHash || review.bundle?.manifestHash !== bundle.manifestHash
+    || !Array.isArray(review.records) || review.records.length !== records.size
+    || typeof approvals.payloadBoundary !== 'string' || approvals.payloadBoundary !== review.scope.payloadBoundary
+    || typeof approvals.retryPolicy !== 'string' || !approvals.retryPolicy.trim()) fail('parent review scope/intake mismatch');
+  for (const name of ['intake.private.json', 'summary.json', 'source-index.private.json']) {
+    if (!HEX.test(bundle.fileHashes?.[name]) || bundle.fileHashes[name] !== review.bundle.fileSha256?.[name]) fail('parent-reviewed bundle file hash mismatch');
+  }
+  const unknowns = approvals.unknownsPreserved;
+  if (!unknowns || unknowns.eligibleForClaims !== false || unknowns.classifierTruthAssigned !== false || unknowns.humanRatingsCreated !== 0
+    || ['humanQuality', 'perceivedAiPolish', 'expectedShortFormTells', 'editingActor', 'editDepth'].some(key => unknowns[key] !== null)) fail('parent approval must preserve unknown labels');
+  const reviewed = new Map();
+  for (const row of review.records) {
+    const record = records.get(row.textHash);
+    if (!record || reviewed.has(row.textHash) || row.decision !== 'approve' || row.scope !== scope || row.bindingEvidence?.verified !== true
+      || !Array.isArray(row.deferredReasons) || row.deferredReasons.length || row.recordId !== record.id) fail('unmatched, deferred or unverified reviewed text');
+    for (const key of ['language', 'register', 'documentType', 'chars', 'originKind', 'contextConflict', 'rights', 'labels', 'eligibleForClaims']) {
+      if (encode(row.preservedMetadata?.[key]) !== encode(record[key])) fail('reviewed provenance/unknowns mismatch');
+    }
+    reviewed.set(row.textHash, row);
+  }
+  // Direct consumption preserves both source documents, their decisions, and
+  // parent-selected order. It never rewrites the pending content-review file.
+  return hashes.map(textHash => ({ textHash, decision: 'approved', sourceDecision: reviewed.get(textHash).decision,
+    parentApprovalSha256: source.approvalSha256, reviewSha256: source.reviewSha256 }));
+}
+export function validateApprovals(bundle, candidate, approvals, source) {
+  if (source && (hash(source.approvalBytes) !== source.approvalSha256 || encode(decode(source.approvalBytes)) !== encode(approvals))) fail('approval source bytes/hash mismatch');
+  if (approvals && Object.hasOwn(approvals, 'parentApproved')) return validateParentApproval(bundle, candidate, approvals, source);
   const records = new Map(bundle.intake.records.map(row => [row.textHash, row]));
   if (approvals?.schemaVersion !== 1 || approvals.intakeHash !== bundle.intakeHash || approvals.candidateHash !== hash(candidate) || !Array.isArray(approvals.decisions)) fail('separate processing-approval manifest required');
   const decisions = new Map();
@@ -249,7 +311,7 @@ function savedSnapshot(output) {
   assertSecretFree(snapshot); validateTransport(snapshot.candidate);
   if (hash(snapshot.candidateProtocolBytes) !== snapshot.candidateProtocolHash || encode(JSON.parse(snapshot.candidateProtocolBytes)) !== encode(snapshot.protocol)
     || snapshot.protocol.candidates.filter(candidate => encode(candidate) === encode(snapshot.candidate)).length !== 1) fail('frozen candidate protocol mismatch');
-  const admission = validateApprovals({ intake: { records: snapshot.records }, intakeHash: snapshot.intakeHash }, snapshot.candidate, snapshot.approvals);
+  const admission = validateApprovals({ intake: { records: snapshot.records }, intakeHash: snapshot.intakeHash, manifestHash: snapshot.manifestHash, fileHashes: snapshot.bundleFileHashes }, snapshot.candidate, snapshot.approvals, snapshot.approvalSource);
   if (encode(admission.filter(row => row.decision === 'approved').map(row => row.textHash)) !== encode(snapshot.matrix)) fail('saved approval matrix mismatch');
   return { snapshot, protocolHash: binding.protocolHash };
 }
@@ -354,7 +416,8 @@ export async function collectRebaselineScores(options, { complete = boundedCompl
     if ([resolve(options.intake, 'intake.private.json'), resolve(options.protocol), resolve(options.config)].includes(resolve(options.approvals))) fail('approval must be a separate manifest');
     const bundle = loadNullableIntake(options.intake);
     const { protocol, candidate } = selectCandidate(options.protocol, options.protocolSha256, options.candidateId);
-    const approvals = readJson(options.approvals), admission = validateApprovals(bundle, candidate, approvals);
+    const { approvals, source: approvalSource } = loadProcessingApproval(options.approvals);
+    const admission = validateApprovals(bundle, candidate, approvals, approvalSource);
     const matrix = admission.filter(row => row.decision === 'approved').map(row => row.textHash);
     if (!Number.isSafeInteger(options.maxCalls) || options.maxCalls < 0 || options.maxCalls > matrix.length * 2 || (matrix.length && !options.maxCalls)) fail('explicit call bound must be 1..2*approved (zero for empty admission)');
     const timeoutMs = options.timeoutMs ?? 60000;
@@ -365,11 +428,12 @@ export async function collectRebaselineScores(options, { complete = boundedCompl
       await scoreText({ ...inputs.prepared[record.textHash], text: record.text, model: candidate.model, logger: { warn() {}, info() {}, debug() {} },
         callLLM: async args => { prompts[record.textHash] = args.prompt; throw new Error('prompt capture only'); } });
       if (typeof prompts[record.textHash] !== 'string') fail('scorer prompt capture failed');
+      if (!prompts[record.textHash].includes(record.text)) fail('scorer fencing changes approved text; new review required');
     }
     snapshot = { schemaVersion: 1, kind: 'nullable-rebaseline-score-collection', candidate, protocol, candidateProtocolHash: options.protocolSha256, candidateProtocolBytes: fs.readFileSync(options.protocol, 'utf8'),
-      intakeHash: bundle.intakeHash, manifestHash: bundle.manifestHash, sourceIndexHash: bundle.sourceIndexHash, sourceIndex: bundle.sourceIndex, records: bundle.intake.records,
+      intakeHash: bundle.intakeHash, manifestHash: bundle.manifestHash, sourceIndexHash: bundle.sourceIndexHash, sourceIndex: bundle.sourceIndex, bundleFileHashes: bundle.fileHashes, records: bundle.intake.records,
       targetLabels: { expected_hot: null, class: null, authorship: null, humanQuality: null, expected_short_form_tells: null, perceived_ai_polish: null },
-      approvals, admission, matrix, maxCalls: options.maxCalls, timeoutMs, repeats: 1, parserInvocationsPerText: 2, transportRetries: 0,
+      approvals, approvalSource, admission, matrix, maxCalls: options.maxCalls, timeoutMs, repeats: 1, parserInvocationsPerText: 2, transportRetries: 0,
       budgetUnit: ['http', 'opencodex'].includes(candidate.transport) ? 'HTTP-request' : 'CLI-invocation',
       nativeUpstreamAttemptCountVerified: false, runtime: { node: process.version, platform: process.platform, arch: process.arch },
       inputs, prompts, codeHashes: currentCodeHashes() };

--- a/scripts/research/collect-rebaseline-scores.mjs
+++ b/scripts/research/collect-rebaseline-scores.mjs
@@ -15,7 +15,7 @@ import { scoreDeterministicSignals, scoreText } from '../../src/scoring.js';
 import { studySemantics } from './study-validation.mjs';
 import { acquireStudyWriter, bindStudyProtocol, safeCallRecord } from './study-journal.mjs';
 import { replayPreparationRow } from './preparation-replay.mjs';
-import { studyCompletion, validateTransport, readCredential, safeStudyError, installStudySignals } from './model-evaluation-transport.mjs';
+import { studyCompletion, validateTransport, readCredential, safeStudyError, installStudySignals, getStudyCancellationSignal } from './model-evaluation-transport.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const SELF = 'scripts/research/collect-rebaseline-scores.mjs';
@@ -249,7 +249,16 @@ function normalizedObservation(row) {
 
 // Exact credential-free HTTP body, one fetch only: no automatic temperature
 // fallback, HTTP retry, redirect, alternate provider or environment-file lookup.
+function interruptedRequest(kind, dispatched, started) {
+  const message = kind === 'operator-cancelled' ? 'Study cancelled' : kind === 'deadline' ? 'LLM request timed out' : 'Network transport interrupted';
+  const error = new Error(message);
+  error.studyResult = { interruption: kind, attempts: dispatched ? 1 : 0, effectiveModels: [], usage: null, identityEvidence: 'unverified', durationMs: Date.now() - started };
+  return error;
+}
 export async function boundedCompletion(candidate, prompt, options, observe) {
+  const studySignal = getStudyCancellationSignal();
+  const started = Date.now();
+  if (studySignal.aborted) throw interruptedRequest('operator-cancelled', false, started);
   if (['claude-cli', 'kimi-cli'].includes(candidate.transport)) {
     try {
       const result = await studyCompletion(candidate, prompt, { ...options, maxRetries: 0 });
@@ -260,22 +269,39 @@ export async function boundedCompletion(candidate, prompt, options, observe) {
       throw error;
     }
   }
-  const apiKey = candidate.transport === 'opencodex' ? 'opencodex-local' : readCredential(candidate.apiKeyEnv);
-  if (!apiKey) throw new Error('Required transport credential unavailable');
-  const body = { ...(candidate.extraBody || {}), model: candidate.model, messages: [{ role: 'user', content: prompt }], temperature: options.temperature };
-  if (options.responseFormat) body.response_format = options.responseFormat;
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), options.timeoutMs);
-  const started = Date.now();
+  let timer, reader, timedOut = false, dispatched = false;
+  const onStudyAbort = () => controller.abort(new Error('Study cancelled'));
+  const checkInterruption = () => {
+    if (studySignal.aborted) throw interruptedRequest('operator-cancelled', dispatched, started);
+    if (timedOut) throw interruptedRequest('deadline', dispatched, started);
+  };
   try {
+    studySignal.addEventListener('abort', onStudyAbort, { once: true });
+    // addEventListener does not notify a listener added after the abort event.
+    if (studySignal.aborted) onStudyAbort();
+    checkInterruption();
+    timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort(new Error('Request deadline expired'));
+    }, options.timeoutMs);
+    const apiKey = candidate.transport === 'opencodex' ? 'opencodex-local' : readCredential(candidate.apiKeyEnv);
+    if (!apiKey) throw new Error('Required transport credential unavailable');
+    const body = { ...(candidate.extraBody || {}), model: candidate.model, messages: [{ role: 'user', content: prompt }], temperature: options.temperature };
+    if (options.responseFormat) body.response_format = options.responseFormat;
+    checkInterruption();
+    dispatched = true;
     const response = await fetch(`${candidate.baseURL}/chat/completions`, { method: 'POST', redirect: 'error', signal: controller.signal,
       headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+    checkInterruption();
     let raw = '', size = 0;
-    const reader = response.body.getReader(); const decoder = new globalThis.TextDecoder();
+    reader = response.body.getReader(); const decoder = new globalThis.TextDecoder();
     for (let chunk = await reader.read(); !chunk.done; chunk = await reader.read()) {
-      size += chunk.value.byteLength; if (size > 4 * 1024 * 1024) { controller.abort(); throw new Error('Response size bound exceeded'); }
+      checkInterruption();
+      size += chunk.value.byteLength; if (size > 4 * 1024 * 1024) { controller.abort(new Error('Response size bound exceeded')); throw new Error('Response size bound exceeded'); }
       raw += decoder.decode(chunk.value, { stream: true });
     }
+    checkInterruption();
     raw += decoder.decode();
     observe({ scope: 'http-body', requestBody: body, responseBody: raw, httpStatus: response.status });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -285,8 +311,21 @@ export async function boundedCompletion(candidate, prompt, options, observe) {
     const result = { text, effectiveModels: typeof data.model === 'string' ? [data.model] : [], usage: data.usage ?? null, attempts: 1,
       durationMs: Date.now() - started, requestedTemperature: options.temperature, effectiveTemperature: body.temperature };
     options.onAttempt?.({ attemptIndex: 1, requestedModel: candidate.model, effectiveModel: data.model ?? null, usage: result.usage, outcome: 'success', retryReason: 'initial' });
+    checkInterruption();
     return result;
-  } finally { clearTimeout(timer); }
+  } catch (error) {
+    // Fetch implementations may reject with AbortError, the supplied reason,
+    // or a network error. Classification follows our controls, not that name.
+    checkInterruption();
+    if (error?.name === 'AbortError' || error?.cause?.name === 'AbortError' || /aborted/i.test(error?.message || '')) {
+      throw interruptedRequest('network', dispatched, started);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+    studySignal.removeEventListener('abort', onStudyAbort);
+    reader?.releaseLock();
+  }
 }
 function credentialFreeRequest(candidate, prompt, options) {
   return { candidate, prompt, temperature: options.temperature ?? .2, responseFormat: options.responseFormat ?? null, extraBody: options.extraBody ?? null,

--- a/scripts/research/collect-rebaseline-scores.mjs
+++ b/scripts/research/collect-rebaseline-scores.mjs
@@ -357,21 +357,37 @@ function savedSnapshot(output) {
 function evidenceHash(output, id) {
   return hash(['calls', 'wire'].flatMap(kind => filesBelow(resolve(output, kind, hash(id)))).sort().map(path => [relative(output, path), hash(fs.readFileSync(path))]));
 }
+function validateNotStarted(receipt, wirePath, isLast) {
+  const fields = new Set(['schemaVersion', 'state', 'requestHash', 'promptHash', 'temperature', 'error', 'durationMs', 'transportAttempts', 'startedAt', 'endedAt', 'notStarted', 'replayed']);
+  if (!isLast || receipt.state !== 'error' || receipt.error !== 'request-timeout' || receipt.startedAt !== null || receipt.durationMs !== 0
+    || !Array.isArray(receipt.transportAttempts) || receipt.transportAttempts.length
+    || typeof receipt.endedAt !== 'string' || !Number.isFinite(Date.parse(receipt.endedAt))
+    || (receipt.replayed !== undefined && typeof receipt.replayed !== 'boolean')
+    || Object.keys(receipt).some(key => !fields.has(key))) fail('invalid zero-dispatch deadline receipt');
+  if (fs.existsSync(wirePath)) fail('zero-dispatch receipt must not have a wire artifact');
+}
 function checkWire(output, id, candidate, record, snapshot, protocolHash) {
   const group = resolve(output, 'calls', hash(id));
   const paths = filesBelow(group);
   if (!paths.length) fail('started evaluation lacks recorded calls');
+  if (paths.length > snapshot.parserInvocationsPerText) fail('receipt sequence exceeds parser bound');
   const receipts = paths.map((_, i) => readJson(resolve(group, `${i + 1}.private.json`)));
+  let dispatched = 0;
   for (const [i, receipt] of receipts.entries()) {
-    if (!['completed', 'error'].includes(receipt.state)) fail('unresolved call; no paid replay');
-    const wire = readJson(resolve(output, 'wire', hash(id), `${i + 1}.private.json`));
+    if (receipt.schemaVersion !== 1 || !['completed', 'error'].includes(receipt.state)) fail('unresolved call; no paid replay');
+    const identity = { logicalId: id, index: i + 1, candidate, promptHash: hash(snapshot.prompts[record.textHash]), temperature: i === 0 ? .1 : 0, responseFormat: null, extraBody: null };
+    if (receipt.promptHash !== identity.promptHash || receipt.temperature !== identity.temperature || receipt.requestHash !== hash(identity)) fail('journal request/prompt/ordinal binding mismatch');
+    const wirePath = resolve(output, 'wire', hash(id), `${i + 1}.private.json`);
+    if (receipt.notStarted === true) { validateNotStarted(receipt, wirePath, i === receipts.length - 1); continue; }
+    dispatched++;
+    const wire = readJson(wirePath);
     if (wire.protocolHash !== protocolHash || wire.preparedHash !== hash(encode(snapshot.inputs.prepared[record.textHash])) || wire.request.prompt !== snapshot.prompts[record.textHash]
       || !['completed', 'error'].includes(wire.state) || wire.requestHash !== receipt.requestHash || hash(wire.request.prompt) !== receipt.promptHash
       || wire.textHash !== record.textHash || hash(wire.request.candidate) !== hash(candidate)) fail('wire/request binding mismatch or unresolved paid call');
     if (receipt.state === 'completed' && encode(wire.response) !== encode(receipt.response)) fail('response receipt mismatch');
     if (receipt.state === 'error' && (wire.error !== receipt.error || encode(wire.errorMetadata ?? null) !== encode(receipt.errorMetadata ?? null))) fail('error receipt mismatch');
   }
-  if (filesBelow(resolve(output, 'wire', hash(id))).length !== receipts.length) fail('extra wire receipts');
+  if (filesBelow(resolve(output, 'wire', hash(id))).length !== dispatched) fail('extra wire receipts');
   return { calls: receipts.map(receipt => safeCallRecord(receipt, candidate)) };
 }
 async function replayOne(output, snapshot, protocolHash, record, stored) {
@@ -386,6 +402,18 @@ async function replayOne(output, snapshot, protocolHash, record, stored) {
           error.studyResult = { ...(error.studyResult || {}), durationMs: receiptRow.calls[ordinal]?.durationMs }; throw error;
         }
       }, preparedInputs: snapshot.inputs.prepared[record.textHash], logicalId: id, timeoutMs: snapshot.timeoutMs }) });
+  // The generic in-memory journal sees the offline receipt reader as a call.
+  // Restore only the two dispatch flags from a strictly validated notStarted
+  // receipt; this neither creates a wire/reservation nor invokes a provider.
+  for (const [i, expectedCall] of receiptRow.calls.entries()) {
+    if (!expectedCall.notStarted) continue;
+    const actual = clone(replay.calls[i]), expected = clone(expectedCall);
+    if (!actual || actual.notStarted !== false || actual.attempts !== null) fail('zero-dispatch replay unexpectedly observed an attempt');
+    actual.notStarted = true; actual.attempts = 0;
+    delete actual.recovered_from_journal; delete expected.recovered_from_journal;
+    if (encode(actual) !== encode(expected)) fail('zero-dispatch replay metadata mismatch');
+    replay.calls[i].notStarted = true; replay.calls[i].attempts = 0;
+  }
   annotateObservation(replay, record, snapshot.inputs.prepared[record.textHash]);
   if (stored && encode(normalizedObservation(stored)) !== encode(normalizedObservation(replay))) fail('observed replay mismatch');
   replay.productionResult = await replayPreparationRow({ directory: output, logicalId: id, row: receiptRow, candidate: snapshot.candidate,

--- a/scripts/research/collect-rebaseline-scores.mjs
+++ b/scripts/research/collect-rebaseline-scores.mjs
@@ -150,6 +150,7 @@ export function prepareInputs(records, configFile) {
   let config; try { config = yaml.load(configBytes); } catch { fail('invalid pinned config'); }
   if (!config || Array.isArray(config) || typeof config !== 'object') fail('config must be a mapping');
   assertSecretFree(config);
+  if (config.register != null && !['casual', 'professional'].includes(config.register)) fail('pinned register must use the delivery-register axis');
   if (['profile', 'tone', 'formality'].some(key => Object.hasOwn(config, key))) fail('retired configuration field');
   if (config.stylometry?.structural_model?.path || config.stylometry?.classifier?.model_path || config.private_model?.path) fail('explicit structural model unsupported by this absence-frozen collector');
   config.documentType = config['document-type'] || config.documentType || 'default'; delete config['document-type'];
@@ -173,8 +174,12 @@ export function prepareInputs(records, configFile) {
   assertSecretFree(result); return result;
 }
 function currentCodeHashes() { return { ...studySemantics(ROOT), [SELF]: hash(fs.readFileSync(resolve(ROOT, SELF))), 'scripts/research/preparation-replay.mjs': hash(fs.readFileSync(resolve(ROOT, 'scripts/research/preparation-replay.mjs'))) }; }
-function fixture(record) { return { fixture_id: record.id, text_hash: record.textHash, text: record.text, language: record.language, documentType: record.documentType,
-  register: record.register ?? null, class: record.class ?? null, expected_hot: record.expected_hot ?? null, source: null }; }
+function fixture(record, prepared) { return { fixture_id: record.id, text_hash: record.textHash, text: record.text, language: record.language, documentType: prepared.config.documentType,
+  register: prepared.config.register ?? null, class: null, expected_hot: null, source: null }; }
+function annotateObservation(row, record, prepared) {
+  row.datasetGenre = { value: record.register ?? null, reviewStatus: record.labels?.registerStatus ?? null, source: 'intake.register' };
+  row.documentTypeSelection = { value: prepared.config.documentType, source: record.documentType ? 'intake.documentType' : 'pinned-config', inferredFromGenreByCollector: false };
+}
 const logical = (protocolHash, candidate, record) => `${protocolHash}/${candidate.id}/${record.id}/0/score`;
 function normalizedObservation(row) {
   const value = clone(row); delete value.productionResult; value.calls.forEach(call => { delete call.recovered_from_journal; }); return value;
@@ -273,13 +278,14 @@ async function replayOne(output, snapshot, protocolHash, record, stored) {
   const receiptRow = checkWire(output, id, snapshot.candidate, record, snapshot, protocolHash);
   let consumed = 0;
   const replay = await replayPreparationRow({ directory: output, logicalId: id, row: stored || receiptRow, candidate: snapshot.candidate,
-    run: complete => evaluateScorerFixture(fixture(record), snapshot.candidate, {
+    run: complete => evaluateScorerFixture(fixture(record, snapshot.inputs.prepared[record.textHash]), snapshot.candidate, {
       complete: async (...args) => {
         const ordinal = consumed++;
         try { return await complete(...args); } catch (error) {
           error.studyResult = { ...(error.studyResult || {}), durationMs: receiptRow.calls[ordinal]?.durationMs }; throw error;
         }
       }, preparedInputs: snapshot.inputs.prepared[record.textHash], logicalId: id, timeoutMs: snapshot.timeoutMs }) });
+  annotateObservation(replay, record, snapshot.inputs.prepared[record.textHash]);
   if (stored && encode(normalizedObservation(stored)) !== encode(normalizedObservation(replay))) fail('observed replay mismatch');
   replay.productionResult = await replayPreparationRow({ directory: output, logicalId: id, row: receiptRow, candidate: snapshot.candidate,
     run: complete => scoreText({ ...snapshot.inputs.prepared[record.textHash], text: record.text, model: snapshot.candidate.model, logger: { warn() {}, info() {}, debug() {} },
@@ -362,6 +368,7 @@ export async function collectRebaselineScores(options, { complete = boundedCompl
     }
     snapshot = { schemaVersion: 1, kind: 'nullable-rebaseline-score-collection', candidate, protocol, candidateProtocolHash: options.protocolSha256, candidateProtocolBytes: fs.readFileSync(options.protocol, 'utf8'),
       intakeHash: bundle.intakeHash, manifestHash: bundle.manifestHash, sourceIndexHash: bundle.sourceIndexHash, sourceIndex: bundle.sourceIndex, records: bundle.intake.records,
+      targetLabels: { expected_hot: null, class: null, authorship: null, humanQuality: null, expected_short_form_tells: null, perceived_ai_polish: null },
       approvals, admission, matrix, maxCalls: options.maxCalls, timeoutMs, repeats: 1, parserInvocationsPerText: 2, transportRetries: 0,
       budgetUnit: ['http', 'opencodex'].includes(candidate.transport) ? 'HTTP-request' : 'CLI-invocation',
       nativeUpstreamAttemptCountVerified: false, runtime: { node: process.version, platform: process.platform, arch: process.arch },
@@ -407,7 +414,7 @@ export async function collectRebaselineScores(options, { complete = boundedCompl
       const record = snapshot.records.find(row => row.textHash === textHash), id = logical(protocolHash, snapshot.candidate, record);
       progress.entries[textHash] = { state: 'started' }; save(progressPath, progress);
       let ordinal = 0;
-      const observation = await evaluateScorerFixture(fixture(record), snapshot.candidate, { preparedInputs: snapshot.inputs.prepared[textHash], journalDirectory: output, logicalId: id, timeoutMs: snapshot.timeoutMs,
+      const observation = await evaluateScorerFixture(fixture(record, snapshot.inputs.prepared[record.textHash]), snapshot.candidate, { preparedInputs: snapshot.inputs.prepared[textHash], journalDirectory: output, logicalId: id, timeoutMs: snapshot.timeoutMs,
         complete: async (candidate, prompt, args) => {
           if (fatal) throw fatal;
           if (++ordinal > 2 || invocations >= snapshot.maxCalls) { fatal = new Error('rebaseline: call budget exhausted'); throw fatal; }
@@ -434,6 +441,7 @@ export async function collectRebaselineScores(options, { complete = boundedCompl
         } });
       if (fatal) throw fatal;
       if (observation.calls.some(call => ['study-journal-persistence-failed', 'study-call-unobserved', 'study-call-inflight', 'study-cancelled'].includes(call.error))) fail('unresolved journal; collection stopped');
+      annotateObservation(observation, record, snapshot.inputs.prepared[textHash]);
       const recovered = await replayOne(output, snapshot, protocolHash, record, null);
       if (encode(normalizedObservation(observation)) !== encode(normalizedObservation(recovered))) fail('fresh receipt replay mismatch');
       observation.productionResult = recovered.productionResult;

--- a/scripts/research/model-evaluation-transport.mjs
+++ b/scripts/research/model-evaluation-transport.mjs
@@ -11,6 +11,8 @@ const cancellation = new AbortController();
 const children = new Map();
 let signalsInstalled = false;
 export function assertStudyActive() { if (cancellation.signal.aborted) throw new Error('Study cancelled'); }
+// Consumers may observe cancellation; the controller and abort authority stay here.
+export function getStudyCancellationSignal() { return cancellation.signal; }
 export function abortStudy() {
   cancellation.abort();
   for (const child of children.values()) child.stop(new Error('Study cancelled'));

--- a/tests/unit/rebaseline-score-collection.test.js
+++ b/tests/unit/rebaseline-score-collection.test.js
@@ -250,3 +250,49 @@ test('native profile admission remains distinct from server model verification',
   assert.equal(snapshot.nativeUpstreamAttemptCountVerified, false);
   assert.equal((await replayCollection(options.output)).fullObservedReplay, true);
 });
+
+test('dataset genre and delivery register remain separate; source labels never label new targets', async t => {
+  const { options, records, approval, root } = setup(t, 4);
+  const genres = ['social', 'marketing', 'chat-update', 'chat-update'];
+  const documentTypes = ['social', 'marketing', undefined, 'casual-conversation'];
+  records.forEach((record, i) => {
+    record.register = genres[i];
+    if (documentTypes[i]) record.documentType = documentTypes[i]; else delete record.documentType;
+    record.labels.registerStatus = 'source-declared-unreviewed';
+    record.expected_hot = i % 2 === 0; record.class = i % 2 === 0 ? 'ai' : 'natural';
+    record.origins[0].originalFixtureExpectedHot = true;
+    approval.decisions[i].sourceEvidenceHash = canonical(record.origins);
+  });
+  const intake = read(resolve(options.intake, 'intake.private.json')); intake.records = records;
+  write(resolve(options.intake, 'intake.private.json'), intake);
+  const summary = read(resolve(options.intake, 'summary.json'));
+  summary.intakeHash = canonical(intake); summary.manifestHash = canonical(records);
+  write(resolve(options.intake, 'summary.json'), summary);
+  approval.intakeHash = summary.intakeHash; write(options.approvals, approval);
+  const config = fs.readFileSync(options.config, 'utf8').replace(/^register:.*$/m, 'register: professional');
+  options.config = resolve(root, 'pinned-delivery-register.yaml'); fs.writeFileSync(options.config, config);
+  const report = await collectRebaselineScores(options, { complete: async () => valid() });
+  assert.equal(report.valid, 4); assert.equal(report.classificationMetrics, null);
+  const snapshot = read(resolve(options.output, 'snapshot.private.json'));
+  assert.ok(Object.values(snapshot.targetLabels).every(value => value === null));
+  assert.deepEqual(snapshot.records.map(record => record.expected_hot), [true, false, true, false]);
+  records.forEach((record, i) => {
+    const row = read(resolve(options.output, 'rows', `${record.textHash}.private.json`));
+    assert.equal(row.register, 'professional');
+    assert.equal(row.datasetGenre.value, genres[i]);
+    assert.equal(row.datasetGenre.reviewStatus, 'source-declared-unreviewed');
+    assert.equal(row.expected_hot, null); assert.equal(row.class, null);
+    assert.equal(row.documentTypeSelection.value, documentTypes[i] ?? 'default');
+    assert.equal(row.documentTypeSelection.source, documentTypes[i] ? 'intake.documentType' : 'pinned-config');
+    assert.equal(row.documentTypeSelection.inferredFromGenreByCollector, false);
+    assert.equal(snapshot.inputs.prepared[record.textHash].config.register, 'professional');
+  });
+  assert.equal((await replayCollection(options.output)).fullObservedReplay, true);
+});
+
+test('a dataset genre in pinned config.register is rejected instead of treated as delivery register', async t => {
+  const { options, root } = setup(t);
+  const config = fs.readFileSync(options.config, 'utf8').replace(/^register:.*$/m, 'register: marketing');
+  options.config = resolve(root, 'invalid-register.yaml'); fs.writeFileSync(options.config, config);
+  await assert.rejects(collectRebaselineScores(options, { complete: async () => assert.fail('invalid register cannot dispatch') }), /delivery-register axis/);
+});

--- a/tests/unit/rebaseline-score-collection.test.js
+++ b/tests/unit/rebaseline-score-collection.test.js
@@ -546,3 +546,106 @@ test('ordinary deadlines and network AbortError are recorded errors and the coho
     assert.equal((await replayCollection(options.output)).fullObservedReplay, true);
   }
 });
+
+async function exhaustParserDeadline(options, records, dependencies) {
+  const originalNow = Date.now, originalFetch = globalThis.fetch;
+  let offset = 0, fetches = 0;
+  const byText = new Map();
+  Date.now = () => originalNow() + offset;
+  globalThis.fetch = async (_url, request) => {
+    const prompt = JSON.parse(request.body).messages[0].content;
+    const record = records.find(item => prompt.includes(item.text));
+    assert.ok(record);
+    byText.set(record.textHash, (byText.get(record.textHash) || 0) + 1);
+    fetches++;
+    if (fetches === 1) offset += options.timeoutMs + 50;
+    return new Response(JSON.stringify({ model: candidate.model, usage: { prompt_tokens: 10, completion_tokens: 10 },
+      choices: [{ message: { content: fetches === 1 ? 'malformed score' : valid().text } }] }), { status: 200 });
+  };
+  try { return { report: await collectRebaselineScores(options, dependencies), fetches, byText }; }
+  catch (error) { return { error, fetches, byText }; }
+  finally { Date.now = originalNow; globalThis.fetch = originalFetch; }
+}
+
+test('logical deadline after malformed response records two journals but only one dispatched wire', async t => {
+  const { options, records } = setup(t, 2); options.timeoutMs = 1000;
+  const result = await exhaustParserDeadline(options, records);
+  const snapshot = read(resolve(options.output, 'snapshot.private.json'));
+  const protocolHash = read(resolve(options.output, 'study-protocol.json')).protocolHash;
+  const group = hash(`${protocolHash}/${snapshot.candidate.id}/${records[0].id}/0/score`);
+  const journal = resolve(options.output, 'calls', group), wire = resolve(options.output, 'wire', group);
+  assert.equal(result.byText.get(records[0].textHash), 1);
+  assert.equal(paths(journal).length, 2); assert.equal(paths(wire).length, 1);
+  const zero = read(resolve(journal, '2.private.json'));
+  assert.equal(zero.notStarted, true); assert.equal(zero.error, 'request-timeout');
+  assert.equal(zero.startedAt, null); assert.equal(zero.durationMs, 0); assert.deepEqual(zero.transportAttempts, []);
+  assert.equal(fs.existsSync(resolve(wire, '2.private.json')), false);
+  assert.equal(result.error, undefined);
+  assert.equal(result.fetches, 2, 'the next fixture gets one normal request');
+  assert.equal(result.report.errors, 1); assert.equal(result.report.valid, 1);
+  const row = read(resolve(options.output, 'rows', `${records[0].textHash}.private.json`));
+  assert.equal(row.error, 'request-timeout'); assert.equal(row.overall, null);
+  assert.equal(row.calls[1].notStarted, true); assert.equal(row.calls[1].attempts, 0);
+  assert.equal(read(resolve(options.output, 'rows', `${records[1].textHash}.private.json`)).status, 'ok');
+  const before = Object.fromEntries(paths(options.output).map(path => [path, hash(fs.readFileSync(path))]));
+  const previous = globalThis.fetch; t.after(() => { globalThis.fetch = previous; });
+  globalThis.fetch = async () => assert.fail('no replacement fetch on replay or resume');
+  assert.equal((await replayCollection(options.output)).fullObservedReplay, true);
+  await collectRebaselineScores(resume(options), { complete: async () => assert.fail('no replacement completion') });
+  assert.deepEqual(Object.fromEntries(paths(options.output).map(path => [path, hash(fs.readFileSync(path))])), before);
+});
+
+test('wireless notStarted timeout recovers a missing row without a replacement completion', async t => {
+  const { options, records } = setup(t); options.timeoutMs = 1000;
+  const result = await exhaustParserDeadline(options, records, { persist: (path, value) => {
+    if (path.includes('/rows/')) throw new Error('row persistence interrupted');
+    persistPrivate(path, value);
+  } });
+  assert.match(result.error.message, /persistence/); assert.equal(result.fetches, 1);
+  const recorded = Object.fromEntries(['calls', 'wire'].flatMap(kind => paths(resolve(options.output, kind))).map(path => [path, hash(fs.readFileSync(path))]));
+  const previous = globalThis.fetch; t.after(() => { globalThis.fetch = previous; });
+  globalThis.fetch = async () => assert.fail('recovery cannot fetch');
+  const report = await collectRebaselineScores(resume(options), { complete: async () => assert.fail('recovery cannot dispatch') });
+  assert.equal(report.attempted, 1); assert.equal(report.errors, 1); assert.equal(report.errorClasses['request-timeout'], 1);
+  const row = read(resolve(options.output, 'rows', `${records[0].textHash}.private.json`));
+  assert.equal(row.calls[1].notStarted, true); assert.equal(row.calls[1].attempts, 0);
+  assert.deepEqual(Object.fromEntries(['calls', 'wire'].flatMap(kind => paths(resolve(options.output, kind))).map(path => [path, hash(fs.readFileSync(path))])), recorded);
+  assert.equal((await replayCollection(options.output)).fullObservedReplay, true);
+});
+
+test('zero-dispatch receipts require exact prompt/request/ordinal/state and no dispatch evidence', async t => {
+  const { options, records } = setup(t); options.timeoutMs = 1000;
+  const result = await exhaustParserDeadline(options, records);
+  assert.equal(result.error, undefined);
+  const progressPath = resolve(options.output, 'progress.private.json');
+  const progress = read(progressPath); progress.entries[records[0].textHash] = { state: 'started' }; write(progressPath, progress);
+  fs.unlinkSync(resolve(options.output, 'rows', `${records[0].textHash}.private.json`));
+  const journal = paths(resolve(options.output, 'calls')).find(path => path.endsWith('2.private.json'));
+  const original = fs.readFileSync(journal);
+  const fakeWire = journal.replace('/calls/', '/wire/');
+  const shifted = journal.replace('2.private.json', '3.private.json');
+  for (const variant of ['prompt', 'request', 'temperature', 'state', 'response', 'owner', 'startedAt', 'attempts', 'duration', 'endedAt', 'notStarted', 'wire', 'ordinal']) {
+    const receipt = JSON.parse(original);
+    if (variant === 'prompt') receipt.promptHash = hash('different prompt');
+    if (variant === 'request') receipt.requestHash = hash('different request');
+    if (variant === 'temperature') receipt.temperature = .1;
+    if (variant === 'state') receipt.state = 'completed';
+    if (variant === 'response') receipt.response = valid();
+    if (variant === 'owner') receipt.owner = { pid: 123 };
+    if (variant === 'startedAt') receipt.startedAt = receipt.endedAt;
+    if (variant === 'attempts') receipt.transportAttempts = [{ outcome: 'success' }];
+    if (variant === 'duration') receipt.durationMs = 1;
+    if (variant === 'endedAt') receipt.endedAt = null;
+    if (variant === 'notStarted') receipt.notStarted = false;
+    write(journal, receipt);
+    if (variant === 'wire') write(fakeWire, { state: 'error' });
+    if (variant === 'ordinal') fs.renameSync(journal, shifted);
+    try {
+      await assert.rejects(collectRebaselineScores(resume(options), { complete: async () => assert.fail('invalid receipt cannot authorize dispatch') }), undefined, variant);
+    } finally {
+      if (fs.existsSync(fakeWire)) fs.unlinkSync(fakeWire);
+      if (fs.existsSync(shifted)) fs.unlinkSync(shifted);
+      fs.writeFileSync(journal, original);
+    }
+  }
+});

--- a/tests/unit/rebaseline-score-collection.test.js
+++ b/tests/unit/rebaseline-score-collection.test.js
@@ -1,0 +1,252 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadLexicon } from '../../src/features/lexicon.js';
+import { hash, collectRebaselineScores, replayCollection, loadNullableIntake, persistPrivate, boundedCompletion, main } from '../../scripts/research/collect-rebaseline-scores.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const sort = value => Array.isArray(value) ? value.map(sort) : value && typeof value === 'object' ? Object.fromEntries(Object.keys(value).sort().map(key => [key, sort(value[key])])) : value;
+const canonical = value => hash(sort(value));
+const read = path => JSON.parse(fs.readFileSync(path, 'utf8'));
+const write = (path, value) => fs.writeFileSync(path, JSON.stringify(value), { mode: 0o600 });
+const paths = root => fs.readdirSync(root, { withFileTypes: true }).flatMap(item => item.isDirectory() ? paths(resolve(root, item.name)) : [resolve(root, item.name)]);
+const candidate = { id: 'unit-collector', provider: 'openai', transport: 'opencodex', baseURL: 'http://127.0.0.1:10100/v1', model: 'unit-test-model' };
+function setup(t, count = 1) {
+  const root = fs.mkdtempSync(resolve(tmpdir(), 'patina-rebaseline-collector-test-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const intake = resolve(root, 'intake'); fs.mkdirSync(resolve(intake, 'evidence'), { recursive: true, mode: 0o700 });
+  const records = Array.from({ length: count }, (_, i) => {
+    const text = `The train leaves at noon. I packed ${i + 1} bag for the trip.`;
+    return { id: `unit-${i}`, text, textHash: hash(text), language: 'en', documentType: 'default', register: 'source-declared',
+      origins: [{ kind: 'unknown', evidenceHash: hash('unit evidence') }], originKind: 'unknown',
+      expected_hot: null, labels: { generator: null, humanQuality: null, expected_short_form_tells: null },
+      rights: { status: 'needs-review', sharing: 'private' }, eligibleForClaims: false };
+  });
+  const sourceIndex = { 'unit-evidence': { sha256: hash('unit evidence'), bytes: Buffer.byteLength('unit evidence') } };
+  const data = { records, excluded: [], counts: { retained: records.length } };
+  fs.writeFileSync(resolve(intake, 'evidence', hash('unit evidence')), 'unit evidence', { mode: 0o600 });
+  write(resolve(intake, 'intake.private.json'), data); write(resolve(intake, 'source-index.private.json'), sourceIndex);
+  write(resolve(intake, 'summary.json'), { intakeHash: canonical(data), manifestHash: canonical(records) });
+  const protocol = resolve(root, 'protocol.json'); write(protocol, { schemaVersion: 1, candidates: [candidate] });
+  const approvals = resolve(root, 'approval.private.json');
+  const approval = { schemaVersion: 1, intakeHash: canonical(data), candidateHash: hash(candidate), decisions: records.map(record => ({
+    textHash: record.textHash, sourceEvidenceHash: canonical(record.origins), decision: 'approved', reviewer: 'unit-test-only', reviewedAt: '2026-09-05T00:00:00Z',
+    provider: candidate.provider, transport: candidate.transport, model: candidate.model, permittedLocalAnalysis: true, permittedProviderProcessing: true,
+    retention: 'private-only', publication: 'summary-only' })) };
+  write(approvals, approval);
+  return { root, records, approval, options: { intake, protocol, protocolSha256: hash(fs.readFileSync(protocol)), candidateId: candidate.id,
+    config: resolve(ROOT, '.patina.default.yaml'), approvals, output: resolve(root, 'output'), maxCalls: count * 2, timeoutMs: 60000, live: true } };
+}
+const valid = (model = candidate.model, overall = 5) => ({ text: JSON.stringify({ overall, categories: { content: { detected: 0, sum: 0, max: 30, score: 0, weighted: 0 } } }),
+  effectiveModels: [model], usage: { prompt_tokens: 10, completion_tokens: 10 }, attempts: 1, durationMs: 2 });
+
+function resume(options, live = true) { return { output: options.output, resume: true, live }; }
+
+test('nullable intake verifies bytes and evidence without inventing human or generator labels', t => {
+  const { options, records } = setup(t);
+  const bundle = loadNullableIntake(options.intake);
+  assert.deepEqual(bundle.intake.records[0].labels, records[0].labels);
+  assert.equal(bundle.intake.records[0].expected_hot, null);
+  fs.writeFileSync(resolve(options.intake, 'evidence', hash('unit evidence')), 'changed');
+  assert.throws(() => loadNullableIntake(options.intake), /evidence mismatch/);
+});
+
+test('no opt-in means no call; snapshots preserve exact private inputs and loaded resources', async t => {
+  const { options, records } = setup(t);
+  const report = await collectRebaselineScores({ ...options, live: false }, { complete: async () => assert.fail('not opted in') });
+  assert.equal(report.attempted, 0);
+  const snapshot = read(resolve(options.output, 'snapshot.private.json'));
+  assert.deepEqual(snapshot.records, records);
+  assert.equal(snapshot.inputs.configSource.ambientOverrides, false);
+  assert.ok(snapshot.prompts[records[0].textHash].includes(records[0].text));
+  assert.deepEqual(snapshot.inputs.lexicons.en, JSON.parse(JSON.stringify(loadLexicon('en', ROOT))));
+  assert.ok(snapshot.inputs.prepared[records[0].textHash].deterministicScore.bands);
+  assert.equal(fs.readFileSync(resolve(options.output, '.gitignore'), 'utf8'), '*\n');
+  for (const path of paths(options.output)) assert.equal(fs.statSync(path).mode & 0o777, 0o600);
+});
+
+test('missing, unknown, denied and route-mismatched approvals never dispatch', async t => {
+  for (const variant of ['missing', 'unknown', 'blocked', 'wrong-route', 'wrong-evidence']) {
+    const { options, approval } = setup(t);
+    if (variant === 'missing') fs.unlinkSync(options.approvals);
+    else {
+      if (['unknown', 'blocked'].includes(variant)) { approval.decisions[0].decision = variant; options.maxCalls = 0; }
+      if (variant === 'wrong-route') approval.decisions[0].model = 'another-model';
+      if (variant === 'wrong-evidence') approval.decisions[0].sourceEvidenceHash = hash('other evidence');
+      write(options.approvals, approval);
+    }
+    await assert.rejects(collectRebaselineScores(options, { complete: async () => assert.fail('unapproved processing') }));
+  }
+});
+
+test('mixed admission freezes the full denominator and preserves nullable labels', async t => {
+  const { options, approval, records } = setup(t, 2);
+  approval.decisions[1].decision = 'unknown'; options.maxCalls = 2; write(options.approvals, approval);
+  let calls = 0;
+  const report = await collectRebaselineScores(options, { complete: async () => { calls++; return valid(); } });
+  assert.equal(calls, 1); assert.equal(report.denominator, 2); assert.equal(report.approved, 1); assert.equal(report.excluded, 1);
+  const row = read(resolve(options.output, 'rows', `${records[0].textHash}.private.json`));
+  assert.equal(row.expected_hot, null); assert.equal(row.class, null);
+  assert.ok(row.productionResult.llmScore); assert.ok(row.productionResult.deterministicScore);
+  assert.equal(report.classificationMetrics, null);
+  assert.doesNotMatch(JSON.stringify(report), /\b(?:FNR|FPR|AUC|accuracy|precision|recall)\b/i);
+  assert.ok(report.languages.en.packs.content);
+  assert.equal(report.languages.en.packs['viral-hook'].missing, 1);
+});
+
+test('completed observations replay offline byte-for-byte; resume never pays for them again', async t => {
+  const { options } = setup(t, 2); let calls = 0;
+  await collectRebaselineScores(options, { complete: async () => { calls++; return valid(); } });
+  assert.equal(calls, 2);
+  const before = Object.fromEntries(paths(options.output).map(path => [path, hash(fs.readFileSync(path))]));
+  const replay = await replayCollection(options.output);
+  assert.equal(replay.fullObservedReplay, true); assert.equal(replay.attempted, 2);
+  assert.deepEqual(Object.fromEntries(paths(options.output).map(path => [path, hash(fs.readFileSync(path))])), before);
+  await collectRebaselineScores(resume(options), { complete: async () => assert.fail('already paid') });
+});
+
+test('production JSON retry is retained, while valid-JSON schema failure is a separate missing score', async t => {
+  const { options } = setup(t, 2); const temperatures = [];
+  const report = await collectRebaselineScores(options, { complete: async (_candidate, _prompt, args) => {
+    temperatures.push(args.temperature);
+    if (temperatures.length === 1) return { ...valid(), text: 'not JSON' };
+    if (temperatures.length === 3) return { ...valid(), text: JSON.stringify({ overall: 0, categories: { content: { detected: 999, sum: 0, max: 1, score: 0, weighted: 0 } } }) };
+    return valid();
+  } });
+  assert.deepEqual(temperatures, [.1, 0, .1]);
+  assert.equal(report.valid, 1); assert.equal(report.errors, 1); assert.equal(report.distributions.rawLlm.n, 1);
+  assert.equal(report.errorClasses['score-schema-failure'], 1);
+  assert.equal((await replayCollection(options.output)).fullObservedReplay, true);
+});
+
+test('transport failures remain errors and missing scores, with no transport retry', async t => {
+  const { options } = setup(t); let calls = 0;
+  const report = await collectRebaselineScores(options, { complete: async () => { calls++; throw new Error('HTTP 429'); } });
+  assert.equal(calls, 1); assert.equal(report.valid, 0); assert.equal(report.distributions.overall.n, 0);
+  assert.equal(report.errorClasses['provider-rate-limited (HTTP 429)'], 1);
+  assert.equal((await replayCollection(options.output)).fullObservedReplay, true);
+});
+
+test('snapshot/row/receipt changes and missing parser receipts reject before any resumed paid call', async t => {
+  for (const variant of ['snapshot', 'row', 'wire', 'missing-parser-call']) {
+    const { options, records } = setup(t); let count = 0;
+    await collectRebaselineScores(options, { complete: async () => (++count === 1 && variant === 'missing-parser-call' ? { ...valid(), text: 'malformed' } : valid()) });
+    if (variant === 'snapshot') {
+      const path = resolve(options.output, 'snapshot.private.json'), data = read(path); data.inputs.config.language = 'zh'; write(path, data);
+    } else if (variant === 'row') {
+      const path = resolve(options.output, 'rows', `${records[0].textHash}.private.json`), data = read(path); data.overall = 99; write(path, data);
+    } else if (variant === 'wire') {
+      const path = paths(resolve(options.output, 'wire'))[0], data = read(path); data.response.text = '{}'; write(path, data);
+    } else {
+      for (const kind of ['calls', 'wire']) for (const path of paths(resolve(options.output, kind)).filter(path => path.endsWith('2.private.json'))) fs.unlinkSync(path);
+      const progressPath = resolve(options.output, 'progress.private.json'), progress = read(progressPath);
+      progress.entries[records[0].textHash] = { state: 'started' }; write(progressPath, progress);
+      fs.unlinkSync(resolve(options.output, 'rows', `${records[0].textHash}.private.json`));
+    }
+    await assert.rejects(collectRebaselineScores(resume(options), { complete: async () => assert.fail('unrecorded paid replay') }));
+  }
+});
+
+test('persistence failure before dispatch pays nothing; after dispatch it stops and blocks paid resume', async t => {
+  for (const phase of ['started', 'completed']) {
+    const { options } = setup(t, 2); let calls = 0;
+    await assert.rejects(collectRebaselineScores(options, {
+      complete: async () => { calls++; return valid(); },
+      persist: (path, value) => { if (path.includes('/wire/') && value.state === phase) throw new Error('disk full'); persistPrivate(path, value); },
+    }), /persistence/);
+    assert.equal(calls, phase === 'started' ? 0 : 1);
+    await assert.rejects(collectRebaselineScores(resume(options), { complete: async () => assert.fail('unresolved paid call') }));
+  }
+});
+
+test('completed paid receipts can recover a missing row offline after row persistence failure', async t => {
+  const { options } = setup(t); let calls = 0;
+  await assert.rejects(collectRebaselineScores(options, { complete: async () => { calls++; return valid(); },
+    persist: (path, value) => { if (path.includes('/rows/')) throw new Error('disk full'); persistPrivate(path, value); } }), /persistence/);
+  const report = await collectRebaselineScores(resume(options), { complete: async () => assert.fail('recovery must use receipts') });
+  assert.equal(calls, 1); assert.equal(report.valid, 1);
+});
+
+test('secrets reject preparation or response capture; no redacted full-replay claim', async t => {
+  const secret = 'sk-' + 'x'.repeat(32);
+  const a = setup(t); a.options.config = resolve(a.root, 'secret.yaml'); fs.writeFileSync(a.options.config, `api_key: ${secret}\n`);
+  await assert.rejects(collectRebaselineScores(a.options, { complete: async () => assert.fail('secret config') }), /secret/);
+  const b = setup(t); let calls = 0;
+  await assert.rejects(collectRebaselineScores(b.options, { complete: async () => { calls++; return { ...valid(), text: secret }; } }), /rejected/);
+  assert.equal(calls, 1);
+  for (const path of paths(b.options.output)) assert.ok(!fs.readFileSync(path, 'utf8').includes(secret));
+  await assert.rejects(replayCollection(b.options.output));
+});
+
+test('Gemini direct API candidates, protocol drift, unknown CLI flags and unsafe output paths reject', async t => {
+  const { options } = setup(t);
+  write(options.protocol, { candidates: [{ ...candidate, provider: 'gemini', model: 'gemini-unit', transport: 'http', baseURL: 'https://example.invalid', apiKeyEnv: 'GEMINI_API_KEY' }] });
+  await assert.rejects(collectRebaselineScores(options), /protocol hash/);
+  options.protocolSha256 = hash(fs.readFileSync(options.protocol));
+  await assert.rejects(collectRebaselineScores(options), /OpenCodex/);
+  await assert.rejects(main(['--output', options.output, '--env-file', 'forbidden']), /unknown/);
+  const b = setup(t); fs.symlinkSync(b.root, b.options.output);
+  await assert.rejects(collectRebaselineScores(b.options), /symlink/);
+});
+
+test('the bounded HTTP path sends once even for temperature rejection and captures credential-free bodies', async t => {
+  const previous = globalThis.fetch; t.after(() => { globalThis.fetch = previous; });
+  let calls = 0, observed;
+  globalThis.fetch = async (_url, options) => {
+    calls++; assert.equal(options.redirect, 'error');
+    return new Response('temperature is unsupported', { status: 400 });
+  };
+  await assert.rejects(boundedCompletion(candidate, 'unit prompt', { temperature: .1, timeoutMs: 1000 }, value => { observed = value; }), /HTTP 400/);
+  assert.equal(calls, 1); assert.equal(observed.httpStatus, 400);
+  assert.equal(observed.requestBody.temperature, .1);
+  assert.ok(!JSON.stringify(observed).includes('Authorization'));
+});
+
+test('opt-in is boolean and the bound includes every production parser invocation', async t => {
+  const a = setup(t);
+  const report = await collectRebaselineScores({ ...a.options, live: 'false' }, { complete: async () => assert.fail('string is not opt-in') });
+  assert.equal(report.attempted, 0);
+  const b = setup(t);
+  await assert.rejects(collectRebaselineScores({ ...b.options, maxCalls: 3 }, { complete: async () => assert.fail('oversized budget') }), /call bound/);
+  let calls = 0;
+  await assert.rejects(collectRebaselineScores({ ...b.options, maxCalls: 1 }, { complete: async () => { calls++; return { ...valid(), text: 'malformed' }; } }), /budget exhausted/);
+  assert.equal(calls, 1);
+  await assert.rejects(collectRebaselineScores(resume(b.options), { complete: async () => assert.fail('budget cannot grow on resume') }));
+});
+
+test('observed partial error metadata survives replay without a new invocation', async t => {
+  const { options } = setup(t);
+  const report = await collectRebaselineScores(options, { complete: async () => {
+    const error = new Error('CLI failed');
+    error.studyResult = { effectiveModels: [], identityEvidence: 'unverified', usage: { prompt_tokens: 9, completion_tokens: 0 }, attempts: 1 };
+    throw error;
+  } });
+  assert.equal(report.errors, 1);
+  const replay = await replayCollection(options.output);
+  assert.equal(replay.fullObservedReplay, true);
+});
+
+test('native profile admission remains distinct from server model verification', async t => {
+  const { options, approval, records } = setup(t);
+  const native = { id: 'unit-native', provider: 'kimi', transport: 'kimi-cli', model: 'kimi-code/kimi-for-coding' };
+  write(options.protocol, { schemaVersion: 1, candidates: [native] });
+  options.protocolSha256 = hash(fs.readFileSync(options.protocol)); options.candidateId = native.id;
+  approval.candidateHash = hash(native);
+  Object.assign(approval.decisions[0], { provider: native.provider, transport: native.transport, model: native.model });
+  write(options.approvals, approval);
+  const report = await collectRebaselineScores(options, { complete: async selected => {
+    assert.deepEqual(selected, native);
+    return { ...valid(native.model), identityEvidence: 'cli-request-trace', usageEvidence: 'cli-session-trace', effectiveTemperature: null };
+  } });
+  assert.equal(report.valid, 1);
+  const row = read(resolve(options.output, 'rows', `${records[0].textHash}.private.json`));
+  assert.equal(row.calls[0].profileIdentityVerified, true);
+  assert.equal(row.calls[0].modelIdentityVerified, false);
+  const snapshot = read(resolve(options.output, 'snapshot.private.json'));
+  assert.equal(snapshot.budgetUnit, 'CLI-invocation');
+  assert.equal(snapshot.nativeUpstreamAttemptCountVerified, false);
+  assert.equal((await replayCollection(options.output)).fullObservedReplay, true);
+});

--- a/tests/unit/rebaseline-score-collection.test.js
+++ b/tests/unit/rebaseline-score-collection.test.js
@@ -1,6 +1,8 @@
 import test, { after } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { getEventListeners } from 'node:events';
 import { tmpdir } from 'node:os';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -17,6 +19,7 @@ fs.symlinkSync(resolve(SOURCE_ROOT, 'node_modules'), resolve(ROOT, 'node_modules
 after(() => fs.rmSync(ROOT, { recursive: true, force: true }));
 const { hash, collectRebaselineScores, replayCollection, loadNullableIntake, loadProcessingApproval, validateApprovals, persistPrivate, boundedCompletion, main } =
   await import(pathToFileURL(resolve(ROOT, 'scripts/research/collect-rebaseline-scores.mjs')).href);
+const { getStudyCancellationSignal } = await import(pathToFileURL(resolve(ROOT, 'scripts/research/model-evaluation-transport.mjs')).href);
 const sort = value => Array.isArray(value) ? value.map(sort) : value && typeof value === 'object' ? Object.fromEntries(Object.keys(value).sort().map(key => [key, sort(value[key])])) : value;
 const canonical = value => hash(sort(value));
 const read = path => JSON.parse(fs.readFileSync(path, 'utf8'));
@@ -430,4 +433,116 @@ test('offline replay still rejects actual scorer code changes in the isolated so
     await assert.rejects(replayCollection(options.output), /collector source changed/);
     await assert.rejects(collectRebaselineScores(resume(options), { complete: async () => assert.fail('changed source cannot dispatch') }), /collector source changed/);
   } finally { fs.writeFileSync(path, before); }
+});
+
+// abortStudy is deliberately irreversible. Test real programmatic and process
+// cancellation in child processes, without resetting the production controller.
+const cancellationProgram = String.raw`
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { getEventListeners } from 'node:events';
+import { pathToFileURL } from 'node:url';
+const [root, serializedOptions, mode] = process.argv.slice(1);
+const options = JSON.parse(serializedOptions);
+const collector = await import(pathToFileURL(root + '/scripts/research/collect-rebaseline-scores.mjs').href);
+const transport = await import(pathToFileURL(root + '/scripts/research/model-evaluation-transport.mjs').href);
+const candidate = JSON.parse(fs.readFileSync(options.protocol)).candidates[0];
+const signal = transport.getStudyCancellationSignal();
+let fetchCalls = 0, activeSignal;
+if (mode === 'already' || mode === 'attach-race') {
+  globalThis.fetch = async () => { fetchCalls++; assert.fail('cancelled before dispatch'); };
+  if (mode === 'already') transport.abortStudy();
+  else {
+    const add = signal.addEventListener.bind(signal);
+    signal.addEventListener = (...args) => { transport.abortStudy(); return add(...args); };
+  }
+  await assert.rejects(collector.boundedCompletion(candidate, 'unit prompt', { temperature: .1, timeoutMs: 1000 }, () => {}),
+    error => transport.safeStudyError(error) === 'study-cancelled');
+  assert.equal(fetchCalls, 0);
+} else {
+  transport.installStudySignals();
+  let ready;
+  const fetchStarted = new Promise(resolve => { ready = resolve; });
+  globalThis.fetch = async (_url, request) => {
+    fetchCalls++; activeSignal = request.signal;
+    return new Promise((_resolve, reject) => {
+      const stop = () => reject(Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }));
+      activeSignal.addEventListener('abort', stop, { once: true });
+      if (activeSignal.aborted) stop();
+      ready();
+    });
+  };
+  const collection = collector.collectRebaselineScores(options);
+  const stopped = assert.rejects(collection, /unresolved journal/);
+  await fetchStarted;
+  if (mode === 'programmatic') transport.abortStudy();
+  else {
+    const cancelled = new Promise(resolve => signal.addEventListener('abort', resolve, { once: true }));
+    process.kill(process.pid, 'SIGTERM');
+    await cancelled;
+  }
+  assert.equal(signal.aborted, true);
+  assert.equal(activeSignal.aborted, true, 'study cancellation must synchronously reach active fetch');
+  await stopped;
+  assert.equal(fetchCalls, 1, 'no later text may dispatch after cancellation');
+  const progress = JSON.parse(fs.readFileSync(options.output + '/progress.private.json'));
+  assert.equal(Object.keys(progress.entries).length, 1);
+  assert.equal(fs.existsSync(options.output + '/rows'), false);
+  const group = fs.readdirSync(options.output + '/wire')[0];
+  const wire = JSON.parse(fs.readFileSync(options.output + '/wire/' + group + '/1.private.json'));
+  assert.equal(wire.state, 'error'); assert.equal(wire.error, 'study-cancelled');
+  assert.equal(wire.errorMetadata.interruption, 'operator-cancelled');
+}
+assert.equal(getEventListeners(signal, 'abort').length, 0, 'per-call cancellation listener must be removed');
+console.log(JSON.stringify({ mode, fetchCalls, globalAborted: signal.aborted, activeFetchAborted: activeSignal?.aborted ?? null }));
+`;
+
+test('programmatic abortStudy and real SIGTERM abort active HTTP fetch and stop later texts', t => {
+  for (const mode of ['programmatic', 'sigterm']) {
+    const { options } = setup(t, 2); options.timeoutMs = 5000;
+    const result = execFileSync(process.execPath, ['--input-type=module', '-e', cancellationProgram, ROOT, JSON.stringify(options), mode], { encoding: 'utf8', timeout: 15000 });
+    const evidence = JSON.parse(result);
+    assert.equal(evidence.fetchCalls, 1); assert.equal(evidence.globalAborted, true); assert.equal(evidence.activeFetchAborted, true);
+  }
+});
+
+test('already-aborted and listener-installation races dispatch zero HTTP requests', t => {
+  for (const mode of ['already', 'attach-race']) {
+    const { options } = setup(t);
+    const result = execFileSync(process.execPath, ['--input-type=module', '-e', cancellationProgram, ROOT, JSON.stringify(options), mode], { encoding: 'utf8', timeout: 10000 });
+    assert.equal(JSON.parse(result).fetchCalls, 0);
+  }
+});
+
+test('ordinary deadlines and network AbortError are recorded errors and the cohort continues', async t => {
+  const previous = globalThis.fetch; t.after(() => { globalThis.fetch = previous; });
+  const signal = getStudyCancellationSignal();
+  const baseline = getEventListeners(signal, 'abort').length;
+  for (const cause of ['deadline', 'network']) {
+    const { options, records } = setup(t, 2); options.timeoutMs = 1000;
+    let calls = 0, firstSignal;
+    globalThis.fetch = async (_url, request) => {
+      calls++;
+      if (calls === 1) {
+        firstSignal = request.signal;
+        if (cause === 'network') throw Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+        return new Promise((_resolve, reject) => firstSignal.addEventListener('abort', () => {
+          reject(Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }));
+        }, { once: true }));
+      }
+      return new Response(JSON.stringify({ model: candidate.model, choices: [{ message: { content: valid().text } }] }), { status: 200 });
+    };
+    const report = await collectRebaselineScores(options);
+    assert.equal(calls, 2); assert.equal(report.attempted, 2); assert.equal(report.errors, 1); assert.equal(report.valid, 1);
+    assert.equal(signal.aborted, false);
+    assert.equal(firstSignal.aborted, cause === 'deadline');
+    assert.equal(getEventListeners(signal, 'abort').length, baseline);
+    const row = read(resolve(options.output, 'rows', `${records[0].textHash}.private.json`));
+    assert.equal(row.error, cause === 'deadline' ? 'request-timeout' : 'study-call-failed');
+    assert.equal(row.overall, null);
+    const wire = paths(resolve(options.output, 'wire')).map(read).find(entry => entry.textHash === records[0].textHash);
+    assert.equal(wire.state, 'error'); assert.equal(wire.errorMetadata.interruption, cause);
+    assert.equal(read(resolve(options.output, 'rows', `${records[1].textHash}.private.json`)).status, 'ok');
+    assert.equal((await replayCollection(options.output)).fullObservedReplay, true);
+  }
 });

--- a/tests/unit/rebaseline-score-collection.test.js
+++ b/tests/unit/rebaseline-score-collection.test.js
@@ -1,13 +1,22 @@
-import test from 'node:test';
+import test, { after } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { loadLexicon } from '../../src/features/lexicon.js';
-import { hash, collectRebaselineScores, replayCollection, loadNullableIntake, persistPrivate, boundedCompletion, main } from '../../scripts/research/collect-rebaseline-scores.mjs';
-
-const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+// Source hashes are part of the behavior under test. A private source copy
+// keeps concurrent repository tests from changing this suite's frozen inputs.
+const SOURCE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const ROOT = fs.mkdtempSync(resolve(tmpdir(), 'patina-rebaseline-test-source-'));
+for (const name of ['package.json', '.patina.default.yaml', 'src', 'patterns', 'core', 'document-types', 'lexicon', 'personas', 'scripts/research', 'tests/quality']) {
+  const destination = resolve(ROOT, name); fs.mkdirSync(dirname(destination), { recursive: true });
+  fs.cpSync(resolve(SOURCE_ROOT, name), destination, { recursive: true });
+}
+fs.symlinkSync(resolve(SOURCE_ROOT, 'node_modules'), resolve(ROOT, 'node_modules'), 'dir');
+after(() => fs.rmSync(ROOT, { recursive: true, force: true }));
+const { hash, collectRebaselineScores, replayCollection, loadNullableIntake, loadProcessingApproval, validateApprovals, persistPrivate, boundedCompletion, main } =
+  await import(pathToFileURL(resolve(ROOT, 'scripts/research/collect-rebaseline-scores.mjs')).href);
 const sort = value => Array.isArray(value) ? value.map(sort) : value && typeof value === 'object' ? Object.fromEntries(Object.keys(value).sort().map(key => [key, sort(value[key])])) : value;
 const canonical = value => hash(sort(value));
 const read = path => JSON.parse(fs.readFileSync(path, 'utf8'));
@@ -295,4 +304,130 @@ test('a dataset genre in pinned config.register is rejected instead of treated a
   const config = fs.readFileSync(options.config, 'utf8').replace(/^register:.*$/m, 'register: marketing');
   options.config = resolve(root, 'invalid-register.yaml'); fs.writeFileSync(options.config, config);
   await assert.rejects(collectRebaselineScores(options, { complete: async () => assert.fail('invalid register cannot dispatch') }), /delivery-register axis/);
+});
+
+function parentSetup(t, count = 2) {
+  const base = setup(t, count), { options, root, records } = base;
+  const gemini = { id: 'gemini-3.7', provider: 'gemini', transport: 'opencodex', baseURL: 'http://127.0.0.1:10100/v1', model: 'google-antigravity/gemini-3.7-flash' };
+  records.forEach(record => {
+    record.origins[0].sourceUrl = 'https://source.invalid/DO_NOT_SEND_SOURCE_URL';
+    record.origins[0].priorReceipt = { prompt: 'DO_NOT_SEND_PRIOR_PROMPT', text: 'DO_NOT_SEND_PRIOR_RECEIPT' };
+    record.origins[0].fullSourceDocument = 'DO_NOT_SEND_FULL_SOURCE_DOCUMENT';
+    record.labels.generator = ['DO_NOT_SEND_GENERATOR_ID'];
+  });
+  const intake = read(resolve(options.intake, 'intake.private.json')); intake.records = records;
+  write(resolve(options.intake, 'intake.private.json'), intake);
+  const summary = read(resolve(options.intake, 'summary.json'));
+  summary.intakeHash = canonical(intake); summary.manifestHash = canonical(records);
+  write(resolve(options.intake, 'summary.json'), summary);
+  const payloadBoundary = 'Only approved text and necessary scoring instructions; no provenance metadata.';
+  const review = { schemaVersion: 1, status: 'pending-parent-review-before-any-live-call', scope: { id: 'private-benchmark-scoring-only', allowedCorpusSize: count, payloadBoundary },
+    bundle: { intakeSemanticHash: summary.intakeHash, manifestHash: summary.manifestHash,
+      fileSha256: Object.fromEntries(['intake.private.json', 'summary.json', 'source-index.private.json'].map(name => [name, hash(fs.readFileSync(resolve(options.intake, name)))])) },
+    summary: { parentApprovalRecorded: false, noCallsAuthorizedByThisWorker: true },
+    records: records.map(record => ({ textHash: record.textHash, recordId: record.id, decision: 'approve', scope: 'private-benchmark-scoring-only',
+      parentReviewRequiredBeforeLiveCall: true, deferredReasons: [], bindingEvidence: { verified: true },
+      preservedMetadata: Object.fromEntries(['language', 'register', 'documentType', 'chars', 'originKind', 'contextConflict', 'rights', 'labels', 'eligibleForClaims'].filter(key => Object.hasOwn(record, key)).map(key => [key, record[key]])) })) };
+  const reviewPath = resolve(root, 'processing-review.private.json'); write(reviewPath, review);
+  const parent = { schemaVersion: 1, status: 'parent-approved-for-private-benchmark-scoring', parentApproved: true, approvedAt: '2026-09-05T00:00:00Z',
+    reviewPath, reviewHash: hash(fs.readFileSync(reviewPath)), scope: 'private-benchmark-scoring-only', authority: 'synthetic unit-test parent approval',
+    approvedTextHashes: records.map(record => record.textHash).reverse(), candidate: gemini, logicalObservationLimit: count, repeats: 1,
+    retryPolicy: 'Only bounded receipted parser retries; no quality replacements', payloadBoundary,
+    unknownsPreserved: { humanQuality: null, perceivedAiPolish: null, expectedShortFormTells: null, editingActor: null, editDepth: null, eligibleForClaims: false, classifierTruthAssigned: false, humanRatingsCreated: 0 },
+    notAuthorized: ['raw-publication', 'training-or-finetuning-job', 'changed-or-unlisted-texts', 'human-authorship-or-quality-labels'] };
+  write(options.protocol, { schemaVersion: 1, candidates: [gemini] }); options.protocolSha256 = hash(fs.readFileSync(options.protocol)); options.candidateId = gemini.id;
+  write(options.approvals, parent);
+  const config = fs.readFileSync(options.config, 'utf8') + '\nauditOnly: DO_NOT_SEND_UNRELATED_CONFIG\n';
+  options.config = resolve(root, 'parent-pinned-config.yaml'); fs.writeFileSync(options.config, config);
+  return { ...base, gemini, parent, review, reviewPath };
+}
+
+test('parent approval is consumed losslessly and only approved text/scoring instructions reach HTTP', async t => {
+  const { options, parent, reviewPath, records, gemini } = parentSetup(t);
+  const approvalBytes = fs.readFileSync(options.approvals, 'utf8'), reviewBytes = fs.readFileSync(reviewPath, 'utf8');
+  const previous = globalThis.fetch; t.after(() => { globalThis.fetch = previous; });
+  const sentTexts = [];
+  globalThis.fetch = async (url, request) => {
+    assert.equal(url, gemini.baseURL + '/chat/completions');
+    const body = JSON.parse(request.body);
+    assert.deepEqual(Object.keys(body), ['model', 'messages', 'temperature']);
+    assert.equal(body.model, gemini.model); assert.equal(body.messages.length, 1);
+    assert.equal(body.messages[0].role, 'user');
+    const matches = records.filter(record => body.messages[0].content.includes(record.text));
+    assert.equal(matches.length, 1); sentTexts.push(matches[0].textHash);
+    for (const marker of ['DO_NOT_SEND_SOURCE_URL', 'DO_NOT_SEND_PRIOR_PROMPT', 'DO_NOT_SEND_PRIOR_RECEIPT', 'DO_NOT_SEND_FULL_SOURCE_DOCUMENT', 'DO_NOT_SEND_GENERATOR_ID', 'DO_NOT_SEND_UNRELATED_CONFIG', 'DO_NOT_SEND_PRIOR_COMPLETION', 'sourceIndex', 'approvedTextHashes', 'reviewHash']) assert.ok(!request.body.includes(marker));
+    return new Response(JSON.stringify({ model: gemini.model, usage: { prompt_tokens: 10, completion_tokens: 10 }, choices: [{ message: { content: sentTexts.length === 1 ? 'DO_NOT_SEND_PRIOR_COMPLETION' : valid().text } }] }), { status: 200 });
+  };
+  const report = await collectRebaselineScores(options);
+  assert.equal(report.attempted, records.length); assert.equal(report.valid, records.length);
+  assert.deepEqual(sentTexts, [parent.approvedTextHashes[0], ...parent.approvedTextHashes]);
+  const snapshot = read(resolve(options.output, 'snapshot.private.json'));
+  assert.deepEqual(snapshot.approvals, parent);
+  assert.equal(snapshot.approvalSource.approvalBytes, approvalBytes);
+  assert.equal(snapshot.approvalSource.approvalSha256, hash(approvalBytes));
+  assert.equal(snapshot.approvalSource.reviewBytes, reviewBytes);
+  assert.equal(snapshot.approvalSource.reviewSha256, parent.reviewHash);
+  assert.deepEqual(snapshot.matrix, parent.approvedTextHashes);
+  assert.equal(JSON.parse(snapshot.approvalSource.reviewBytes).summary.parentApprovalRecorded, false);
+  assert.ok(snapshot.records.every(record => record.rights.status === 'needs-review' && record.labels.humanQuality === null));
+  assert.ok(Object.values(snapshot.targetLabels).every(value => value === null));
+  globalThis.fetch = async () => assert.fail('offline replay must not send a request');
+  assert.equal((await replayCollection(options.output)).fullObservedReplay, true);
+  assert.equal(fs.readFileSync(options.approvals, 'utf8'), approvalBytes);
+  assert.equal(fs.readFileSync(reviewPath, 'utf8'), reviewBytes);
+});
+
+test('parent/review mismatches, deferred decisions, changed texts and expanded passes cannot dispatch', async t => {
+  for (const variant of ['no-parent', 'review-hash', 'deferred', 'duplicate-hash', 'unlisted-hash', 'route', 'repeat', 'limit', 'provenance', 'bundle-bytes']) {
+    const { options, parent, review, reviewPath } = parentSetup(t);
+    if (variant === 'no-parent') parent.parentApproved = false;
+    if (variant === 'review-hash') parent.reviewHash = hash('not the review');
+    if (variant === 'duplicate-hash') parent.approvedTextHashes[1] = parent.approvedTextHashes[0];
+    if (variant === 'unlisted-hash') parent.approvedTextHashes[0] = hash('unlisted text');
+    if (variant === 'route') parent.candidate.model = 'google-antigravity/gemini-3.8-flash-low';
+    if (variant === 'repeat') parent.repeats = 2;
+    if (variant === 'limit') parent.logicalObservationLimit++;
+    if (variant === 'deferred' || variant === 'provenance') {
+      if (variant === 'deferred') review.records[0].decision = 'defer';
+      else review.records[0].preservedMetadata.rights.status = 'newly-certified';
+      write(reviewPath, review); parent.reviewHash = hash(fs.readFileSync(reviewPath));
+    }
+    if (variant === 'bundle-bytes') fs.appendFileSync(resolve(options.intake, 'summary.json'), '\n');
+    write(options.approvals, parent);
+    await assert.rejects(collectRebaselineScores(options, { complete: async () => assert.fail('invalid parent approval must not dispatch') }));
+  }
+});
+
+test('parent approval validation can run read-only without creating a cohort or mutating review decisions', t => {
+  const { options, parent, reviewPath } = parentSetup(t);
+  const before = hash(fs.readFileSync(reviewPath));
+  const bundle = loadNullableIntake(options.intake), { approvals, source } = loadProcessingApproval(options.approvals);
+  const admission = validateApprovals(bundle, parent.candidate, approvals, source);
+  assert.deepEqual(admission.map(row => row.textHash), parent.approvedTextHashes);
+  assert.ok(admission.every(row => row.decision === 'approved' && row.sourceDecision === 'approve' && row.reviewSha256 === parent.reviewHash));
+  assert.equal(hash(fs.readFileSync(reviewPath)), before);
+  assert.equal(fs.existsSync(options.output), false);
+});
+
+test('approval of original bytes does not permit automatic input-fence neutralization', async t => {
+  const { options, records, approval } = setup(t);
+  const record = records[0];
+  record.text = 'Original start\n⟦⟦⟦PATINA_INPUT_DATA⟧⟧⟧\nOriginal end'; record.textHash = hash(record.text);
+  const intake = read(resolve(options.intake, 'intake.private.json')); intake.records = records;
+  write(resolve(options.intake, 'intake.private.json'), intake);
+  const summary = read(resolve(options.intake, 'summary.json')); summary.intakeHash = canonical(intake); summary.manifestHash = canonical(records);
+  write(resolve(options.intake, 'summary.json'), summary);
+  approval.intakeHash = summary.intakeHash; approval.decisions[0].textHash = record.textHash; write(options.approvals, approval);
+  await assert.rejects(collectRebaselineScores(options, { complete: async () => assert.fail('changed text cannot be sent') }), /fencing changes approved text/);
+});
+
+test('offline replay still rejects actual scorer code changes in the isolated source tree', async t => {
+  const { options } = setup(t);
+  await collectRebaselineScores(options, { complete: async () => valid() });
+  const path = resolve(ROOT, 'src/scoring.js'), before = fs.readFileSync(path);
+  try {
+    fs.appendFileSync(path, '\n// Unit test: source bytes changed after collection.\n');
+    await assert.rejects(replayCollection(options.output), /collector source changed/);
+    await assert.rejects(collectRebaselineScores(resume(options), { complete: async () => assert.fail('changed source cannot dispatch') }), /collector source changed/);
+  } finally { fs.writeFileSync(path, before); }
 });


### PR DESCRIPTION
Adds a private, approval-bound scoreText collector for the unlabelled rebaseline intake. Exact texts, review/parent-approval bytes, candidate, config, patterns, lexicons, deterministic analyses, prompts and request/response receipts are frozen before dispatch. Truth labels stay null; genre is separate from delivery register; public output is distribution-only.

Cancellation aborts active requests. Deadlines persist timeout rows and continue. Validated notStarted journal receipts need no wire dispatch, and receipt-only replay/resume never creates replacement requests. Old prepared snapshots remain unchanged.

Validation: full1,930 tests passed,2 skipped; lint clean. Independent Astra/xhigh review passed29 targeted tests and reproductions for operator cancellation, deadline continuation, one-fetch/two-journal/one-wire recovery, row-write failure and zero replacement calls.

Parent-approved85-text Gemini/OpenCodex pass is now executing from frozen a5bef6d; local source remains frozen through replay. This patch does not claim completed human evaluation, authorship labels, redistribution rights, or FNR gates. Supports #412.
