### PR TITLE
feat(perf): report measured CLI and package metrics without false zeros

### DIFF
--- a/scripts/perf-report.mjs
+++ b/scripts/perf-report.mjs
@@ -5,7 +5,9 @@
 // is informational (latency p50/p95/p99 of the offline analyzer); it is NOT a
 // release gate and applies no latency threshold. Timing numbers are
 // machine-dependent, so the checked-in artifact is a snapshot, not a CI-drift
-// target.
+// target. Pass --costmetrics only when an npm pack byte count is wanted.
+//
+// Usage: node scripts/perf-report.mjs [--costmetrics]
 
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
@@ -23,6 +25,17 @@ function fmt(value) {
   return value == null ? 'n/a' : Number(value).toFixed(3);
 }
 
+function fmtBytes(value) {
+  return value == null ? 'n/a' : `${Number(value)} B`;
+}
+
+export function perfReportOptions(argv = process.argv.slice(2)) {
+  return {
+    measureCliColdStart: true,
+    costMetrics: argv.includes('--costmetrics'),
+  };
+}
+
 export function renderMarkdown(report) {
   const lines = [];
   lines.push('# Performance report (report-only)');
@@ -35,6 +48,13 @@ export function renderMarkdown(report) {
   lines.push(`- Node: ${report.nodeVersion} · ${report.platform}/${report.arch}`);
   lines.push(`- Passes: ${report.passes} measured (+${report.warmupPasses} warmup) per fixture`);
   lines.push(`- Fixtures: ${report.fixtureCount}`);
+  lines.push(`- Analyzer timing: ${report.repeatConditions?.analyzer?.timingMode || 'warm-in-process'}; warmup excluded`);
+  const cli = report.cliColdStart || {};
+  lines.push(`- CLI coldstart: ${cli.status || 'unknown'}; ${fmt(cli.meanMs)} ms mean over ${cli.passes ?? 'n/a'} fresh processes`);
+  const memory = report.memory || {};
+  lines.push(`- Process memory: ${memory.status || 'unknown'}; ${memory.definition || 'RSS definition unavailable'}; delta ${fmtBytes(memory.rssDeltaBytes)}`);
+  const costs = report.costMetrics || {};
+  lines.push(`- Cost metrics: ${costs.status || 'unknown'}; calls=${costs.calls == null ? 'unknown' : costs.calls}; costUsd=${costs.costUsd == null ? 'unknown' : costs.costUsd}; npm tarball=${fmtBytes(costs.tarballBytes)}`);
   lines.push(`- Full data: [perf-latest.json](./perf-latest.json)`);
   lines.push('');
   lines.push('## Per size bucket');
@@ -47,10 +67,10 @@ export function renderMarkdown(report) {
   lines.push('');
   lines.push('## Per fixture');
   lines.push('');
-  lines.push('| fixture | lang | bucket | chars | paras | p50 ms | p95 ms | p99 ms | mean ms | texts/sec |');
-  lines.push('|---------|------|--------|------:|------:|-------:|-------:|-------:|--------:|----------:|');
+  lines.push('| fixture | lang | bucket | chars | paras | input sha256 | p50 ms | p95 ms | p99 ms | mean ms | texts/sec |');
+  lines.push('|---------|------|--------|------:|------:|--------------|-------:|-------:|-------:|--------:|----------:|');
   for (const f of report.fixtures) {
-    lines.push(`| ${f.id} | ${f.lang} | ${f.sizeBucket} | ${f.inputChars} | ${f.inputParagraphs} | ${fmt(f.p50Ms)} | ${fmt(f.p95Ms)} | ${fmt(f.p99Ms)} | ${fmt(f.meanMs)} | ${fmt(f.textsPerSec)} |`);
+    lines.push(`| ${f.id} | ${f.lang} | ${f.sizeBucket} | ${f.inputChars} | ${f.inputParagraphs} | ${f.inputSha256 || 'n/a'} | ${fmt(f.p50Ms)} | ${fmt(f.p95Ms)} | ${fmt(f.p99Ms)} | ${fmt(f.meanMs)} | ${fmt(f.textsPerSec)} |`);
   }
   lines.push('');
   return `${lines.join('\n')}\n`;
@@ -64,7 +84,7 @@ export function writePerfReport(report, { jsonPath = JSON_PATH, markdownPath = M
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  const report = buildPerfReport();
+  const report = buildPerfReport(perfReportOptions());
   const { jsonPath, markdownPath } = writePerfReport(report);
   console.log(`Wrote ${relative(REPO_ROOT, markdownPath)}`);
   console.log(`Wrote ${relative(REPO_ROOT, jsonPath)}`);

--- a/tests/quality/perf.mjs
+++ b/tests/quality/perf.mjs
@@ -6,11 +6,14 @@
 // applies no latency threshold. Timing uses node:perf_hooks (monotonic), with a
 // warmup pass excluded from measurement. No network, no LLM, no randomness.
 //
-// Usage: node tests/quality/perf.mjs [--quiet]
+// Usage: node tests/quality/perf.mjs [--quiet] [--costmetrics]
 
 import { performance } from 'node:perf_hooks';
-import { readFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { isAbsolute, join, relative, resolve, sep, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { analyzeText } from '../../src/features/index.js';
@@ -19,9 +22,34 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../..');
 const FIXTURES_PATH = resolve(__dirname, 'perf-fixtures.jsonl');
 
-export const PERF_SCHEMA_VERSION = 1;
+export const PERF_SCHEMA_VERSION = 2;
 export const DEFAULT_WARMUP_PASSES = 1;
 export const DEFAULT_PASSES = 7; // measured passes per fixture (5..11)
+export const DEFAULT_CLI_PASSES = 3;
+export const ANALYZER_TIMING_MODE = 'warm-in-process';
+export const CLI_TIMING_MODE = 'cold-process';
+export const PROCESS_MEMORY_DEFINITION =
+  'RSS bytes from process.memoryUsage().rss, sampled before and after this report; this is resident memory, not heap usage or a peak sample.';
+
+const CLI_ENTRYPOINT = 'bin/patina.js';
+const CLI_ARGS = ['--version'];
+
+function errorMessage(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.slice(0, 240);
+}
+
+function positiveInteger(value, fallback) {
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function positiveBytes(value) {
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+export function hashInput(text) {
+  return createHash('sha256').update(String(text), 'utf8').digest('hex');
+}
 
 // Resolve a fixture's text: either a literal `text` or a deterministic
 // `textRepeat: { unit, times }` so synthetic worst cases stay small in the file.
@@ -56,24 +84,73 @@ export function percentile(sortedAsc, p) {
 
 export function mean(values) {
   if (values.length === 0) return null;
-  return values.reduce((sum, v) => sum + v, 0) / values.length;
+  const scale = Math.max(...values.map((value) => Math.abs(value)));
+  if (!Number.isFinite(scale) || scale === 0) {
+    return values.reduce((sum, value) => sum + value, 0) / values.length;
+  }
+  return scale * (values.reduce((sum, value) => sum + (value / scale), 0) / values.length);
 }
 
 function round(value) {
-  return value == null ? null : Math.round(value * 1000) / 1000;
+  if (value == null || !Number.isFinite(value)) return value;
+  const scaled = value * 1000;
+  if (!Number.isFinite(scaled)) return value;
+  const rounded = Math.round(scaled) / 1000;
+  return rounded === 0 && value !== 0 ? value : rounded;
+}
+
+function invalidSummary(error) {
+  return {
+    status: 'error',
+    error,
+    p50Ms: null,
+    p95Ms: null,
+    p99Ms: null,
+    meanMs: null,
+    textsPerSec: null,
+  };
 }
 
 // Pure summary of a measured-duration array (warmup already excluded).
 export function summarizeDurations(durations) {
+  if (!Array.isArray(durations) || durations.length === 0) {
+    return {
+      status: 'unknown',
+      error: 'no measured durations',
+      p50Ms: null,
+      p95Ms: null,
+      p99Ms: null,
+      meanMs: null,
+      textsPerSec: null,
+    };
+  }
+  const invalidIndex = durations.findIndex((duration) => (
+    typeof duration !== 'number' || !Number.isFinite(duration) || duration <= 0
+  ));
+  if (invalidIndex !== -1) {
+    return {
+      status: 'error',
+      error: `invalid measured duration at pass ${invalidIndex + 1}; expected a finite value greater than zero`,
+      p50Ms: null,
+      p95Ms: null,
+      p99Ms: null,
+      meanMs: null,
+      textsPerSec: null,
+    };
+  }
   const sorted = [...durations].sort((a, b) => a - b);
   const meanMs = mean(durations);
-  return {
+  const summary = {
     p50Ms: round(percentile(sorted, 0.5)),
     p95Ms: round(percentile(sorted, 0.95)),
     p99Ms: round(percentile(sorted, 0.99)),
     meanMs: round(meanMs),
     textsPerSec: round(meanMs ? 1000 / meanMs : null),
   };
+  if (Object.values(summary).some((value) => !Number.isFinite(value) || value <= 0)) {
+    return invalidSummary('derived analyzer timing metric is not finite and positive');
+  }
+  return { status: 'measured', ...summary };
 }
 
 function countParagraphs(text) {
@@ -84,25 +161,424 @@ function countParagraphs(text) {
 }
 
 // Measure one fixture. `run` is injectable for tests; defaults to analyzeText.
-export function measureFixture(fixture, { warmupPasses = DEFAULT_WARMUP_PASSES, passes = DEFAULT_PASSES, run, now = () => performance.now() } = {}) {
-  const text = resolveFixtureText(fixture);
-  const work = run || (() => analyzeText(text, { lang: fixture.lang, repoRoot: REPO_ROOT }));
-  for (let i = 0; i < warmupPasses; i++) work();
+export function measureFixture(fixture, {
+  warmupPasses = DEFAULT_WARMUP_PASSES,
+  passes = DEFAULT_PASSES,
+  run,
+  now = () => performance.now(),
+  repoRoot = REPO_ROOT,
+} = {}) {
+  let text = null;
+  try {
+    text = resolveFixtureText(fixture);
+  } catch (error) {
+    return {
+      id: fixture?.id,
+      lang: fixture?.lang,
+      sizeBucket: fixture?.sizeBucket,
+      inputChars: null,
+      inputBytes: null,
+      inputSha256: null,
+      inputParagraphs: null,
+      timingMode: ANALYZER_TIMING_MODE,
+      passes,
+      warmupPasses,
+      status: 'error',
+      error: errorMessage(error),
+      p50Ms: null,
+      p95Ms: null,
+      p99Ms: null,
+      meanMs: null,
+      textsPerSec: null,
+    };
+  }
+  const work = run || (() => analyzeText(text, { lang: fixture.lang, repoRoot }));
+  try {
+    for (let i = 0; i < warmupPasses; i++) work();
+  } catch (error) {
+    return {
+      id: fixture.id,
+      lang: fixture.lang,
+      sizeBucket: fixture.sizeBucket,
+      inputChars: text.length,
+      inputBytes: Buffer.byteLength(text, 'utf8'),
+      inputSha256: hashInput(text),
+      inputParagraphs: countParagraphs(text),
+      timingMode: ANALYZER_TIMING_MODE,
+      passes,
+      warmupPasses,
+      status: 'error',
+      error: errorMessage(error),
+      completedPasses: 0,
+      p50Ms: null,
+      p95Ms: null,
+      p99Ms: null,
+      meanMs: null,
+      textsPerSec: null,
+    };
+  }
   const durations = [];
   for (let i = 0; i < passes; i++) {
-    const t0 = now();
-    work();
-    durations.push(now() - t0);
+    try {
+      const t0 = now();
+      work();
+      durations.push(now() - t0);
+    } catch (error) {
+      return {
+        id: fixture.id,
+        lang: fixture.lang,
+        sizeBucket: fixture.sizeBucket,
+        inputChars: text.length,
+        inputBytes: Buffer.byteLength(text, 'utf8'),
+        inputSha256: hashInput(text),
+        inputParagraphs: countParagraphs(text),
+        timingMode: ANALYZER_TIMING_MODE,
+        passes,
+        warmupPasses,
+        status: 'error',
+        error: errorMessage(error),
+        completedPasses: durations.length,
+        p50Ms: null,
+        p95Ms: null,
+        p99Ms: null,
+        meanMs: null,
+        textsPerSec: null,
+      };
+    }
   }
   return {
     id: fixture.id,
     lang: fixture.lang,
     sizeBucket: fixture.sizeBucket,
     inputChars: text.length,
+    inputBytes: Buffer.byteLength(text, 'utf8'),
+    inputSha256: hashInput(text),
     inputParagraphs: countParagraphs(text),
+    timingMode: ANALYZER_TIMING_MODE,
     passes,
     warmupPasses,
+    completedPasses: durations.length,
     ...summarizeDurations(durations),
+  };
+}
+
+function cliCommand({ processInfo = process, repoRoot = REPO_ROOT, command } = {}) {
+  if (command && typeof command === 'object') {
+    const executable = typeof command.executable === 'string' && command.executable
+      ? command.executable
+      : processInfo.execPath || process.execPath;
+    const args = Array.isArray(command.args) ? command.args.slice() : [resolve(repoRoot, CLI_ENTRYPOINT), ...CLI_ARGS];
+    return { executable, args };
+  }
+  return {
+    executable: processInfo.execPath || process.execPath,
+    args: [resolve(repoRoot, CLI_ENTRYPOINT), ...CLI_ARGS],
+  };
+}
+
+function unknownCliResult({ passes, command, status = 'not-requested', error = null, completedPasses = 0 } = {}) {
+  return {
+    status,
+    timingMode: CLI_TIMING_MODE,
+    command,
+    passes,
+    warmupPasses: 0,
+    processPerPass: true,
+    completedPasses,
+    p50Ms: null,
+    p95Ms: null,
+    p99Ms: null,
+    meanMs: null,
+    textsPerSec: null,
+    ...(error ? { error } : {}),
+  };
+}
+
+// Measure a fresh CLI process for every pass. This intentionally does not share
+// the in-process analyzer timings above: import/startup work belongs to this
+// cold-process measurement, while fixture timings are warm analyzer work.
+export function measureCliColdStart({
+  passes = DEFAULT_CLI_PASSES,
+  spawn = spawnSync,
+  now = () => performance.now(),
+  processInfo = process,
+  repoRoot = REPO_ROOT,
+  command,
+} = {}) {
+  const repeatPasses = positiveInteger(passes, 0);
+  const cli = cliCommand({ processInfo, repoRoot, command });
+  if (!repeatPasses) {
+    return unknownCliResult({
+      passes,
+      command: cli,
+      status: 'unknown',
+      error: 'CLI passes must be a positive integer',
+    });
+  }
+  if (typeof spawn !== 'function') {
+    return unknownCliResult({
+      passes: repeatPasses,
+      command: cli,
+      status: 'unknown',
+      error: 'CLI process runner is unavailable',
+    });
+  }
+
+  const durations = [];
+  for (let pass = 0; pass < repeatPasses; pass++) {
+    let started;
+    try {
+      started = now();
+      const child = spawn(cli.executable, cli.args, {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        stdio: 'ignore',
+      });
+      const elapsed = now() - started;
+      if (!Number.isFinite(elapsed) || elapsed <= 0) {
+        return unknownCliResult({
+          passes: repeatPasses,
+          command: cli,
+          status: 'error',
+          completedPasses: durations.length,
+          error: 'CLI clock produced an invalid duration',
+        });
+      }
+      if (!child || typeof child !== 'object') {
+        return unknownCliResult({
+          passes: repeatPasses,
+          command: cli,
+          status: 'error',
+          completedPasses: durations.length,
+          error: 'CLI process runner returned no result',
+        });
+      }
+      if (child.error) {
+        return unknownCliResult({
+          passes: repeatPasses,
+          command: cli,
+          status: 'error',
+          completedPasses: durations.length,
+          error: errorMessage(child.error),
+        });
+      }
+      if ('status' in child && child.status !== 0) {
+        return unknownCliResult({
+          passes: repeatPasses,
+          command: cli,
+          status: 'error',
+          completedPasses: durations.length,
+          error: `CLI exited with status ${child.status}`,
+        });
+      }
+      if (child.signal) {
+        return unknownCliResult({
+          passes: repeatPasses,
+          command: cli,
+          status: 'error',
+          completedPasses: durations.length,
+          error: `CLI terminated by ${child.signal}`,
+        });
+      }
+      durations.push(elapsed);
+    } catch (error) {
+      return unknownCliResult({
+        passes: repeatPasses,
+        command: cli,
+        status: 'error',
+        completedPasses: durations.length,
+        error: errorMessage(error),
+      });
+    }
+  }
+
+  return {
+    status: 'measured',
+    timingMode: CLI_TIMING_MODE,
+    command: cli,
+    passes: repeatPasses,
+    warmupPasses: 0,
+    processPerPass: true,
+    completedPasses: durations.length,
+    ...summarizeDurations(durations),
+  };
+}
+
+function sampleRss(processInfo) {
+  try {
+    if (!processInfo || typeof processInfo.memoryUsage !== 'function') {
+      return { status: 'unknown', rssBytes: null, error: 'process.memoryUsage is unavailable' };
+    }
+    const usage = processInfo.memoryUsage();
+    const rssBytes = positiveBytes(usage?.rss);
+    if (rssBytes == null) {
+      return { status: 'unknown', rssBytes: null, error: 'process.memoryUsage().rss is unavailable' };
+    }
+    return { status: 'measured', rssBytes };
+  } catch (error) {
+    return { status: 'error', rssBytes: null, error: errorMessage(error) };
+  }
+}
+
+export function measureProcessMemory({ processInfo = process } = {}) {
+  const sample = sampleRss(processInfo);
+  return {
+    definition: PROCESS_MEMORY_DEFINITION,
+    ...sample,
+  };
+}
+
+function memoryReport(before, after) {
+  const errors = [before.error, after.error].filter(Boolean);
+  const measured = before.status === 'measured' && after.status === 'measured';
+  return {
+    status: measured ? 'measured' : errors.length ? 'error' : 'unknown',
+    definition: PROCESS_MEMORY_DEFINITION,
+    rssBeforeBytes: before.rssBytes,
+    rssAfterBytes: after.rssBytes,
+    rssDeltaBytes: measured ? after.rssBytes - before.rssBytes : null,
+    ...(errors.length ? { errors } : {}),
+  };
+}
+
+function packJson(stdout) {
+  if (typeof stdout !== 'string' || !stdout.trim()) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+  return Array.isArray(parsed) ? parsed[0] : parsed;
+}
+
+function packMeasurementFromResult(result, destination) {
+  if (!result || typeof result !== 'object') {
+    return { status: 'unknown', tarballBytes: null, error: 'npm pack returned no result' };
+  }
+  if (result.error) {
+    return { status: 'error', tarballBytes: null, error: errorMessage(result.error) };
+  }
+  if ('status' in result && result.status !== 0) {
+    return { status: 'error', tarballBytes: null, error: `npm pack exited with status ${result.status}` };
+  }
+
+  const metadata = packJson(result.stdout);
+  const reportedBytes = positiveBytes(
+    result.tarballBytes ?? result.npmTarballBytes ?? result.bytes ?? result.size ?? metadata?.size
+  );
+  const filename = metadata?.filename || result.filename;
+  const candidatePath = result.tarballPath || result.path || (filename ? join(destination, filename) : null);
+  const resolvedCandidate = candidatePath ? resolve(destination, candidatePath) : null;
+  if (!resolvedCandidate || !existsSync(resolvedCandidate)) {
+    return {
+      status: 'unknown',
+      tarballBytes: null,
+      error: reportedBytes == null
+        ? 'npm pack did not identify a produced tarball file'
+        : 'npm pack reported metadata bytes without a produced tarball file',
+    };
+  }
+  let destinationReal;
+  let candidateReal;
+  try {
+    destinationReal = realpathSync(destination);
+    candidateReal = realpathSync(resolvedCandidate);
+  } catch (error) {
+    return { status: 'error', tarballBytes: null, error: errorMessage(error) };
+  }
+  const candidateRelative = relative(destinationReal, candidateReal);
+  if (
+    candidateRelative === ''
+    || candidateRelative === '..'
+    || candidateRelative.startsWith(`..${sep}`)
+    || isAbsolute(candidateRelative)
+  ) {
+    return {
+      status: 'unknown',
+      tarballBytes: null,
+      error: 'npm pack tarball path is outside the fresh pack destination',
+    };
+  }
+  let actualBytes = null;
+  try {
+    const stats = statSync(candidateReal);
+    if (!stats.isFile() || stats.size <= 0) {
+      return {
+        status: 'unknown',
+        tarballBytes: null,
+        error: 'npm pack did not produce a positive-size tarball file',
+      };
+    }
+    actualBytes = positiveBytes(stats.size);
+  } catch (error) {
+    return { status: 'error', tarballBytes: null, error: errorMessage(error) };
+  }
+  if (actualBytes != null && reportedBytes != null && actualBytes !== reportedBytes) {
+    return {
+      status: 'error',
+      tarballBytes: null,
+      error: `npm pack byte count mismatch (${actualBytes} actual, ${reportedBytes} reported)`,
+    };
+  }
+  const tarballBytes = actualBytes ?? reportedBytes;
+  if (tarballBytes == null) {
+    return { status: 'unknown', tarballBytes: null, error: 'npm pack did not report a positive tarball byte count' };
+  }
+  return {
+    status: 'measured',
+    tarballBytes,
+    npmTarballBytes: tarballBytes,
+    ...(reportedBytes != null ? { reportedBytes } : {}),
+  };
+}
+
+// Run npm pack only when the caller explicitly requests cost metrics. The
+// temporary destination keeps a report run from leaving a tarball in the
+// repository; pack failures remain an unknown report value, not a gate.
+export function measureNpmTarball({
+  repoRoot = REPO_ROOT,
+  spawn = spawnSync,
+  pack,
+} = {}) {
+  let destination = null;
+  try {
+    destination = mkdtempSync(join(tmpdir(), 'patina-perf-pack-'));
+    const args = ['pack', '--json', '--ignore-scripts', '--pack-destination', destination];
+    const result = typeof pack === 'function'
+      ? pack({ cwd: repoRoot, destination, args })
+      : spawn('npm', args, {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    return packMeasurementFromResult(result, destination);
+  } catch (error) {
+    return { status: 'error', tarballBytes: null, error: errorMessage(error) };
+  } finally {
+    if (destination) rmSync(destination, { recursive: true, force: true });
+  }
+}
+
+function costMetrics({ enabled = false, repoRoot = REPO_ROOT, spawn, pack } = {}) {
+  const base = {
+    enabled,
+    status: enabled ? 'unknown' : 'not-requested',
+    calls: null,
+    costUsd: null,
+    unknownCalls: true,
+    unknownCost: true,
+    tarballBytes: null,
+    npmTarballBytes: null,
+  };
+  if (!enabled) return base;
+  const tarball = measureNpmTarball({ repoRoot, spawn, pack });
+  return {
+    ...base,
+    status: tarball.status,
+    tarballBytes: tarball.tarballBytes,
+    npmTarballBytes: tarball.npmTarballBytes ?? tarball.tarballBytes,
+    ...(tarball.error ? { error: tarball.error } : {}),
   };
 }
 
@@ -111,6 +587,15 @@ export function measureFixture(fixture, { warmupPasses = DEFAULT_WARMUP_PASSES, 
 export function aggregateBuckets(measured) {
   const byBucket = new Map();
   for (const m of measured) {
+    if (
+      !m
+      || (m.status !== undefined && m.status !== 'measured')
+      || !Number.isFinite(m.meanMs)
+      || m.meanMs <= 0
+      || !Number.isFinite(1000 / m.meanMs)
+    ) {
+      continue;
+    }
     if (!byBucket.has(m.sizeBucket)) byBucket.set(m.sizeBucket, []);
     byBucket.get(m.sizeBucket).push(m);
   }
@@ -131,21 +616,97 @@ export function aggregateBuckets(measured) {
     });
 }
 
-export function buildPerfReport({ fixtures, warmupPasses = DEFAULT_WARMUP_PASSES, passes = DEFAULT_PASSES, run, now = () => new Date().toISOString() } = {}) {
+export function buildPerfReport(options = {}) {
+  const {
+    fixtures,
+    warmupPasses = DEFAULT_WARMUP_PASSES,
+    passes = DEFAULT_PASSES,
+    run,
+    now = () => new Date().toISOString(),
+    repoRoot = REPO_ROOT,
+  } = options;
+  const processInfo = options.processInfo ?? options.process ?? process;
+  const timingNow = options.timingNow ?? options.clock ?? (() => performance.now());
+  const cliNow = options.cliNow ?? timingNow;
+  const cliPasses = options.cliPasses ?? DEFAULT_CLI_PASSES;
+  const shouldMeasureCli = options.measureCliColdStart ?? options.measureCli ?? true;
+  const cliSpawn = options.cliSpawn ?? options.spawn;
+  const cliCommandOptions = options.cliCommand;
+  const costMetricsEnabled = options.costMetrics === true
+    || options.costmetrics === true
+    || (options.costMetrics && options.costMetrics.enabled === true);
+  const pack = options.pack ?? options.costMetrics?.pack;
+
   // Always emit fixtures in a deterministic id order, whether loaded from the
   // file or injected by a caller/test.
-  const list = (fixtures || loadPerfFixtures())
+  const list = (fixtures || loadPerfFixtures(FIXTURES_PATH))
     .slice()
     .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
-  const measured = list.map((f) => measureFixture(f, { warmupPasses, passes, run }));
+  const memoryBefore = sampleRss(processInfo);
+  const measured = list.map((f) => measureFixture(f, {
+    warmupPasses,
+    passes,
+    run,
+    now: timingNow,
+    repoRoot,
+  }));
+  const cliColdStart = shouldMeasureCli
+    ? measureCliColdStart({
+      passes: cliPasses,
+      spawn: cliSpawn || spawnSync,
+      now: cliNow,
+      processInfo,
+      repoRoot,
+      command: cliCommandOptions,
+    })
+    : unknownCliResult({
+      passes: cliPasses,
+      command: cliCommand({ processInfo, repoRoot, command: cliCommandOptions }),
+    });
+  const memoryAfter = sampleRss(processInfo);
+
+  const environment = {
+    nodeVersion: processInfo.version || process.version,
+    platform: processInfo.platform || process.platform,
+    arch: processInfo.arch || process.arch,
+    execPath: processInfo.execPath || process.execPath,
+    cwd: repoRoot,
+    analyzerClock: 'node:perf_hooks performance.now (monotonic wall time)',
+    timestampClock: 'Date.toISOString supplied by caller',
+  };
+
   return {
     schemaVersion: PERF_SCHEMA_VERSION,
     generatedAt: now(),
-    nodeVersion: process.version,
-    platform: process.platform,
-    arch: process.arch,
+    nodeVersion: environment.nodeVersion,
+    platform: environment.platform,
+    arch: environment.arch,
+    environment,
     warmupPasses,
     passes,
+    repeatConditions: {
+      fixtureOrder: 'ascending id',
+      analyzer: {
+        timingMode: ANALYZER_TIMING_MODE,
+        warmupPasses,
+        measuredPasses: passes,
+        warmupExcluded: true,
+      },
+      cliColdStart: {
+        timingMode: CLI_TIMING_MODE,
+        warmupPasses: 0,
+        measuredPasses: cliPasses,
+        processPerPass: true,
+      },
+    },
+    memory: memoryReport(memoryBefore, memoryAfter),
+    cliColdStart,
+    costMetrics: costMetrics({
+      enabled: costMetricsEnabled,
+      repoRoot,
+      spawn: options.packSpawn ?? options.costMetrics?.spawn ?? options.spawn,
+      pack,
+    }),
     fixtureCount: measured.length,
     fixtures: measured,
     buckets: aggregateBuckets(measured),
@@ -153,7 +714,7 @@ export function buildPerfReport({ fixtures, warmupPasses = DEFAULT_WARMUP_PASSES
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  const report = buildPerfReport();
+  const report = buildPerfReport({ costMetrics: process.argv.includes('--costmetrics') });
   if (!process.argv.includes('--quiet')) {
     console.error(`# perf harness — ${report.fixtureCount} fixtures, ${report.passes} passes (report-only; not a CI gate)`);
   }

--- a/tests/unit/perf-report.test.js
+++ b/tests/unit/perf-report.test.js
@@ -1,5 +1,7 @@
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
+import { writeFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
 
 import {
   percentile,
@@ -10,8 +12,12 @@ import {
   buildPerfReport,
   loadPerfFixtures,
   PERF_SCHEMA_VERSION,
+  hashInput,
+  measureCliColdStart,
+  measureProcessMemory,
+  measureNpmTarball,
 } from '../../tests/quality/perf.mjs';
-import { renderMarkdown } from '../../scripts/perf-report.mjs';
+import { perfReportOptions, renderMarkdown } from '../../scripts/perf-report.mjs';
 
 test('percentile uses nearest-rank (ceil) and clamps', () => {
   const s = [1, 2, 3, 4, 5];
@@ -29,6 +35,7 @@ test('mean is arithmetic mean, null on empty', () => {
 
 test('summarizeDurations pins p50/p95/p99/mean and textsPerSec=1000/meanMs', () => {
   const s = summarizeDurations([5, 1, 3, 2, 4]); // mean 3
+  assert.equal(s.status, 'measured');
   assert.equal(s.p50Ms, 3);
   assert.equal(s.p95Ms, 5);
   assert.equal(s.p99Ms, 5);
@@ -36,10 +43,82 @@ test('summarizeDurations pins p50/p95/p99/mean and textsPerSec=1000/meanMs', () 
   assert.equal(s.textsPerSec, Math.round((1000 / 3) * 1000) / 1000);
 });
 
+test('invalid analyzer durations become null metrics and do not aggregate', () => {
+  for (const invalid of [[0, 1], [-1, 1], [Number.NaN, 1], [Number.POSITIVE_INFINITY, 1]]) {
+    const summary = summarizeDurations(invalid);
+    assert.equal(summary.status, 'error');
+    assert.equal(summary.meanMs, null);
+    assert.equal(summary.p95Ms, null);
+  }
+  const fixtures = [
+    { id: 'bad', lang: 'en', sizeBucket: 'short', text: 'bad' },
+    { id: 'good', lang: 'en', sizeBucket: 'short', text: 'good' },
+  ];
+  const clock = [0, 0, 10, 11];
+  const report = buildPerfReport({
+    fixtures,
+    warmupPasses: 0,
+    passes: 1,
+    run: () => {},
+    timingNow: () => clock.shift(),
+    measureCliColdStart: false,
+    now: () => 'FIXED_TS',
+  });
+  assert.equal(report.fixtures.find((fixture) => fixture.id === 'bad').status, 'error');
+  assert.equal(report.fixtures.find((fixture) => fixture.id === 'bad').meanMs, null);
+  assert.deepEqual(report.buckets.map((bucket) => bucket.fixtureCount), [1]);
+
+  const positiveOnly = aggregateBuckets([
+    { sizeBucket: 'short', status: 'measured', meanMs: 0 },
+    { sizeBucket: 'short', status: 'measured', meanMs: -1 },
+    { sizeBucket: 'short', status: 'measured', meanMs: Number.NaN },
+    { sizeBucket: 'short', status: 'measured', meanMs: 2 },
+  ]);
+  assert.deepEqual(positiveOnly.map((bucket) => bucket.fixtureCount), [1]);
+  assert.equal(positiveOnly[0].meanMs, 2);
+
+  const huge = summarizeDurations([Number.MAX_VALUE, Number.MAX_VALUE]);
+  assert.equal(huge.status, 'measured');
+  assert.equal(huge.meanMs, Number.MAX_VALUE);
+  for (const field of ['p50Ms', 'p95Ms', 'p99Ms', 'meanMs', 'textsPerSec']) {
+    assert.equal(Number.isFinite(huge[field]), true, `huge ${field} must remain finite`);
+    assert.ok(huge[field] > 0, `huge ${field} must remain positive`);
+  }
+
+  const tiny = summarizeDurations([0.0001]);
+  assert.equal(tiny.status, 'measured');
+  assert.equal(tiny.p50Ms, 0.0001);
+  assert.equal(tiny.meanMs, 0.0001);
+  assert.equal(tiny.textsPerSec, 10_000_000);
+
+  const underflow = summarizeDurations([Number.MIN_VALUE]);
+  assert.equal(underflow.status, 'error');
+  assert.equal(underflow.meanMs, null);
+  assert.equal(underflow.textsPerSec, null);
+});
+
 test('resolveFixtureText supports literal and deterministic textRepeat', () => {
   assert.equal(resolveFixtureText({ id: 'a', text: 'hi' }), 'hi');
   assert.equal(resolveFixtureText({ id: 'b', textRepeat: { unit: 'ab', times: 3 } }), 'ababab');
   assert.throws(() => resolveFixtureText({ id: 'c' }), /neither text nor textRepeat/);
+});
+
+test('input hashes are SHA-256 over the resolved UTF-8 fixture text', () => {
+  const text = '한글 and emoji ✓';
+  const fixture = { id: 'hash', lang: 'ko', sizeBucket: 'short', text };
+  let now = 0;
+  const measured = buildPerfReport({
+    fixtures: [fixture],
+    warmupPasses: 0,
+    passes: 1,
+    run: () => {},
+    timingNow: () => (now += 1),
+    measureCliColdStart: false,
+    now: () => 'FIXED_TS',
+  }).fixtures[0];
+  assert.equal(measured.inputSha256, hashInput(text));
+  assert.match(measured.inputSha256, /^[0-9a-f]{64}$/);
+  assert.equal(measured.inputBytes, Buffer.byteLength(text, 'utf8'));
 });
 
 test('aggregateBuckets groups by sizeBucket with documented math', () => {
@@ -62,11 +141,23 @@ test('buildPerfReport emits the full schema and is report-only (no gate fields)'
     { id: 'f-a', lang: 'ko', sizeBucket: 'short', text: '한 문장' },
   ];
   let n = 0;
+  let timing = 0;
+  let memoryCalls = 0;
+  const injectedProcess = {
+    version: 'v-test',
+    platform: 'test-platform',
+    arch: 'test-arch',
+    execPath: '/test/node',
+    memoryUsage: () => ({ rss: Buffer.byteLength('rss sample') + (++memoryCalls * 10) }),
+  };
   const report = buildPerfReport({
     fixtures,
     warmupPasses: 1,
     passes: 5,
     run: () => { n += 1; }, // injected workload: no analyzer, deterministic shape
+    timingNow: () => (timing += 1),
+    processInfo: injectedProcess,
+    measureCliColdStart: false,
     now: () => 'FIXED_TS',
   });
   // Top-level schema fields.
@@ -76,6 +167,13 @@ test('buildPerfReport emits the full schema and is report-only (no gate fields)'
   assert.equal(report.schemaVersion, PERF_SCHEMA_VERSION);
   assert.equal(report.generatedAt, 'FIXED_TS');
   assert.equal(report.fixtureCount, 2);
+  assert.equal(report.environment.nodeVersion, 'v-test');
+  assert.equal(report.repeatConditions.analyzer.warmupExcluded, true);
+  assert.equal(report.cliColdStart.status, 'not-requested');
+  assert.equal(report.memory.status, 'measured');
+  assert.ok(report.memory.rssAfterBytes > report.memory.rssBeforeBytes);
+  assert.equal(report.costMetrics.calls, null);
+  assert.equal(report.costMetrics.costUsd, null);
   // No latency-gate / pass-fail field exists anywhere in the report.
   for (const k of ['gate', 'failed', 'pass', 'threshold', 'regression']) {
     assert.equal(k in report, false, `report-only must not expose ${k}`);
@@ -83,7 +181,7 @@ test('buildPerfReport emits the full schema and is report-only (no gate fields)'
   // Per-fixture required fields + stable order by id.
   assert.deepEqual(report.fixtures.map((f) => f.id), ['f-a', 'f-b']);
   for (const f of report.fixtures) {
-    for (const k of ['id', 'lang', 'sizeBucket', 'inputChars', 'inputParagraphs', 'passes', 'warmupPasses', 'p50Ms', 'p95Ms', 'p99Ms', 'meanMs', 'textsPerSec']) {
+    for (const k of ['id', 'lang', 'sizeBucket', 'inputChars', 'inputBytes', 'inputSha256', 'inputParagraphs', 'timingMode', 'passes', 'warmupPasses', 'p50Ms', 'p95Ms', 'p99Ms', 'meanMs', 'textsPerSec']) {
       assert.ok(k in f, `fixture missing ${k}`);
     }
     assert.equal(f.passes, 5);
@@ -95,6 +193,101 @@ test('buildPerfReport emits the full schema and is report-only (no gate fields)'
   const md = renderMarkdown(report);
   assert.match(md, /report-only/i);
   assert.match(md, /not a release gate/i);
+  assert.match(md, /CLI coldstart/);
+  assert.match(md, /Cost metrics/);
+});
+
+test('CLI coldstart uses fresh injected processes and reports plausible timings', () => {
+  let clock = 0;
+  let calls = 0;
+  const result = measureCliColdStart({
+    passes: 3,
+    processInfo: { execPath: '/test/node' },
+    spawn: (executable, args, options) => {
+      calls += 1;
+      assert.equal(executable, '/test/node');
+      assert.equal(args.at(-1), '--version');
+      assert.equal(options.cwd.endsWith('/'), false);
+      return { status: 0 };
+    },
+    now: () => (clock += 7),
+    repoRoot: '/test/repo',
+  });
+  assert.equal(calls, 3);
+  assert.equal(result.status, 'measured');
+  assert.equal(result.processPerPass, true);
+  assert.equal(result.completedPasses, 3);
+  assert.ok(result.meanMs > 0);
+});
+
+test('CLI coldstart errors remain unknown rather than zero', () => {
+  const result = measureCliColdStart({
+    passes: 2,
+    spawn: () => ({ status: 1 }),
+    now: (() => {
+      let clock = 0;
+      return () => (clock += 1);
+    })(),
+  });
+  assert.equal(result.status, 'error');
+  assert.equal(result.completedPasses, 0);
+  assert.equal(result.meanMs, null);
+  assert.notEqual(result.meanMs, 0);
+});
+
+test('memory and opt-in npm pack metrics preserve unknown failures', () => {
+  const memory = measureProcessMemory({
+    processInfo: { memoryUsage: () => ({ rss: Buffer.byteLength('memory') }) },
+  });
+  assert.equal(memory.status, 'measured');
+  assert.ok(memory.rssBytes > 0);
+  const packBytes = Buffer.byteLength('fixture tarball bytes');
+  const packed = measureNpmTarball({
+    repoRoot: '/test/repo',
+    pack: ({ args, destination }) => {
+      assert.deepEqual(args.slice(0, 3), ['pack', '--json', '--ignore-scripts']);
+      const tarballPath = join(destination, 'fixture.tgz');
+      writeFileSync(tarballPath, Buffer.alloc(packBytes, 0x61));
+      return {
+        status: 0,
+        stdout: JSON.stringify([{ filename: 'fixture.tgz', size: packBytes }]),
+      };
+    },
+  });
+  assert.equal(packed.status, 'measured');
+  assert.equal(packed.tarballBytes, packBytes);
+
+  const external = measureNpmTarball({
+    pack: () => ({ status: 0, tarballPath: process.execPath }),
+  });
+  assert.equal(external.status, 'unknown');
+  assert.equal(external.tarballBytes, null);
+
+  const traversal = measureNpmTarball({
+    pack: ({ destination }) => ({
+      status: 0,
+      tarballPath: relative(destination, process.execPath),
+    }),
+  });
+  assert.equal(traversal.status, 'unknown');
+  assert.equal(traversal.tarballBytes, null);
+
+  const metadataOnly = measureNpmTarball({
+    pack: () => ({ status: 0, tarballBytes: packBytes }),
+  });
+  assert.equal(metadataOnly.status, 'unknown');
+  assert.equal(metadataOnly.tarballBytes, null);
+
+  const failed = measureNpmTarball({ pack: () => { throw new Error('pack unavailable'); } });
+  assert.equal(failed.status, 'error');
+  assert.equal(failed.tarballBytes, null);
+  assert.notEqual(failed.tarballBytes, 0);
+});
+
+test('perf report options require explicit costmetrics opt-in', () => {
+  assert.equal(perfReportOptions([]).costMetrics, false);
+  assert.equal(perfReportOptions(['--quiet']).costMetrics, false);
+  assert.equal(perfReportOptions(['--costmetrics']).costMetrics, true);
 });
 
 test('the repo perf fixtures load and cover the required buckets', () => {


### PR DESCRIPTION
Refs #783 — P20 only. Three files; 830 raw changed lines. Owner explicitly approved per-domain size exception to retain implementation and negative fixtures together. Report-only metrics: finite positive durations, fresh CLI processes, RSS, actual contained tarball stat, unknown calls/cost=null. No thresholds or model calls. Local perf/lifecycle20 tests and integrated test/lint/release/private gates pass; clean PR CI required. Rollback: revert this PR; no external state. Historical reports unchanged.