### PR TITLE
research: publish audited rebaseline score distributions

### DIFF
--- a/docs/benchmarks/live-rebaseline-20260905.json
+++ b/docs/benchmarks/live-rebaseline-20260905.json
@@ -1,0 +1,276 @@
+{
+  "schemaVersion": 1,
+  "study": "patina-live-rebaseline-20260905",
+  "asOfDate": "2026-09-05",
+  "candidate": {
+    "id": "gemini-3.7",
+    "model": "google-antigravity/gemini-3.7-flash",
+    "transport": "OpenCodex loopback"
+  },
+  "sourceCommit": "a5bef6d20d4767b54757a4c338276f01ebfa7573",
+  "scope": "Private, nullable-label score distributions; not authorship or human-quality evaluation",
+  "sourceComposition": {
+    "recordedModelOutputs": 35,
+    "publisherExcerptsWithUnverifiedAuthorship": 50,
+    "uniqueTexts": 85
+  },
+  "observations": {
+    "protocolHash": "9a7910f04362a408106e90d319ecb1242dde12b5776789ba7ed1855521e90e09",
+    "fullObservedReplay": true,
+    "schemaVersion": 1,
+    "scope": "unlabelled-score-distributions-only",
+    "candidateId": "gemini-3.7",
+    "denominator": 85,
+    "approved": 85,
+    "excluded": 0,
+    "attempted": 85,
+    "valid": 85,
+    "errors": 0,
+    "errorClasses": {},
+    "distributions": {
+      "overall": {
+        "n": 85,
+        "min": 0,
+        "median": 0,
+        "mean": 1.6148235294117645,
+        "p95": 10.55,
+        "max": 16.95
+      },
+      "rawLlm": {
+        "n": 85,
+        "min": 0,
+        "median": 0,
+        "mean": 1.6148235294117645,
+        "p95": 10.55,
+        "max": 16.95
+      },
+      "deterministic": {
+        "n": 85,
+        "min": 0,
+        "median": 0,
+        "mean": 5.310588235294118,
+        "p95": 50,
+        "max": 100
+      }
+    },
+    "languages": {
+      "ko": {
+        "attempted": 68,
+        "valid": 68,
+        "errors": 0,
+        "overall": {
+          "n": 68,
+          "min": 0,
+          "median": 0,
+          "mean": 1.717205882352941,
+          "p95": 11.11,
+          "max": 16.95
+        },
+        "rawLlm": {
+          "n": 68,
+          "min": 0,
+          "median": 0,
+          "mean": 1.717205882352941,
+          "p95": 11.11,
+          "max": 16.95
+        },
+        "deterministic": {
+          "n": 68,
+          "min": 0,
+          "median": 0,
+          "mean": 5.882352941176471,
+          "p95": 50,
+          "max": 100
+        },
+        "packs": {
+          "communication": {
+            "n": 68,
+            "min": 0,
+            "median": 0,
+            "mean": 0,
+            "p95": 0,
+            "max": 0,
+            "missing": 0
+          },
+          "content": {
+            "n": 68,
+            "min": 0,
+            "median": 0,
+            "mean": 3.7579411764705886,
+            "p95": 27.78,
+            "max": 33.33,
+            "missing": 0
+          },
+          "filler": {
+            "n": 68,
+            "min": 0,
+            "median": 0,
+            "mean": 1.0623529411764707,
+            "p95": 5.56,
+            "max": 16.67,
+            "missing": 0
+          },
+          "language": {
+            "n": 68,
+            "min": 0,
+            "median": 0,
+            "mean": 1.961764705882353,
+            "p95": 16.67,
+            "max": 16.67,
+            "missing": 0
+          },
+          "structure": {
+            "n": 68,
+            "min": 0,
+            "median": 0,
+            "mean": 1.5694117647058825,
+            "p95": 6.7,
+            "max": 26.67,
+            "missing": 0
+          },
+          "style": {
+            "n": 68,
+            "min": 0,
+            "median": 0,
+            "mean": 0.31499999999999995,
+            "p95": 0,
+            "max": 7.14,
+            "missing": 0
+          },
+          "viral-hook": {
+            "n": 68,
+            "min": 0,
+            "median": 0,
+            "mean": 3.1050000000000004,
+            "p95": 22.22,
+            "max": 27.8,
+            "missing": 0
+          }
+        }
+      },
+      "en": {
+        "attempted": 17,
+        "valid": 17,
+        "errors": 0,
+        "overall": {
+          "n": 17,
+          "min": 0,
+          "median": 0,
+          "mean": 1.2052941176470588,
+          "p95": 4.76,
+          "max": 4.76
+        },
+        "rawLlm": {
+          "n": 17,
+          "min": 0,
+          "median": 0,
+          "mean": 1.2052941176470588,
+          "p95": 4.76,
+          "max": 4.76
+        },
+        "deterministic": {
+          "n": 17,
+          "min": 0,
+          "median": 0,
+          "mean": 3.023529411764706,
+          "p95": 50,
+          "max": 50
+        },
+        "packs": {
+          "communication": {
+            "n": 17,
+            "min": 0,
+            "median": 0,
+            "mean": 0,
+            "p95": 0,
+            "max": 0,
+            "missing": 0
+          },
+          "content": {
+            "n": 17,
+            "min": 0,
+            "median": 0,
+            "mean": 2.6147058823529408,
+            "p95": 11.11,
+            "max": 11.11,
+            "missing": 0
+          },
+          "filler": {
+            "n": 17,
+            "min": 0,
+            "median": 0,
+            "mean": 1.308235294117647,
+            "p95": 5.56,
+            "max": 5.56,
+            "missing": 0
+          },
+          "language": {
+            "n": 17,
+            "min": 0,
+            "median": 0,
+            "mean": 0.32705882352941174,
+            "p95": 5.56,
+            "max": 5.56,
+            "missing": 0
+          },
+          "structure": {
+            "n": 17,
+            "min": 0,
+            "median": 0,
+            "mean": 0,
+            "p95": 0,
+            "max": 0,
+            "missing": 0
+          },
+          "style": {
+            "n": 17,
+            "min": 0,
+            "median": 0,
+            "mean": 1.2599999999999998,
+            "p95": 7.14,
+            "max": 7.14,
+            "missing": 0
+          },
+          "viral-hook": {
+            "n": 17,
+            "min": 0,
+            "median": 0,
+            "mean": 2.6147058823529408,
+            "p95": 11.11,
+            "max": 11.11,
+            "missing": 0
+          }
+        }
+      }
+    },
+    "classificationMetrics": null,
+    "humanQualityRatings": null
+  },
+  "commitments": {
+    "snapshot": "ba8ffe2c448b16f1e0e0e3a362717501d3cce5cfb466677701ff578250c15b7d",
+    "progress": "98d0e6d894d7e7c7a29ad355a01f5d2bb18eeb8a9d3dbb7f288d95470e23e844",
+    "summary": "cd4a3906319c2d819b9a08a616f5a55383c07eb5fd99e836ac8ff131ac9e461e",
+    "replayReport": "e6597c1acc64c7c1c9d6d9ea8fe2cc93bb335a082325fb69ade8c76add13fade",
+    "rows": {
+      "files": 85,
+      "sha256": "9765761326c072fa8d0ee6ed4e0b53cfdf1258d5f1969c45768846dfb54367d4"
+    },
+    "wire": {
+      "files": 85,
+      "sha256": "60c59a32b3499459e147a14b6346b98c2e25d64b37eaddf25c23cb9f945ff161"
+    },
+    "journal": {
+      "files": 85,
+      "sha256": "4cc3e5542934849e81daa9269294bd8c3d66a754505deade7b455513a30fa1f6"
+    }
+  },
+  "commitmentEncoding": "SHA-256 of UTF-8 sorted-key compact JSON arrays of relative path and file SHA-256; filenames sorted lexicographically.",
+  "limitations": [
+    "No authenticated human-origin, human polish, meaning-review or tell labels were assigned.",
+    "The source distribution is17 EN and68 KO; repeats/excerpts from shared sources are dependent.",
+    "Approval covers private scoring only, not public text redistribution or a new training job.",
+    "Proxy response model labels and client controls do not independently prove upstream model, effort, retry count or cost.",
+    "Corpus distributions are diagnostics, not FNR/FPR/AUC or CI thresholds.",
+    "Exact replay requires the private frozen bundle and recorded source commit. No new model request is made by replay."
+  ]
+}

--- a/docs/benchmarks/live-rebaseline-20260905.md
+++ b/docs/benchmarks/live-rebaseline-20260905.md
@@ -1,0 +1,58 @@
+# Live rebaseline score distributions — September 5, 2026
+
+All **85 approved texts produced valid score observations**, with zero observed errors. The complete captured-input replay passed without another model call.
+
+This is the rebaseline companion to the [49-fixture live scorer report](live-scorer-20260905.md). It exercises production `scoreText` with an explicit Gemini 3.7 route through the loopback OpenCodex proxy. The [JSON companion](live-rebaseline-20260905.json) preserves full-precision statistics and integrity commitments.
+
+## Input and measurement scope
+
+The private intake contains 35 recorded model outputs and 50 publisher excerpts whose human authorship remains unverified. There are 17 English and 68 Korean texts. Selection and exact-text processing approvals preceded scoring. Source rights and quality labels remain unresolved; approval did not create human-negative or AI-positive ground truth.
+
+Document type comes from the pinned configuration or an explicit intake declaration. Dataset genre is kept separate from the CLI delivery-register axis. No generator identity, source URL, old receipt, or quality label was sent as scoring evidence.
+
+| Language | Valid / attempted | Overall mean / median / p95 | Raw LLM mean / median / p95 | Deterministic mean / median / p95 |
+|---|---:|---:|---:|---:|
+| ko | 68/68 | 1.717 / 0.000 / 11.110 | 1.717 / 0.000 / 11.110 | 5.882 / 0.000 / 50.000 |
+| en | 17/17 | 1.205 / 0.000 / 4.760 | 1.205 / 0.000 / 4.760 | 3.024 / 0.000 / 50.000 |
+
+## Pattern-pack distributions
+
+These are recorded category scores, not individual-pattern accuracy. Missing values are counted rather than replaced with zero.
+
+| Language | Pack | n | Missing | Mean | Median | p95 | Maximum |
+|---|---|---:|---:|---:|---:|---:|---:|
+| ko | communication | 68 | 0 | 0.000 | 0.000 | 0.000 | 0.000 |
+| ko | content | 68 | 0 | 3.758 | 0.000 | 27.780 | 33.330 |
+| ko | filler | 68 | 0 | 1.062 | 0.000 | 5.560 | 16.670 |
+| ko | language | 68 | 0 | 1.962 | 0.000 | 16.670 | 16.670 |
+| ko | structure | 68 | 0 | 1.569 | 0.000 | 6.700 | 26.670 |
+| ko | style | 68 | 0 | 0.315 | 0.000 | 0.000 | 7.140 |
+| ko | viral-hook | 68 | 0 | 3.105 | 0.000 | 22.220 | 27.800 |
+| en | communication | 17 | 0 | 0.000 | 0.000 | 0.000 | 0.000 |
+| en | content | 17 | 0 | 2.615 | 0.000 | 11.110 | 11.110 |
+| en | filler | 17 | 0 | 1.308 | 0.000 | 5.560 | 5.560 |
+| en | language | 17 | 0 | 0.327 | 0.000 | 5.560 | 5.560 |
+| en | structure | 17 | 0 | 0.000 | 0.000 | 0.000 | 0.000 |
+| en | style | 17 | 0 | 1.260 | 0.000 | 7.140 | 7.140 |
+| en | viral-hook | 17 | 0 | 2.615 | 0.000 | 11.110 | 11.110 |
+
+## Evidence and reproduction
+
+Protocol: `9a7910f04362a408106e90d319ecb1242dde12b5776789ba7ed1855521e90e09`. Source commit: `a5bef6d20d4767b54757a4c338276f01ebfa7573`.
+
+The frozen snapshot contains the exact configuration, patterns, lexicons, deterministic analyses, approved texts, expected prompts and request controls. Each observation has a bound wire record, scorer journal and complete production result. All 85 rows were replayed against those captured inputs; labels remained null and no replacement requests were issued.
+
+The original approval and review bytes are retained privately. The public JSON exposes hashes and counts only. Raw texts, URLs, source records, prompts, responses and credentials are not published.
+
+Use the [private collection runbook](../research/rebaseline-score-collection-20260905.md) from the recorded source commit with the frozen private output. `--replay` reads existing snapshots and receipts without a provider call; `--live` is a separate explicit opt-in.
+
+## Limits
+
+- No human ratings or authenticated authorship labels are present. FNR, FPR, AUC and human-quality metrics remain undefined.
+- Texts from a shared source are dependent. These distributions support no population-confidence or independent-sample claim.
+- A low score means fewer measured writing patterns under this configuration, not proof of human authorship.
+- The recorded proxy route does not establish the upstream model revision, applied effort, internal retry count or actual charge.
+- Public reproduction of the private text collection is not authorized by this report. Operators with the approved frozen bundle can replay the exact observations.
+- This diagnostic run is not a mandatory CI score gate or a replacement for the deterministic benchmark.
+
+Issue #412 now has actual fixture and rebaseline score distributions. The genuine-human and labelled short-form requirements tracked in #159 and #643 remain separate and unfinished.

--- a/tests/quality/README.md
+++ b/tests/quality/README.md
@@ -51,6 +51,15 @@ analyzer). They only affect the hot/cold decision through the conservative
 
 Per-language metrics use `expected_hot=true` as the positive class.
 
+## Opt-in live scoring
+
+The [live scorer report](../../docs/benchmarks/live-scorer-20260905.md) covers
+931 observations on 49 curated fixtures. The [private rebaseline report](../../docs/benchmarks/live-rebaseline-20260905.md) adds 85 nullable-label
+observations with captured-input replay. Both report language and pattern-pack
+distributions; they do not establish human-authorship accuracy or add a CI gate.
+See the [collection runbook](../../docs/research/rebaseline-score-collection-20260905.md)
+for explicit preparation, approval, execution and receipt-only replay.
+
 ## Opt-in live rewrite quality
 
 `npm run quality:live` runs the live-quality runner without calling a model by


### PR DESCRIPTION
Publishes distribution-only results from the approved85-text private rebaseline scoring pass: all85 observations valid, zero errors, full captured-input replay with no new calls. Public JSON and tables contain only aggregate statistics and integrity commitments. Raw texts, prompts, URLs, responses and approval contents stay private.

Together with the existing931-observation fixture report, this completes #412’s opt-in diagnostic scope. Unknown authorship, rights and quality labels remain unchanged; #159/#643 and their human/gold-label requirements remain unfinished. No CI score gate or runtime default changes.

Validation: full2,004 tests passed,2 skipped; lint and prose gate passed. Independent Astra/xhigh review verifiedall85 rows,approval/snapshot/172codehashes,16table rows and7commitments; no private payload leaked.
