### PR TITLE
feat(maintenance): validate and synchronize plugin version mirrors

### DIFF
--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -79,6 +79,98 @@ export function collectReleaseMetadataErrors({ repoRoot = REPO_ROOT, env = proce
   return { errors: checks, version };
 }
 
+/**
+ * Synchronize the two Claude plugin version mirrors from package.json.
+ *
+ * This is intentionally an explicit maintenance operation. The normal release
+ * metadata check remains read-only and only reports drift. Every input is read
+ * and validated before either mirror is written, so a malformed or missing
+ * plugin manifest cannot leave a partially updated pair behind.
+ *
+ * @param {{repoRoot?: string}} [options]
+ * @returns {{version: string, updated: string[], changed: boolean}}
+ * @throws {Error} When package or plugin metadata is missing or malformed.
+ */
+export function syncPluginVersions({ repoRoot = REPO_ROOT } = {}) {
+  const repoPath = (path) => resolve(repoRoot, path);
+  const packagePath = repoPath('package.json');
+  const pluginPath = repoPath('.claude-plugin/plugin.json');
+  const marketplacePath = repoPath('.claude-plugin/marketplace.json');
+
+  const readJsonForSync = (path, label) => {
+    let text;
+    try {
+      text = readFileSync(path, 'utf8');
+    } catch (error) {
+      throw new Error(`${label} is missing or unreadable: ${error.message}`, { cause: error });
+    }
+    try {
+      return { data: JSON.parse(text), text };
+    } catch (error) {
+      throw new Error(`${label} is malformed JSON: ${error.message}`, { cause: error });
+    }
+  };
+
+  const packageData = readJsonForSync(packagePath, 'package.json').data;
+  const version = packageData?.version;
+  if (typeof version !== 'string' || !version.trim()) {
+    throw new Error('package.json version must be a non-empty string');
+  }
+
+  const pluginFile = readJsonForSync(pluginPath, '.claude-plugin/plugin.json');
+  const marketplaceFile = readJsonForSync(marketplacePath, '.claude-plugin/marketplace.json');
+  const plugin = pluginFile.data;
+  const marketplace = marketplaceFile.data;
+
+  if (!plugin || Array.isArray(plugin) || typeof plugin !== 'object' || plugin.name !== 'patina') {
+    throw new Error('.claude-plugin/plugin.json must be an object with name "patina"');
+  }
+  if (typeof plugin.version !== 'string' || !plugin.version.trim()) {
+    throw new Error('.claude-plugin/plugin.json version must be a non-empty string');
+  }
+  if (!marketplace || Array.isArray(marketplace) || typeof marketplace !== 'object' || !Array.isArray(marketplace.plugins)) {
+    throw new Error('.claude-plugin/marketplace.json must contain a plugins array');
+  }
+  const marketplacePlugins = marketplace.plugins.filter((entry) => entry && typeof entry === 'object' && entry.name === 'patina');
+  if (marketplacePlugins.length === 0) {
+    throw new Error('.claude-plugin/marketplace.json must list a patina plugin entry');
+  }
+  if (marketplacePlugins.length > 1) {
+    throw new Error('.claude-plugin/marketplace.json must list exactly one patina plugin entry');
+  }
+  const marketplacePlugin = marketplacePlugins[0];
+  if (typeof marketplacePlugin.version !== 'string' || !marketplacePlugin.version.trim()) {
+    throw new Error('.claude-plugin/marketplace.json patina plugin version must be a non-empty string');
+  }
+
+  const pluginNeedsSync = plugin.version !== version;
+  const marketplaceNeedsSync = marketplacePlugin.version !== version;
+  if (!pluginNeedsSync && !marketplaceNeedsSync) {
+    return { version, updated: [], changed: false };
+  }
+
+  plugin.version = version;
+  marketplacePlugin.version = version;
+
+  const encodeJson = (data, originalText) => {
+    const newline = originalText.endsWith('\n') ? '\n' : '';
+    return `${JSON.stringify(data, null, 2)}${newline}`;
+  };
+  const pluginText = encodeJson(plugin, pluginFile.text);
+  const marketplaceText = encodeJson(marketplace, marketplaceFile.text);
+  const updated = [];
+  if (pluginNeedsSync && pluginText !== pluginFile.text) {
+    writeFileSync(pluginPath, pluginText);
+    updated.push('.claude-plugin/plugin.json');
+  }
+  if (marketplaceNeedsSync && marketplaceText !== marketplaceFile.text) {
+    writeFileSync(marketplacePath, marketplaceText);
+    updated.push('.claude-plugin/marketplace.json');
+  }
+
+  return { version, updated, changed: updated.length > 0 };
+}
+
 export function runReleaseMetadataCheck(options = {}) {
   const { stderr = process.stderr, stdout = process.stdout, ...collectorOptions } = options;
   const { errors, version } = collectReleaseMetadataErrors(collectorOptions);
@@ -91,7 +183,19 @@ export function runReleaseMetadataCheck(options = {}) {
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  process.exitCode = runReleaseMetadataCheck();
+  if (process.argv.includes('--sync-plugin-versions')) {
+    try {
+      const result = syncPluginVersions();
+      const suffix = result.updated.length ? `: ${result.updated.join(', ')}` : ': already current';
+      process.stdout.write(`Plugin versions synced to ${result.version}${suffix}\n`);
+      process.exitCode = 0;
+    } catch (error) {
+      process.stderr.write(`${error.message}\n`);
+      process.exitCode = 1;
+    }
+  } else {
+    process.exitCode = runReleaseMetadataCheck();
+  }
 }
 
 function escapeRegex(value) {

--- a/scripts/check-release-metadata.mjs
+++ b/scripts/check-release-metadata.mjs
@@ -131,6 +131,9 @@ export function syncPluginVersions({ repoRoot = REPO_ROOT } = {}) {
   if (!marketplace || Array.isArray(marketplace) || typeof marketplace !== 'object' || !Array.isArray(marketplace.plugins)) {
     throw new Error('.claude-plugin/marketplace.json must contain a plugins array');
   }
+  if (marketplace.plugins.some((entry) => !entry || typeof entry !== 'object' || Array.isArray(entry))) {
+    throw new Error('.claude-plugin/marketplace.json plugins must contain only objects');
+  }
   const marketplacePlugins = marketplace.plugins.filter((entry) => entry && typeof entry === 'object' && entry.name === 'patina');
   if (marketplacePlugins.length === 0) {
     throw new Error('.claude-plugin/marketplace.json must list a patina plugin entry');

--- a/tests/unit/check-release-metadata.test.js
+++ b/tests/unit/check-release-metadata.test.js
@@ -6,6 +6,7 @@ import { test } from 'node:test';
 import {
   collectReleaseMetadataErrors,
   runReleaseMetadataCheck,
+  syncPluginVersions,
 } from '../../scripts/check-release-metadata.mjs';
 
 const VERSION = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8')).version;
@@ -90,6 +91,54 @@ test('runner reports success without exiting the importing process', () => {
   });
   assert.equal(exitCode, 0);
   assert.equal(output, `Release metadata OK for ${VERSION}\n`);
+});
+
+test('explicit plugin sync updates only the two Claude mirrors and keeps the checker coherent', () => {
+  withFixture((root) => {
+    writeFixtureFile(root, '.claude-plugin/plugin.json', JSON.stringify({ name: 'patina', version: '0.0.0' }));
+    writeFixtureFile(root, '.claude-plugin/marketplace.json', JSON.stringify({
+      plugins: [{ name: 'patina', version: '0.0.0' }, { name: 'other', version: '3.0.0' }],
+    }));
+
+    const first = syncPluginVersions({ repoRoot: root });
+    assert.deepEqual(first, {
+      version: VERSION,
+      updated: ['.claude-plugin/plugin.json', '.claude-plugin/marketplace.json'],
+      changed: true,
+    });
+    assert.equal(readJson(root, '.claude-plugin/plugin.json').version, VERSION);
+    assert.equal(readJson(root, '.claude-plugin/marketplace.json').plugins[0].version, VERSION);
+    assert.equal(readJson(root, '.claude-plugin/marketplace.json').plugins[1].version, '3.0.0');
+    assert.deepEqual(collectReleaseMetadataErrors({ repoRoot: root }).errors, []);
+
+    const pluginText = readFileSync(join(root, '.claude-plugin/plugin.json'), 'utf8');
+    const marketplaceText = readFileSync(join(root, '.claude-plugin/marketplace.json'), 'utf8');
+    const second = syncPluginVersions({ repoRoot: root });
+    assert.deepEqual(second, { version: VERSION, updated: [], changed: false });
+    assert.equal(readFileSync(join(root, '.claude-plugin/plugin.json'), 'utf8'), pluginText);
+    assert.equal(readFileSync(join(root, '.claude-plugin/marketplace.json'), 'utf8'), marketplaceText);
+  });
+});
+
+test('plugin sync validates malformed or missing manifests before writing either mirror', () => {
+  withFixture((root) => {
+    const pluginPath = join(root, '.claude-plugin/plugin.json');
+    const marketplacePath = join(root, '.claude-plugin/marketplace.json');
+    const marketplaceBefore = readFileSync(marketplacePath, 'utf8');
+    writeFileSync(pluginPath, '{not-json');
+    assert.throws(() => syncPluginVersions({ repoRoot: root }), /plugin\.json is malformed JSON/);
+    assert.equal(readFileSync(marketplacePath, 'utf8'), marketplaceBefore);
+
+    rmSync(pluginPath);
+    assert.throws(() => syncPluginVersions({ repoRoot: root }), /plugin\.json is missing or unreadable/);
+    assert.equal(readFileSync(marketplacePath, 'utf8'), marketplaceBefore);
+
+    writeFileSync(pluginPath, JSON.stringify({ name: 'patina', version: '0.0.0' }));
+    const pluginBefore = readFileSync(pluginPath, 'utf8');
+    writeFileSync(marketplacePath, '{not-json');
+    assert.throws(() => syncPluginVersions({ repoRoot: root }), /marketplace\.json is malformed JSON/);
+    assert.equal(readFileSync(pluginPath, 'utf8'), pluginBefore);
+  });
 });
 
 for (const { label, mutate, message } of [

--- a/tests/unit/check-release-metadata.test.js
+++ b/tests/unit/check-release-metadata.test.js
@@ -120,6 +120,23 @@ test('explicit plugin sync updates only the two Claude mirrors and keeps the che
   });
 });
 
+test('plugin sync rejects malformed marketplace entries without writing either mirror', () => {
+  for (const invalid of [null, [], 'invalid', 1]) {
+    for (const first of [true, false]) {
+      withFixture((root) => {
+        const pluginPath = join(root, '.claude-plugin/plugin.json');
+        const marketplacePath = join(root, '.claude-plugin/marketplace.json');
+        writeFileSync(pluginPath, JSON.stringify({ name: 'patina', version: '0.0.0' }));
+        const target = { name: 'patina', version: '0.0.0' };
+        writeFileSync(marketplacePath, JSON.stringify({ plugins: first ? [invalid, target] : [target, invalid] }));
+        const before = [pluginPath, marketplacePath].map(path => readFileSync(path, 'utf8'));
+        assert.throws(() => syncPluginVersions({ repoRoot: root }), /plugins must contain only objects/);
+        assert.deepEqual([pluginPath, marketplacePath].map(path => readFileSync(path, 'utf8')), before);
+      });
+    }
+  }
+});
+
 test('plugin sync validates malformed or missing manifests before writing either mirror', () => {
   withFixture((root) => {
     const pluginPath = join(root, '.claude-plugin/plugin.json');


### PR DESCRIPTION
## Scope
Refs #783 — P05 version SSOT pilot. Add explicit plugin mirror synchronization to the existing metadata checker; validate every input before writing. Root/package version remains 8.6.0. No publication or deployment.

## Acceptance and verification
- Root version is sole input; unrelated manifest fields preserved.
- Missing/malformed inputs fail before any mirror write; repeated synchronization is a no-op.
- `node --test tests/unit/check-release-metadata.test.js`: 27 pass, exit 0.
- `node scripts/check-release-metadata.mjs`: exit 0.
- Base b8b7b756423d61582ea83b06bd59a49fdaa4738a; implementation cf474ca. Focused check ran against exact committed source/test bytes within the maintenance worktree; hosted clean-checkout CI is required before merge.

## Risk / rollback / impact
Two files; raw diff 155 additions and 2 deletions. No exclusions. Additive maintenance CLI behavior; no product version bump. Revert this commit to remove the pilot. Existing checks remain.

## Authority
Maintainer requested continued completion, commits and merge to dev in this session. No main release, tags, registry/deployment/account writes are authorized by this PR. Package script and canonical maintenance documentation wiring are tracked separately in #783.