### PR TITLE
docs(research): align human panel agreement metrics

### DIFF
--- a/docs/research/human-eval-panel.md
+++ b/docs/research/human-eval-panel.md
@@ -34,7 +34,7 @@ For each pair, ask:
 | naturalness preference | Patina / original / tie counts with confidence interval |
 | meaning concern | rate of reported fact/caveat loss |
 | register split | results by language and register |
-| rater agreement | kappa or raw agreement, depending on labels |
+| rater agreement | Krippendorff's nominal alpha for preferences; interval alpha for naturalness ratings |
 | exclusions | samples removed and why |
 
 ## Privacy rule


### PR DESCRIPTION
The human-panel plan still named kappa/raw agreement, while the execution contract and evaluator report Krippendorff’s alpha. Align the plan with nominal alpha for preferences and interval alpha for naturalness ratings.

Validation: full suite 2,004 passed / 2 skipped; lint passed; prose gate 0/30. One documentation row only; human-panel responses are still pending. Independent review passed against the execution contract and evaluator.
