### PR TITLE
docs: provide a qualified task-specific model guide

### DIFF
--- a/docs/research/model-guide-20260905.json
+++ b/docs/research/model-guide-20260905.json
@@ -1,0 +1,941 @@
+{
+  "schemaVersion": 1,
+  "date": "2026-09-05",
+  "timezone": "Asia/Seoul",
+  "language": "ko",
+  "status": "qualified-within-provider-task-guide",
+  "scope": "Recorded Patina task comparisons and documentation shortlists; no absolute six-model ranking.",
+  "sources": [
+    {
+      "id": "rewrite-confirmation",
+      "path": "model-rewrite-confirmation-20260905.json",
+      "report": "model-rewrite-confirmation-20260905.md",
+      "sha256": "67628d6ceb709d480f43ac8c6c872e8021c617b6d33c04dbe81f13232697ea55"
+    },
+    {
+      "id": "pattern-scorer-prior",
+      "path": "../benchmarks/live-scorer-20260905.json",
+      "report": "../benchmarks/live-scorer-20260905.md",
+      "sha256": "1b4a9e74ba41a54bd41e84a1d8db4d4c8f71a322ff95530e94deabe263260901"
+    },
+    {
+      "id": "provider-openai-anthropic",
+      "path": "provider-openai-anthropic-20260905.json",
+      "report": "provider-openai-anthropic-20260905.md",
+      "sha256": "f6e851e5fee296f4e8f9f71669ee6ab2199942ee42127938e32dcad5f6329fb0"
+    },
+    {
+      "id": "provider-gemini-kimi-deepseek",
+      "path": "provider-gemini-kimi-deepseek-20260905.json",
+      "report": "provider-gemini-kimi-deepseek-20260905.md",
+      "sha256": "9d9e1fc2e3077287a4929901b2c1dadafe249d7f1d8904d63e55f6ad5d32b5dc"
+    },
+    {
+      "id": "provider-groq-together-minimax",
+      "path": "provider-groq-together-minimax-20260905.json",
+      "report": "provider-groq-together-minimax-20260905.md",
+      "sha256": "53b2e35b12bc7ef12c88e1b84586d9d261fbac6683e9fe2f402aa63760e3c681"
+    }
+  ],
+  "rewrite": {
+    "sourceReportCommit": "ef4c454660d5646c41880b7713e8bf892e0efc05",
+    "source": "rewrite-confirmation",
+    "uniqueFixtures": 34,
+    "repeatsPerFixture": 3,
+    "attemptedPerCandidate": 102,
+    "selectionRule": [
+      "safe-rate descending",
+      "median paired model-rated naturalness descending",
+      "generation latency median ascending"
+    ],
+    "safeDefinition": "Numeric proxy pass plus two configured different-upstream-family valid judgments, each MPS/fidelity >=90 and zero hard failures. All attempts remain in the denominator.",
+    "uncertainty": "5000 paired fixture-cluster resamples within language; selected fixtures, unadjusted descriptive intervals.",
+    "recommendations": [
+      {
+        "provider": "openai",
+        "preferredCandidate": "openai-astra",
+        "alternativeCandidate": "openai-terra",
+        "confidence": "moderate-within-observed-fixtures",
+        "candidates": [
+          {
+            "identity": {
+              "candidateId": "openai-astra",
+              "requestedModel": "gpt-6-astra",
+              "transport": "opencodex",
+              "requestedSettings": {
+                "extraBody": {
+                  "reasoning_effort": "low"
+                }
+              },
+              "effectiveEffortVerified": false,
+              "upstreamWeightsVerified": false,
+              "source": {
+                "path": "model-evaluation-20260904.json",
+                "pointer": "/candidates/0"
+              }
+            },
+            "attempted": 102,
+            "safe": 58,
+            "safeRate": 0.5686274509803921,
+            "modelRatedPairNaturalnessMedian": 2.5,
+            "generationSharedLoadMedianMs": 13531,
+            "configuredJudgePanel": [
+              {
+                "candidateId": "gemini-3.7",
+                "requestedModel": "google-antigravity/gemini-3.7-flash",
+                "transport": "opencodex"
+              },
+              {
+                "candidateId": "anthropic-sonnet",
+                "requestedModel": "claude-sonnet-5",
+                "transport": "claude-cli"
+              }
+            ]
+          },
+          {
+            "identity": {
+              "candidateId": "openai-terra",
+              "requestedModel": "gpt-5.6-terra",
+              "transport": "opencodex",
+              "requestedSettings": {
+                "extraBody": {
+                  "reasoning_effort": "low"
+                }
+              },
+              "effectiveEffortVerified": false,
+              "upstreamWeightsVerified": false,
+              "source": {
+                "path": "model-evaluation-20260904.json",
+                "pointer": "/candidates/2"
+              }
+            },
+            "attempted": 102,
+            "safe": 45,
+            "safeRate": 0.4411764705882353,
+            "modelRatedPairNaturalnessMedian": 3,
+            "generationSharedLoadMedianMs": 5320,
+            "configuredJudgePanel": [
+              {
+                "candidateId": "gemini-3.7",
+                "requestedModel": "google-antigravity/gemini-3.7-flash",
+                "transport": "opencodex"
+              },
+              {
+                "candidateId": "anthropic-sonnet",
+                "requestedModel": "claude-sonnet-5",
+                "transport": "claude-cli"
+              }
+            ]
+          }
+        ],
+        "preferredMinusAlternativeSafeRate": 0.12745098039215685,
+        "pairedFixtureInterval95": [
+          0.02941176470588236,
+          0.23529411764705876
+        ],
+        "source": "rewrite-confirmation"
+      },
+      {
+        "provider": "anthropic",
+        "preferredCandidate": "anthropic-sonnet",
+        "alternativeCandidate": "anthropic-fable",
+        "confidence": "low-paired-interval-includes-zero",
+        "candidates": [
+          {
+            "identity": {
+              "candidateId": "anthropic-sonnet",
+              "requestedModel": "claude-sonnet-5",
+              "transport": "claude-cli",
+              "requestedSettings": {
+                "effort": "high"
+              },
+              "effectiveEffortVerified": false,
+              "upstreamWeightsVerified": false,
+              "source": {
+                "path": "model-evaluation-claude-isolated-20260905.json",
+                "pointer": "/candidates/2"
+              }
+            },
+            "attempted": 102,
+            "safe": 42,
+            "safeRate": 0.4117647058823529,
+            "modelRatedPairNaturalnessMedian": 3.5,
+            "generationSharedLoadMedianMs": 8357.5,
+            "configuredJudgePanel": [
+              {
+                "candidateId": "openai-5.5",
+                "requestedModel": "gpt-5.5",
+                "transport": "opencodex"
+              },
+              {
+                "candidateId": "gemini-3.7",
+                "requestedModel": "google-antigravity/gemini-3.7-flash",
+                "transport": "opencodex"
+              }
+            ]
+          },
+          {
+            "identity": {
+              "candidateId": "anthropic-fable",
+              "requestedModel": "claude-fable-5-1",
+              "transport": "claude-cli",
+              "requestedSettings": {
+                "effort": "high"
+              },
+              "effectiveEffortVerified": false,
+              "upstreamWeightsVerified": false,
+              "source": {
+                "path": "model-evaluation-claude-isolated-20260905.json",
+                "pointer": "/candidates/0"
+              }
+            },
+            "attempted": 102,
+            "safe": 36,
+            "safeRate": 0.35294117647058826,
+            "modelRatedPairNaturalnessMedian": 3.5,
+            "generationSharedLoadMedianMs": 17961,
+            "configuredJudgePanel": [
+              {
+                "candidateId": "openai-5.5",
+                "requestedModel": "gpt-5.5",
+                "transport": "opencodex"
+              },
+              {
+                "candidateId": "gemini-3.7",
+                "requestedModel": "google-antigravity/gemini-3.7-flash",
+                "transport": "opencodex"
+              }
+            ]
+          }
+        ],
+        "preferredMinusAlternativeSafeRate": 0.05882352941176466,
+        "pairedFixtureInterval95": [
+          -0.05882352941176472,
+          0.19607843137254902
+        ],
+        "source": "rewrite-confirmation"
+      },
+      {
+        "provider": "gemini",
+        "preferredCandidate": "gemini-3.8-medium",
+        "alternativeCandidate": "gemini-3.8-high",
+        "confidence": "low-route-and-effort-unverified",
+        "candidates": [
+          {
+            "identity": {
+              "candidateId": "gemini-3.8-medium",
+              "requestedModel": "google-antigravity/gemini-3.8-flash-medium",
+              "transport": "opencodex",
+              "requestedSettings": {},
+              "effectiveEffortVerified": false,
+              "upstreamWeightsVerified": false,
+              "source": {
+                "path": "model-evaluation-20260904.json",
+                "pointer": "/candidates/9"
+              }
+            },
+            "attempted": 102,
+            "safe": 18,
+            "safeRate": 0.17647058823529413,
+            "modelRatedPairNaturalnessMedian": 2.5,
+            "generationSharedLoadMedianMs": 8702,
+            "configuredJudgePanel": [
+              {
+                "candidateId": "openai-5.5",
+                "requestedModel": "gpt-5.5",
+                "transport": "opencodex"
+              },
+              {
+                "candidateId": "anthropic-sonnet",
+                "requestedModel": "claude-sonnet-5",
+                "transport": "claude-cli"
+              }
+            ]
+          },
+          {
+            "identity": {
+              "candidateId": "gemini-3.8-high",
+              "requestedModel": "google-antigravity/gemini-3.8-flash-high",
+              "transport": "opencodex",
+              "requestedSettings": {},
+              "effectiveEffortVerified": false,
+              "upstreamWeightsVerified": false,
+              "source": {
+                "path": "model-evaluation-20260904.json",
+                "pointer": "/candidates/10"
+              }
+            },
+            "attempted": 102,
+            "safe": 10,
+            "safeRate": 0.09803921568627451,
+            "modelRatedPairNaturalnessMedian": 2.5,
+            "generationSharedLoadMedianMs": 8492,
+            "configuredJudgePanel": [
+              {
+                "candidateId": "openai-5.5",
+                "requestedModel": "gpt-5.5",
+                "transport": "opencodex"
+              },
+              {
+                "candidateId": "anthropic-sonnet",
+                "requestedModel": "claude-sonnet-5",
+                "transport": "claude-cli"
+              }
+            ]
+          }
+        ],
+        "preferredMinusAlternativeSafeRate": 0.07843137254901962,
+        "pairedFixtureInterval95": [
+          0,
+          0.1568627450980392
+        ],
+        "source": "rewrite-confirmation"
+      }
+    ]
+  },
+  "patternScorer": {
+    "task": "AI-writing-pattern scoreText after deterministic reconciliation; not MPS/fidelity judging or authorship accuracy",
+    "publicPriorSource": "pattern-scorer-prior",
+    "confirmationEvidence": "Independently audited A/C/D aggregate, published here without source rows or private audit material.",
+    "evidenceLimits": {
+      "ac": "Source/receipt/protocol and observed execution commitments verified; complete historical config objects unavailable.",
+      "d": "Full approved V8 inputs and observed scorer replay verified; only aggregate findings are published here."
+    },
+    "uniqueFixtures": 49,
+    "initialMeasurementsPerCandidate": 49,
+    "confirmationMeasurementsPerCandidate": 98,
+    "pooledMeasurementsPerCandidate": 147,
+    "selectionRule": [
+      "valid-output rate descending",
+      "production-score ROC-AUC descending",
+      "all-row latency median ascending"
+    ],
+    "uncertainty": "10000 paired label-stratified fixture-cluster resamples retaining all three observations; exploratory 95% intervals; selection bias uncorrected.",
+    "recommendations": [
+      {
+        "provider": "openai",
+        "preferredCandidate": "openai-5.5",
+        "alternativeCandidate": "openai-terra",
+        "confidence": "moderate-within-observed-fixtures",
+        "confirmationOnlyPreferred": "openai-5.5",
+        "preferredMinusAlternativeAuc": 0.02749907097733184,
+        "pairedFixtureInterval95": [
+          0.0014864362690449884,
+          0.06586770717205503
+        ],
+        "latencyTieBreakUsed": false,
+        "candidates": [
+          {
+            "identity": {
+              "candidateId": "openai-5.5",
+              "requestedModel": "gpt-5.5",
+              "transport": "opencodex",
+              "requestedSettings": {
+                "extraBody": {
+                  "reasoning_effort": "low"
+                }
+              },
+              "effectiveEffortVerified": false,
+              "upstreamWeightsVerified": false,
+              "source": {
+                "path": "model-evaluation-20260904.json",
+                "pointer": "/candidates/4"
+              }
+            },
+            "initial": {
+              "observed": 49,
+              "valid": 49,
+              "rocAuc": 0.9882943143812709,
+              "sharedLoadMedianMs": 14537
+            },
+            "confirmation": {
+              "observed": 98,
+              "valid": 98,
+              "rocAuc": 0.9905936454849499,
+              "sharedLoadMedianMs": 14246.5
+            },
+            "pooled": {
+              "observed": 147,
+              "valid": 147,
+              "rocAuc": 0.9890375325157934,
+              "strictSchemaErrors": 0,
+              "sharedLoadMedianMs": 14463
+            },
+            "perRepeatRocAuc": [
+              0.9882943143812709,
+              0.9949832775919732,
+              0.9899665551839465
+            ],
+            "stability": {
+              "exactScoreStableFixtures": 10,
+              "medianScoreRange": 2.1999999999999997
+            }
+          },
+          {
+            "identity": {
+              "candidateId": "openai-terra",
+              "requestedModel": "gpt-5.6-terra",
+              "transport": "opencodex",
+              "requestedSettings": {
+                "extraBody": {
+                  "reasoning_effort": "low"
+                }
+              },
+              "effectiveEffortVerified": false,
+              "upstreamWeightsVerified": false,
+              "source": {
+                "path": "model-evaluation-20260904.json",
+                "pointer": "/candidates/2"
+              }
+            },
+            "initial": {
+              "observed": 49,
+              "valid": 49,
+              "rocAuc": 0.9949832775919732,
+              "sharedLoadMedianMs": 11480
+            },
+            "confirmation": {
+              "observed": 98,
+              "valid": 98,
+              "rocAuc": 0.9443979933110368,
+              "sharedLoadMedianMs": 11628
+            },
+            "pooled": {
+              "observed": 147,
+              "valid": 147,
+              "rocAuc": 0.9615384615384616,
+              "strictSchemaErrors": 0,
+              "sharedLoadMedianMs": 11484
+            },
+            "perRepeatRocAuc": [
+              0.9949832775919732,
+              0.9297658862876255,
+              0.967391304347826
+            ],
+            "stability": {
+              "exactScoreStableFixtures": 13,
+              "medianScoreRange": 1.2000000000000002
+            }
+          }
+        ]
+      },
+      {
+        "provider": "gemini",
+        "preferredCandidate": "gemini-pro",
+        "alternativeCandidate": "gemini-3.8-low",
+        "confidence": "moderate-within-observed-fixtures",
+        "confirmationOnlyPreferred": "gemini-pro",
+        "preferredMinusAlternativeAuc": 0.20484949832775912,
+        "pairedFixtureInterval95": [
+          0.11343366778149366,
+          0.29803279450018577
+        ],
+        "latencyTieBreakUsed": false,
+        "candidates": [
+          {
+            "identity": {
+              "candidateId": "gemini-pro",
+              "requestedModel": "google-antigravity/gemini-3.1-pro",
+              "transport": "opencodex",
+              "requestedSettings": {},
+              "effectiveEffortVerified": false,
+              "upstreamWeightsVerified": false,
+              "source": {
+                "path": "model-evaluation-20260904.json",
+                "pointer": "/candidates/6"
+              }
+            },
+            "initial": {
+              "observed": 49,
+              "valid": 49,
+              "rocAuc": 0.9765886287625418,
+              "sharedLoadMedianMs": 23135
+            },
+            "confirmation": {
+              "observed": 98,
+              "valid": 98,
+              "rocAuc": 0.977633779264214,
+              "sharedLoadMedianMs": 23939
+            },
+            "pooled": {
+              "observed": 147,
+              "valid": 147,
+              "rocAuc": 0.9774247491638796,
+              "strictSchemaErrors": 0,
+              "sharedLoadMedianMs": 23477
+            },
+            "perRepeatRocAuc": [
+              0.9765886287625418,
+              0.9790969899665551,
+              0.9765886287625418
+            ],
+            "stability": {
+              "exactScoreStableFixtures": 22,
+              "medianScoreRange": 1.4500000000000002
+            }
+          },
+          {
+            "identity": {
+              "candidateId": "gemini-3.8-low",
+              "requestedModel": "google-antigravity/gemini-3.8-flash-low",
+              "transport": "opencodex",
+              "requestedSettings": {},
+              "effectiveEffortVerified": false,
+              "upstreamWeightsVerified": false,
+              "source": {
+                "path": "model-evaluation-20260904.json",
+                "pointer": "/candidates/8"
+              }
+            },
+            "initial": {
+              "observed": 49,
+              "valid": 49,
+              "rocAuc": 0.7993311036789298,
+              "sharedLoadMedianMs": 8853
+            },
+            "confirmation": {
+              "observed": 98,
+              "valid": 98,
+              "rocAuc": 0.7591973244147158,
+              "sharedLoadMedianMs": 8534
+            },
+            "pooled": {
+              "observed": 147,
+              "valid": 147,
+              "rocAuc": 0.7725752508361204,
+              "strictSchemaErrors": 0,
+              "sharedLoadMedianMs": 8741
+            },
+            "perRepeatRocAuc": [
+              0.7993311036789298,
+              0.7591973244147158,
+              0.7591973244147158
+            ],
+            "stability": {
+              "exactScoreStableFixtures": 33,
+              "medianScoreRange": 0
+            }
+          }
+        ]
+      },
+      {
+        "provider": "anthropic",
+        "preferredCandidate": "anthropic-sonnet4.6",
+        "alternativeCandidate": "anthropic-opus",
+        "confidence": "low",
+        "confirmationOnlyPreferred": "anthropic-opus",
+        "preferredMinusAlternativeAuc": 0.0024154589371980784,
+        "pairedFixtureInterval95": [
+          -0.021181716833890918,
+          0.030657748049052417
+        ],
+        "latencyTieBreakUsed": false,
+        "candidates": [
+          {
+            "identity": {
+              "candidateId": "anthropic-sonnet4.6",
+              "requestedModel": "claude-sonnet-4-6",
+              "transport": "claude-cli",
+              "requestedSettings": {
+                "effort": "high"
+              },
+              "effectiveEffortVerified": false,
+              "upstreamWeightsVerified": false,
+              "source": {
+                "path": "model-evaluation-claude-isolated-20260905.json",
+                "pointer": "/candidates/3"
+              }
+            },
+            "initial": {
+              "observed": 49,
+              "valid": 49,
+              "rocAuc": 1,
+              "sharedLoadMedianMs": 68390
+            },
+            "confirmation": {
+              "observed": 98,
+              "valid": 98,
+              "rocAuc": 0.9820234113712375,
+              "sharedLoadMedianMs": 68485
+            },
+            "pooled": {
+              "observed": 147,
+              "valid": 147,
+              "rocAuc": 0.9876439985135638,
+              "strictSchemaErrors": 0,
+              "sharedLoadMedianMs": 68390
+            },
+            "perRepeatRocAuc": [
+              1,
+              0.9882943143812709,
+              0.9749163879598662
+            ],
+            "stability": {
+              "exactScoreStableFixtures": 6,
+              "medianScoreRange": 3.130000000000001
+            }
+          },
+          {
+            "identity": {
+              "candidateId": "anthropic-opus",
+              "requestedModel": "claude-opus-5",
+              "transport": "claude-cli",
+              "requestedSettings": {
+                "effort": "high"
+              },
+              "effectiveEffortVerified": false,
+              "upstreamWeightsVerified": false,
+              "source": {
+                "path": "model-evaluation-claude-isolated-20260905.json",
+                "pointer": "/candidates/1"
+              }
+            },
+            "initial": {
+              "observed": 49,
+              "valid": 49,
+              "rocAuc": 0.9782608695652174,
+              "sharedLoadMedianMs": 17152
+            },
+            "confirmation": {
+              "observed": 98,
+              "valid": 98,
+              "rocAuc": 0.987876254180602,
+              "sharedLoadMedianMs": 16984.5
+            },
+            "pooled": {
+              "observed": 147,
+              "valid": 147,
+              "rocAuc": 0.9852285395763657,
+              "strictSchemaErrors": 0,
+              "sharedLoadMedianMs": 17152
+            },
+            "perRepeatRocAuc": [
+              0.9782608695652174,
+              0.9882943143812709,
+              0.9874581939799331
+            ],
+            "stability": {
+              "exactScoreStableFixtures": 9,
+              "medianScoreRange": 1.7000000000000002
+            }
+          }
+        ]
+      }
+    ],
+    "anthropicPracticalAlternative": {
+      "candidateId": "anthropic-opus",
+      "reason": "Smaller observed shared-load median latency; confirmation-only AUC favors Opus. No causal latency or stable superiority claim."
+    }
+  },
+  "kimi": {
+    "status": "screening-and-availability-only-unconfirmed",
+    "confirmedRecommendation": null,
+    "rewriteScreening": {
+      "uniqueFixtures": 12,
+      "candidates": [
+        {
+          "identity": {
+            "candidateId": "kimi-code-standard",
+            "requestedModel": "kimi-code/kimi-for-coding",
+            "transport": "kimi-cli",
+            "requestedSettings": {},
+            "effectiveEffortVerified": false,
+            "upstreamWeightsVerified": false,
+            "source": {
+              "path": "model-evaluation-kimi-code-20260905.json",
+              "pointer": "/candidates/2"
+            }
+          },
+          "safe": 6,
+          "attempted": 12
+        },
+        {
+          "identity": {
+            "candidateId": "kimi-code-highspeed",
+            "requestedModel": "kimi-code/kimi-for-coding-highspeed",
+            "transport": "kimi-cli",
+            "requestedSettings": {},
+            "effectiveEffortVerified": false,
+            "upstreamWeightsVerified": false,
+            "source": {
+              "path": "model-evaluation-kimi-code-20260905.json",
+              "pointer": "/candidates/3"
+            }
+          },
+          "safe": 6,
+          "attempted": 12
+        }
+      ]
+    },
+    "patternScorerInitialOrAvailability": {
+      "description": "Highspeed uses the separate availability follow-up; K3-256k uses initial screening. These are not confirmed results.",
+      "candidates": [
+        {
+          "identity": {
+            "candidateId": "kimi-code-highspeed",
+            "requestedModel": "kimi-code/kimi-for-coding-highspeed",
+            "transport": "kimi-cli",
+            "requestedSettings": {},
+            "effectiveEffortVerified": false,
+            "upstreamWeightsVerified": false,
+            "source": {
+              "path": "model-evaluation-kimi-code-20260905.json",
+              "pointer": "/candidates/3"
+            }
+          },
+          "observed": 49,
+          "valid": 49,
+          "rocAuc": 0.9565217391304348,
+          "dataset": "highspeed-availability-followup"
+        },
+        {
+          "identity": {
+            "candidateId": "kimi-code-k3-256k",
+            "requestedModel": "kimi-code/k3-256k",
+            "transport": "kimi-cli",
+            "requestedSettings": {},
+            "effectiveEffortVerified": false,
+            "upstreamWeightsVerified": false,
+            "source": {
+              "path": "model-evaluation-kimi-code-20260905.json",
+              "pointer": "/candidates/1"
+            }
+          },
+          "observed": 49,
+          "valid": 49,
+          "rocAuc": 0.9506688963210702,
+          "dataset": "scorer"
+        }
+      ]
+    },
+    "patternScorerConfirmation": {
+      "observed": 196,
+      "valid": 37,
+      "schemaErrors": 1,
+      "callFailuresWithoutScore": 158,
+      "status": "unconfirmed-no-quality-winner",
+      "diagnosis": "Current-limit diagnosis is operator-reported; it does not establish the cause of every missing score."
+    },
+    "fullRewriteConfirmation": {
+      "plannedGenerations": 204,
+      "generationsStarted": 0,
+      "status": "unrun"
+    },
+    "identityLimit": "Kimi Code selected profiles do not attest upstream server weights; effective effort is unverified. Moonshot API has separate access and billing.",
+    "source": "provider-gemini-kimi-deepseek"
+  },
+  "documentationOnly": [
+    {
+      "provider": "deepseek",
+      "status": "documentation-shortlist-only",
+      "empiricalRecommendation": null,
+      "access": "funded-api-input-missing",
+      "candidates": [
+        {
+          "identity": {
+            "candidateId": "deepseek-flash",
+            "requestedModel": "deepseek-v4-flash",
+            "transport": "http",
+            "requestedSettings": {
+              "extraBody": {
+                "thinking": {
+                  "type": "disabled"
+                }
+              }
+            },
+            "effectiveEffortVerified": false,
+            "upstreamWeightsVerified": false,
+            "source": {
+              "path": "model-evaluation-20260904.json",
+              "pointer": "/candidates/15"
+            }
+          }
+        },
+        {
+          "identity": {
+            "candidateId": "deepseek-pro",
+            "requestedModel": "deepseek-v4-pro",
+            "transport": "http",
+            "requestedSettings": {
+              "extraBody": {
+                "thinking": {
+                  "type": "disabled"
+                }
+              }
+            },
+            "effectiveEffortVerified": false,
+            "upstreamWeightsVerified": false,
+            "source": {
+              "path": "model-evaluation-20260904.json",
+              "pointer": "/candidates/16"
+            }
+          }
+        }
+      ],
+      "source": "provider-gemini-kimi-deepseek"
+    },
+    {
+      "provider": "groq",
+      "status": "documentation-shortlist-only",
+      "empiricalRecommendation": null,
+      "access": "access-or-funded-input-not-established",
+      "candidates": [
+        {
+          "model": "qwen/qwen3.8-27b",
+          "upstreamFamily": "qwen",
+          "proposedSettings": {
+            "reasoning_effort": "none",
+            "reasoning_format": "hidden",
+            "max_completion_tokens": 8192
+          },
+          "source": {
+            "path": "provider-groq-together-minimax-20260905.json",
+            "pointer": "/documentedCandidates/0"
+          }
+        },
+        {
+          "model": "openai/gpt-oss-120b",
+          "upstreamFamily": "openai",
+          "proposedSettings": {
+            "reasoning_effort": "low",
+            "include_reasoning": false,
+            "max_completion_tokens": 8192
+          },
+          "source": {
+            "path": "provider-groq-together-minimax-20260905.json",
+            "pointer": "/documentedCandidates/1"
+          }
+        },
+        {
+          "model": "openai/gpt-oss-20b",
+          "upstreamFamily": "openai",
+          "proposedSettings": {
+            "reasoning_effort": "low",
+            "include_reasoning": false,
+            "max_completion_tokens": 8192
+          },
+          "source": {
+            "path": "provider-groq-together-minimax-20260905.json",
+            "pointer": "/documentedCandidates/2"
+          }
+        }
+      ]
+    },
+    {
+      "provider": "together",
+      "status": "documentation-shortlist-only",
+      "empiricalRecommendation": null,
+      "access": "access-or-funded-input-not-established",
+      "candidates": [
+        {
+          "model": "Qwen/Qwen3.5-9B",
+          "upstreamFamily": "qwen",
+          "proposedSettings": {
+            "reasoning": {
+              "enabled": false
+            },
+            "max_tokens": 8192
+          },
+          "source": {
+            "path": "provider-groq-together-minimax-20260905.json",
+            "pointer": "/documentedCandidates/3"
+          }
+        },
+        {
+          "model": "zai-org/GLM-5.3-Flash",
+          "upstreamFamily": "glm",
+          "proposedSettings": {
+            "max_tokens": 8192
+          },
+          "source": {
+            "path": "provider-groq-together-minimax-20260905.json",
+            "pointer": "/documentedCandidates/4"
+          }
+        },
+        {
+          "model": "MiniMaxAI/MiniMax-M3",
+          "upstreamFamily": "minimax",
+          "proposedSettings": {
+            "reasoning": {
+              "enabled": false
+            },
+            "max_tokens": 8192
+          },
+          "source": {
+            "path": "provider-groq-together-minimax-20260905.json",
+            "pointer": "/documentedCandidates/6"
+          }
+        }
+      ]
+    },
+    {
+      "provider": "minimax",
+      "status": "documentation-shortlist-only",
+      "empiricalRecommendation": null,
+      "access": "access-or-funded-input-not-established",
+      "candidates": [
+        {
+          "model": "MiniMax-M3",
+          "upstreamFamily": "minimax",
+          "proposedSettings": {
+            "thinking": {
+              "type": "disabled"
+            },
+            "reasoning_split": true,
+            "service_tier": "standard",
+            "max_completion_tokens": 8192
+          },
+          "source": {
+            "path": "provider-groq-together-minimax-20260905.json",
+            "pointer": "/documentedCandidates/8"
+          }
+        },
+        {
+          "model": "MiniMax-M2.7",
+          "upstreamFamily": "minimax",
+          "proposedSettings": {
+            "reasoning_split": true,
+            "max_tokens": 8192
+          },
+          "source": {
+            "path": "provider-groq-together-minimax-20260905.json",
+            "pointer": "/documentedCandidates/9"
+          }
+        },
+        {
+          "model": "MiniMax-M2.7-highspeed",
+          "upstreamFamily": "minimax",
+          "proposedSettings": {
+            "reasoning_split": true,
+            "max_tokens": 8192
+          },
+          "source": {
+            "path": "provider-groq-together-minimax-20260905.json",
+            "pointer": "/documentedCandidates/10"
+          }
+        }
+      ]
+    }
+  ],
+  "interpretationLimits": {
+    "withinProviderPrimary": true,
+    "globalRanking": false,
+    "differentGeneratorFamiliesUseDifferentJudgePanels": true,
+    "sameUpstreamFamilyIndependentJudgeAllowed": false,
+    "hostIsNotUpstreamFamily": true,
+    "proxyResponseEchoIsUpstreamAttestation": false,
+    "modelRatedNaturalnessIsHumanRating": false,
+    "repeatedFixturesAreIndependentSamples": false,
+    "latencyIsControlledCausalEstimate": false,
+    "actualBillingKnown": false,
+    "defaultModelChanged": false,
+    "patternScorerIsMpsFidelityJudge": false
+  },
+  "publication": {
+    "aggregateOnly": true,
+    "rawTextsIncluded": false,
+    "privateProofsIncluded": false,
+    "liveCallsMade": 0,
+    "runtimeOrSkillChanges": false
+  }
+}

--- a/docs/research/model-guide-20260905.md
+++ b/docs/research/model-guide-20260905.md
@@ -1,0 +1,67 @@
+# Patina 모델 선택 가이드 — 2026-09-05
+
+용도부터 고르면 된다. 아래 표는 글 다듬기와 AI 표현 패턴 점수 작업을 구분하고, 같은 제공업체 안에서 비교를 마친 후보를 정리한 결과다. 다른 입력이나 계정에서의 결과는 아직 모른다. 세부 수치와 설정은 [JSON](model-guide-20260905.json)을 참고하자.
+
+## 글 다듬기
+
+[전체 확인 리포트](model-rewrite-confirmation-20260905.md)는 모델마다 34개 입력을 세 번씩 처리했다. 표의 통과 수는 102회 전체 시도가 분모다. 숫자 검사와 두 심판의 MPS·fidelity 90점 이상, hard fail 없음 조건을 모두 만족해야 통과한다. 심판 오류가 난 시도도 분모에 남는다.
+
+| 제공업체 | 먼저 검토할 후보 | 같은 업체의 비교 후보 | 통과 수 | 판단 강도 |
+|---|---|---|---|---|
+| OpenAI | **Astra** | Terra | 58/102 대 45/102 | 이 입력군에서는 중간 |
+| Anthropic | **Sonnet 5** | Fable 5.1 | 42/102 대 36/102 | 낮음: 차이 불확실 |
+| Gemini | **3.8 medium 경로** | 3.8 high 경로 | 18/102 대 10/102 | 낮음: 경로·실제 effort 미확인 |
+
+Astra와 Terra의 통과율 차이는 +12.7%p이며, 짝지은 입력 단위 95% 구간은 +2.9~+23.5%p다. Sonnet과 Fable의 차이는 +5.9%p지만 구간이 −5.9~+19.6%p로 넓고 Gemini medium과 high의 구간도 0을 포함하므로, 두 쌍의 순서를 확정하기는 어렵다. 업체 안의 비교까지만 읽자. 여섯 모델 전체의 절대 순위는 아니다.
+
+## AI 표현 패턴 점수
+
+여기서는 `scoreText`의 최종 패턴 점수를 비교하며, 의미 보존을 평가하는 MPS·fidelity 심판까지 추천하지는 않는다. 용도가 다르다. 특히 점수용 추천 모델을 같은 계열의 생성물에 붙이면 독립 심판 조건을 만족하지 못한다.
+
+[공개 점수 리포트](../benchmarks/live-scorer-20260905.md)의 A/C 결과에 검증을 마친 D 집계를 더하면, 각 후보는 최초 49회와 재확인 98회를 합쳐 147/147회에서 유효한 점수를 냈다. 입력은 49개다. 같은 글을 세 번 측정한 것이므로 147개의 독립 글이나 사람 표본으로 세면 안 된다. 선택 순서는 유효 출력률 → AUC → 지연시간이다.
+
+| 제공업체 | 규칙상 추천 | 비교 후보 | 합산 AUC | 판단 강도 |
+|---|---|---|---|---|
+| OpenAI | **GPT-5.5** | Terra | 0.989038 대 0.961538 | 이 입력군에서는 중간 |
+| Gemini | **Pro 경로** | 3.8 low 경로 | 0.977425 대 0.772575 | 이 입력군에서는 중간 |
+| Anthropic | **Sonnet 4.6** | Opus 5 | 0.987644 대 0.985229 | 낮음 |
+
+GPT-5.5는 두 재확인 회차에서 Terra를 앞섰고 Pro는 세 회차 모두 3.8 low를 앞섰지만, Sonnet 4.6과 Opus의 합산 AUC 차이는 0.002415에 불과하다. 차이는 작다. 짝지은 입력 단위 95% 구간도 −0.021182~+0.030658로 0을 포함하며, 재확인 98회만 보면 Opus가 앞선다.
+
+기다리는 시간이 중요하다면 Anthropic 점수용 대안으로 **Opus 5**를 검토할 만하다. 근거는 관측 지연이다. 147회 합산 중앙값이 Opus 17.152초, Sonnet 4.6 68.390초였지만 동시 작업이 있는 환경에서 측정했으므로 모델 자체의 속도 차이로 단정할 수는 없다. 초기·재확인·합산 지연은 JSON에 따로 적었다.
+
+## 사용한 ID와 설정
+
+아래 ID는 실험에 요청한 문자열이다. OpenAI·Gemini는 OpenCodex 경로, Claude는 개인 설정을 배제한 native CLI를 썼다. `low`·`high` 요청값이 실제로 적용됐다는 뜻은 아니다. [OpenAI·Anthropic 조사](provider-openai-anthropic-20260905.md)와 [Gemini 경로 조사](provider-gemini-kimi-deepseek-20260905.md)에 공식 문서와의 대응 관계가 있다.
+
+| 용도 | 요청 ID | 기록된 설정 |
+|---|---|---|
+| OpenAI 글 다듬기 | `gpt-6-astra` / `gpt-5.6-terra` | `reasoning_effort: low` 요청 |
+| OpenAI 패턴 점수 | `gpt-5.5` / `gpt-5.6-terra` | `reasoning_effort: low` 요청 |
+| Claude 글 다듬기 | `claude-sonnet-5` / `claude-fable-5-1` | CLI `effort: high` 요청 |
+| Claude 패턴 점수 | `claude-sonnet-4-6` / `claude-opus-5` | CLI `effort: high` 요청 |
+| Gemini 글 다듬기 | `google-antigravity/gemini-3.8-flash-medium` / `google-antigravity/gemini-3.8-flash-high` | 접미사는 경로 라벨; 실제 effort 미확인 |
+| Gemini 패턴 점수 | `google-antigravity/gemini-3.1-pro` / `google-antigravity/gemini-3.8-flash-low` | Pro effort 미지정; low 적용 미확인 |
+
+## Kimi와 아직 비교하지 못한 제공업체
+
+Kimi Code 글 다듬기는 예비 비교에서 **standard·highspeed가 각각 6/12회** 통과했다. 전체 확인 204회는 아직 실행하지 않았다. 패턴 점수 후보는 **highspeed·K3-256k**지만, 최초·가용성 확인 각 49회의 결과만 참고할 수 있다. 재확인 196회는 유효 37건, 스키마 오류 1건, 점수가 없는 호출 실패 158건이었다. 사용한도 진단이 보고됐으나 모든 실패의 원인을 확정한 것은 아니다. 확인 완료 추천은 보류한다.
+
+해당 프로필은 `kimi-code/kimi-for-coding`, `kimi-code/kimi-for-coding-highspeed`, `kimi-code/k3-256k`다. 실제 effort와 서버 모델은 미확인이다. Kimi Code와 Moonshot API는 접근 권한과 과금 경로도 다르다. [Kimi 조사](provider-gemini-kimi-deepseek-20260905.md)를 함께 읽어야 한다.
+
+| 제공업체 | 문서상 검토 후보 — 실측 추천 아님 |
+|---|---|
+| DeepSeek | `deepseek-v4-flash`, `deepseek-v4-pro` |
+| Groq | `qwen/qwen3.8-27b`, `openai/gpt-oss-120b`, `openai/gpt-oss-20b` |
+| Together | `Qwen/Qwen3.5-9B`, `zai-org/GLM-5.3-Flash`, `MiniMaxAI/MiniMax-M3` |
+| MiniMax | `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed` |
+
+접근부터 확인해야 한다. 이 후보들은 권한이나 유료 API 입력이 확보되지 않아 비교를 마치지 못했고, 문서 등재만으로 이 계정의 호출 가능 여부를 알 수도 없다. [DeepSeek 조사](provider-gemini-kimi-deepseek-20260905.md)와 [Groq·Together·MiniMax 조사](provider-groq-together-minimax-20260905.md)에 제안 설정과 미확인 항목이 있다. 호스팅 업체가 달라도 GPT-OSS는 OpenAI 계열이므로 OpenAI 계열 생성물의 독립 심판으로 쓰면 안 된다.
+
+## 결과를 읽을 때
+
+설정상 OpenAI 생성물은 Gemini·Claude가 평가했고, Claude 생성물에는 OpenAI·Gemini를, Gemini 생성물에는 OpenAI·Claude를 심판으로 배정했다. 업체 안의 비교가 우선이다. 생성 모델 계열마다 심판 패널도 바뀌기 때문에 업체 간 순위에는 패널 효과가 섞이며, 이를 생성 모델만의 품질 차이로 읽을 수는 없다.
+
+OpenCodex의 `response.model`은 요청한 별칭을 되돌려줄 수 있다. 별칭 일치가 upstream 모델·가중치 확인은 아니다. 자연스러움과 의미 보존 판정도 모델 평가이며 사람의 평점이 없다. 패턴 점수의 AUC 역시 이 입력군의 라벨 구분력이지 인간·AI 저자 판별 정확도가 아니다.
+
+A/C 점수 결과는 원본·영수증·실행 결과가 서로 맞는지 검증했으나 전체 과거 설정 객체는 복구하지 못한 반면, D는 전체 V8 입력과 점수 재현까지 확인했다. 재표집 구간으로도 같은 입력에서 후보를 고른 편향은 사라지지 않는다. 실제 청구액도 미확인이다. 이 가이드는 기본 모델·CLI·스킬 동작을 변경하지 않는다.


### PR DESCRIPTION
Adds a Korean-readable, task-specific model selection guide based on verified rewrite and scorer evidence. Recommendations stay within provider and distinguish AI-pattern scoring from MPS/fidelity judging. Confidence, different judge panels, proxy aliases, actual billing limits and missing human labels remain explicit. Kimi is unconfirmed after limit-related failures; untested providers remain documentation shortlists. No runtime defaults change.

Validation: values, IDs/settings and source links checked; JSON/diff/prose gate0; full1,975 tests passed,2 skipped; lint clean. Independent Astra/xhigh review verified six rewrite candidates/panels,18 scorer phase summaries and all caveats. No model calls.
