### PR TITLE
docs: cancel deferred human evaluation research

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -338,9 +338,10 @@ lives, so nobody re-triages from a stale snapshot.
   miss-review manifest) is complete per the September 7 ledger
   (`docs/operations/remaining-work-20260905.md`); its session handoff stays
   maintainer-private (`docs/internal/ko-gpt-miss-review-handoff-20260902.md`).
-  The registered downstream sequence stays deferred under the September 6
-  scope decision; only the specific human acceptance criteria (#159 ratings,
-  #643 human labels) necessarily require people. No research item is active.
+  The registered downstream sequence is not an active execution queue.
+  The owner cancelled the previously deferred human panel (#159) and
+  human-labeled short-form corpus (#643) on 2026-09-08. Both issues are closed
+  `not_planned`; their cancellation does not activate other research.
 - Rewrite-efficacy study series: `2026-rewrite-efficacy-study1.md` (EN doc
   −23.4, KO doc −6.0), `study2.md` / `study3.md` (structure pack and plan-step
   both failed; nothing shipped), `2026-rewrite-efficacy-study4.md` (complete;
@@ -349,7 +350,8 @@ lives, so nobody re-triages from a stale snapshot.
   `2026-panel-v2-design.md`. Korean program verdict:
   `ko-confirmatory-verdict-20260901.md`. External literature survey:
   `humanization-literature-2026-09.md`.
-- #159 blinded human panel = step 3 of the frozen order
+- #159 blinded human panel, formerly step 3 of the frozen order, was cancelled
+  without running the panel. Its design is retained as history
   (`docs/research/human-eval-panel.md`). #158 cross-judge matrix was closed
   2026-07-12 as answered by Study 1's cross-family panel agreement
   (α 0.751 en / 0.526 ko); `2026-judge-calibration.md` adds per-judge AUC and
@@ -385,11 +387,12 @@ Checked 2026-09-08 against the issue records and the [editor client record](inte
   in this change at that checkpoint. See #772, its associated PR and CI for
   later acceptance and integration evidence.
 
-The [2026-09-06 scope decision](https://github.com/devswha/patina/issues/643#issuecomment-5559803306)
-excludes human evaluation and owner-time work from the active research stream.
-#159 and the human-labeled acceptance criteria of #643 remain unmet and deferred.
-Automation-only diagnostics keep unknown labels unknown; they do not establish
-human false-positive or false-negative rates.
+The owner's 2026-09-08 cancellation of #159 and #643 supersedes their
+[September 6 deferral](https://github.com/devswha/patina/issues/643#issuecomment-5559803306).
+They are not pending work and require a new explicit request before resuming.
+Their human acceptance criteria remain unmet. Retained automation-only
+diagnostics keep unknown labels unknown; cancellation does not establish human
+false-positive or false-negative rates.
 
 ### Operating rules
 

--- a/docs/operations/non-npm-status-20260908.md
+++ b/docs/operations/non-npm-status-20260908.md
@@ -6,6 +6,10 @@ and support messages are excluded. This record publishes aggregate and
 status facts only: no tokens, no customer data, no private drafts and no raw
 hashes of removed private objects.
 
+Later research decision, 2026-09-08: the owner cancelled #159 and #643 and both
+were closed `not_planned`. This supersedes their earlier deferral; the recorded
+pre-merge inventories below remain historical observations.
+
 ## Evidence-based ideal state
 
 - The four root READMEs, `docs/integrations/editors.md`, `docs/ROADMAP.md`
@@ -17,8 +21,8 @@ hashes of removed private objects.
 - The Aside integration and the core skills/CLI stay documented as active.
 - The npm publication gap stays explicit: source/web 8.5.1, npm 8.3.0.
 - Research records show the KO GPT-family miss review and Study 4 complete,
-  with human evaluation (#159) and the human-labeled corpus criteria of #643
-  deferred, not active.
+  with the previously deferred human evaluation (#159) and human-labeled
+  short-form corpus (#643) cancelled, not pending.
 - The recorded pre-merge issue inventory listed #772 (CLI-first skill execution)
   as the active open item, #207/#284 as retired and closed, and #159/#643 as deferred.
 
@@ -38,9 +42,10 @@ hashes of removed private objects.
 3. **#207 and #284 are closed.** Both were classified retired/not planned
    and were closed as not planned on 2026-09-08, at 06:29:20Z and 06:29:21Z,
    without comments.
-4. **#159 and #643 stay deferred.** Their human acceptance criteria remain
-   unmet under the 2026-09-06 scope decision; automation-only diagnostics do
-   not substitute for human labels.
+4. **#159 and #643 are cancelled.** The owner cancelled both studies on
+   2026-09-08 and the issues were closed `not_planned`. Their human acceptance
+   criteria remain unmet; retained diagnostics are not human labels. Neither
+   study is queued for resumption without a new explicit request.
 5. **Research completion stands.** The KO GPT-family miss review and Study 4
    are complete per the September 7 ledger; Study 4 supported promotion in
    neither language. Records must not regress to claiming active unfinished
@@ -122,5 +127,3 @@ hashes of removed private objects.
    later acceptance and integration evidence.
 5. **npm publication.** Requires restored npm authorization; excluded from
    this stream.
-6. **Human criteria of #159/#643.** Require human raters and labels under
-   the deferred scope decision; no automation substitute is accepted.

--- a/docs/operations/remaining-work-20260905.md
+++ b/docs/operations/remaining-work-20260905.md
@@ -9,7 +9,12 @@ review, the full test/lint gate, and integration into `dev`. Human ratings,
 publication, live operation, and model results require their own direct evidence.
 An implementation alone does not close those requirements.
 
-Status checked 2026-09-07. The
+Research disposition updated 2026-09-08: the owner cancelled the previously
+deferred #159 human panel and #643 human-labeled short-form corpus. Both are
+closed `not_planned`, not pending work or completed studies. Existing evidence
+is retained; resuming either study requires a new explicit request.
+
+The earlier status check was 2026-09-07. The
 [September 6 scope decision](https://github.com/devswha/patina/issues/643#issuecomment-5559803306)
 defers human evaluation and work requiring owner time. Human acceptance criteria
 stay unmet; they are not active recruitment or annotation tasks.
@@ -22,8 +27,8 @@ stay unmet; they are not active recruitment or annotation tasks.
 | Failed rewrite allowance | Bounded, idempotent recovery of charged requests/characters; concurrency and storage-failure tests | Shipped in 8.1.3 (#726, #728–729); independent review, real Redis and full gates passed |
 | Model comparison | Available-model inventory, fixed protocol, repeated live runs, cross-family judges, per-provider recommendations | Six-finalist confirmation and qualified guide published September 5; Kimi and other unconfirmed routes retain the guide's limits |
 | #412 live scorer benchmark | Run `src/scoring.js` against real fixture/rebaseline texts; distributions by pattern pack, recorded model/usage/errors | Complete: 930/931 valid fixture observations plus 85/85 separate rebaseline observations; issue closed September 5 |
-| #643 short-form corpus | Real human/AI sources, human labels, all requested slices and counterfactual pairs, FNR/exact-zero gates | Open; human acceptance deferred. Automation-only runner changes and September 6 diagnostics are recorded below |
-| #159 human evaluation | 30 randomized pairs × 5 actual human raters, agreement and score/rating association | Open but deferred; no rater recruitment or owner annotations in the active stream |
+| #643 short-form corpus | Real human/AI sources, human labels, all requested slices and counterfactual pairs, FNR/exact-zero gates | Cancelled by owner September 8; closed `not_planned`. Human acceptance remains unmet; existing automation and diagnostics are retained as evidence, not a remaining task |
+| #159 human evaluation | 30 randomized pairs × 5 actual human raters, agreement and score/rating association | Cancelled by owner September 8; closed `not_planned`. The panel was not run and is no longer queued |
 | #206 VS Code | Separate repository; status score, diagnostics, selection rewrite with diff confirmation, settings, editor verification | Complete: 1.1.0 VSIX and editor guide available; issue closed. Client retired September 8; local repository deleted, remote repository left unchanged |
 | #207 Obsidian | Separate repository; note score/audit, selection rewrite, settings/status bar, directory submission | 1.0.0 release and actual host/backend checks complete; client retired September 8 (local repository deleted, remote left unchanged). Community directory submission classified not planned; issue closed as not planned on September 8 (06:29:20Z) |
 | #211 community packs | Starter-pack repository/schema, install/list/remove CLI, documentation and untrusted-pack tests | Complete in 8.2.0; issue closed. Starter repository archived and local copy deleted September 8; optional community-pattern CLI commands removed in source commit 31ae86e |
@@ -132,18 +137,19 @@ additional provider calls.
 That receipt records 2,176 tests passed, two skipped, lint passed, analyzer
 49/49 and scorer 8/8. Those are September 6 results, not a fresh test run by
 this status update. The associated runner changes preserve hashes, explicit
-document types and unknown labels; they do not complete #643's deferred
-human-labeled acceptance criteria.
+document types and unknown labels; they do not establish the human evidence
+requested by #643. The remaining study was cancelled September 8.
 
 ## Research sequence carried forward
 
 KO GPT-family miss review and Study 4 are complete. Study 4 did not support
 promotion in either language. The historical registered sequence below is
-retained for context; the September 6 scope decision leaves human-dependent
-steps deferred rather than active next actions:
+retained for context, not as an execution queue. The September 8 decision
+cancelled #159 and #643; it does not authorize other research or waive any
+evidence requirements:
 
 1. Edited-AI policy/schema and corpus.
-2. Human evaluation (#159).
+2. Human evaluation (#159; cancelled September 8).
 3. Bounded deterministic merge/split and seam-only infill (H-4a).
 4. Selective Korean treatment.
 5. Independent meaning-proxy calibration and metamorphic checks.

--- a/docs/research/human-eval-panel.md
+++ b/docs/research/human-eval-panel.md
@@ -1,9 +1,12 @@
 # Blinded human evaluation panel plan
 
-Status: study design ready; panel not run.
-Related issue: #159.
+Status: cancelled by owner on 2026-09-08; panel not run.
+Related issue: #159, closed `not_planned`.
 
-This plan keeps human preference work separate from deterministic scoring. It should run only with texts that can be shown to reviewers and redistributed or summarized under consent.
+The unexecuted design below is retained as history, not as active or deferred
+work. No recruitment or ratings are scheduled. Resuming requires a new explicit
+request. Cancellation supplies no human-validation evidence and changes no
+deterministic scoring behavior.
 
 ## Research question
 

--- a/docs/research/humanization-data-backlog.md
+++ b/docs/research/humanization-data-backlog.md
@@ -1,10 +1,16 @@
 # Humanization Data Backlog
 
-Status: research brief, no corpus generated  
+Status: research brief; #159 and #643 cancelled on 2026-09-08
+
 Written: 2026-06-06  
 Scope: AI 문체 신호 완화와 자연스러운 글 품질 개선에 필요한 데이터 생성 후보, 미해결 이슈, 검증 기준을 정리한다.
 
 이 문서는 구현 변경이나 새 데이터 생성을 하지 않는다. 기존 리베이스라인과 연구 메모를 바탕으로 다음 작업을 이슈화하기 위한 백로그다. Patina의 기준은 탐지 회피가 아니라 의미 보존, 주장 보존, 재현 가능한 문체 신호 완화다.
+
+2026-09-08 결정: 보류했던 사람 블라인드 평가 #159와 사람 라벨 기반
+짧은 글 코퍼스 #643은 폐기하고 `not_planned`로 종료했다. 아래에 남긴
+해당 설계와 요구사항은 이력이며 대기 작업이 아니다. 명시적인 새 요청 없이
+재개하지 않는다. 이 결정은 다른 연구의 실행이나 검증 기준 생략을 승인하지 않는다.
 
 ## Source Documents
 
@@ -67,7 +73,7 @@ Scope: AI 문체 신호 완화와 자연스러운 글 품질 개선에 필요한
    - Acceptance: record model name, version, serving path, decoding params, and prompt hash.
    - Non-goal: do not mix open-weight rows into published claims until n gates are met.
 
-5. Run rewrite human-evaluation pilot
+5. Cancelled: rewrite human-evaluation pilot (#159)
    - Acceptance: at least 30 before/after pairs, 5 raters, randomized order, naturalness preference, and meaning-loss labels.
    - Acceptance: report safe gain as score reduction only when meaning loss is not flagged.
    - Non-goal: do not treat MPS proxy as a humanness score.
@@ -175,7 +181,7 @@ Execution order frozen for the next performance-only cycle (2026-09-01):
 
 1. **KO GPT-family miss-review manifest.** Classify the currently available misses (up to 100) by register, deterministic signal breakdown, and root cause. Do not change thresholds or production behavior in this step. **Reviewed 2026-09-02 — GO (measure-only); design, data contract, taxonomy, procedure and acceptance criteria in [`ko-gpt-miss-review-step1-decision-20260902.md`](./ko-gpt-miss-review-step1-decision-20260902.md); implementation deferred to its own branches. Implemented 2026-09-02 (PR #718): hash-only discovery manifest (48 reviewed rows + 8 precondition exclusions from analyzer drift), blinded two-reviewer labels, and the measure-only report [`docs/benchmarks/ko-gpt-miss-review-v1.md`](../benchmarks/ko-gpt-miss-review-v1.md); taxonomy constants in [`ko-gpt-miss-taxonomy-v1.md`](./ko-gpt-miss-taxonomy-v1.md).**
 2. **Edited-AI intake and corpus.** Freeze light/heavy edit policies and the manifest schema before generating samples.
-3. **Rewrite human-evaluation panel.** Run at least 30 randomized before/after pairs with 5 raters, separating naturalness preference from meaning-loss labels.
+3. **Rewrite human-evaluation panel (#159; cancelled 2026-09-08).** The unexecuted design required at least 30 randomized before/after pairs with 5 raters, separating naturalness preference from meaning-loss labels. It is no longer queued.
 4. **Deterministic structure-transform experiment.** Test bounded merge/split and seam-only LLM infill against the single-pass baseline; keep it research-only.
 5. **Selective Korean treatment.** Apply short diagnosis guidance only to suspect paragraphs, with clean paragraphs preserve-only and no global diagnosis payload.
 6. **Meaning-proxy calibration.** Complete two independent calibration rounds plus metamorphic number, polarity, causation, entity-role, modality, honorific, and speech-level fixtures before considering enforcement.

--- a/docs/research/scorer-path-corpus-20260905.md
+++ b/docs/research/scorer-path-corpus-20260905.md
@@ -1,9 +1,11 @@
 # Scorer-path corpus intake, 2026-09-05
 
-Issue #643 now has an offline intake of 85 unique texts and an audit of the
-evidence behind them. There are no authenticated human authorship labels,
-human polish ratings, or human-edited AI pairs in this intake. The issue stays
-open, and no corpus metric becomes a CI gate.
+The September 5 work for issue #643 produced an offline intake of 85 unique
+texts and an audit of the evidence behind them. There are no authenticated human authorship labels,
+human polish ratings, or human-edited AI pairs in this intake. The owner
+cancelled the remaining study on 2026-09-08; #643 is closed `not_planned`, not
+deferred or completed. Existing results and tools are retained as history.
+Resuming requires a new explicit request; no corpus metric becomes a CI gate.
 
 The [JSON summary](scorer-path-corpus-20260905.json) contains counts, diagnostic
 results, hashes and an optional generation plan. Texts, prompts, source records
@@ -148,6 +150,9 @@ prompt, repeat and actual model metadata. At handoff this plan was not an execut
 and cannot fill the missing human evidence.
 
 ## Remaining acceptance requirements
+
+The remaining collection and evaluation work below was cancelled on September
+8. These gaps describe the evidence limits, not a pending execution queue.
 
 - Obtain authenticated human social/marketing text and reviewed sharing rights.
 - Collect actual text-bound human polish, quality, register and tell labels.


### PR DESCRIPTION
## Summary

Record the owner's cancellation of the two deferred research projects:

- #159: blinded human evaluation panel.
- #643: human-labeled short-form/SNS scorer corpus.

Both issues are closed as `not_planned`, not completed studies. The roadmap,
work ledgers and study documents now treat them as cancelled rather than
pending. Resuming requires a new explicit request.

Existing experiments, data summaries, scoring code, tests and historical
observations are preserved. No human-validation evidence is invented, and
the cancellation does not activate other research or waive evidence gates.

## Verification

- Six Markdown files only; no runtime, test, dataset JSON or dependency changes.
- QA-by-read and `git diff --check` passed.
- `npm test`: 2,313 passed, 0 failed, 2 existing conditional skips.
- `npm run lint` and `npm run release:check` passed.
- No new prose-pinning test, provider call, publication or deployment command.
