### PR TITLE
docs: record bounded human-edit data eligibility review

### DIFF
--- a/docs/research/human-edit-evidence-20260905.json
+++ b/docs/research/human-edit-evidence-20260905.json
@@ -1,0 +1,286 @@
+{
+  "schemaVersion": 1,
+  "date": "2026-09-05",
+  "checkedAt": "2026-09-05T08:38:28.260973+00:00",
+  "issue": 643,
+  "status": "blocked-before-intake",
+  "scope": "At most three primary controlled co-writing datasets; actual released files inspected; no new framework or provider calls",
+  "datasetsInvestigated": 3,
+  "acceptedHumanEditedAiPairs": 0,
+  "qualifiedSourceBoundPairs": 0,
+  "submittedToProviders": 0,
+  "newModelCalls": 0,
+  "newHumanContacts": 0,
+  "newPatinaPanelRatings": 0,
+  "decision": "No investigated release satisfies both an explicit dataset reuse grant and the required before/after provenance in this bounded review. Stop without admitting rows.",
+  "actorBoundary": "Published participant/revision protocols can attest the role of human editors. They do not independently biologically verify each event author. Any future admitted actor must remain DATASET-ATTESTED.",
+  "datasets": [
+    {
+      "name": "CoAuthor",
+      "decision": "not-admitted",
+      "humanEditEvidence": "Paper describes qualified crowd writers accepting and editing GPT-3 suggestions; released archive is a session-log collection.",
+      "participantBoundary": "Dataset-attested crowd-writer role only; no independent biological verification or new participant attestations.",
+      "license": {
+        "datasetReuse": "not-verified",
+        "interfaceRepository": "MIT",
+        "interfaceGrantDoesNotEstablishSessionLogRights": true,
+        "paperLicenseDoesNotEstablishDatasetRights": true
+      },
+      "releaseInspection": {
+        "archiveBytes": 49956179,
+        "archiveEntries": 1448,
+        "sessionJsonlMembers": 1447,
+        "nonSessionMembers": [
+          "coauthor-v1.0/"
+        ],
+        "separatelyNamedLicenseMembers": 0,
+        "onlyCentralDirectoryInspected": true,
+        "centralDirectoryByteRange": [
+          49767955,
+          49956178
+        ],
+        "paperReportedSessions": 1445,
+        "archivePaperCountDifferenceUnresolved": true
+      },
+      "sources": {
+        "website": {
+          "url": "https://coauthor.stanford.edu/",
+          "retrievedAt": "2026-09-05T08:27:23.535143+00:00",
+          "sha256": "4399bed2d9244452091ad31175a0e56184afb3efceb8e5a9a3331ef795f3e750",
+          "bytes": 8321
+        },
+        "paper": {
+          "url": "https://arxiv.org/html/2201.06796v2",
+          "retrievedAt": "2026-09-05T08:27:23.587751+00:00",
+          "sha256": "1b0e3dcb524e542079595af1a31079a39ad052e192f5212b858089358dd2f7c6",
+          "bytes": 288033
+        },
+        "interfaceRepositoryMetadata": {
+          "url": "https://api.github.com/repos/minalee-research/coauthor-interface",
+          "retrievedAt": "2026-09-05T08:27:24.089384+00:00",
+          "sha256": "bae9e744cc76f0e146fa4d3cdb09780ed466089985fff0d499d5c372c3059043",
+          "bytes": 5979
+        },
+        "archiveDirectory": {
+          "url": "https://drive.google.com/file/d/1C9FCCsyY-5I7mcBHi-__R7lxHkGX_-9Q/view",
+          "retrievedAt": "2026-09-05T08:32:29.068882+00:00",
+          "sha256": "4bdf37ff858921dbf95e749a235787f440058b28bb0e081f9e4616399b2a8d14",
+          "bytes": 188224
+        }
+      },
+      "blockers": [
+        "No explicit dataset reuse grant located for writer submissions and generated suggestions in the checked owner materials. MIT applies to the interface repository.",
+        "The served archive lists1447 session-named JSONL members while the paper reports1445 sessions; membership reconciliation remains unresolved."
+      ],
+      "nextEvidence": "An explicit owner-published session-data license and release membership/version mapping before event replay."
+    },
+    {
+      "name": "MixSet",
+      "decision": "not-admitted",
+      "humanEditEvidence": "Authors describe manual token-level and sentence-level adaptation of machine-generated text. Both inspected human-edit files contain original and revised strings.",
+      "participantBoundary": "Role is dataset-attested through the paper and operation category, not independently verified biology. The inspected rows do not provide per-editor identities, consent records or timestamped editing events.",
+      "license": {
+        "datasetReuse": "not-verified",
+        "githubRepositoryLicenseField": null,
+        "licenseNamedInRepositoryTree": false,
+        "huggingFaceLicenseTagPresent": false,
+        "paperDistributionComplianceStatementIsNotADatasetGrant": true
+      },
+      "releaseInspection": {
+        "repositoryTreeObjectSha": "f37eea51fcb7fd490391431c52adf79848cb1e89",
+        "huggingFaceRevision": "b6063c77f660c2ef2e17461d85c24219a88f7d19",
+        "originalPoolRows": 300,
+        "originalPoolUniqueIds": 300,
+        "humanEditFiles": [
+          {
+            "file": "MGT_polish_token.json",
+            "authorCategory": "token-level author category",
+            "rows": 300,
+            "bothTextsNonempty": 300,
+            "changedPairs": 271,
+            "unchangedPairs": 29,
+            "sameIdAllSourceFieldsMatch": 207,
+            "exactOriginalTextModelCategoryJoinAnywhere": 250,
+            "unresolvedExactOriginalJoins": 50,
+            "source": {
+              "url": "https://api.github.com/repos/Dongping-Chen/MixSet/git/blobs/1dba11546f90edc4732f12d248e71057cc208d7b",
+              "retrievedAt": "2026-09-05T08:35:23.620908+00:00",
+              "sha256": "17e1bd030fec1a797cfdaf3f59e7aee4358e12f18ad0d0a5132e2af738b1283a",
+              "bytes": 622066,
+              "gitBlobSha": "1dba11546f90edc4732f12d248e71057cc208d7b",
+              "decodedSha256": "280c03f4acada8284c9c9d28733dbdc7773b22729adfc903f64a1ba3ec217123",
+              "decodedBytes": 451288
+            }
+          },
+          {
+            "file": "MGT_polish_sentence.json",
+            "authorCategory": "sentence-level author category",
+            "rows": 300,
+            "bothTextsNonempty": 300,
+            "changedPairs": 293,
+            "unchangedPairs": 7,
+            "sameIdAllSourceFieldsMatch": 207,
+            "exactOriginalTextModelCategoryJoinAnywhere": 250,
+            "unresolvedExactOriginalJoins": 50,
+            "source": {
+              "url": "https://api.github.com/repos/Dongping-Chen/MixSet/git/blobs/f53315abac434bd1b564f9f10cfefc2c0992b0e0",
+              "retrievedAt": "2026-09-05T08:35:23.622004+00:00",
+              "sha256": "d8d0cd34cb7c78b4013badc1d509424d22063c8359906f8326a7be5013a3da7f",
+              "bytes": 621430,
+              "gitBlobSha": "f53315abac434bd1b564f9f10cfefc2c0992b0e0",
+              "decodedSha256": "5fc02eabd245375c014f1f9e9fbdae947d22ca4bc08beb6de6fee1a7105fab7a",
+              "decodedBytes": 450828
+            }
+          }
+        ],
+        "totalRowsInspected": 600,
+        "totalChangedPairs": 564,
+        "sameIdJoinsAreNotReliable": true,
+        "unresolvedJoinCause": "Unknown release/version discrepancy; not evidence of fabricated source text."
+      },
+      "sources": {
+        "paper": {
+          "url": "https://arxiv.org/html/2401.05952v2",
+          "retrievedAt": "2026-09-05T08:30:02.673425+00:00",
+          "sha256": "6ad5677a1eda917ca1e9cfb85e73566a6aa6f4fad5748d6e206a582ecb82c5ed",
+          "bytes": 406413
+        },
+        "repositoryMetadata": {
+          "url": "https://api.github.com/repos/Dongping-Chen/MixSet",
+          "retrievedAt": "2026-09-05T08:30:02.973256+00:00",
+          "sha256": "6ebca8c4003e79ef732ac663c57edc7581db54b3fcd990a006baa5ed61aa53b8",
+          "bytes": 5232
+        },
+        "repositoryTree": {
+          "url": "https://api.github.com/repos/Dongping-Chen/MixSet/git/trees/main?recursive=1",
+          "retrievedAt": "2026-09-05T08:31:19.278087+00:00",
+          "sha256": "890d47e2444c52437c11f5f9d1ce13b4bc639a2b69f0bc5a860871c73514f768",
+          "bytes": 11596
+        },
+        "datasetCard": {
+          "url": "https://huggingface.co/datasets/ONE-Lab/MixSet/raw/main/README.md",
+          "retrievedAt": "2026-09-05T08:30:02.673873+00:00",
+          "sha256": "7a0c917ed064c8911be87cf3c62927adb1683a37f9882faff7915163280752be",
+          "bytes": 4074
+        },
+        "datasetMetadata": {
+          "url": "https://huggingface.co/api/datasets/ONE-Lab/MixSet",
+          "retrievedAt": "2026-09-05T08:31:19.277736+00:00",
+          "sha256": "d4e5f85afcb304b98d53db36eb9a9f945b3e201b2b82e4f0f837cf9cbd73763e",
+          "bytes": 1239
+        },
+        "originalPool": {
+          "url": "https://api.github.com/repos/Dongping-Chen/MixSet/git/blobs/788ab8954b61e400993749c29c9a3060d20c8f52",
+          "retrievedAt": "2026-09-05T08:35:23.622382+00:00",
+          "sha256": "b3988c7fb549de57c72306036ce40f1fa261298532a657de6f278c5484e33d59",
+          "bytes": 328646,
+          "gitBlobSha": "788ab8954b61e400993749c29c9a3060d20c8f52",
+          "decodedSha256": "31d2835ccd16830a98b75952ccfd217673200987aba312d0616d999202c57eaa",
+          "decodedBytes": 238323
+        }
+      },
+      "blockers": [
+        "No explicit dataset reuse license located in the linked author repository or dataset card/metadata.",
+        "Fifty original strings per human-edit file do not match the released original pool by exact text hash plus model/category; positional/ID joins would misbind sources."
+      ],
+      "nextEvidence": "An explicit reuse grant with source/derivative scope, then a source-version mapping for the50 unmatched originals in each file. Hash-based joins can resolve250/300 per file without relying on IDs."
+    },
+    {
+      "name": "SynthBio",
+      "decision": "not-admitted",
+      "humanEditEvidence": "The author paper describes crowd raters revising generated biographies and supplies annotation instructions.",
+      "participantBoundary": "Dataset-attested editor role only. Published ratings and aggregate study results are not annotations of arbitrary excerpts.",
+      "license": {
+        "datasetReuse": "Apache-2.0",
+        "evidence": "Author paper v2 Data Card, Licensing Information",
+        "paperLicense": "CC-BY-4.0",
+        "paperAndDatasetLicensesKeptDistinct": true
+      },
+      "releaseInspection": {
+        "records": 2237,
+        "biographies": 4270,
+        "recordFields": [
+          "attrs",
+          "biographies",
+          "notable_type",
+          "serialized_attrs"
+        ],
+        "biographyType": "string",
+        "originalDraftFieldsPresent": false,
+        "editEventFieldsPresent": false,
+        "beforeAfterCorrespondencePresent": false,
+        "fullDocumentOrExcerptQualityLabelsImported": false
+      },
+      "sources": {
+        "paper": {
+          "url": "https://arxiv.org/html/2111.06467v2",
+          "retrievedAt": "2026-09-05T08:35:23.622730+00:00",
+          "sha256": "78a554e36f64f368125878ddf9ba3c07494b7cef22e02dd8ec3153ba9b662120",
+          "bytes": 485949
+        },
+        "releasedData": {
+          "url": "https://storage.googleapis.com/gem-benchmark/SynthBio.json",
+          "retrievedAt": "2026-09-05T08:30:02.672918+00:00",
+          "sha256": "acb5b0c5b7bc385ab468528e4c65d644437e8e8bd1c4a38040b76d6dab48ffa6",
+          "bytes": 5630571,
+          "storageGeneration": "1638886515365769"
+        }
+      },
+      "blockers": [
+        "The inspected release contains final biographies and conditioning attributes, not corresponding pre-edit biography drafts or revision logs.",
+        "Multiple biographies attached to an entity are not established before/after versions; attribute lists are not pre-edit biography text."
+      ],
+      "nextEvidence": "The corresponding pre-edit generated drafts or revision histories with stable pair identifiers under a matching reuse grant."
+    }
+  ],
+  "intakeState": {
+    "pairs": 0,
+    "editingActor": null,
+    "editDepth": null,
+    "meaningReview": "UNKNOWN",
+    "perceivedAiPolish": "UNKNOWN",
+    "expectedShortFormTells": "UNKNOWN",
+    "humanQuality": "UNKNOWN",
+    "registerReview": "UNKNOWN",
+    "eligibleForClaims": false,
+    "ciGatePromoted": false
+  },
+  "existingPolicy": {
+    "path": "docs/research/edited-ai-intake-policy.md",
+    "sha256": "97089ded563491ec5a82e14d588d203887fbe4c9756b17ba4c4a2ca321878a50",
+    "validatorPath": "scripts/research/edited-ai-intake.mjs",
+    "validatorSha256": "9f16a24398d9c5b1990d0b728c284e6a237a93e3e5fe866b08a25bfc6022d35a",
+    "lightHeavyLabelsAssigned": 0,
+    "reason": "No admitted pair to classify. Author operation names are not substituted for Patina token-edit/order checks."
+  },
+  "patinaPanelBoundary": "This evidence does not supply a new Patina30-pair, five-rater panel or any new human ratings.",
+  "privacy": {
+    "publicRawText": false,
+    "publicParticipantIdentifiers": false,
+    "privateRoot": "/tmp/patina-human-edit-evidence-20260905",
+    "gitignore": "*",
+    "providerSubmission": "not-authorized; parent review required"
+  },
+  "limitations": [
+    "This is a bounded inspection of three releases, not a claim that no license or pre-edit data exists anywhere.",
+    "A missing exact source join is left unresolved; no normalization, inferred version mapping or synthetic draft was used.",
+    "No quality-conditioned selection, human-origin inference from URLs/dates, excerpt ratings, or biological-verification claims were introduced."
+  ],
+  "stopCondition": "Three candidates exhausted; required rights/provenance evidence remains missing. No further collection, extraction or API submission in this task.",
+  "validation": {
+    "status": "passed",
+    "sourceByteHashesVerified": 17,
+    "gitBlobsVerified": 3,
+    "archiveEntriesVerified": 1448,
+    "mixsetRowsInspected": 600,
+    "sourceJoinsByExactTextPerFile": 250,
+    "unresolvedOriginalTextJoinsPerFile": 50,
+    "synthbioRows": 2237,
+    "synthbioBiographyStrings": 4270,
+    "publicRawTextLeaks": 0,
+    "proseScore": 11.11111111111111,
+    "proseGate": 30,
+    "prosePassed": true,
+    "runtimeCodeChanged": false
+  }
+}

--- a/docs/research/human-edit-evidence-20260905.md
+++ b/docs/research/human-edit-evidence-20260905.md
@@ -1,0 +1,120 @@
+# Human-edit dataset evidence, 2026-09-05
+
+Three primary dataset releases were checked for #643 and the edited-AI intake.
+**No pairs were admitted.** CoAuthor and MixSet lack a verified dataset reuse
+grant in the materials inspected. SynthBio has an explicit grant, but its
+released JSON does not supply the pre-edit drafts needed to form pairs.
+
+This is a completed, bounded source audit. It adds no extraction framework,
+human ratings, or CI gate. The [JSON record](human-edit-evidence-20260905.json)
+contains source URLs, retrieval times, hashes, counts and unresolved gates.
+Downloaded source text remains private.
+
+| Dataset | Human-edit evidence | Rights found | Intake decision |
+| --- | --- | --- | --- |
+| CoAuthor | Controlled writing study and session logs | MIT for the interface; session-data grant not verified | Not admitted |
+| MixSet | Manual adaptation described by authors; paired strings released | No dataset grant found in the checked repository/card | Not admitted |
+| SynthBio | Study annotators revised generated biographies | Apache-2.0 in the author data card | Not admitted: pre-edit drafts missing |
+
+## CoAuthor
+
+The [author paper](https://arxiv.org/html/2201.06796v2) describes qualification
+and participation through Amazon Mechanical Turk. Writers could accept and
+edit model suggestions. That supports a **DATASET-ATTESTED** writer role; it
+does not independently verify the biological author of each logged action.
+
+The [project website](https://coauthor.stanford.edu/) links the downloadable
+session archive and the
+[interface repository](https://github.com/minalee-research/coauthor-interface).
+The repository identifies an MIT license. Its software license does not by
+itself establish a reuse grant for the separately hosted session logs. The
+paper's own license is also a separate matter.
+
+The archive directory was inspected through bounded HTTP range reads. It lists
+1,447 session-named JSONL members and one directory entry, with no separately
+named license file. This is a directory inspection, not a claim to have read
+every session for licensing statements. The paper reports 1,445 sessions; the
+release-membership difference remains unresolved. The private evidence records
+the exact byte range and its hash, not a fictitious full-archive hash.
+
+Required next evidence: an explicit session-data reuse grant covering writer
+submissions and suggestions, plus the release membership/version mapping.
+No sessions were replayed into an intake.
+
+## MixSet
+
+The [author repository](https://github.com/Dongping-Chen/MixSet) links its
+[dataset release](https://huggingface.co/datasets/ONE-Lab/MixSet). The
+[paper](https://arxiv.org/html/2401.05952v2) describes manual token-level and
+sentence-level adaptation of machine-generated text. This is dataset-level
+attestation of the editing role. The inspected paired rows do not supply
+individual editor identities, consent records or timestamped edit events.
+
+Three files were fetched by immutable Git blob identity. Both human-adaptation
+files contain 300 before/after records; the released original pool has 300
+records. All 600 pairs have nonempty text on both sides. There are 564 changed
+pairs and 36 unchanged pairs. These are source-file counts, not admitted data.
+
+Exact provenance joins expose a release discrepancy:
+
+| Check, applied separately to each 300-row edit file | Matches |
+| --- | ---: |
+| Same ID, original text, model label and category | 207 |
+| Exact original-text hash, model label and category anywhere in original pool | 250 |
+| Original text still unresolved after hash-based joining | 50 |
+
+Joining by ID would misbind some source records. Hash-based matching resolves
+250 rows per file, while the remaining 50 need a source-version explanation.
+This discrepancy is not evidence that the text was fabricated. No normalization
+or inferred version mapping was used to make the joins pass.
+
+No explicit dataset reuse grant was found in the checked repository, its file
+tree, or the linked dataset card and metadata. The paper's statement about
+following source licenses is not itself a grant for this release. Required
+next evidence: a reuse license with source/derivative scope and a version
+mapping for the unmatched originals. No rows were admitted, including the
+250 with exact joins.
+
+## SynthBio
+
+The [author paper's v2 data card](https://arxiv.org/html/2111.06467v2) specifies
+**Apache-2.0** for the dataset and describes the annotators' revision task.
+That dataset grant is distinct from the article's CC-BY-4.0 license.
+
+The [released JSON](https://storage.googleapis.com/gem-benchmark/SynthBio.json)
+was inspected and bound to storage generation `1638886515365769` and its
+SHA-256 digest. This served version contains 2,237 records and 4,270 biography
+strings. The record fields are `notable_type`, `attrs`, `serialized_attrs` and
+`biographies`.
+
+The biography values are final strings. The inspected release has no
+corresponding original-draft field, revision-event field or before/after link.
+Conditioning attributes are not pre-edit biography text. Multiple biographies
+for one entity are not established edit versions of each other. Neither can
+be used to manufacture pairs.
+
+Required next evidence: corresponding pre-edit drafts or revision logs, with
+stable pair identities and applicable reuse rights. Published whole-document
+evaluations and aggregate results were not transferred to excerpts.
+
+## Intake boundary and validation
+
+Accepted pairs, light/heavy labels, exact-text human quality labels, and new
+Patina panel ratings are all **zero**. Meaning, perceived AI polish and expected
+short-form tells remain **UNKNOWN**. The author's token/sentence operation
+names were not substituted for the existing
+[light/heavy policy](edited-ai-intake-policy.md), which also checks edit ratio
+and sentence/paragraph order. No new 30-pair, five-rater panel is supplied.
+
+The private evidence is under `/tmp/patina-human-edit-evidence-20260905`, with
+`.gitignore` containing `*` and restricted file permissions. It includes source
+snapshots, verified Git blob identities, the archive directory listing and
+validation results. No private source text or participant identifiers appear
+in these public files. No provider received source text; parent review remains
+required before any future submission.
+
+Validation recomputes source hashes, Git blob identities, archive-member counts,
+MixSet joins and SynthBio field/count checks. The report also passes the prose
+gate. With three candidates exhausted and the rights/provenance gates still
+unmet, this task stops here. This does not claim that the missing evidence
+cannot exist elsewhere.


### PR DESCRIPTION
Records a bounded primary-source review of CoAuthor, MixSet and SynthBio for genuine human-edited AI pairs. No pairs were admitted: dataset reuse rights/source joins or pre-edit drafts remain unresolved. Software/article licenses are kept separate from dataset rights; no claim is made that no other datasets exist.

Validation:17 source hashes,3Git blobs, archive counts and source-join counts checked; prose gate11.11≤30; full tests/lint passed. Independent Astra/xhigh review passed. No raw texts, participant IDs, fabricated human/meaning labels or model calls. Supports the unresolved data-intake requirements of#643; does not close#159/#643.
