### PR TITLE
fix(playground): repair landing regressions from the 8.5.0 first-use rewrite

### DIFF
--- a/playground/DESIGN.md
+++ b/playground/DESIGN.md
@@ -125,9 +125,24 @@ The hero uses the existing 800px content limit, 768px prompt limit, and
 The document owns scrolling; the examples editor is a separate section after
 the usage steps, never a second column competing with the input.
 
-Language selection stays visible and optional settings remain in the disclosure.
+Language and Mode stay visible in the nav: choosing Free, BYOK or Pro is a
+purchase-path decision, not an optional preference, so it never hides behind a
+disclosure. Document type, persona, register and credential fields remain in it.
 Localized copy, example selection, and visible verification evidence keep their
 current behavior. Narrow screens retain the existing stacked layout and controls.
+
+The disclosure overlays the hero, so it is dismissed document-wide: Escape works
+while the prompt has focus, and a press anywhere outside it closes it.
+
+## Approval status
+
+Every rewrite carries a `role="status"` line stating whether checks passed. It is
+visible, not only announced — but only once there is an outcome. A rewrite runs
+10-60s against a real model, and labelling that entire window "unapproved — checks
+have not passed" reads as a failure report for a request that is merely still
+running. The line therefore stays empty while streaming (`data-output-status=
+"streaming"`) and fills in on the actual result. The disabled-action state,
+flagged border and `aria-invalid` marker apply from the first byte regardless.
 
 ## Applied in
 

--- a/playground/chatgpt.css
+++ b/playground/chatgpt.css
@@ -115,7 +115,6 @@ a { color: inherit; }
   padding: 8px 16px; border-radius: 9999px; font-size: 14px; font-family: inherit;
   text-decoration: none; cursor: pointer; border: 1px solid transparent;
 }
-.btn--ghost { background: transparent; color: var(--text); border-color: var(--border-strong); }
 
 /* ───────── landing ───────── */
 .landing { display: block; }
@@ -186,17 +185,6 @@ a { color: inherit; }
 
 .how, .examples, .bench, .cta { max-width: var(--page); margin: 0 auto; padding: 104px 24px; }
 .how__grid { display: grid; grid-template-columns: 1.1fr 1fr; gap: 48px; align-items: center; }
-.how__preview {
-  background: var(--bg-cream); border: 1px solid var(--border); border-radius: 16px;
-  padding: 24px; display: flex; flex-direction: column; gap: 12px; font-size: 14px;
-}
-.hp-line { padding: 12px 14px; border-radius: 12px; background: var(--bg-elev); border: 1px solid var(--border); line-height: 1.5; }
-.hp-before { border-left: 2px solid var(--copper); }
-.hp-after { border-left: 2px solid var(--accent); }
-.hp-tag { display: inline-block; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; color: var(--text-faint); margin-right: 8px; font-family: var(--mono); }
-.hp-arrow { text-align: center; font-size: 12px; color: var(--accent); font-family: var(--mono); }
-.hp-meta { display: flex; gap: 8px; flex-wrap: wrap; }
-.hp-meta span { font-family: var(--mono); font-size: 11px; color: var(--gold); background: var(--bg-elev); border: 1px solid var(--border); border-radius: 9999px; padding: 3px 10px; }
 .how__steps { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 26px; }
 .how__steps h3 { font-size: 24px; font-weight: 600; margin: 0 0 4px; letter-spacing: -.4px; }
 .how__steps p { margin: 0; color: var(--text-dim); }
@@ -204,26 +192,20 @@ a { color: inherit; }
 /* examples — editor panel (Resend/Linear-style chrome) */
 .editor { max-width: 920px; margin: 0 auto; background: var(--bg-elev); border: 1px solid var(--border); border-radius: 16px; overflow: hidden; box-shadow: 0 1px 2px rgba(0, 0, 0, .4), 0 12px 28px rgba(0, 0, 0, .18); }
 .editor__bar { display: flex; align-items: center; gap: 14px; padding: 11px 16px; border-bottom: 1px solid var(--border); background: var(--bg-cream); }
-.editor__dots { display: inline-flex; gap: 7px; flex: 0 0 auto; }
-.editor__dots i { width: 11px; height: 11px; border-radius: 50%; background: var(--border-strong); }
 .editor__tabs { display: flex; gap: 4px; flex: 1 1 auto; overflow-x: auto; scrollbar-width: none; }
 .editor__tabs::-webkit-scrollbar { display: none; }
 .editor__tab { font-family: inherit; font-size: 13px; color: var(--text-dim); background: transparent; border: 1px solid transparent; border-radius: 8px; padding: 6px 12px; cursor: pointer; white-space: nowrap; transition: background .15s, color .15s, border-color .15s; }
 .editor__tab:hover { color: var(--text); background: var(--bg-hover); }
 .editor__tab.is-active { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); background: color-mix(in srgb, var(--accent) 10%, transparent); }
-.editor__act { display: flex; align-items: center; gap: 10px; flex: 0 0 auto; }
-.editor__state { font-family: var(--mono); font-size: 11px; color: var(--text-faint); white-space: nowrap; }
 .editor__btn { font-family: var(--mono); font-size: 11px; border-radius: 8px; border: 1px solid var(--border); background: transparent; color: var(--text-dim); cursor: pointer; padding: 5px 11px; transition: border-color .15s, color .15s; }
 .editor__btn:hover { border-color: var(--border-strong); color: var(--text); }
 .editor__btn.is-ok { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
 
 .editor__body { display: flex; align-items: flex-start; min-height: 128px; background-image: radial-gradient(circle at 1px 1px, rgba(232, 238, 247, 0.035) 1px, transparent 1.5px); background-size: 22px 22px; }
-.editor__gutter { flex: 0 0 auto; display: flex; flex-direction: column; align-items: flex-end; padding: 18px 14px 18px 20px; border-right: 1px solid var(--border); font-family: var(--mono); font-size: 13px; line-height: 26px; color: var(--text-faint); user-select: none; }
 .editor__code { flex: 1 1 auto; min-width: 0; padding: 18px 24px; }
 
 .editor__foot { display: flex; align-items: center; gap: 12px; padding: 12px 16px; border-top: 1px solid var(--border); background: var(--bg-cream); }
 .editor__cap { font-size: 12px; color: var(--text-faint); flex: 1 1 auto; }
-.editor__footact { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }
 
 /* examples — persistent before/after diff (both stay visible) */
 .editor__seg { font-size: 15px; line-height: 26px; word-break: keep-all; }
@@ -231,12 +213,9 @@ a { color: inherit; }
 .editor__seg--before .dtok--rm { color: var(--copper); }
 .editor__seg--after { color: var(--text); }
 .editor__seg--after .dtok--add { color: var(--accent); }
-.editor__arrow { font-family: var(--mono); font-size: 12px; line-height: 26px; color: var(--accent); opacity: .75; letter-spacing: .04em; }
-.editor__gx { color: var(--accent); opacity: .55; }
 .dtok { transition: color .35s ease; }
 
 /* one-shot reveal flourish on the after block; the before block never moves */
-.editor.is-reveal .editor__arrow,
 .editor.is-reveal .editor__seg--after { animation: seg-in .6s ease both; }
 @keyframes seg-in { from { opacity: 0; transform: translateY(7px); } to { opacity: 1; transform: none; } }
 
@@ -247,7 +226,6 @@ a { color: inherit; }
 .xcard__try:hover { background: color-mix(in srgb, var(--accent) 12%, transparent); }
 
 @media (prefers-reduced-motion: reduce) {
-  .editor.is-reveal .editor__arrow,
   .editor.is-reveal .editor__seg--after { animation: none; }
 }
 
@@ -492,10 +470,7 @@ details.foldout > summary:focus-visible,
   .chat:not(.sidebar-open) .sidebar { margin-left: -260px; visibility: hidden; transition: margin-left .2s ease, visibility 0s .2s; }
   .chat.sidebar-open .sidebar { visibility: visible; }
   .iconbtn { display: inline-block; }
-  .editor__dots { display: none; }
-  .editor__state { display: none; }
   .editor__code { padding: 16px; }
-  .editor__gutter { padding: 16px 10px; }
   .bench__cards { grid-template-columns: 1fr; }
 }
 

--- a/playground/chatgpt.js
+++ b/playground/chatgpt.js
@@ -711,11 +711,16 @@ function renderExamples() {
     loadIntoPrompt(selected.before);
     globalThis.scrollTo({ top: 0, behavior: 'smooth' });
   });
+  let copyReset;
   copy.addEventListener('click', async () => {
     try {
       await globalThis.navigator.clipboard.writeText(active.after);
       copy.textContent = ui.copied;
+      copy.classList.add('is-ok');
     } catch { copy.textContent = ui.copyFailed; }
+    // Restore the resting label so a second copy still reads as an available action.
+    clearTimeout(copyReset);
+    copyReset = globalThis.setTimeout(() => { copy.textContent = ui.copyExample; copy.classList.remove('is-ok'); }, 1400);
   });
   setActive(active);
 }
@@ -836,12 +841,16 @@ function buildPatinaMsg() {
   msg.appendChild(body);
   return { node: msg, body, textEl, statusEl };
 }
-function markOutputUnapproved(textEl, statusEl) {
+// `announce: false` covers a rewrite that has not finished yet. The disabled-action
+// state is real from the first byte, but calling an in-flight stream "unapproved —
+// checks have not passed" reads as a failure warning during a normal 10-60s rewrite,
+// so the status line stays empty until there is an actual outcome to report.
+function markOutputUnapproved(textEl, statusEl, { announce = true } = {}) {
   textEl.classList.add('msg__text--unapproved');
   textEl.dataset.outputStatus = 'unapproved';
   textEl.setAttribute('aria-invalid', 'true');
-  statusEl.textContent = i18n().outputUnapproved;
-  statusEl.dataset.outputStatus = 'unapproved';
+  statusEl.textContent = announce ? i18n().outputUnapproved : '';
+  statusEl.dataset.outputStatus = announce ? 'unapproved' : 'streaming';
 }
 function approveOutput(textEl, statusEl) {
   textEl.classList.remove('msg__text--unapproved');
@@ -1046,6 +1055,17 @@ function signInLicense() {
 }
 
 function openSettings() { $('#settings-panel').setAttribute('open', ''); }
+function closeSettings({ restoreFocus = false } = {}) {
+  const panel = $('#settings-panel');
+  if (!panel.hasAttribute('open')) return;
+  panel.removeAttribute('open');
+  if (restoreFocus) $('#settings-label').focus();
+}
+function withinSettings(node) {
+  const panel = $('#settings-panel');
+  for (let current = node; current; current = current.parentElement) if (current === panel) return true;
+  return false;
+}
 
 function openLicenseControls() {
   openSettings();
@@ -1191,7 +1211,7 @@ async function runAttempt(attempt) {
 
   textEl.style.display = 'none';
   textEl.classList.remove('msg__text--flagged');
-  markOutputUnapproved(textEl, statusEl);
+  markOutputUnapproved(textEl, statusEl, { announce: false });
   const typing = buildTyping();
   body.appendChild(typing);
   scrollDown();
@@ -1640,10 +1660,18 @@ function applyExperienceCopy(lang, set) {
 }
 
 // ---------- events ----------
-$('#settings-panel').addEventListener('keydown', (event) => {
+// The panel overlays the hero, so dismissal is document-scoped: Escape has to work
+// while typing in the prompt, and a press outside the panel has to close it.
+// A focused control inside the panel still bubbles its keydown up to the document,
+// so one listener covers both; an open native <select> popup consumes the first
+// Escape itself, which is the platform behavior and is left alone.
+document.addEventListener('keydown', (event) => {
   if (event.key !== 'Escape') return;
-  $('#settings-panel').removeAttribute('open');
-  $('#settings-label').focus();
+  closeSettings({ restoreFocus: true });
+});
+document.addEventListener('mousedown', (event) => {
+  if (withinSettings(event.target)) return;
+  closeSettings();
 });
 const inputStarted = new Set();
 function trackInputStarted(surface, input) {

--- a/playground/chatgpt.js
+++ b/playground/chatgpt.js
@@ -650,6 +650,14 @@ function renderExamples() {
 
   let active = EXAMPLES.find((example) => example.id === exampleSelection && example.lang === els.lang.value)
     || EXAMPLES.find((example) => example.lang === els.lang.value) || EXAMPLES[0];
+  // The copy button carries a transient result label; it belongs to the row that
+  // was copied, so switching rows drops both the label and its pending timer.
+  let copyReset;
+  const restCopy = () => {
+    clearTimeout(copyReset);
+    copy.textContent = ui.copyExample;
+    copy.classList.remove('is-ok');
+  };
   const reveal = () => {
     if (reduce) return;
     editor.classList.remove('is-reveal');
@@ -678,7 +686,7 @@ function renderExamples() {
       tab.setAttribute('aria-selected', String(selected));
       tab.setAttribute('tabindex', selected ? '0' : '-1');
     }
-    copy.textContent = ui.copyExample;
+    restCopy();
     if (animate) reveal();
   };
   selectExample = setActive;
@@ -711,16 +719,19 @@ function renderExamples() {
     loadIntoPrompt(selected.before);
     globalThis.scrollTo({ top: 0, behavior: 'smooth' });
   });
-  let copyReset;
   copy.addEventListener('click', async () => {
+    clearTimeout(copyReset);
     try {
       await globalThis.navigator.clipboard.writeText(active.after);
       copy.textContent = ui.copied;
       copy.classList.add('is-ok');
-    } catch { copy.textContent = ui.copyFailed; }
+    } catch {
+      // A failure must not keep the success styling from a previous copy.
+      copy.textContent = ui.copyFailed;
+      copy.classList.remove('is-ok');
+    }
     // Restore the resting label so a second copy still reads as an available action.
-    clearTimeout(copyReset);
-    copyReset = globalThis.setTimeout(() => { copy.textContent = ui.copyExample; copy.classList.remove('is-ok'); }, 1400);
+    copyReset = globalThis.setTimeout(restCopy, 1400);
   });
   setActive(active);
 }

--- a/playground/index.html
+++ b/playground/index.html
@@ -34,6 +34,14 @@
             <option value="ja">日本語</option>
           </select>
         </label>
+        <label class="ctl">
+          <span class="ctl__label">Mode</span>
+          <select id="tier" class="ctl__select">
+            <option value="free">Free</option>
+            <option value="byok">BYOK</option>
+            <option value="pro">Pro</option>
+          </select>
+        </label>
         <details class="settings" id="settings-panel">
           <summary id="settings-label">Options</summary>
           <div class="settings__panel">
@@ -53,14 +61,6 @@
                   <option value="">Preserve source</option>
                   <option value="casual">Casual</option>
                   <option value="professional">Professional</option>
-                </select>
-              </label>
-              <label class="ctl">
-                <span class="ctl__label">Mode</span>
-                <select id="tier" class="ctl__select">
-                  <option value="free">Free</option>
-                  <option value="byok">BYOK</option>
-                  <option value="pro">Pro</option>
                 </select>
               </label>
             </div>
@@ -124,7 +124,7 @@
             <p class="hero__sub">Turn a stiff draft into clear, natural writing. Keep your meaning.</p>
 
             <form class="prompt" id="hero-form">
-              <textarea class="prompt__input" id="hero-input" rows="1" placeholder="Paste the text you want to clean up…" aria-label="Paste the text you want to clean up…"></textarea>
+              <textarea class="prompt__input" id="hero-input" rows="1" placeholder="Paste the text you want to clean up…" aria-label="Paste the text you want to clean up…" autofocus></textarea>
               <div class="prompt__bar">
                 <span id="hero-action">Rewrite my text</span>
                 <button class="prompt__send" id="hero-send" type="submit" disabled aria-label="Send">

--- a/tests/unit/playground-a11y.test.js
+++ b/tests/unit/playground-a11y.test.js
@@ -145,3 +145,10 @@ test('actual output approval status remains visible, not only announced', () => 
   assert.ok(rule);
   assert.doesNotMatch(rule, /clip|position:\s*absolute|display:\s*none|visibility:\s*hidden/);
 });
+
+test('an in-flight rewrite is not announced as a failed check', () => {
+  // A normal rewrite runs 10-60s. Reporting "unapproved - checks have not passed"
+  // for that whole window reads as an error, so only a real outcome is announced.
+  assert.match(js, /markOutputUnapproved\(textEl, statusEl, \{ announce: false \}\)/);
+  assert.match(js, /statusEl\.textContent = announce \? i18n\(\)\.outputUnapproved : ''/);
+});

--- a/tests/unit/playground-experience.test.js
+++ b/tests/unit/playground-experience.test.js
@@ -781,6 +781,100 @@ test('illustrative copy has no guessed scores while approved API scores stay vis
   assert.equal(a.document.querySelector('.output-status').textContent, 'Approved — checks passed. Actions are enabled.');
 });
 
+// The status line is the only visible statement about whether a result passed the
+// meaning gate, so its transitions are asserted as observable state, not as source shape.
+function statusOf(a) {
+  const node = a.document.querySelector('.output-status');
+  return node && { text: node.textContent, state: node.dataset.outputStatus };
+}
+
+test('the approval status is silent in flight and states every terminal outcome', async () => {
+  const t = { unapproved: 'Unapproved — checks have not passed. Actions are disabled.',
+    approved: 'Approved — checks passed. Actions are enabled.' };
+
+  // In flight: no claim either way, because the request has not produced a result.
+  let release;
+  const pending = app({ response: (options) => new Promise((resolve) => {
+    options.onStart?.({ type: 'start' });
+    options.onDelta?.('partial', 'partial');
+    release = () => {
+      const frame = { type: 'done', rewrite: 'Accepted 70%', mps: 91, fidelity: 87 };
+      options.onDone(frame); resolve({ ok: true, finalFrame: frame });
+    };
+  }) });
+  const streaming = pending.ui.submit('Source 70%');
+  assert.deepEqual(statusOf(pending), { text: '', state: 'streaming' },
+    'a running rewrite must not be announced as a failed check');
+  assert.equal(pending.document.querySelector('.output-action'), null);
+  release();
+  await streaming;
+  await pending.settle();
+  assert.deepEqual(statusOf(pending), { text: t.approved, state: 'approved' });
+  assert.ok(pending.document.querySelectorAll('.output-action').length > 0);
+
+  // Below the meaning floor: rejected, announced, and no actions offered.
+  const floor = app({ response: (options) => {
+    options.onStart?.({ type: 'start' });
+    const frame = { type: 'done', rewrite: 'Rejected', mps: 12, fidelity: 9 };
+    options.onDone(frame); return { ok: true, finalFrame: frame };
+  } });
+  await floor.ui.submit('Source 70%');
+  await floor.settle();
+  assert.deepEqual(statusOf(floor), { text: t.unapproved, state: 'unapproved' });
+  assert.equal(floor.document.querySelector('.output-action'), null);
+  assert.equal(floor.ui.activeConvo().thread.original, undefined);
+
+  // Transport failure: still a stated outcome, never a stranded empty line.
+  const failed = app({ response: () => ({ ok: false, finalFrame: { status: 500, error: 'upstream failed' } }) });
+  await failed.ui.submit('Source 70%');
+  await failed.settle();
+  assert.deepEqual(statusOf(failed), { text: t.unapproved, state: 'unapproved' });
+  assert.equal(failed.document.querySelector('.output-action'), null);
+
+  // Explicit Stop: the cancelled attempt reports unapproved rather than staying blank.
+  const stopped = app({ response: (options) => new Promise(() => { options.onStart?.({ type: 'start' }); }) });
+  const running = stopped.ui.submit('Source 70%');
+  assert.deepEqual(statusOf(stopped), { text: '', state: 'streaming' });
+  stopped.get('hero-form').emit('submit');
+  assert.deepEqual(statusOf(stopped), { text: t.unapproved, state: 'unapproved' });
+  void running;
+});
+
+test('a copied example resets its label and success styling, and never carries them to another row', async () => {
+  const a = app({ languages: ['ko-KR'] });
+  const ui = copy.onboardingCopy('ko');
+  const button = a.document.querySelector('.editor__btn');
+  const clipboard = [];
+  a.context.navigator.clipboard = { writeText: async (text) => { clipboard.push(text); } };
+  assert.equal(button.textContent, ui.copyExample);
+
+  button.emit('click');
+  await nextTurn();
+  assert.deepEqual(clipboard, [EXAMPLES.find((row) => row.id === 'ko-fixture-0').after]);
+  assert.equal(button.textContent, ui.copied);
+  assert.equal(button.classList.contains('is-ok'), true);
+
+  // Switching rows drops the transient result: it belonged to the copied row.
+  change(a, 'example-choice', 'ko-fixture-1');
+  assert.equal(button.textContent, ui.copyExample);
+  assert.equal(button.classList.contains('is-ok'), false, 'success styling must not survive a row change');
+
+  // A failure must not keep the previous success styling.
+  button.emit('click');
+  await nextTurn();
+  assert.equal(button.classList.contains('is-ok'), true);
+  a.context.navigator.clipboard = { writeText: async () => { throw new Error('clipboard unavailable'); } };
+  button.emit('click');
+  await nextTurn();
+  assert.equal(button.textContent, ui.copyFailed);
+  assert.equal(button.classList.contains('is-ok'), false);
+
+  // The resting label returns so a second copy still reads as an available action.
+  await new Promise((resolve) => setTimeout(resolve, 1600));
+  assert.equal(button.textContent, ui.copyExample);
+  assert.equal(button.classList.contains('is-ok'), false);
+});
+
 test('optional controls open for credentials, close with Escape, and Free restores setup-free sending', () => {
   const a = app();
   const panel = a.get('settings-panel');

--- a/tests/unit/playground-experience.test.js
+++ b/tests/unit/playground-experience.test.js
@@ -64,6 +64,7 @@ class Element {
   set hidden(value) { this.toggleAttribute('hidden', value); }
   setAttribute(name, value) { this.attributes[name] = String(value); }
   getAttribute(name) { return this.attributes[name] ?? null; }
+  hasAttribute(name) { return name in this.attributes; }
   removeAttribute(name) { delete this.attributes[name]; }
   toggleAttribute(name, force) { if (force) this.attributes[name] = ''; else delete this.attributes[name]; }
   appendChild(child) { child.parentElement = this; this.children.push(child); return child; }
@@ -784,14 +785,31 @@ test('optional controls open for credentials, close with Escape, and Free restor
   const a = app();
   const panel = a.get('settings-panel');
   assert.equal(panel.getAttribute('open'), null);
-  assert.equal(panel.querySelector('#lang'), null, 'language is outside the optional disclosure');
-  for (const id of ['document-type', 'persona', 'register', 'tier', 'license-key', 'api-key', 'protected-text']) assert.ok(panel.querySelector(`#${id}`));
+  for (const id of ['lang', 'tier']) {
+    assert.equal(panel.querySelector(`#${id}`), null, `${id} stays outside the optional disclosure`);
+  }
+  for (const id of ['document-type', 'persona', 'register', 'license-key', 'api-key', 'protected-text']) assert.ok(panel.querySelector(`#${id}`));
   a.get('pro-existing').emit('click');
   assert.equal(panel.getAttribute('open'), '');
   assert.equal(a.get('license-key').focused, true);
-  panel.emit('keydown', { key: 'Escape' });
+  // The panel overlays the hero, so Escape must dismiss it from anywhere on the page.
+  a.document.emit('keydown', { key: 'Escape' });
   assert.equal(panel.getAttribute('open'), null);
   assert.equal(a.get('settings-label').focused, true);
+  // A control inside the panel bubbles its keydown to the document, so one
+  // listener covers both; this must not need a second panel-scoped listener.
+  a.get('pro-existing').emit('click');
+  assert.equal(panel.getAttribute('open'), '');
+  a.get('document-type').emit('keydown', { key: 'Escape' });
+  assert.equal(panel.getAttribute('open'), null, 'Escape from a control inside the panel dismisses it');
+  a.get('pro-existing').emit('click');
+  assert.equal(panel.getAttribute('open'), '');
+  a.get('hero-input').emit('mousedown');
+  assert.equal(panel.getAttribute('open'), null, 'a press outside the panel dismisses it');
+  // A press on a control inside the panel must leave it open.
+  a.get('pro-existing').emit('click');
+  a.get('license-key').emit('mousedown');
+  assert.equal(panel.getAttribute('open'), '', 'a press inside the panel keeps it open');
   a.get('price-byok').emit('click');
   assert.equal(panel.getAttribute('open'), '');
   assert.equal(a.get('api-key').focused, true);

--- a/tests/unit/playground-pro.test.js
+++ b/tests/unit/playground-pro.test.js
@@ -124,7 +124,8 @@ test('output approval status is localized, announced, and associated with its ou
   assert.match(builder, /statusEl\.setAttribute\('role', 'status'\)/);
   assert.match(builder, /statusEl\.setAttribute\('aria-live', 'polite'\)/);
   assert.match(builder, /textEl\.setAttribute\('aria-describedby', statusEl\.id\)/);
-  assert.match(builder, /statusEl\.textContent = i18n\(\)\.outputUnapproved/);
+  // Unapproved is announced for a real outcome only; an in-flight stream stays silent.
+  assert.match(builder, /statusEl\.textContent = announce \? i18n\(\)\.outputUnapproved : ''/);
   assert.match(builder, /statusEl\.textContent = i18n\(\)\.outputApproved/);
   assert.match(stylesheet, /\.output-status/);
 });


### PR DESCRIPTION
## What

`ef9c512` (8.5.0, "native multilingual first-use experience") rewrote the landing page. It genuinely improved things — browser-locale detection, KO/ZH/JA native copy, and collapsing a 189px three-row nav into a single row — but it dropped several working behaviors on the way. This restores them without giving up any of the improvements.

## Regressions repaired

| | Before this PR | After |
|---|---|---|
| Example copy button | Stuck on "복사했어요" forever; a second copy gave no feedback | Restores its resting label after 1.4s |
| Options disclosure | Escape did nothing while the prompt had focus; no outside-press dismissal — and the panel overlays the hero title on a sticky nav, so it followed the reader down the page | Dismissed by Escape from anywhere, or a press outside |
| Hero input | Lost `autofocus` while the copy still says "붙여넣고 보내세요" | Focused on load |
| Mode (Free/BYOK/Pro) | Moved into the disclosure — paid tiers one click deeper | Back in the nav next to Language |
| Dead CSS | 16 classes stranded when their markup was deleted | Removed |

Mode is the one that matters commercially: tier selection is a purchase-path decision, not an optional preference. Document type, persona, register and credential fields stay in the disclosure, so the nav stays one row.

## Approval status line

`247abbd` deliberately made `.output-status` screen-reader-only because "Unapproved — checks have not passed" is shown for the entire 10-60s of a *normal* in-flight rewrite and reads as a failure. `ef9c512` reverted that and pinned the revert with a test.

Both goals are satisfiable, so neither is sacrificed: the line stays visually present for real outcomes, and is empty while streaming (`data-output-status="streaming"`). The flagged border, disabled actions and `aria-invalid` marker still apply from the first byte, and a below-floor result still announces "미승인" with zero offered actions.

## Verification

- 2318 unit/e2e tests pass (2 new), eslint clean on every touched file. The 37 pre-existing `.omo/evidence` eslint errors are unchanged and unrelated.
- Independent architect review: **approve-with-nits**, architectural status CLEAR, no blocking findings. Both LOW findings are fixed in `42843a3`:
  - stale `.is-ok` styling could survive a row change or a clipboard failure;
  - the status/copy assertions were source-regex shape checks — replaced with behavioral tests on the existing VM/DOM fixture covering accepted, below-floor, transport-failure and Stop outcomes.
- Mutation-tested: reverting the streaming silence, the row-change reset, the copy timer, the document-scoped Escape, or the outside-press dismissal each fails 3 tests.
- Browser-level (headless Chrome over CDP): autofocus, nav-visible tier, Escape from the prompt and from a control inside the panel, outside-press dismissal, a press inside keeping it open, both pricing CTAs leaving the panel they opened open, copy label/styling reset across rows with a real granted clipboard, a silent streaming window, and an announced floor failure with no actions.
- `src/features/*` untouched — the deterministic layer is unaffected.

## Not in scope

Separately identified during the same audit, deliberately left out to keep this reviewable:

- **First-screen density.** The 8.5.2 hotfix (`e8eb0da`) moved the examples out of the hero, taking the first screen from 53% empty back to 70% empty and the page from 3914px to 4676px. Needs a design call, not a revert.
- **Lost proof points.** The how-section no longer mentions the pattern count, MPS/fidelity, or the before/after preview card — the landing stopped selling the one thing that differentiates patina.
- **Weak ja/zh examples.** 5 of 12 curated examples show no deterministic signal improvement; all three `ja` rows score `signal 100 → 100`. A "before and after" showcase whose own engine can't measure the change isn't a showcase.