### PR TITLE
fix(playground): validate clipboard races and browser state transitions

### DIFF
--- a/docs/integrations/playground.md
+++ b/docs/integrations/playground.md
@@ -29,6 +29,34 @@ never talks directly to a provider in v1).
 - Vercel routes: [`vercel.json`](../../vercel.json)
 - OG image: [`assets/social/patina-og.svg`](../../assets/social/patina-og.svg)
 
+## Browser regression tests
+
+The Chromium suite is opt-in and is not included in the default `npm test`
+unit/e2e glob. Install the pinned Playwright development dependency and its
+browser once, then run:
+
+```bash
+npm install
+npx playwright install chromium
+npm run test:browser
+```
+
+The direct equivalent is `node --test tests/browser/playground.test.js`.
+
+To use an already-installed system browser instead of Playwright's managed
+binary, set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` (for example,
+`/snap/bin/chromium`):
+
+```bash
+PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/snap/bin/chromium npm run test:browser
+```
+
+The tests start `scripts/dev-server.mjs` on an ephemeral loopback port and
+intercept `/api/rewrite` with local NDJSON contract fixtures. They make no
+provider or live-auth calls and do not measure model quality. Chromium is real,
+but the rewrite transport is mocked: a passing browser regression only proves
+UI/controller and stream-state behavior, not real-model quality.
+
 ## Deploy notes
 
 Deploy the repository root on Vercel so the root `vercel.json` can rewrite `/` to

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "eslint": "^8.57.1",
         "jsdoc-to-markdown": "^9.1.3",
         "typescript": "^5.4.5",
-        "espree": "9.6.1"
+        "espree": "9.6.1",
+        "playwright": "1.63.0"
       },
       "engines": {
         "node": ">=18.1.0"
@@ -3266,6 +3267,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "benchmark:ko-miss-review:extract": "node scripts/ko-miss-review-extract.mjs",
     "benchmark:ko-miss-review:validate": "node scripts/ko-miss-review-validate.mjs",
     "benchmark:ko-miss-review:report": "node scripts/ko-miss-review-report.mjs",
-    "check:architecture": "node scripts/check-architecture.mjs"
+    "check:architecture": "node scripts/check-architecture.mjs",
+    "test:browser": "node --test tests/browser/*.test.js"
   },
   "dependencies": {
     "js-yaml": "^4.1.0"
@@ -228,6 +229,7 @@
     "eslint": "^8.57.1",
     "jsdoc-to-markdown": "^9.1.3",
     "typescript": "^5.4.5",
-    "espree": "9.6.1"
+    "espree": "9.6.1",
+    "playwright": "1.63.0"
   }
 }

--- a/playground/chatgpt.js
+++ b/playground/chatgpt.js
@@ -669,8 +669,11 @@ function renderExamples() {
   // The copy button carries a transient result label; it belongs to the row that
   // was copied, so switching rows drops both the label and its pending timer.
   let copyReset;
+  let copyGeneration = 0;
   const restCopy = () => {
+    copyGeneration += 1;
     clearTimeout(copyReset);
+    copyReset = undefined;
     copy.textContent = ui.copyExample;
     copy.classList.remove('is-ok');
   };
@@ -737,11 +740,15 @@ function renderExamples() {
   });
   copy.addEventListener('click', async () => {
     clearTimeout(copyReset);
+    const copiedText = active.after;
+    const requestGeneration = ++copyGeneration;
     try {
-      await globalThis.navigator.clipboard.writeText(active.after);
+      await globalThis.navigator.clipboard.writeText(copiedText);
+      if (requestGeneration !== copyGeneration) return;
       copy.textContent = ui.copied;
       copy.classList.add('is-ok');
     } catch {
+      if (requestGeneration !== copyGeneration) return;
       // A failure must not keep the success styling from a previous copy.
       copy.textContent = ui.copyFailed;
       copy.classList.remove('is-ok');

--- a/tests/browser/fixtures.js
+++ b/tests/browser/fixtures.js
@@ -1,0 +1,258 @@
+import { once } from 'node:events';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { chromium } from 'playwright';
+
+import { fidelityResult, mpsResult } from '../fixtures/verification-results.js';
+import { buildWebRewriteReceipt } from '../../src/web-rewrite-receipt.js';
+import { encodeStreamFrame } from '../../src/web-rewrite-contract.js';
+
+export const ROOT = fileURLToPath(new URL('../../', import.meta.url));
+export const INPUT_TEXT = 'It is important to note that we retain 12 audit logs.';
+export const OUTPUT_TEXT = 'We retain 12 audit logs.';
+export const FIXTURE_API_KEY = 'sk-browser-fixture-key';
+export const FIXTURE_LICENSE = 'license-browser-fixture';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function fixtureDiff() {
+  return {
+    beforeChars: INPUT_TEXT.length,
+    afterChars: OUTPUT_TEXT.length,
+    charDelta: OUTPUT_TEXT.length - INPUT_TEXT.length,
+    beforeWords: INPUT_TEXT.split(/\s+/).length,
+    afterWords: OUTPUT_TEXT.split(/\s+/).length,
+    wordDelta: OUTPUT_TEXT.split(/\s+/).length - INPUT_TEXT.split(/\s+/).length,
+  };
+}
+
+function fixtureSignals() {
+  return {
+    before: { signalScore: 32, hotParagraphs: 0, paragraphCount: 1 },
+    after: { signalScore: 0, hotParagraphs: 0, paragraphCount: 1 },
+  };
+}
+
+function fixtureReceipt(request, mps, fidelity) {
+  return buildWebRewriteReceipt({
+    request,
+    documentType: request.documentType || 'default',
+    original: request.original || request.text,
+    latest: request.text,
+    prompt: 'browser regression fixture',
+    output: OUTPUT_TEXT,
+    mps,
+    fidelity,
+    signals: fixtureSignals(),
+    diff: fixtureDiff(),
+  });
+}
+
+function framesForScenario(scenario, request) {
+  const mps = mpsResult(scenario === 'belowfloor' ? 69 : 100);
+  const fidelity = fidelityResult(12);
+  const receipt = fixtureReceipt(request, mps, fidelity);
+  const start = { type: 'start' };
+  const deltas = [];
+  for (let i = 0; i < OUTPUT_TEXT.length; i += 4) {
+    deltas.push({ type: 'delta', text: OUTPUT_TEXT.slice(i, i + 4) });
+  }
+
+  if (scenario === 'transmissionfailure') {
+    return { frames: [start, ...deltas.slice(0, 2), {
+      type: 'error',
+      status: 503,
+      error: 'rewrite service unavailable',
+    }] };
+  }
+  if (scenario === 'cancel') {
+    return {
+      delayMs: 1500,
+      frames: [start, ...deltas, {
+        type: 'done',
+        rewrite: OUTPUT_TEXT,
+        mps,
+        fidelity,
+        signals: fixtureSignals(),
+        diff: fixtureDiff(),
+        receipt,
+      }],
+    };
+  }
+  // `belowfloor` intentionally uses a syntactically accepted `done` frame with
+  // a score below the shared 70-point floor. The browser must reject it.
+  return {
+    frames: [start, ...deltas, {
+      type: 'done',
+      rewrite: OUTPUT_TEXT,
+      mps,
+      fidelity,
+      signals: fixtureSignals(),
+      diff: fixtureDiff(),
+      receipt,
+    }],
+  };
+}
+
+/**
+ * Spawn the repository's real local preview server on an ephemeral port.
+ * @param {import('node:test').TestContext} t
+ * @returns {Promise<string>}
+ */
+export async function startDevServer(t) {
+  const child = spawn(process.execPath, [path.join(ROOT, 'scripts/dev-server.mjs'), '--host', '127.0.0.1', '--port', '0'], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      PATINA_DEV_LLM_BASE_URL: '',
+      PATINA_DEV_LLM_KEY: '',
+      PATINA_DEV_LLM_MODEL: '',
+      PATINA_DEV_LLM_SCORE: '',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let output = '';
+  child.stdout.on('data', (chunk) => { output += String(chunk); });
+  child.stderr.on('data', (chunk) => { output += String(chunk); });
+
+  t.after(async () => {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    const exited = once(child, 'exit');
+    child.kill();
+    const timer = setTimeout(() => child.kill('SIGKILL'), 2000);
+    try {
+      await exited;
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Preview startup timed out: ${output}`)), 10000);
+    const onError = (error) => {
+      clearTimeout(timer);
+      reject(error);
+    };
+    const onExit = () => onError(new Error(`Preview exited before listening: ${output}`));
+    child.once('error', onError);
+    child.once('exit', onExit);
+    child.stdout.on('data', () => {
+      const address = output.match(/http:\/\/127\.0\.0\.1:\d+\//)?.[0];
+      if (!address) return;
+      clearTimeout(timer);
+      child.removeListener('error', onError);
+      child.removeListener('exit', onExit);
+      resolve(address);
+    });
+  });
+}
+
+/**
+ * Launch Chromium using an explicitly supplied executable or Playwright's
+ * managed browser.
+ * @param {import('node:test').TestContext} t
+ */
+export async function launchChromium(t) {
+  const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+  const browser = await chromium.launch({ headless: true, ...(executablePath ? { executablePath } : {}) });
+  t.after(async () => {
+    await browser.close();
+  });
+  return browser;
+}
+
+/**
+ * Install a same-origin-only network boundary and a deterministic local stream
+ * fixture. Every rewrite request is captured so tests can assert tier and
+ * authorization behavior without contacting an auth or provider endpoint.
+ * @param {import('playwright').Page} page
+ * @param {string} base
+ * @param {{scenario?: string, onRequest?: (request: {body: Record<string, unknown>, authorization: string}) => void}} [options]
+ */
+export async function installBrowserFixture(page, base, { scenario = 'accepted', onRequest } = {}) {
+  const origin = new URL(base).origin;
+  const requests = [];
+
+  await page.route('**/*', async (route) => {
+    const requestUrl = new URL(route.request().url());
+    if (requestUrl.origin !== origin) {
+      // The document includes a remote font preconnect/style for production,
+      // but browser regressions never allow it (or any other external request)
+      // out.
+      await route.abort();
+      return;
+    }
+    if (requestUrl.pathname !== '/api/rewrite') {
+      await route.continue();
+      return;
+    }
+    let body;
+    try {
+      body = route.request().postDataJSON();
+    } catch {
+      body = {};
+    }
+    const request = {
+      body: /** @type {Record<string, unknown>} */ (body || {}),
+      authorization: route.request().headers().authorization || '',
+    };
+    requests.push(request);
+    onRequest?.(request);
+    const fixture = framesForScenario(scenario, request.body);
+    if (fixture.delayMs) await wait(fixture.delayMs);
+    try {
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'Content-Type': 'application/x-ndjson',
+          'Cache-Control': 'no-store',
+        },
+        body: fixture.frames.map(encodeStreamFrame).join(''),
+      });
+    } catch {
+      // Cancellation closes the page request before the delayed fixture can
+      // fulfill it. That is the expected transport behavior for this case.
+    }
+  });
+
+  return requests;
+}
+
+/**
+ * Create a context with clipboard permission and a page whose local routes are
+ * installed before navigation.
+ * @param {import('playwright').Browser} browser
+ * @param {string} base
+ * @param {{viewport?: {width:number,height:number}, scenario?: string, onRequest?: (request: {body: Record<string, unknown>, authorization: string}) => void}} [options]
+ */
+export async function openPlayground(browser, base, {
+  viewport = { width: 1280, height: 900 },
+  scenario = 'accepted',
+  onRequest,
+} = {}) {
+  const context = await browser.newContext({
+    viewport,
+    permissions: ['clipboard-read', 'clipboard-write'],
+  });
+  const page = await context.newPage();
+  const requests = await installBrowserFixture(page, base, { scenario, onRequest });
+  const url = new URL(base);
+  url.searchParams.set('lang', 'en');
+  try {
+    await page.goto(url.href, { waitUntil: 'domcontentloaded' });
+    await page.locator('#example-panel').waitFor();
+  } catch (error) {
+    await context.close();
+    throw error;
+  }
+  return {
+    context,
+    page,
+    requests,
+    async close() {
+      await context.close();
+    },
+  };
+}

--- a/tests/browser/playground.test.js
+++ b/tests/browser/playground.test.js
@@ -1,0 +1,217 @@
+// @ts-check
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  FIXTURE_API_KEY,
+  FIXTURE_LICENSE,
+  INPUT_TEXT,
+  OUTPUT_TEXT,
+  launchChromium,
+  openPlayground,
+  startDevServer,
+} from './fixtures.js';
+
+/**
+ * @param {() => Promise<boolean>} check
+ * @param {number} [timeout]
+ */
+async function eventually(check, timeout = 5000) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    if (await check()) return;
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for browser state');
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+/**
+ * @param {import('playwright').Locator} locator
+ * @returns {Promise<string>}
+ */
+async function text(locator) {
+  return (await locator.textContent()) || '';
+}
+
+/**
+ * @param {import('playwright').Page} page
+ */
+async function submitHero(page) {
+  await page.locator('#hero-input').fill(INPUT_TEXT);
+  await page.locator('#hero-send').click();
+}
+
+test('playground browser regressions', { timeout: 120000 }, async (t) => {
+  const base = await startDevServer(t);
+  const browser = await launchChromium(t);
+
+  await t.test('example copy resets cleanly and repeated clicks do not race timers', async () => {
+    const app = await openPlayground(browser, base);
+    try {
+      const copy = app.page.locator('#example-panel .editor__btn');
+      assert.equal(await text(copy), 'Copy example');
+      await app.page.clock.install();
+
+      await copy.click();
+      await eventually(async () => (await text(copy)) === 'Copied');
+      await app.page.clock.fastForward(1000);
+      assert.equal(await text(copy), 'Copied', 'the first reset is 1400ms after the first click');
+      await copy.click();
+      await eventually(async () => (await text(copy)) === 'Copied');
+      await app.page.clock.fastForward(500);
+      assert.equal(await text(copy), 'Copied', 'the second click must own the reset timer');
+
+      await app.page.locator('#example-choice').selectOption('en-report-support');
+      assert.equal(await text(copy), 'Copy example', 'switching rows resets the transient label');
+      await app.page.clock.fastForward(1000);
+      assert.equal(await text(copy), 'Copy example', 'the previous row timer must not mutate the new row');
+
+      await copy.click();
+      await eventually(async () => (await text(copy)) === 'Copied');
+    } finally {
+      await app.close();
+    }
+  });
+
+  await t.test('Escape and outside click dismiss settings while IME Enter stays a draft', async () => {
+    const rewriteRequests = [];
+    const app = await openPlayground(browser, base, { onRequest: (request) => rewriteRequests.push(request) });
+    try {
+      const settings = app.page.locator('#settings-panel');
+      await app.page.locator('#settings-label').click();
+      assert.equal(await settings.getAttribute('open'), '');
+
+      // Focus the prompt without a mouse event (which would intentionally
+      // dismiss the panel), then exercise the controller's document Escape path.
+      await app.page.locator('#hero-input').focus();
+      await app.page.keyboard.press('Escape');
+      assert.equal(await settings.getAttribute('open'), null);
+      assert.equal(await app.page.evaluate(() => globalThis.document.activeElement?.id), 'settings-label');
+
+      await app.page.locator('#settings-label').click();
+      assert.equal(await settings.getAttribute('open'), '');
+      await app.page.locator('.hero__title').click();
+      assert.equal(await settings.getAttribute('open'), null);
+
+      await app.page.locator('#hero-input').fill(INPUT_TEXT);
+      await app.page.evaluate(() => {
+        const input = globalThis.document.querySelector('#hero-input');
+        const event = new globalThis.KeyboardEvent('keydown', {
+          bubbles: true,
+          key: 'Enter',
+          isComposing: true,
+        });
+        Object.defineProperty(event, 'keyCode', { value: 229 });
+        input.dispatchEvent(event);
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      assert.equal(rewriteRequests.length, 0, 'IME composition Enter must not submit');
+      assert.equal(await app.page.locator('#app').getAttribute('data-view'), 'landing');
+    } finally {
+      await app.close();
+    }
+  });
+
+  await t.test('Free, BYOK and Pro entrypoints work in a narrow viewport', async () => {
+    const app = await openPlayground(browser, base, {
+      viewport: { width: 390, height: 844 },
+    });
+    try {
+      assert.equal(await app.page.evaluate(() => globalThis.innerWidth), 390);
+      assert.equal(await app.page.locator('#tier').inputValue(), 'free');
+
+      await app.page.locator('#price-free').click();
+      assert.equal(await app.page.locator('#tier').inputValue(), 'free');
+      assert.equal(await app.page.locator('#settings-panel').getAttribute('open'), null);
+
+      await app.page.locator('#price-byok').click();
+      assert.equal(await app.page.locator('#tier').inputValue(), 'byok');
+      assert.equal(await app.page.locator('#byok-row').isHidden(), false);
+      assert.equal(await app.page.evaluate(() => globalThis.document.activeElement?.id), 'api-key');
+      await app.page.locator('#api-key').fill(FIXTURE_API_KEY);
+      await submitHero(app.page);
+      await eventually(async () => (await app.page.locator('[data-output-status="approved"]').count()) === 1);
+      assert.equal(app.requests.at(-1)?.body.tier, 'byok');
+      assert.equal(app.requests.at(-1)?.body.apiKey, FIXTURE_API_KEY);
+      assert.equal(app.requests.at(-1)?.authorization, '');
+      assert.equal(app.requests.at(-1)?.body.text, INPUT_TEXT);
+
+      await app.page.locator('#home-link').click();
+      await app.page.locator('#pro-existing').click();
+      assert.equal(await app.page.locator('#tier').inputValue(), 'pro');
+      assert.equal(await app.page.locator('#pro-row').isHidden(), false);
+      assert.equal(await app.page.evaluate(() => globalThis.document.activeElement?.id), 'license-key');
+      await app.page.locator('#license-key').fill(FIXTURE_LICENSE);
+      await app.page.locator('#license-sign-in').click();
+      assert.equal(await app.page.locator('#license-key').inputValue(), '');
+      assert.equal(await app.page.locator('#license-sign-in').isHidden(), true);
+
+      await app.page.keyboard.press('Escape');
+      assert.equal(await app.page.locator('#settings-panel').getAttribute('open'), null);
+      await submitHero(app.page);
+      await eventually(async () => (await app.page.locator('[data-output-status="approved"]').count()) === 1);
+      assert.equal(app.requests.at(-1)?.body.tier, 'pro');
+      assert.equal(app.requests.at(-1)?.body.apiKey, undefined);
+      assert.equal(app.requests.at(-1)?.authorization, `Bearer ${FIXTURE_LICENSE}`);
+      assert.equal(app.requests.at(-1)?.body.text, INPUT_TEXT);
+    } finally {
+      await app.close();
+    }
+  });
+
+  await t.test('accepted, below-floor, transmission-failure and cancellation states are visible and copy-safe', async (t) => {
+    await t.test('accepted output exposes the approved copy action', async () => {
+      const app = await openPlayground(browser, base, { scenario: 'accepted' });
+      try {
+        await submitHero(app.page);
+        await eventually(async () => (await app.page.locator('[data-output-status="approved"]').count()) === 1);
+        assert.equal(await text(app.page.locator('.msg--patina .msg__text').last()), OUTPUT_TEXT);
+        const copy = app.page.locator('.msg--patina .output-action').first();
+        assert.equal(await text(copy), 'Copy');
+        await copy.click();
+        await eventually(async () => (await text(copy)) === 'Copied');
+      } finally {
+        await app.close();
+      }
+    });
+
+    await t.test('an intentionally bad accepted terminal is rejected below the floor', async () => {
+      const app = await openPlayground(browser, base, { scenario: 'belowfloor' });
+      try {
+        await submitHero(app.page);
+        await eventually(async () => (await app.page.locator('.msg__text--unapproved').count()) === 1);
+        assert.equal(await app.page.locator('.msg--patina .output-actions').count(), 0);
+        assert.match(await text(app.page.locator('.msg--patina .error-note').last()), /drifted too far/i);
+        assert.notEqual(await app.page.locator('.msg--patina .msg__text').last().getAttribute('data-output-status'), 'approved');
+      } finally {
+        await app.close();
+      }
+    });
+
+    await t.test('transmission failure stays unapproved and offers no copy action', async () => {
+      const app = await openPlayground(browser, base, { scenario: 'transmissionfailure' });
+      try {
+        await submitHero(app.page);
+        await eventually(async () => (await app.page.locator('.msg--patina .error-note').count()) === 1);
+        assert.match(await text(app.page.locator('.msg--patina .error-note').last()), /temporarily unavailable/i);
+        assert.equal(await app.page.locator('.msg--patina .output-actions').count(), 0);
+      } finally {
+        await app.close();
+      }
+    });
+
+    await t.test('stop cancels an in-flight local stream and keeps the result unapproved', async () => {
+      const app = await openPlayground(browser, base, { scenario: 'cancel' });
+      try {
+        await submitHero(app.page);
+        await eventually(async () => (await app.page.locator('#send[aria-label="Stop"]').count()) === 1);
+        await app.page.locator('#send[aria-label="Stop"]').click();
+        await eventually(async () => (await app.page.locator('.msg--patina .error-note').count()) === 1);
+        assert.match(await text(app.page.locator('.msg--patina .error-note').last()), /cancelled/i);
+        assert.equal(await app.page.locator('.msg--patina .output-actions').count(), 0);
+      } finally {
+        await app.close();
+      }
+    });
+  });
+});

--- a/tests/unit/playground-experience.test.js
+++ b/tests/unit/playground-experience.test.js
@@ -915,6 +915,61 @@ test('a copied example resets its label and success styling, and never carries t
   assert.equal(button.classList.contains('is-ok'), false);
 });
 
+test('stale example copy completions cannot relabel a reset row or clobber the latest copy', async () => {
+  const a = app({ languages: ['ko-KR'] });
+  const ui = copy.onboardingCopy('ko');
+  const button = a.document.querySelector('.editor__btn');
+  const requests = [];
+  a.context.navigator.clipboard = {
+    writeText(text) {
+      let resolve, reject;
+      const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+      requests.push({ text, resolve, reject });
+      return promise;
+    },
+  };
+  const first = EXAMPLES.find((row) => row.id === 'ko-fixture-0');
+  const second = EXAMPLES.find((row) => row.id === 'ko-fixture-1');
+
+  // A completion from the previous row must not restore its transient label.
+  button.emit('click');
+  assert.deepEqual(requests.map((request) => request.text), [first.after]);
+  change(a, 'example-choice', second.id);
+  requests[0].resolve();
+  await nextTurn();
+  assert.equal(button.textContent, ui.copyExample);
+  assert.equal(button.classList.contains('is-ok'), false);
+
+  // The same row reset must discard a rejected write as well.
+  change(a, 'example-choice', first.id);
+  button.emit('click');
+  assert.equal(requests[1].text, first.after, 'the failed write starts before switching rows');
+  change(a, 'example-choice', second.id);
+  requests[1].reject(new Error('clipboard unavailable'));
+  await nextTurn();
+  assert.equal(button.textContent, ui.copyExample);
+  assert.equal(button.classList.contains('is-ok'), false);
+
+  // If copies overlap, the latest result owns the button even when the old
+  // request settles afterwards.
+  change(a, 'example-choice', first.id);
+  button.emit('click');
+  change(a, 'example-choice', second.id);
+  button.emit('click');
+  assert.deepEqual(requests.map((request) => request.text), [first.after, first.after, first.after, second.after]);
+  requests[3].resolve();
+  await nextTurn();
+  assert.equal(button.textContent, ui.copied);
+  assert.equal(button.classList.contains('is-ok'), true);
+  requests[2].reject(new Error('old request failed'));
+  await nextTurn();
+  assert.equal(button.textContent, ui.copied);
+  assert.equal(button.classList.contains('is-ok'), true);
+
+  // Do not leave the latest reset timer pending for the rest of the suite.
+  change(a, 'example-choice', first.id);
+});
+
 test('optional controls open for credentials, close with Escape, and Free restores setup-free sending', () => {
   const a = app();
   const panel = a.get('settings-panel');


### PR DESCRIPTION
Refs #783. Focused browser domain in the maintenance delivery stack. Base bot/maintenance-architecture-delivery-20260909; retarget to dev only after prerequisite units integrate.

Owner approved coherent per-domain size exceptions, not aggregate approval. Regression tests and required docs remain together. No version bump, scoring change, publication or account writes. Local integrated tests/lint/release/private gates passed; current clean hosted CI and independent review required before Ready/merge.

Rollback: revert this domain commit, considering dependent units before reversal. Existing registry/production state remains untouched. Historical local receipts are not current hosted acceptance. Applicable unavailable client/OS/backend/account checks remain inconclusive, not passed.