### PR TITLE
feat(release): verify artifact provenance and bounded recovery

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    groups:
+      devtools:
+        dependency-type: development
+        update-types:
+          - patch
+          - minor
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1

--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ github.sha }}
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
@@ -28,17 +28,32 @@ jobs:
       - run: npm ci
       - name: Export hash-reviewed public fixtures
         run: node scripts/export-hf-dataset.mjs --output artifacts/hf-export
+      - name: Verify immutable export provenance
+        id: source
+        env:
+          DISPATCH_SHA: ${{ github.sha }}
+        run: |
+          test -n "$DISPATCH_SHA"
+          test "$(git rev-parse HEAD)" = "$DISPATCH_SHA"
+          source_commit="$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('artifacts/hf-export/source-manifest.json', 'utf8')).sourceCommit)")"
+          test "$source_commit" = "$DISPATCH_SHA"
+          printf 'source_commit=%s\n' "$source_commit" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@v4
         with:
           name: patina-hf-dataset
           path: artifacts/hf-export
+          if-no-files-found: error
       - name: Publish reviewed main history
         if: inputs.publish == true
         env:
           HF_TOKEN: ${{ secrets.HF_DATASET_WRITE_TOKEN }}
           HF_DATASET_REPO: ${{ vars.HF_DATASET_REPO }}
+          SOURCE_COMMIT: ${{ steps.source.outputs.source_commit }}
         run: |
           test -n "$HF_TOKEN"
           test -n "$HF_DATASET_REPO"
+          test -n "$SOURCE_COMMIT"
           git fetch origin main
+          git merge-base --is-ancestor "$SOURCE_COMMIT" origin/main
+          test "$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('artifacts/hf-export/source-manifest.json', 'utf8')).sourceCommit)")" = "$SOURCE_COMMIT"
           node scripts/publish-hf-dataset.mjs --directory artifacts/hf-export --repository "$HF_DATASET_REPO" --publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,21 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  # One release publisher at a time. queue:max keeps up to GitHub's hosted
+  # pending-run limit; cancel-in-progress is deliberately false.
+  group: patina-release-publication
+  queue: max
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
   verify:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.artifacts.outputs.version }}
     steps:
       - uses: actions/checkout@v6
 
@@ -72,6 +81,26 @@ jobs:
       - name: Alias npm package dry run
         run: cd packages/patina-humanizer && npm pack --dry-run
 
+      - name: Build and verify release tarballs
+        id: artifacts
+        run: |
+          node scripts/release-artifacts.mjs --output-dir .release-artifacts --source-sha "$GITHUB_SHA"
+          node --input-type=module <<'EOF' >> "$GITHUB_OUTPUT"
+          import { readFileSync } from 'node:fs';
+          const manifest = JSON.parse(readFileSync('.release-artifacts/release-manifest.json', 'utf8'));
+          const version = JSON.parse(readFileSync('package.json', 'utf8')).version;
+          if (manifest.version !== version || manifest.sourceSHA !== process.env.GITHUB_SHA) throw new Error('Release artifact identity mismatch');
+          console.log(`version=${version}`);
+          EOF
+
+      - name: Upload verified release tarballs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-artifacts-${{ github.sha }}
+          path: .release-artifacts
+          include-hidden-files: true
+          if-no-files-found: error
+
   authorize-source:
     needs: verify
     runs-on: ubuntu-latest
@@ -115,15 +144,25 @@ jobs:
       - name: Verify release metadata
         run: npm run release:check
 
-      - name: Publish patina-cli
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --provenance
+      - name: Download verified release tarballs
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-artifacts-${{ github.sha }}
+          path: .release-artifacts
 
-      - name: Publish patina-humanizer alias
+      - name: Verify downloaded release tarballs
+        env:
+          RELEASE_VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          test -n "$RELEASE_VERSION"
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then test "$GITHUB_REF_NAME" = "v$RELEASE_VERSION"; fi
+          node scripts/release-artifacts.mjs --verify-only --output-dir .release-artifacts --source-sha "$GITHUB_SHA" --version "$RELEASE_VERSION"
+
+      - name: Publish verified release tarballs with recovery
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: cd packages/patina-humanizer && npm publish --access public --provenance
+          RELEASE_VERSION: ${{ needs.verify.outputs.version }}
+        run: node scripts/release-artifacts.mjs --publish --output-dir .release-artifacts --source-sha "$GITHUB_SHA" --version "$RELEASE_VERSION"
 
   github-release:
     needs: [verify, npm]
@@ -135,6 +174,15 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set up Node 24 for GitHub release helpers
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install release helper dependencies
+        run: npm ci
 
       - name: Extract changelog notes for this version
         run: |
@@ -150,15 +198,105 @@ jobs:
           EOF
           cat release-notes.md | head -3
 
-      - name: Create GitHub release
+      - name: Create or update GitHub release without stale latest promotion
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
-          gh release create "$GITHUB_REF_NAME" \
-            --title "v${VERSION}" \
-            --notes-file release-notes.md \
-            --latest
+          query_release() {
+            local endpoint="$1"
+            local response_file="$2"
+            local command_status
+            if gh api --include "$endpoint" >"$response_file"; then
+              command_status=0
+            else
+              command_status=$?
+            fi
+            GH_RESPONSE_FILE="$response_file" GH_COMMAND_STATUS="$command_status" node --input-type=module <<'EOF'
+          import { readFileSync } from 'node:fs';
+          import {
+            classifyGithubReleaseLookup,
+            parseGithubApiStatus,
+          } from './scripts/release-artifacts.mjs';
+          const output = readFileSync(process.env.GH_RESPONSE_FILE, 'utf8');
+          process.stdout.write(classifyGithubReleaseLookup({
+            httpStatus: parseGithubApiStatus(output),
+            commandStatus: Number(process.env.GH_COMMAND_STATUS),
+          }));
+          EOF
+          }
+
+          release_response="$(mktemp)"
+          latest_response="$(mktemp)"
+          trap 'rm -f "$release_response" "$latest_response"' EXIT
+
+          verify_release_tag() {
+            git fetch --no-tags origin "+refs/tags/${GITHUB_REF_NAME}:refs/patina/release-check"
+            test "$(git rev-parse 'refs/patina/release-check^{commit}')" = "$GITHUB_SHA"
+          }
+
+          # A tag query distinguishes an existing release from auth, network,
+          # or gh-tool failures. Only an explicit HTTP 404 means absent.
+          release_state="$(query_release "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" "$release_response")"
+          if [ "$release_state" = present ]; then
+            # A rerun updates only the failed release step and preserves the
+            # existing latest marker.
+            verify_release_tag
+            gh release edit "$GITHUB_REF_NAME" \
+              --title "v${VERSION}" \
+              --notes-file release-notes.md
+            exit 0
+          fi
+
+          # /releases/latest is authoritative; do not use the limited release
+          # list, whose default page can omit the current latest release.
+          latest_state="$(query_release "repos/${GITHUB_REPOSITORY}/releases/latest" "$latest_response")"
+          current_latest=""
+          if [ "$latest_state" = present ]; then
+            current_latest="$(GH_RESPONSE_FILE="$latest_response" node --input-type=module <<'EOF'
+          import { readFileSync } from 'node:fs';
+          import {
+            parseGithubApiJson,
+            parseGithubReleaseTag,
+          } from './scripts/release-artifacts.mjs';
+          const release = parseGithubApiJson(readFileSync(process.env.GH_RESPONSE_FILE, 'utf8'));
+          process.stdout.write(parseGithubReleaseTag(release.tag_name));
+          EOF
+            )"
+          fi
+
+          action="$(CURRENT_LATEST="$current_latest" CANDIDATE="$VERSION" node --input-type=module <<'EOF'
+          import { decideGithubReleaseAction } from './scripts/release-artifacts.mjs';
+          process.stdout.write(decideGithubReleaseAction({
+            candidateVersion: process.env.CANDIDATE,
+            currentLatestVersion: process.env.CURRENT_LATEST || undefined,
+          }));
+          EOF
+          )"
+          case "$action" in
+            create-latest)
+              verify_release_tag
+              gh release create "$GITHUB_REF_NAME" \
+                --verify-tag \
+                --title "v${VERSION}" \
+                --notes-file release-notes.md \
+                --latest
+              ;;
+            create-not-latest)
+              echo "::warning::Not promoting stale version v${VERSION} to GitHub latest (current latest v${current_latest})."
+              verify_release_tag
+              gh release create "$GITHUB_REF_NAME" \
+                --verify-tag \
+                --title "v${VERSION}" \
+                --notes-file release-notes.md \
+                --latest=false
+              ;;
+            *)
+              echo "::error::Unexpected GitHub release action: $action"
+              exit 1
+              ;;
+          esac
 
   ghcr:
     needs: [verify, authorize-source]

--- a/docs/integrations/huggingface.md
+++ b/docs/integrations/huggingface.md
@@ -22,13 +22,35 @@ must be reviewed and committed before publication. The publisher verifies the
 export against that reviewed source and refuses unreviewed Git history,
 unmanaged target datasets, checksum changes and source downgrades.
 
-The **Publish benchmark dataset** workflow supports a manual dry run and an
-explicit publish run from reviewed main history. Configure the repository
-environment secret `HF_DATASET_WRITE_TOKEN` in `hf-dataset-production` and
-variable `HF_DATASET_REPO=OWNER/patina-suspect-zones` before publishing. Restrict
-that environment to the `main` branch. The job also checks out `main` explicitly
-and rejects dispatches from other branches. There is no automatic release upload until the namespace and
-credential configuration have been confirmed.
+## Provenance procedure
 
-The published URL and cross-links will be added after successful remote
-verification. An exported folder alone is not a published dataset.
+1. Review every fixture change in
+   `docs/research/hf-fixture-license-review.json`, including its source-file
+   hash, before exporting.
+2. From the reviewed `main` branch, dispatch **Publish benchmark dataset** with
+   `publish: false`. The workflow checks out the dispatch SHA (not a moving
+   branch), exports `artifacts/hf-export`, and records that SHA in
+   `source-manifest.json`. It refuses to continue if the checkout, manifest,
+   and dispatch SHA differ.
+3. Inspect the uploaded export and its `source-manifest.json`. Confirm
+   `sourceCommit`, `sourceVersion`, `dataSha256`, `licenseSha256`,
+   `licenseReviewSha256`, row counts, and file hashes against the reviewed
+   source checkout. The publisher reads this same export; it does not rebuild
+   from a later branch tip.
+4. Configure the `hf-dataset-production` environment secret
+   `HF_DATASET_WRITE_TOKEN` and variable
+   `HF_DATASET_REPO=OWNER/patina-suspect-zones`, restrict the environment to
+   `main`, and obtain maintainer approval. A separate dispatch with
+   `publish: true` is required. The workflow verifies that the pinned source
+   remains an ancestor of `origin/main` without changing the checked-out
+   source.
+5. After the publisher returns, verify the Hugging Face commit and every
+   uploaded-file checksum. Record that remote commit together with the
+   manifest; an exported folder or workflow artifact alone is not a
+   publication.
+
+## Current publication state
+
+No Hugging Face dataset has been published or remotely verified for this
+repository. The namespace and production credential are therefore not evidence
+of a release, and this documentation intentionally contains no published URL.

--- a/docs/integrations/release.md
+++ b/docs/integrations/release.md
@@ -2,6 +2,15 @@
 
 `release.yml` is the maintainer path for npm distribution artifacts.
 
+<!-- maintenance-lifecycle: npm-token-publishing; owner=repository-maintainer; review=2026-10-09; remove-after=root-and-alias-trusted-publishing-verified -->
+
+The npm `NPM_TOKEN` path remains an intentional hold. The repository maintainer
+owns the path and reviews it monthly (next review: **2026-10-09**). Remove the
+hold and token path **only after trusted publishing/OIDC has been verified for
+both `patina-cli` and `patina-humanizer` in the actual npm accounts**. No
+automatic credential deletion, dist-tag change, or hold release is implied by
+the workflow.
+
 ## Source and web deployment while npm publication is pending
 
 The 8.5.2 source and web hotfix restores the centered landing page and separate examples section. Multilingual copy, optional settings, and rewrite verification stay unchanged. Unreleased dev changes are excluded.
@@ -29,6 +38,45 @@ gh workflow run release.yml -f publish=false -f publish_ghcr=false
 
 The dry run (`verify` job) runs, in order: `npm run lint`, `npm run release:check` (version metadata across `package.json`, skill files, `.patina.default.yaml`, README, CHANGELOG, plus the retired-concepts scan), `npm test`, `npm run benchmark:report` and `npm run benchmark:compare` with a checked-in `docs/benchmarks` drift check, `npm run dogfood`, `npm run check:no-private-assets`, and `npm pack --dry-run` for both `patina-cli` and the `patina-humanizer` alias package.
 
+It then builds the real root and alias `.tgz` files once with
+`scripts/release-artifacts.mjs`. The script records `sourceSHA`, the shared
+version, each tarball's SHA-256/SHA-512/SRI integrity, and the packed file
+lists in `release-manifest.json`. A clean fixture installs **both tarballs in
+one `npm install` command**, then runs `npm ci` from that generated lockfile
+dependencies (currently
+`js-yaml`/`argparse`) may use the public registry; the lockfile must show
+`file:` resolutions and matching integrity for both `patina-cli` and
+`patina-humanizer`, with paths resolving to the two supplied tarballs, so
+neither package can silently fall back to a registry version. The fixture
+verifies that the alias's exact `patina-cli` dependency resolves to the
+supplied root tarball and runs both CLI `--version` smoke checks. The verified
+directory is uploaded as an artifact named for the commit SHA.
+The build output directory and smoke fixture are required to be new or empty;
+the script refuses to delete caller-owned files.
+The verify job exports the checked manifest version to the publication job.
+Manual dispatch from `main` uses that version rather than treating the branch
+name as a package version; tag runs also require the tag to match that version.
+
+The build does not invoke the source package's `prepublishOnly` lifecycle: it
+packs and later publishes the already-verified tarballs. The ordinary source
+`prepublishOnly` safety checks remain unchanged for a direct source publish;
+the release path does not use a blanket `--ignore-scripts` bypass.
+
+The local commands are:
+
+```bash
+# Choose one fresh output directory for the build:
+node scripts/release-artifacts.mjs \
+  --output-dir .release-artifacts --source-sha "$GITHUB_SHA"
+# `--dry-run` is an explicit spelling of the default no-publish mode.
+node scripts/release-artifacts.mjs --dry-run \
+  --output-dir .release-artifacts-dry-run --source-sha "$GITHUB_SHA"
+# Verify an existing artifact directory without packing source again:
+node scripts/release-artifacts.mjs \
+  --verify-only --output-dir .release-artifacts \
+  --source-sha "$GITHUB_SHA" --version "${GITHUB_REF_NAME#v}"
+```
+
 ## Publish
 
 Publishing the npm packages is intended for `v*.*.*` tags:
@@ -45,8 +93,49 @@ Required secret:
 
 On a tag push the workflow:
 
-- publishes `patina-cli` and the `patina-humanizer` alias to npm (`npm` job);
+- downloads the verify job's exact tarballs, rechecks `release-manifest.json`
+  and both hashes against the tagged SHA, then publishes those paths with the
+  explicit `--publish` mode (never re-packs source);
 - creates the GitHub Release from the CHANGELOG entry (`github-release` job).
+
+Root and alias publication are tracked separately. A timeout is inspected in
+the registry before any retry; an existing exact integrity is treated as the
+completed step, while a version with different bytes fails closed. A root
+success followed by alias failure therefore retries only the alias. A stale
+version cannot promote npm or GitHub `latest`, and the workflow never performs
+arbitrary dist-tag changes. A failed GitHub Release step is idempotent: a rerun
+edits the existing release without changing its latest marker.
+Immediately before either GitHub create or edit, the workflow fetches the
+current tag and requires its peeled commit (including annotated tags) to match
+the verified source SHA. Creation also uses `--verify-tag` so a deleted tag is
+not silently recreated at the default branch. A remote tag can still change
+after that check; tag protection and hosted acceptance remain separate gates.
+
+The `github-release` job installs dependencies before importing the local
+release helper (the helper uses the pinned `semver` dependency). Its read-only
+release checks query the GitHub API endpoints `/releases/tags/{tag}` and
+`/releases/latest`; they do not rely on the default limited `gh release list`
+page. Only an explicit HTTP 404 is treated as an absent release. Authentication,
+network, malformed-response, and `gh` tool failures stop the job rather than
+being interpreted as permission to create a duplicate or stale release. A
+legacy actionlint version may not recognize the hosted-runner `queue: max`
+concurrency key; retain the documented GitHub syntax and treat that validator
+result as inconclusive until a current actionlint is available.
+
+Only the publishing job uses the explicit command below; omitting
+`--publish` is always a dry run:
+
+```bash
+node scripts/release-artifacts.mjs \
+  --publish --output-dir .release-artifacts \
+  --source-sha "$GITHUB_SHA" --version "${GITHUB_REF_NAME#v}"
+```
+
+Release runs use the constant `patina-release-publication` concurrency group,
+`cancel-in-progress: false`, and GitHub's `queue: max` setting. GitHub-hosted
+queues retain up to the platform's pending-run limit (currently 100); a full
+queue cancels additional runs, so this is not an unbounded queue guarantee.
+An active publication is never canceled by a newer release request.
 
 Docker / GHCR publishing is decoupled from tag pushes: the `ghcr` job runs only
 on `workflow_dispatch` with `publish_ghcr=true`. Manual publication must run from

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "jsdoc-to-markdown": "^9.1.3",
         "typescript": "^5.4.5",
         "espree": "9.6.1",
-        "playwright": "1.63.0"
+        "playwright": "1.63.0",
+        "semver": "7.8.0"
       },
       "engines": {
         "node": ">=18.1.0"

--- a/package.json
+++ b/package.json
@@ -230,6 +230,7 @@
     "jsdoc-to-markdown": "^9.1.3",
     "typescript": "^5.4.5",
     "espree": "9.6.1",
-    "playwright": "1.63.0"
+    "playwright": "1.63.0",
+    "semver": "7.8.0"
   }
 }

--- a/scripts/check-retired-concepts.mjs
+++ b/scripts/check-retired-concepts.mjs
@@ -7,6 +7,10 @@ import { fileURLToPath } from 'node:url';
 
 const RETIRED_TERM = ['ouro', 'boros'].join('');
 const ARCHIVE_PREFIXES = ['.gjc/', '.insane-review/'];
+export const LIFECYCLE_MARKER_PATH = 'docs/integrations/release.md';
+export const REQUIRED_LIFECYCLE_ID = 'npm-token-publishing';
+const LIFECYCLE_MARKER_PREFIX = '<!-- maintenance-lifecycle:';
+const REQUIRED_LIFECYCLE_FIELDS = ['owner', 'review', 'remove-after'];
 const HISTORICAL_EXPECTATIONS = new Map([
   ['CHANGELOG.md', new Map([
     ['a1aa4b471c432c2582586204d20566967533254171fbbd790a9da36a81412086', [404]],
@@ -29,7 +33,192 @@ function fingerprint(text) {
   return createHash('sha256').update(text).digest('hex');
 }
 
-function changelogHistoricalBoundary(lines) {
+function parseLifecycleMarker(line, lineNumber, path) {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith(LIFECYCLE_MARKER_PREFIX)) return null;
+  if (!trimmed.endsWith('-->')) {
+    return {
+      record: null,
+      markerId: null,
+      errors: [{ path, line: lineNumber, reason: 'lifecycle marker is not closed with -->' }],
+    };
+  }
+  const body = trimmed
+    .slice(LIFECYCLE_MARKER_PREFIX.length, -3)
+    .trim();
+  const parts = body.split(';').map((part) => part.trim());
+  const id = parts[0] || null;
+  const errors = [];
+  if (!body) {
+    errors.push({ path, line: lineNumber, reason: 'lifecycle marker is empty' });
+  }
+  if (parts.some((part) => !part)) {
+    errors.push({ path, line: lineNumber, reason: 'lifecycle marker contains an empty segment' });
+  }
+  if (!id || !/^[a-z][a-z0-9-]*$/.test(id)) {
+    errors.push({ path, line: lineNumber, reason: 'lifecycle marker id is malformed' });
+  }
+  const fields = {};
+  const seen = new Set();
+  for (const part of parts.slice(1)) {
+    const match = /^([a-z][a-z0-9-]*)=(.*)$/.exec(part);
+    if (!match) {
+      errors.push({
+        path,
+        line: lineNumber,
+        segment: part,
+        reason: 'lifecycle marker field segment must be key=value',
+      });
+      continue;
+    }
+    const [, key, rawValue] = match;
+    const value = rawValue.trim();
+    if (seen.has(key)) {
+      errors.push({
+        path,
+        line: lineNumber,
+        field: key,
+        reason: `lifecycle marker field ${key} is duplicated`,
+      });
+      continue;
+    }
+    seen.add(key);
+    if (!REQUIRED_LIFECYCLE_FIELDS.includes(key)) {
+      errors.push({
+        path,
+        line: lineNumber,
+        field: key,
+        reason: `lifecycle marker field ${key} is not recognized`,
+      });
+      continue;
+    }
+    if (!value) {
+      errors.push({
+        path,
+        line: lineNumber,
+        field: key,
+        reason: `lifecycle marker field ${key} must not be empty`,
+      });
+      continue;
+    }
+    fields[key] = value;
+  }
+  if (errors.length) return { record: null, markerId: id, errors };
+  return {
+    record: {
+      id: id || null,
+      ...fields,
+      path,
+      line: lineNumber,
+    },
+    markerId: id,
+    errors: [],
+  };
+}
+
+function validCalendarDate(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (year < 1 || month < 1 || month > 12 || day < 1) return false;
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+  return day <= daysInMonth;
+}
+
+// This pilot intentionally checks one known temporary publication branch. It
+// validates that the owner, review date, and removal condition are recorded;
+// it never compares the review date with the clock or removes the branch.
+export function scanLifecycleText(source, path = LIFECYCLE_MARKER_PATH) {
+  const records = [];
+  const errors = [];
+  if (typeof source !== 'string') {
+    return {
+      records,
+      errors: [{ path, reason: 'required lifecycle file is unavailable' }],
+    };
+  }
+
+  const lines = source.split('\n');
+  for (let index = 0; index < lines.length; index++) {
+    const parsed = parseLifecycleMarker(lines[index], index + 1, path);
+    if (!parsed) continue;
+    if (parsed.errors.length) errors.push(...parsed.errors);
+    if (parsed.record?.id === REQUIRED_LIFECYCLE_ID) records.push(parsed.record);
+    if (parsed.markerId === REQUIRED_LIFECYCLE_ID && parsed.errors.length) {
+      records.push({ id: REQUIRED_LIFECYCLE_ID, path, line: index + 1, malformed: true });
+    }
+  }
+
+  if (records.length === 0) {
+    errors.push({
+      path,
+      reason: `required lifecycle marker ${REQUIRED_LIFECYCLE_ID} is missing`,
+    });
+    return { records, errors };
+  }
+  const validRecords = records.filter((record) => !record.malformed);
+  if (validRecords.length > 1) {
+    errors.push({
+      path,
+      reason: `expected exactly one lifecycle marker ${REQUIRED_LIFECYCLE_ID}`,
+      lines: validRecords.map((record) => record.line),
+    });
+  }
+
+  const record = validRecords[0];
+  if (!record) return { records, errors };
+  for (const field of REQUIRED_LIFECYCLE_FIELDS) {
+    if (typeof record[field] !== 'string' || !record[field]) {
+      errors.push({
+        path,
+        line: record.line,
+        field,
+        reason: `lifecycle marker ${REQUIRED_LIFECYCLE_ID} is missing ${field}`,
+      });
+    }
+  }
+  if (record.review && !validCalendarDate(record.review)) {
+    errors.push({
+      path,
+      line: record.line,
+      field: 'review',
+      reason: 'lifecycle review must be a valid calendar date in YYYY-MM-DD',
+    });
+  }
+  return { records: validRecords, errors };
+}
+
+export function scanLifecycleRecord(root, files = [], scannedSources) {
+  const normalizedFiles = files.map((file) => String(file).replaceAll('\\', '/'));
+  if (!normalizedFiles.includes(LIFECYCLE_MARKER_PATH)) {
+    return {
+      records: [],
+      errors: [{ path: LIFECYCLE_MARKER_PATH, reason: 'required lifecycle file is not tracked' }],
+    };
+  }
+  if (scannedSources instanceof Map) {
+    // A map from scanPaths is authoritative: an absent entry means the
+    // required file was skipped or could not be read, so never reread disk.
+    if (!scannedSources.has(LIFECYCLE_MARKER_PATH)) {
+      return scanLifecycleText(null, LIFECYCLE_MARKER_PATH);
+    }
+    return scanLifecycleText(scannedSources.get(LIFECYCLE_MARKER_PATH), LIFECYCLE_MARKER_PATH);
+  }
+  const absolute = resolve(root, LIFECYCLE_MARKER_PATH);
+  if (!existsSync(absolute)) {
+    return scanLifecycleText(null, LIFECYCLE_MARKER_PATH);
+  }
+  try {
+    return scanLifecycleText(readFileSync(absolute, 'utf8'), LIFECYCLE_MARKER_PATH);
+  } catch {
+    return scanLifecycleText(null, LIFECYCLE_MARKER_PATH);
+  }
+}
+
+export function changelogHistoricalBoundary(lines) {
   const releaseHeadings = lines
     .map((line, index) => (/^## \d+\.\d+\.\d+\b/.test(line) ? { line, index } : null))
     .filter(Boolean);
@@ -100,12 +289,13 @@ export function scanText(source, path) {
   return { forbidden, allowed, historicalDrift };
 }
 
-export function scanPaths(root, inputPaths, { requireHistoricalFiles = false } = {}) {
+export function scanPaths(root, inputPaths, { requireHistoricalFiles = false, requireLifecycleRecords = false } = {}) {
   const absoluteRoot = resolve(root);
   const files = [...new Set(inputPaths.map((path) => String(path).replaceAll('\\', '/')))].sort();
   const forbidden = [];
   const allowed = [];
   const historicalDrift = [];
+  const scannedSources = new Map();
   const scannedPaths = new Set();
   const filesSkipped = { archive: 0, missing: 0, binary: 0 };
 
@@ -126,6 +316,7 @@ export function scanPaths(root, inputPaths, { requireHistoricalFiles = false } =
     }
     const result = scanText(bytes.toString('utf8'), path);
     scannedPaths.add(path);
+    if (path === LIFECYCLE_MARKER_PATH) scannedSources.set(path, bytes.toString('utf8'));
     forbidden.push(...result.forbidden);
     allowed.push(...result.allowed);
     historicalDrift.push(...result.historicalDrift);
@@ -141,6 +332,9 @@ export function scanPaths(root, inputPaths, { requireHistoricalFiles = false } =
     }
   }
 
+  const lifecycle = requireLifecycleRecords
+    ? scanLifecycleRecord(absoluteRoot, files, scannedSources)
+    : { records: [], errors: [] };
   const skippedTotal = Object.values(filesSkipped).reduce((sum, count) => sum + count, 0);
   return {
     root: absoluteRoot,
@@ -150,14 +344,20 @@ export function scanPaths(root, inputPaths, { requireHistoricalFiles = false } =
     allowedHits: allowed.length,
     forbiddenHits: forbidden.length,
     historicalDriftCount: historicalDrift.length,
+    lifecycleRecordCount: lifecycle.records.length,
+    lifecycleDriftCount: lifecycle.errors.length,
     forbidden,
     allowed,
     historicalDrift,
+    lifecycleDrift: lifecycle.errors,
   };
 }
 
 export function scanRoot(root) {
-  return scanPaths(root, discoverTrackedFiles(resolve(root)), { requireHistoricalFiles: true });
+  return scanPaths(root, discoverTrackedFiles(resolve(root)), {
+    requireHistoricalFiles: true,
+    requireLifecycleRecords: true,
+  });
 }
 
 function discoverTrackedFiles(root) {
@@ -186,15 +386,22 @@ function main(argv) {
       `Discovered ${report.filesDiscovered} files; scanned ${report.filesScanned}; skipped ${report.filesSkipped.total} under ${report.root}\n`
     );
     process.stdout.write(
-      `Allowed historical hits: ${report.allowedHits}; forbidden current hits: ${report.forbiddenHits}; historical drift: ${report.historicalDriftCount}\n`
+      `Allowed historical hits: ${report.allowedHits}; forbidden current hits: ${report.forbiddenHits}; historical drift: ${report.historicalDriftCount}; lifecycle drift: ${report.lifecycleDriftCount}\n`
     );
     for (const match of report.allowed) process.stdout.write(`allowed historical: ${formatMatch(match)}\n`);
     for (const match of report.forbidden) process.stderr.write(`forbidden current reference: ${formatMatch(match)}\n`);
     for (const drift of report.historicalDrift) {
       process.stderr.write(`historical allowlist drift: ${drift.path}: ${drift.reason}\n`);
     }
+    for (const drift of report.lifecycleDrift) {
+      process.stderr.write(`lifecycle record drift: ${drift.path}: ${drift.reason}\n`);
+    }
   }
-  return report.forbidden.length === 0 && report.historicalDrift.length === 0 ? 0 : 1;
+  return report.forbidden.length === 0
+    && report.historicalDrift.length === 0
+    && report.lifecycleDrift.length === 0
+    ? 0
+    : 1;
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/release-artifacts.mjs
+++ b/scripts/release-artifacts.mjs
@@ -1,0 +1,1390 @@
+#!/usr/bin/env node
+
+/**
+ * Build, verify, and (when explicitly requested) publish the npm release
+ * artifacts.  This module deliberately treats a tarball as the release
+ * boundary: source is packed once, that exact file is smoke-tested, and the
+ * same file is the only input accepted by the publisher.
+ */
+
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+import { compare as semverCompare, valid as semverValid } from 'semver';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+export const MANIFEST_FILENAME = 'release-manifest.json';
+export const ROOT_PACKAGE_NAME = 'patina-cli';
+export const ALIAS_PACKAGE_NAME = 'patina-humanizer';
+export const PACKAGE_ARTIFACTS = Object.freeze([
+  Object.freeze({
+    key: 'root',
+    name: ROOT_PACKAGE_NAME,
+    packageDir: '.',
+  }),
+  Object.freeze({
+    key: 'alias',
+    name: ALIAS_PACKAGE_NAME,
+    packageDir: 'packages/patina-humanizer',
+  }),
+]);
+
+const DEFAULT_NPM_COMMAND = process.env.NPM_COMMAND || 'npm';
+const DEFAULT_NPM_TIMEOUT_MS = 120_000;
+const NPM_REGISTRY = 'https://registry.npmjs.org';
+
+export class ReleaseArtifactError extends Error {
+  constructor(message, code = 'ERR_RELEASE_ARTIFACT', details = undefined) {
+    super(message);
+    this.name = 'ReleaseArtifactError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export function parseSemver(value) {
+  const normalized = semverValid(String(value ?? '').trim());
+  if (!normalized) {
+    throw new ReleaseArtifactError(`Invalid semantic version: ${value}`, 'ERR_INVALID_VERSION');
+  }
+  return normalized;
+}
+
+export function compareSemver(left, right) {
+  const a = parseSemver(left);
+  const b = parseSemver(right);
+  return semverCompare(a, b);
+}
+
+/**
+ * Equal versions are allowed for idempotent reruns.  A lower version is
+ * never allowed to promote a latest channel.
+ */
+export function canPromoteLatest({ candidateVersion, currentLatestVersion }) {
+  if (!currentLatestVersion) return true;
+  return compareSemver(candidateVersion, currentLatestVersion) >= 0;
+}
+
+/**
+ * Decide how the GitHub Release job should handle a tag after its read-only
+ * lookups complete.  An existing release is always edited in place so a
+ * release-only rerun cannot change its latest marker.  New releases promote
+ * latest only when the candidate is not older than the observed latest tag.
+ */
+export function decideGithubReleaseAction({
+  candidateVersion,
+  currentLatestVersion,
+  existingRelease = false,
+} = {}) {
+  const candidate = parseSemver(candidateVersion);
+  if (existingRelease) return 'edit';
+  if (!currentLatestVersion || canPromoteLatest({
+    candidateVersion: candidate,
+    currentLatestVersion,
+  })) {
+    return 'create-latest';
+  }
+  return 'create-not-latest';
+}
+
+/**
+ * Classify a GitHub API lookup without treating an operational failure as an
+ * absent release.  The API may return a non-zero gh exit status for a 404;
+ * that one explicit status is the only missing-release result accepted.
+ */
+export function classifyGithubReleaseLookup({ httpStatus, commandStatus = 0 } = {}) {
+  const status = Number(httpStatus);
+  const exitStatus = Number(commandStatus);
+  if (status === 404) return 'absent';
+  if (
+    !Number.isInteger(status)
+    || status < 200
+    || status >= 300
+    || !Number.isInteger(exitStatus)
+    || exitStatus !== 0
+  ) {
+    throw new ReleaseArtifactError(
+      'GitHub release lookup failed',
+      'ERR_GITHUB_RELEASE_LOOKUP',
+      { httpStatus, commandStatus }
+    );
+  }
+  return 'present';
+}
+
+/** Extract the HTTP status emitted by `gh api --include`. */
+export function parseGithubApiStatus(output) {
+  const text = String(output ?? '').replace(/\r\n?/g, '\n');
+  const statuses = [];
+  for (const line of text.split('\n')) {
+    const match = line.match(/^HTTP\/\S+\s+(\d{3})(?:\s|$)/);
+    if (match) statuses.push(Number(match[1]));
+  }
+  if (statuses.length > 1) {
+    throw new ReleaseArtifactError(
+      'GitHub API response contained multiple HTTP status lines',
+      'ERR_GITHUB_RELEASE_RESPONSE',
+      { statuses }
+    );
+  }
+  return statuses[0];
+}
+
+/** Parse the JSON body emitted by `gh api --include`. */
+export function parseGithubApiJson(output) {
+  const text = String(output ?? '').replace(/\r\n?/g, '\n');
+  // Validate the status framing before extracting the body so redirects or
+  // repeated response blocks cannot be mistaken for a successful payload.
+  const status = parseGithubApiStatus(text);
+  if (status === undefined || status < 200 || status >= 300) {
+    throw new ReleaseArtifactError(
+      'GitHub API response did not contain a successful HTTP status',
+      'ERR_GITHUB_RELEASE_RESPONSE',
+      { status }
+    );
+  }
+  const separator = text.indexOf('\n\n');
+  const body = separator >= 0
+    ? text.slice(separator + 2).trim()
+    : text.trim();
+  if (!body) {
+    throw new ReleaseArtifactError('GitHub API response did not contain a JSON body', 'ERR_GITHUB_RELEASE_RESPONSE');
+  }
+  try {
+    return JSON.parse(body);
+  } catch (error) {
+    throw new ReleaseArtifactError('GitHub API response was not valid JSON', 'ERR_GITHUB_RELEASE_RESPONSE', { cause: error });
+  }
+}
+
+/** Normalize a GitHub release tag to the semantic version used by npm. */
+export function parseGithubReleaseTag(value) {
+  const tag = String(value ?? '').trim();
+  if (!tag) {
+    throw new ReleaseArtifactError('GitHub release response did not contain a tag', 'ERR_GITHUB_RELEASE_RESPONSE');
+  }
+  return parseSemver(tag.replace(/^v/, ''));
+}
+
+export function assertCanPromoteLatest({ candidateVersion, currentLatestVersion }) {
+  if (!canPromoteLatest({ candidateVersion, currentLatestVersion })) {
+    throw new ReleaseArtifactError(
+      `Refusing to promote stale version ${candidateVersion}; current latest is ${currentLatestVersion}`,
+      'ERR_STALE_LATEST',
+      { candidateVersion, currentLatestVersion }
+    );
+  }
+  return true;
+}
+
+export function hashBytes(value) {
+  const bytes = Buffer.isBuffer(value) ? value : Buffer.from(value);
+  const sha256 = createHash('sha256').update(bytes).digest('hex');
+  const sha512 = createHash('sha512').update(bytes).digest('hex');
+  return {
+    sha256,
+    sha512,
+    integrity: `sha512-${Buffer.from(sha512, 'hex').toString('base64')}`,
+    size: bytes.length,
+  };
+}
+
+export function hashFile(path) {
+  return hashBytes(readFileSync(path));
+}
+
+function packageManifest(repoRoot, packageDir) {
+  const packagePath = resolve(repoRoot, packageDir, 'package.json');
+  if (!existsSync(packagePath)) {
+    throw new ReleaseArtifactError(`Missing package manifest: ${packagePath}`, 'ERR_PACKAGE_MANIFEST');
+  }
+  return {
+    path: packagePath,
+    value: JSON.parse(readFileSync(packagePath, 'utf8')),
+  };
+}
+
+function ensureEmptyDirectory(path, code) {
+  const absolute = resolve(path);
+  const stat = lstatOrNull(absolute);
+  if (stat) {
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      throw new ReleaseArtifactError(`${absolute} must be a regular directory`, code, { path: absolute });
+    }
+    let entries;
+    try {
+      entries = readdirSync(absolute);
+    } catch (error) {
+      throw new ReleaseArtifactError(`Unable to inspect ${absolute}`, code, { cause: error });
+    }
+    if (entries.length > 0) {
+      throw new ReleaseArtifactError(`${absolute} must be empty`, code, { path: absolute, entries });
+    }
+    return;
+  }
+  mkdirSync(absolute, { recursive: true });
+  assertOutputDirectory(absolute, code);
+}
+
+function lstatOrNull(path) {
+  try {
+    return lstatSync(path);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+function isWithinPath(root, candidate) {
+  const child = relative(root, candidate);
+  return child === '' || (child !== '..' && !child.startsWith(`..${sep}`) && !isAbsolute(child));
+}
+
+function assertOutputDirectory(path, code = 'ERR_ARTIFACT_PATH') {
+  const absolute = resolve(path);
+  const stat = lstatOrNull(absolute);
+  if (!stat || stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new ReleaseArtifactError(`${absolute} must be a regular directory`, code, { path: absolute });
+  }
+  let real;
+  try {
+    real = realpathSync(absolute);
+  } catch (error) {
+    throw new ReleaseArtifactError(`Unable to resolve ${absolute}`, code, { cause: error, path: absolute });
+  }
+  return { path: absolute, realpath: real };
+}
+
+function safeOutputPath(outputDir, requestedPath, code = 'ERR_ARTIFACT_PATH', label = 'artifact') {
+  const root = resolve(outputDir);
+  const candidate = resolve(requestedPath);
+  if (!isWithinPath(root, candidate)) {
+    throw new ReleaseArtifactError(`${label} path escapes output directory: ${requestedPath}`, code, {
+      outputDir: root,
+      path: candidate,
+    });
+  }
+  return candidate;
+}
+
+function assertRegularOutputFile(outputDir, path, code, label) {
+  const destination = assertOutputDirectory(outputDir, code);
+  const absolute = safeOutputPath(destination.path, path, code, label);
+  const stat = lstatOrNull(absolute);
+  if (!stat || stat.isSymbolicLink() || !stat.isFile()) {
+    throw new ReleaseArtifactError(`${label} must be a regular file: ${absolute}`, code, { path: absolute });
+  }
+  let real;
+  try {
+    real = realpathSync(absolute);
+  } catch (error) {
+    throw new ReleaseArtifactError(`Unable to resolve ${label}: ${absolute}`, code, { cause: error, path: absolute });
+  }
+  if (!isWithinPath(destination.realpath, real)) {
+    throw new ReleaseArtifactError(`${label} realpath escapes output directory: ${absolute}`, code, {
+      outputDir: destination.realpath,
+      path: real,
+    });
+  }
+  return absolute;
+}
+
+function resolveSourceSHA({ repoRoot, sourceSHA, env = process.env, command = execFileSync }) {
+  const supplied = sourceSHA || env.GITHUB_SHA;
+  if (supplied && String(supplied).trim()) return String(supplied).trim();
+  try {
+    return command('git', ['rev-parse', 'HEAD'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    throw new ReleaseArtifactError(
+      'sourceSHA is required outside a git checkout',
+      'ERR_SOURCE_SHA',
+      { cause: error }
+    );
+  }
+}
+
+function parseNpmPackOutput(output) {
+  const text = String(output).trim();
+  const start = text.indexOf('[');
+  const end = text.lastIndexOf(']');
+  if (start < 0 || end < start) {
+    throw new ReleaseArtifactError('npm pack did not return JSON metadata', 'ERR_PACK_OUTPUT', { output: text });
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(text.slice(start, end + 1));
+  } catch (error) {
+    throw new ReleaseArtifactError('Unable to parse npm pack metadata', 'ERR_PACK_OUTPUT', { cause: error, output: text });
+  }
+  if (!Array.isArray(parsed) || parsed.length !== 1 || typeof parsed[0] !== 'object') {
+    throw new ReleaseArtifactError('npm pack returned unexpected metadata', 'ERR_PACK_OUTPUT', { output: parsed });
+  }
+  return parsed[0];
+}
+
+function safeArtifactPath(outputDir, filename) {
+  if (!filename || basename(filename) !== filename || filename.includes('\0')) {
+    throw new ReleaseArtifactError(`Unsafe artifact filename: ${filename}`, 'ERR_ARTIFACT_PATH');
+  }
+  return safeOutputPath(outputDir, resolve(outputDir, filename), 'ERR_ARTIFACT_PATH', 'Artifact');
+}
+
+function inspectOutputFile(outputDir, path, code, label) {
+  return assertRegularOutputFile(outputDir, path, code, label);
+}
+
+function runCommand(command, args, options = {}, execute = execFileSync) {
+  try {
+    return execute(command, args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...options,
+    });
+  } catch (error) {
+    const detail = error?.stderr ? `: ${String(error.stderr).trim()}` : '';
+    throw new ReleaseArtifactError(
+      `${command} ${args.join(' ')} failed${detail}`,
+      isTimeoutError(error) ? 'ERR_COMMAND_TIMEOUT' : 'ERR_COMMAND',
+      { cause: error, command, args, timedOut: isTimeoutError(error) }
+    );
+  }
+}
+
+function readTarJson(tarballPath, execute = execFileSync) {
+  const output = runCommand(
+    'tar',
+    ['-xOf', tarballPath, 'package/package.json'],
+    {},
+    execute
+  );
+  try {
+    return JSON.parse(output);
+  } catch (error) {
+    throw new ReleaseArtifactError(`Invalid package.json in ${tarballPath}`, 'ERR_TARBALL_MANIFEST', { cause: error });
+  }
+}
+
+function listTarEntries(tarballPath, execute = execFileSync) {
+  const output = runCommand('tar', ['-tzf', tarballPath], {}, execute);
+  return String(output)
+    .split(/\r?\n/)
+    .map((entry) => entry.trim().replace(/\/$/, ''))
+    .filter(Boolean)
+    .sort();
+}
+
+function normalizePackFiles(files) {
+  return (files || [])
+    .map((entry) => ({
+      path: String(entry.path),
+      size: Number(entry.size),
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+/**
+ * Build a manifest from pack metadata.  Kept public so tests and release
+ * tooling can independently create an expected manifest without packing.
+ */
+export function createIntegrityManifest({ sourceSHA, version, artifacts }) {
+  if (!sourceSHA) {
+    throw new ReleaseArtifactError('sourceSHA is required for an integrity manifest', 'ERR_SOURCE_SHA');
+  }
+  if (!version) {
+    throw new ReleaseArtifactError('version is required for an integrity manifest', 'ERR_VERSION');
+  }
+  const normalizedArtifacts = Array.isArray(artifacts)
+    ? artifacts
+    : Object.entries(artifacts || {}).map(([key, value]) => ({ key, ...value }));
+  if (normalizedArtifacts.length !== PACKAGE_ARTIFACTS.length) {
+    throw new ReleaseArtifactError('Both root and alias artifacts are required', 'ERR_ARTIFACT_SET');
+  }
+  const packages = {};
+  const files = [];
+  for (const artifact of normalizedArtifacts) {
+    const key = artifact.key || (artifact.name === ROOT_PACKAGE_NAME ? 'root' : 'alias');
+    const name = artifact.name || (key === 'root' ? ROOT_PACKAGE_NAME : ALIAS_PACKAGE_NAME);
+    const file = artifact.file || artifact.tarball;
+    if (!file || !artifact.sha256 || !artifact.sha512) {
+      throw new ReleaseArtifactError(`Incomplete integrity metadata for ${name}`, 'ERR_ARTIFACT_METADATA');
+    }
+    const descriptor = {
+      key,
+      name,
+      version: artifact.version || version,
+      file: basename(file),
+      size: Number(artifact.size),
+      sha256: artifact.sha256,
+      sha512: artifact.sha512,
+      integrity: artifact.integrity || `sha512-${Buffer.from(artifact.sha512, 'hex').toString('base64')}`,
+      files: normalizePackFiles(artifact.files),
+    };
+    packages[key] = descriptor;
+    files.push({
+      package: key,
+      name,
+      file: descriptor.file,
+      size: descriptor.size,
+      sha256: descriptor.sha256,
+      sha512: descriptor.sha512,
+    });
+  }
+  return {
+    schemaVersion: 1,
+    sourceSHA: String(sourceSHA),
+    version: String(version),
+    packages,
+    files,
+  };
+}
+
+function assertManifestShape(manifest) {
+  if (!manifest || manifest.schemaVersion !== 1 || typeof manifest.sourceSHA !== 'string' || !manifest.version) {
+    throw new ReleaseArtifactError('Invalid release integrity manifest', 'ERR_MANIFEST');
+  }
+  if (!manifest.packages || !manifest.packages.root || !manifest.packages.alias) {
+    throw new ReleaseArtifactError('Release manifest must contain root and alias packages', 'ERR_MANIFEST');
+  }
+  if (!Array.isArray(manifest.files) || manifest.files.length !== 2) {
+    throw new ReleaseArtifactError('Release manifest must list both tarballs', 'ERR_MANIFEST');
+  }
+}
+
+function writeJson(path, value) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeReleaseManifest(outputDir, manifestPath, manifest) {
+  const destination = assertOutputDirectory(outputDir, 'ERR_ARTIFACT_PATH');
+  const target = safeOutputPath(destination.path, manifestPath, 'ERR_MANIFEST', 'Release manifest');
+  if (lstatOrNull(target)) {
+    throw new ReleaseArtifactError(`Release manifest already exists: ${target}`, 'ERR_MANIFEST');
+  }
+  try {
+    writeFileSync(target, `${JSON.stringify(manifest, null, 2)}\n`, { flag: 'wx' });
+  } catch (error) {
+    throw new ReleaseArtifactError(`Unable to write release manifest: ${target}`, 'ERR_MANIFEST', { cause: error });
+  }
+}
+
+/**
+ * Pack both package directories exactly once.  npm pack intentionally runs
+ * ordinary pack lifecycle hooks; `prepublishOnly` is a publish-only source
+ * safety gate and is not bypassed globally or executed for tarball publish.
+ */
+export function buildReleaseArtifacts({
+  repoRoot = REPO_ROOT,
+  outputDir = join(repoRoot, '.release-artifacts'),
+  sourceSHA,
+  npmCommand = DEFAULT_NPM_COMMAND,
+  npmTimeoutMs = DEFAULT_NPM_TIMEOUT_MS,
+  command = execFileSync,
+} = {}) {
+  const root = resolve(repoRoot);
+  const destination = resolve(outputDir);
+  ensureEmptyDirectory(destination, 'ERR_OUTPUT_DIR_NOT_EMPTY');
+  assertOutputDirectory(destination, 'ERR_OUTPUT_DIR_NOT_EMPTY');
+  const resolvedSourceSHA = resolveSourceSHA({
+    repoRoot: root,
+    sourceSHA,
+    command,
+  });
+  const manifests = PACKAGE_ARTIFACTS.map(({ key, name, packageDir }) => {
+    const { value: pkg } = packageManifest(root, packageDir);
+    if (pkg.name !== name) {
+      throw new ReleaseArtifactError(`${packageDir}/package.json name must be ${name}`, 'ERR_PACKAGE_METADATA');
+    }
+    return { key, name, packageDir, pkg };
+  });
+  const rootVersion = manifests[0].pkg.version;
+  if (!rootVersion || manifests.some(({ pkg }) => pkg.version !== rootVersion)) {
+    throw new ReleaseArtifactError('Root and alias package versions must match', 'ERR_PACKAGE_METADATA');
+  }
+  if (manifests[1].pkg.dependencies?.[ROOT_PACKAGE_NAME] !== rootVersion) {
+    throw new ReleaseArtifactError(
+      `Alias dependency must be exact ${ROOT_PACKAGE_NAME}@${rootVersion}`,
+      'ERR_ALIAS_DEPENDENCY'
+    );
+  }
+
+  const artifacts = manifests.map(({ key, name, packageDir }) => {
+    const packOutput = runCommand(
+      npmCommand,
+      ['pack', '--json', '--pack-destination', destination],
+      { cwd: resolve(root, packageDir), timeout: npmTimeoutMs },
+      command
+    );
+    const metadata = parseNpmPackOutput(packOutput);
+    if (metadata.name !== name || metadata.version !== rootVersion) {
+      throw new ReleaseArtifactError(`npm pack metadata mismatch for ${name}`, 'ERR_PACK_METADATA', { metadata });
+    }
+    const file = basename(metadata.filename);
+    const path = safeArtifactPath(destination, file);
+    if (!existsSync(path)) {
+      throw new ReleaseArtifactError(`npm pack did not create ${path}`, 'ERR_PACK_OUTPUT');
+    }
+    inspectOutputFile(destination, path, 'ERR_PACK_OUTPUT', `${name} tarball`);
+    const integrity = hashFile(path);
+    return {
+      key,
+      name,
+      version: metadata.version,
+      file,
+      path,
+      ...integrity,
+      files: metadata.files,
+    };
+  });
+  const manifest = createIntegrityManifest({
+    sourceSHA: resolvedSourceSHA,
+    version: rootVersion,
+    artifacts,
+  });
+  const manifestPath = safeOutputPath(destination, join(destination, MANIFEST_FILENAME), 'ERR_MANIFEST', 'Release manifest');
+  writeReleaseManifest(destination, manifestPath, manifest);
+  return {
+    outputDir: destination,
+    manifestPath,
+    manifest,
+    artifacts,
+  };
+}
+
+function expectedPackageEntries(descriptor) {
+  return descriptor.files.map(({ path }) => `package/${path}`).sort();
+}
+
+/**
+ * Verify hashes and package metadata without packing source again.
+ */
+export function verifyReleaseArtifacts({
+  repoRoot = REPO_ROOT,
+  outputDir = join(repoRoot, '.release-artifacts'),
+  manifestPath = join(outputDir, MANIFEST_FILENAME),
+  sourceSHA,
+  expectedVersion,
+  command = execFileSync,
+}) {
+  const destination = resolve(outputDir);
+  assertOutputDirectory(destination, 'ERR_ARTIFACT_PATH');
+  if (!sourceSHA || !String(sourceSHA).trim()) {
+    throw new ReleaseArtifactError('sourceSHA is required for release verification', 'ERR_SOURCE_SHA');
+  }
+  const manifestFile = safeOutputPath(destination, resolve(manifestPath), 'ERR_MANIFEST', 'Release manifest');
+  if (!existsSync(manifestFile)) {
+    throw new ReleaseArtifactError(`Missing release manifest: ${manifestFile}`, 'ERR_MANIFEST');
+  }
+  inspectOutputFile(destination, manifestFile, 'ERR_MANIFEST', 'Release manifest');
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(manifestFile, 'utf8'));
+  } catch (error) {
+    throw new ReleaseArtifactError(`Unable to parse release manifest: ${manifestFile}`, 'ERR_MANIFEST', { cause: error });
+  }
+  assertManifestShape(manifest);
+  const expectedSource = String(sourceSHA).trim();
+  if (manifest.sourceSHA !== expectedSource) {
+    throw new ReleaseArtifactError(
+      `Manifest sourceSHA ${manifest.sourceSHA} does not match expected ${expectedSource}`,
+      'ERR_SOURCE_SHA_MISMATCH'
+    );
+  }
+  if (expectedVersion && parseSemver(manifest.version) !== parseSemver(expectedVersion)) {
+    throw new ReleaseArtifactError(
+      `Manifest version ${manifest.version} does not match expected ${expectedVersion}`,
+      'ERR_VERSION_MISMATCH'
+    );
+  }
+
+  const verified = [];
+  for (const key of ['root', 'alias']) {
+    const descriptor = manifest.packages[key];
+    const expectedName = key === 'root' ? ROOT_PACKAGE_NAME : ALIAS_PACKAGE_NAME;
+    if (
+      !descriptor
+      || !descriptor.file
+      || descriptor.key !== key
+      || descriptor.name !== expectedName
+      || descriptor.version !== manifest.version
+    ) {
+      throw new ReleaseArtifactError(`Invalid ${key} package descriptor`, 'ERR_MANIFEST');
+    }
+    if (!Array.isArray(descriptor.files) || descriptor.files.some((entry) => !entry || typeof entry.path !== 'string')) {
+      throw new ReleaseArtifactError(`Invalid ${key} package file list`, 'ERR_MANIFEST');
+    }
+    const listed = manifest.files.find((entry) => entry.package === key);
+    if (
+      !listed
+      || listed.file !== descriptor.file
+      || listed.sha256 !== descriptor.sha256
+      || listed.sha512 !== descriptor.sha512
+      || listed.size !== descriptor.size
+    ) {
+      throw new ReleaseArtifactError(`${key} manifest file summary mismatch`, 'ERR_MANIFEST');
+    }
+    const artifactPath = safeArtifactPath(destination, descriptor.file);
+    if (!existsSync(artifactPath)) {
+      throw new ReleaseArtifactError(`Missing ${key} tarball: ${artifactPath}`, 'ERR_TARBALL');
+    }
+    inspectOutputFile(destination, artifactPath, 'ERR_TARBALL', `${key} tarball`);
+    const actual = hashFile(artifactPath);
+    for (const hash of ['sha256', 'sha512', 'integrity']) {
+      if (actual[hash] !== descriptor[hash]) {
+        throw new ReleaseArtifactError(
+          `${key} ${hash} mismatch for ${descriptor.file}`,
+          'ERR_INTEGRITY_MISMATCH',
+          { key, expected: descriptor[hash], actual: actual[hash] }
+        );
+      }
+    }
+    if (descriptor.size !== actual.size) {
+      throw new ReleaseArtifactError(`${key} size mismatch for ${descriptor.file}`, 'ERR_INTEGRITY_MISMATCH');
+    }
+    const packageJson = readTarJson(artifactPath, command);
+    if (packageJson.name !== descriptor.name || packageJson.version !== manifest.version) {
+      throw new ReleaseArtifactError(`${key} tarball package metadata mismatch`, 'ERR_TARBALL_MANIFEST');
+    }
+    if (
+      key === 'alias'
+      && packageJson.dependencies?.[ROOT_PACKAGE_NAME] !== manifest.version
+    ) {
+      throw new ReleaseArtifactError(
+        `Alias tarball must depend on exact ${ROOT_PACKAGE_NAME}@${manifest.version}`,
+        'ERR_ALIAS_DEPENDENCY'
+      );
+    }
+    const entries = listTarEntries(artifactPath, command);
+    const expectedEntries = expectedPackageEntries(descriptor);
+    if (entries.length !== expectedEntries.length || entries.some((entry, index) => entry !== expectedEntries[index])) {
+      throw new ReleaseArtifactError(`${key} tarball file list differs from manifest`, 'ERR_FILE_LIST_MISMATCH');
+    }
+    verified.push({ ...descriptor, path: artifactPath, actual });
+  }
+  return { manifest, manifestPath: manifestFile, artifacts: verified };
+}
+
+function nodeScriptPath(prefix, packageName) {
+  return join(prefix, 'node_modules', packageName, 'package.json');
+}
+
+function runInstallCommand({
+  npmCommand,
+  fixtureDir,
+  cacheDir,
+  npmrcPath,
+  rootTarball,
+  aliasTarball,
+  npmTimeoutMs,
+  command,
+}) {
+  const environment = {
+    ...process.env,
+    NPM_CONFIG_AUDIT: 'false',
+    NPM_CONFIG_FUND: 'false',
+    NPM_CONFIG_UPDATE_NOTIFIER: 'false',
+    NPM_CONFIG_OFFLINE: 'false',
+    NPM_CONFIG_PREFER_ONLINE: 'true',
+    NPM_CONFIG_IGNORE_SCRIPTS: 'false',
+    NPM_CONFIG_CACHE: cacheDir,
+    NPM_CONFIG_USERCONFIG: npmrcPath,
+  };
+  runCommand(
+    npmCommand,
+    [
+      'install',
+      '--prefix',
+      fixtureDir,
+      '--no-audit',
+      '--no-fund',
+      '--prefer-online',
+      '--package-lock=true',
+      '--registry',
+      NPM_REGISTRY,
+      rootTarball,
+      aliasTarball,
+    ],
+    {
+      cwd: fixtureDir,
+      env: environment,
+      timeout: npmTimeoutMs,
+    },
+    command
+  );
+  // Reinstall from the generated lockfile so the smoke exercises the exact
+  // local tarball resolutions, while only ordinary transitive dependencies
+  // (currently js-yaml/argparse) may be fetched from the public registry.
+  return runCommand(
+    npmCommand,
+    [
+      'ci',
+      '--prefix',
+      fixtureDir,
+      '--no-audit',
+      '--no-fund',
+      '--prefer-online',
+      '--registry',
+      NPM_REGISTRY,
+    ],
+    {
+      cwd: fixtureDir,
+      env: environment,
+      timeout: npmTimeoutMs,
+    },
+    command
+  );
+}
+
+/**
+ * Install root.tgz and alias.tgz together into an empty fixture.  npm's
+ * resolver must therefore satisfy the alias's exact patina-cli dependency
+ * from the explicitly supplied root tarball; only transitive dependencies may
+ * use the public registry, and the lockfile is checked for file resolutions.
+ */
+export function runLocalInstallSmoke({
+  outputDir,
+  artifacts,
+  npmCommand = DEFAULT_NPM_COMMAND,
+  npmTimeoutMs = DEFAULT_NPM_TIMEOUT_MS,
+  command = execFileSync,
+  fixtureDir,
+  keepFixture = false,
+} = {}) {
+  const rootArtifact = artifacts?.find((artifact) => artifact.key === 'root');
+  const aliasArtifact = artifacts?.find((artifact) => artifact.key === 'alias');
+  if (!rootArtifact || !aliasArtifact) {
+    throw new ReleaseArtifactError('Root and alias artifacts are required for install smoke', 'ERR_ARTIFACT_SET');
+  }
+  if (!outputDir) {
+    throw new ReleaseArtifactError('outputDir is required for install smoke', 'ERR_ARTIFACT_SET');
+  }
+  const destination = resolve(outputDir);
+  assertOutputDirectory(destination, 'ERR_ARTIFACT_PATH');
+  const rootTarballPath = rootArtifact.path || join(destination, rootArtifact.file);
+  const aliasTarballPath = aliasArtifact.path || join(destination, aliasArtifact.file);
+  const fixture = fixtureDir
+    ? resolve(fixtureDir)
+    : mkdtempSync(join(tmpdir(), 'patina-release-smoke-'));
+  const cacheDir = mkdtempSync(join(tmpdir(), 'patina-release-cache-'));
+  const npmrcPath = join(cacheDir, '.npmrc');
+  try {
+    ensureEmptyDirectory(fixture, 'ERR_SMOKE_DIR_NOT_EMPTY');
+    const rootTarball = inspectOutputFile(destination, rootTarballPath, 'ERR_TARBALL', 'root tarball');
+    const aliasTarball = inspectOutputFile(destination, aliasTarballPath, 'ERR_TARBALL', 'alias tarball');
+    writeFileSync(npmrcPath, `registry=${NPM_REGISTRY}\n`);
+    writeJson(join(fixture, 'package.json'), {
+      name: 'patina-release-smoke-fixture',
+      version: '0.0.0',
+      private: true,
+    });
+    runInstallCommand({
+      npmCommand,
+      fixtureDir: fixture,
+      cacheDir,
+      npmrcPath,
+      rootTarball,
+      aliasTarball,
+      npmTimeoutMs,
+      command,
+    });
+    const nodeModules = join(fixture, 'node_modules');
+    const rootPackagePath = nodeScriptPath(fixture, ROOT_PACKAGE_NAME);
+    const aliasPackagePath = nodeScriptPath(fixture, ALIAS_PACKAGE_NAME);
+    if (!existsSync(rootPackagePath) || !existsSync(aliasPackagePath)) {
+      throw new ReleaseArtifactError('Local install did not place both packages', 'ERR_INSTALL_SMOKE');
+    }
+    const rootPackage = JSON.parse(readFileSync(rootPackagePath, 'utf8'));
+    const aliasPackage = JSON.parse(readFileSync(aliasPackagePath, 'utf8'));
+    if (aliasPackage.dependencies?.[ROOT_PACKAGE_NAME] !== rootPackage.version) {
+      throw new ReleaseArtifactError('Alias dependency is not exact root version', 'ERR_INSTALL_SMOKE');
+    }
+    const aliasRequire = createRequire(aliasPackagePath);
+    const resolvedRootPackage = realpathSync(aliasRequire.resolve(`${ROOT_PACKAGE_NAME}/package.json`));
+    if (resolvedRootPackage !== realpathSync(rootPackagePath)) {
+      throw new ReleaseArtifactError(
+        'Alias resolved patina-cli from a different installation than the supplied root tarball',
+        'ERR_INSTALL_SMOKE'
+      );
+    }
+    const lockfilePath = join(fixture, 'package-lock.json');
+    if (!existsSync(lockfilePath)) {
+      throw new ReleaseArtifactError('Local install did not produce a lockfile', 'ERR_INSTALL_SMOKE');
+    }
+    const lockfile = JSON.parse(readFileSync(lockfilePath, 'utf8'));
+    const rootLock = lockfile.packages?.[`node_modules/${ROOT_PACKAGE_NAME}`];
+    const aliasLock = lockfile.packages?.[`node_modules/${ALIAS_PACKAGE_NAME}`];
+    if (
+      !rootLock?.resolved?.startsWith('file:')
+      || !aliasLock?.resolved?.startsWith('file:')
+      || rootLock.integrity !== rootArtifact.integrity
+      || aliasLock.integrity !== aliasArtifact.integrity
+    ) {
+      throw new ReleaseArtifactError('Install lockfile does not point at local tarballs', 'ERR_INSTALL_SMOKE');
+    }
+    const resolvedTarball = (lockEntry) => resolve(fixture, lockEntry.resolved.slice('file:'.length));
+    if (
+      realpathSync(resolvedTarball(rootLock)) !== realpathSync(rootTarball)
+      || realpathSync(resolvedTarball(aliasLock)) !== realpathSync(aliasTarball)
+    ) {
+      throw new ReleaseArtifactError('Install lockfile points at a different local tarball', 'ERR_INSTALL_SMOKE');
+    }
+    const runCli = (packageName, binPath) => {
+      const executable = join(nodeModules, packageName, binPath);
+      const result = runCommand('node', [executable, '--version'], {}, command).trim();
+      const expected = `patina ${rootPackage.version}`;
+      if (result !== expected) {
+        throw new ReleaseArtifactError(
+          `${packageName} CLI smoke returned ${JSON.stringify(result)}, expected ${JSON.stringify(expected)}`,
+          'ERR_INSTALL_SMOKE'
+        );
+      }
+      return result;
+    };
+    const versions = {
+      root: runCli(ROOT_PACKAGE_NAME, 'bin/patina.js'),
+      alias: runCli(ALIAS_PACKAGE_NAME, 'bin/patina-humanizer.js'),
+    };
+    return {
+      fixtureDir: fixture,
+      rootTarball,
+      aliasTarball,
+      versions,
+      lockfilePath,
+    };
+  } finally {
+    if (!fixtureDir && !keepFixture) {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+    rmSync(cacheDir, { recursive: true, force: true });
+  }
+}
+
+function registryRecordMatches(record, expected) {
+  if (!record) return false;
+  const integrity = record.integrity || record.dist?.integrity;
+  const sha512 = record.sha512 || record.dist?.sha512;
+  const sha256 = record.sha256 || record.dist?.sha256;
+  return (
+    (!expected.integrity || integrity === expected.integrity)
+    // npm's registry exposes the SRI sha512 value, not a hexadecimal sha512
+    // or sha256 field.  Compare those optional fields when a transport
+    // provides them, while requiring the exact SRI integrity above.
+    && (!sha512 || !expected.sha512 || sha512 === expected.sha512)
+    && (!sha256 || !expected.sha256 || sha256 === expected.sha256)
+  );
+}
+
+function isTimeoutError(error) {
+  const candidates = [
+    error,
+    error?.details,
+    error?.details?.cause,
+    error?.cause,
+  ].filter(Boolean);
+  return candidates.some((candidate) => (
+    candidate.timedOut === true
+    || candidate.code === 'ERR_COMMAND_TIMEOUT'
+    || candidate.code === 'ETIMEDOUT'
+    || candidate.code === 'ESOCKETTIMEDOUT'
+    || candidate.name === 'TimeoutError'
+    || (candidate.killed === true && candidate.signal === 'SIGTERM')
+    || /ETIMEDOUT|ESOCKETTIMEDOUT|timed?\s*out|timeout/i.test(String(candidate.message || ''))
+  ));
+}
+
+function isNpmNotFoundError(error) {
+  const candidates = [
+    error,
+    error?.details,
+    error?.details?.cause,
+    error?.cause,
+  ].filter(Boolean);
+  return candidates.some((candidate) => (
+    candidate.code === 'E404'
+    || candidate.statusCode === 404
+    || candidate.status === 404
+    || /\bE404\b/.test(String(candidate.message || ''))
+    || /\bE404\b/.test(String(candidate.stderr || ''))
+  ));
+}
+
+function isNpmConflictError(error) {
+  const candidates = [
+    error,
+    error?.details,
+    error?.details?.cause,
+    error?.cause,
+  ].filter(Boolean);
+  return candidates.some((candidate) => (
+    candidate.code === 'E409'
+    || candidate.code === 'EPUBLISHCONFLICT'
+    || candidate.statusCode === 409
+    || candidate.status === 409
+    || /\bE409\b/.test(String(candidate.stderr || ''))
+  ));
+}
+
+async function sleep(milliseconds) {
+  if (milliseconds > 0) await delay(milliseconds);
+}
+
+/**
+ * Publish root and alias with per-package state and timeout recovery.  The
+ * transport is injectable: `inspect({name, version})` must return null or a
+ * registry record, and `publish({name, version, tarball, artifact})` uploads
+ * the supplied tarball.  No retry occurs until a timed-out upload is checked
+ * in the registry.
+ */
+export async function publishWithRecovery({
+  version,
+  expectedVersion,
+  sourceSHA,
+  artifacts,
+  transport,
+  maxAttempts = 2,
+  retryDelayMs = 0,
+} = {}) {
+  if (!transport || typeof transport.inspect !== 'function' || typeof transport.publish !== 'function') {
+    throw new ReleaseArtifactError('publish transport must provide inspect and publish', 'ERR_TRANSPORT');
+  }
+  const latestTransport = transport.latest || transport.inspectLatest;
+  if (typeof latestTransport !== 'function') {
+    throw new ReleaseArtifactError(
+      'publish transport must provide latest or inspectLatest',
+      'ERR_TRANSPORT'
+    );
+  }
+  const normalizedVersion = parseSemver(version);
+  if (!sourceSHA || !String(sourceSHA).trim()) {
+    throw new ReleaseArtifactError('sourceSHA is required for publication', 'ERR_SOURCE_SHA');
+  }
+  if (!expectedVersion || !String(expectedVersion).trim()) {
+    throw new ReleaseArtifactError('expectedVersion is required for publication', 'ERR_VERSION');
+  }
+  const normalizedExpectedVersion = parseSemver(expectedVersion);
+  if (normalizedVersion !== normalizedExpectedVersion) {
+    throw new ReleaseArtifactError(
+      `Publication version ${normalizedVersion} does not match expected ${normalizedExpectedVersion}`,
+      'ERR_VERSION_MISMATCH',
+      { version: normalizedVersion, expectedVersion: normalizedExpectedVersion }
+    );
+  }
+  const byKey = Array.isArray(artifacts)
+    ? Object.fromEntries(artifacts.map((artifact) => [artifact.key, artifact]))
+    : artifacts;
+  if (!byKey?.root || !byKey?.alias) {
+    throw new ReleaseArtifactError('Both root and alias artifacts are required for publication', 'ERR_ARTIFACT_SET');
+  }
+  const states = { root: 'pending', alias: 'pending' };
+  const attempts = { root: 0, alias: 0 };
+  const retries = { root: 0, alias: 0 };
+  const markFailure = (key, error) => {
+    states[key] = 'failed';
+    if (error && typeof error === 'object') {
+      error.details = {
+        ...(error.details || {}),
+        states: { ...states },
+        attempts: { ...attempts },
+        retries: { ...retries },
+      };
+    }
+    return error;
+  };
+  const expected = (key) => ({
+    integrity: byKey[key].integrity,
+    sha256: byKey[key].sha256,
+    sha512: byKey[key].sha512,
+  });
+  const packageName = (key) => byKey[key].name || (key === 'root' ? ROOT_PACKAGE_NAME : ALIAS_PACKAGE_NAME);
+  const inspect = async (key) => {
+    try {
+      return await transport.inspect({
+        name: packageName(key),
+        version: normalizedVersion,
+        key,
+      });
+    } catch (error) {
+      if (isNpmNotFoundError(error)) return null;
+      throw error;
+    }
+  };
+  const inspectRecovery = async (key, phase) => {
+    try {
+      return await inspect(key);
+    } catch (error) {
+      const failure = error && typeof error === 'object'
+        ? error
+        : new ReleaseArtifactError(
+          `${packageName(key)} registry inspection failed during ${phase}`,
+          'ERR_REGISTRY_INSPECTION',
+          { cause: error }
+        );
+      if (failure && typeof failure === 'object') {
+        failure.details = {
+          ...(failure.details || {}),
+          registryInspectionPhase: phase,
+        };
+      }
+      throw markFailure(key, failure);
+    }
+  };
+  const inspectLatest = async (key) => {
+    let result;
+    try {
+      result = await latestTransport({
+        name: packageName(key),
+        version: normalizedVersion,
+        key,
+      });
+    } catch (error) {
+      if (isNpmNotFoundError(error)) return null;
+      throw error;
+    }
+    if (result == null || result === '') return null;
+    if (typeof result === 'string') return parseSemver(result);
+    const latest = result.version
+      || result.latest
+      || result.distTags?.latest
+      || result['dist-tags']?.latest
+      || result.dist?.['dist-tags']?.latest;
+    if (latest == null || latest === '') {
+      throw new ReleaseArtifactError(
+        `Latest inspection returned no version for ${packageName(key)}`,
+        'ERR_LATEST_RESPONSE',
+        { key, result }
+      );
+    }
+    return parseSemver(latest);
+  };
+  const confirm = async (key, record, phase) => {
+    if (!record) return false;
+    if (!registryRecordMatches(record, expected(key))) {
+      throw markFailure(key, new ReleaseArtifactError(
+        `${packageName(key)}@${version} exists with unexpected integrity during ${phase}`,
+        'ERR_REGISTRY_INTEGRITY_MISMATCH',
+        { key, expected: expected(key), observed: record }
+      ));
+    }
+    states[key] = 'done';
+    return true;
+  };
+
+  for (const key of ['root', 'alias']) {
+    let existing;
+    try {
+      existing = await inspect(key);
+    } catch (error) {
+      throw markFailure(key, error);
+    }
+    if (await confirm(key, existing, 'initial inspection')) continue;
+
+    let completed = false;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      attempts[key] = attempt;
+      try {
+        const currentLatest = await inspectLatest(key);
+        if (currentLatest) {
+          assertCanPromoteLatest({
+            candidateVersion: normalizedVersion,
+            currentLatestVersion: currentLatest,
+          });
+        }
+      } catch (error) {
+        throw markFailure(key, error);
+      }
+      try {
+        await transport.publish({
+          name: packageName(key),
+          version: normalizedVersion,
+          key,
+          tarball: byKey[key].path || byKey[key].file,
+          artifact: byKey[key],
+        });
+        const afterPublish = await inspectRecovery(key, 'post-publish inspection');
+        if (!(await confirm(key, afterPublish, 'post-publish inspection'))) {
+          throw new ReleaseArtifactError(
+            `${packageName(key)} publish returned without an exact registry artifact`,
+            'ERR_PUBLISH_UNCONFIRMED',
+            { key }
+          );
+        }
+        completed = true;
+        break;
+      } catch (error) {
+        if (error?.details?.registryInspectionPhase || error?.code === 'ERR_REGISTRY_INTEGRITY_MISMATCH') throw error;
+        if (isNpmConflictError(error)) {
+          const afterConflict = await inspectRecovery(key, 'conflict inspection');
+          if (await confirm(key, afterConflict, 'conflict inspection')) {
+            completed = true;
+            break;
+          }
+          throw markFailure(key, error);
+        }
+        if (!isTimeoutError(error)) {
+          throw markFailure(key, error);
+        }
+        const afterTimeout = await inspectRecovery(key, 'timeout inspection');
+        if (await confirm(key, afterTimeout, 'timeout inspection')) {
+          completed = true;
+          break;
+        }
+        if (attempt >= maxAttempts) {
+          throw markFailure(key, error);
+        }
+        retries[key] += 1;
+        await sleep(retryDelayMs);
+        // A final inspection immediately before retry closes the race where a
+        // registry became visible while the bounded delay elapsed.
+        const beforeRetry = await inspectRecovery(key, 'pre-retry inspection');
+        if (await confirm(key, beforeRetry, 'pre-retry inspection')) {
+          completed = true;
+          break;
+        }
+      }
+    }
+    if (!completed && states[key] !== 'done') {
+      throw markFailure(
+        key,
+        new ReleaseArtifactError(`${packageName(key)} publication did not complete`, 'ERR_PUBLISH_UNCONFIRMED')
+      );
+    }
+  }
+  return { version: normalizedVersion, states, attempts, retries };
+}
+
+async function npmRegistryInspect({
+  name,
+  version,
+  npmCommand = DEFAULT_NPM_COMMAND,
+  npmTimeoutMs = DEFAULT_NPM_TIMEOUT_MS,
+  command = execFileSync,
+}) {
+  try {
+    const output = runCommand(
+      npmCommand,
+      ['view', `${name}@${version}`, 'dist', '--json', '--registry', NPM_REGISTRY],
+      {
+        env: {
+          ...process.env,
+          NPM_CONFIG_AUDIT: 'false',
+          NPM_CONFIG_FUND: 'false',
+          NPM_CONFIG_OFFLINE: 'false',
+        },
+        timeout: npmTimeoutMs,
+      },
+      command
+    );
+    if (!String(output).trim() || String(output).trim() === 'null') return null;
+    const dist = JSON.parse(output);
+    return dist ? { dist, integrity: dist.integrity, shasum: dist.shasum } : null;
+  } catch (error) {
+    // npm uses E404 for a missing version. Any other failure (including
+    // auth/network) is a hard failure, not evidence that publication is safe.
+    if (isNpmNotFoundError(error)) return null;
+    throw error;
+  }
+}
+
+async function npmRegistryLatest({
+  name,
+  npmCommand = DEFAULT_NPM_COMMAND,
+  npmTimeoutMs = DEFAULT_NPM_TIMEOUT_MS,
+  command = execFileSync,
+}) {
+  try {
+    const output = runCommand(
+      npmCommand,
+      ['view', name, 'dist-tags.latest', '--json', '--registry', NPM_REGISTRY],
+      {
+        env: {
+          ...process.env,
+          NPM_CONFIG_AUDIT: 'false',
+          NPM_CONFIG_FUND: 'false',
+          NPM_CONFIG_OFFLINE: 'false',
+        },
+        timeout: npmTimeoutMs,
+      },
+      command
+    );
+    if (!String(output).trim() || String(output).trim() === 'null') return null;
+    return JSON.parse(output);
+  } catch (error) {
+    // Only an explicit npm E404 means that this package has no latest tag.
+    if (isNpmNotFoundError(error)) return null;
+    throw error;
+  }
+}
+
+async function npmRegistryPublish({
+  tarball,
+  npmCommand = DEFAULT_NPM_COMMAND,
+  npmTimeoutMs = DEFAULT_NPM_TIMEOUT_MS,
+  command = execFileSync,
+}) {
+  return runCommand(
+    npmCommand,
+    ['publish', tarball, '--access', 'public', '--provenance', '--registry', NPM_REGISTRY],
+    {
+      env: {
+        ...process.env,
+        NPM_CONFIG_AUDIT: 'false',
+        NPM_CONFIG_FUND: 'false',
+        NPM_CONFIG_OFFLINE: 'false',
+      },
+      timeout: npmTimeoutMs,
+    },
+    command
+  );
+}
+
+export function createNpmTransport({
+  npmCommand = DEFAULT_NPM_COMMAND,
+  npmTimeoutMs = DEFAULT_NPM_TIMEOUT_MS,
+  command = execFileSync,
+} = {}) {
+  return {
+    inspect: (request) => npmRegistryInspect({ ...request, npmCommand, npmTimeoutMs, command }),
+    latest: (request) => npmRegistryLatest({ ...request, npmCommand, npmTimeoutMs, command }),
+    publish: (request) => npmRegistryPublish({ ...request, npmCommand, npmTimeoutMs, command }),
+  };
+}
+
+function parseCli(argv) {
+  const options = {
+    outputDir: undefined,
+    sourceSHA: undefined,
+    version: undefined,
+    verifyOnly: false,
+    dryRun: false,
+    publish: false,
+    smoke: true,
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--help' || arg === '-h') options.help = true;
+    else if (arg === '--publish') options.publish = true;
+    else if (arg === '--dry-run') options.dryRun = true;
+    else if (arg === '--verify-only') options.verifyOnly = true;
+    else if (arg === '--no-smoke') options.smoke = false;
+    else if (arg === '--output-dir' || arg === '--artifacts-dir') options.outputDir = argv[++index];
+    else if (arg === '--source-sha') options.sourceSHA = argv[++index];
+    else if (arg === '--version') options.version = argv[++index];
+    else throw new ReleaseArtifactError(`Unknown option: ${arg}`, 'ERR_USAGE');
+  }
+  return options;
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/release-artifacts.mjs [options]',
+    '',
+    'Default: build, hash, verify, and locally install-smoke root and alias tarballs.',
+    '  --verify-only              verify existing tarballs and manifest; never pack source',
+    '  --dry-run                  explicit no-publish mode (the default)',
+    '  --publish                  publish verified tarballs with timeout recovery',
+    '  --output-dir <dir>         artifact directory (default .release-artifacts)',
+    '  --source-sha <sha>         source commit recorded in the manifest',
+    '  --version <version>        expected package version during verification',
+    '  --no-smoke                  skip local install smoke (not for release verify)',
+    '  --help                     show this help',
+  ].join('\n');
+}
+
+export async function main(argv = process.argv.slice(2), {
+  repoRoot = REPO_ROOT,
+  env = process.env,
+  npmCommand = DEFAULT_NPM_COMMAND,
+  npmTimeoutMs = DEFAULT_NPM_TIMEOUT_MS,
+  command = execFileSync,
+  transport,
+  stdout = process.stdout,
+} = {}) {
+  const options = parseCli(argv);
+  if (options.help) {
+    stdout.write(`${usage()}\n`);
+    return 0;
+  }
+  if (options.publish && options.dryRun) {
+    throw new ReleaseArtifactError('--publish and --dry-run cannot be combined', 'ERR_USAGE');
+  }
+  const outputDir = resolve(repoRoot, options.outputDir || '.release-artifacts');
+  const sourceSHA = options.sourceSHA || env.GITHUB_SHA;
+  let verified;
+  if (options.verifyOnly || options.publish) {
+    verified = verifyReleaseArtifacts({
+      repoRoot,
+      outputDir,
+      sourceSHA,
+      expectedVersion: options.version,
+      command,
+    });
+  } else {
+    const built = buildReleaseArtifacts({
+      repoRoot,
+      outputDir,
+      sourceSHA,
+      npmCommand,
+      npmTimeoutMs,
+      command,
+    });
+    verified = verifyReleaseArtifacts({
+      repoRoot,
+      outputDir,
+      sourceSHA: built.manifest.sourceSHA,
+      expectedVersion: options.version,
+      command,
+    });
+    if (options.smoke) {
+      runLocalInstallSmoke({
+        outputDir,
+        artifacts: verified.artifacts,
+        npmCommand,
+        npmTimeoutMs,
+        command,
+      });
+    }
+    stdout.write(`Verified ${built.manifest.version} release artifacts at ${outputDir}\n`);
+  }
+  if (options.publish) {
+    const result = await publishWithRecovery({
+      version: verified.manifest.version,
+      expectedVersion: options.version,
+      sourceSHA,
+      artifacts: verified.artifacts,
+      transport: transport || createNpmTransport({ npmCommand, npmTimeoutMs, command }),
+    });
+    stdout.write(`Published ${verified.manifest.version}: ${JSON.stringify(result.states)}\n`);
+  }
+  return 0;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exitCode = 1;
+    }
+  );
+}

--- a/tests/e2e/release-artifacts.test.js
+++ b/tests/e2e/release-artifacts.test.js
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import {
+  buildReleaseArtifacts,
+  verifyReleaseArtifacts,
+  runLocalInstallSmoke,
+} from '../../scripts/release-artifacts.mjs';
+
+test('real root and alias tarballs install together and run both CLIs', { timeout: 120_000 }, () => {
+  const outputDir = mkdtempSync(join(tmpdir(), 'patina-release-artifacts-'));
+  try {
+    const built = buildReleaseArtifacts({
+      outputDir,
+      sourceSHA: 'e2e-source-sha',
+    });
+    const verified = verifyReleaseArtifacts({
+      outputDir,
+      sourceSHA: 'e2e-source-sha',
+      expectedVersion: built.manifest.version,
+    });
+    const smoke = runLocalInstallSmoke({
+      outputDir,
+      artifacts: verified.artifacts,
+    });
+    assert.deepEqual(smoke.versions, {
+      root: `patina ${built.manifest.version}`,
+      alias: `patina ${built.manifest.version}`,
+    });
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+test('real tarball verification rejects bytes changed after the manifest', () => {
+  const outputDir = mkdtempSync(join(tmpdir(), 'patina-release-tamper-'));
+  try {
+    const built = buildReleaseArtifacts({
+      outputDir,
+      sourceSHA: 'e2e-source-sha',
+    });
+    writeFileSync(built.artifacts[0].path, Buffer.concat([
+      Buffer.from('tampered\n'),
+      Buffer.from('not-the-release-tarball'),
+    ]));
+    assert.throws(
+      () => verifyReleaseArtifacts({
+        outputDir,
+        sourceSHA: 'e2e-source-sha',
+      }),
+      (error) => error?.code === 'ERR_INTEGRITY_MISMATCH'
+    );
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+test('real tarball verification rejects a symlinked tarball outside the artifact root', () => {
+  const outputDir = mkdtempSync(join(tmpdir(), 'patina-release-symlink-'));
+  const outsideDir = mkdtempSync(join(tmpdir(), 'patina-release-symlink-target-'));
+  try {
+    const built = buildReleaseArtifacts({
+      outputDir,
+      sourceSHA: 'e2e-source-sha',
+    });
+    const artifact = built.artifacts[0];
+    const outsidePath = join(outsideDir, artifact.file);
+    rmSync(artifact.path);
+    writeFileSync(outsidePath, 'outside artifact bytes');
+    symlinkSync(outsidePath, artifact.path);
+    assert.throws(
+      () => verifyReleaseArtifacts({
+        outputDir,
+        sourceSHA: 'e2e-source-sha',
+      }),
+      (error) => error?.code === 'ERR_TARBALL'
+    );
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/maintenance-workflows.test.js
+++ b/tests/unit/maintenance-workflows.test.js
@@ -1,0 +1,175 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const DEPENDABOT_PATH = resolve(REPO_ROOT, '.github/dependabot.yml');
+const DATASET_WORKFLOW_PATH = resolve(REPO_ROOT, '.github/workflows/publish-dataset.yml');
+
+function readYaml(path) {
+  return yaml.load(readFileSync(path, 'utf8'));
+}
+
+function readDatasetWorkflow() {
+  return { workflow: readYaml(DATASET_WORKFLOW_PATH), source: readFileSync(DATASET_WORKFLOW_PATH, 'utf8') };
+}
+
+test('Dependabot keeps weekly ordinary updates bounded and unautomated', () => {
+  const config = readYaml(DEPENDABOT_PATH);
+  assert.equal(config.version, 2);
+  assert.deepEqual(config.updates.map((update) => update['package-ecosystem']), ['npm', 'github-actions']);
+  assert.equal(config.updates.length, 2);
+  assert.equal(config.updates.reduce((total, update) => total + update['open-pull-requests-limit'], 0), 2);
+
+  for (const update of config.updates) {
+    assert.equal(update.directory, '/');
+    assert.deepEqual(update.schedule, { interval: 'weekly' });
+    assert.equal(update['open-pull-requests-limit'], 1);
+    assert.equal(update['target-branch'], undefined);
+    assert.equal(update['rebase-strategy'], undefined);
+  }
+
+  const npm = config.updates.find((update) => update['package-ecosystem'] === 'npm');
+  assert.deepEqual(npm.groups, {
+    devtools: {
+      'dependency-type': 'development',
+      'update-types': ['patch', 'minor'],
+    },
+  });
+  assert.equal(config.automerge, undefined);
+  assert.doesNotMatch(readFileSync(DEPENDABOT_PATH, 'utf8'), /auto[- ]?(?:merge|approve)|security[^\n]*(?:delay|ignore)/i);
+});
+
+test('dataset workflow holds publication, preserves production environment, and uses one immutable source', () => {
+  const { workflow, source } = readDatasetWorkflow();
+  const dispatch = workflow.on?.workflow_dispatch;
+  const job = workflow.jobs?.dataset;
+  const steps = job?.steps ?? [];
+  const checkout = steps.find((step) => step.uses === 'actions/checkout@v6');
+  const exportStep = steps.find((step) => step.name === 'Export hash-reviewed public fixtures');
+  const sourceStep = steps.find((step) => step.name === 'Verify immutable export provenance');
+  const upload = steps.find((step) => step.uses === 'actions/upload-artifact@v4');
+  const publish = steps.find((step) => step.name === 'Publish reviewed main history');
+
+  assert.equal(dispatch?.inputs?.publish?.type, 'boolean');
+  assert.equal(dispatch?.inputs?.publish?.default, false);
+  assert.equal(job?.environment, 'hf-dataset-production');
+  assert.match(job?.if ?? '', /github\.repository == 'devswha\/patina'/);
+  assert.match(job?.if ?? '', /github\.ref == 'refs\/heads\/main'/);
+  assert.deepEqual(workflow.permissions, { contents: 'read' });
+
+  assert.equal(checkout?.with?.ref, '${{ github.sha }}');
+  assert.equal(checkout?.with?.['fetch-depth'], 0);
+  assert.equal(exportStep?.run, 'node scripts/export-hf-dataset.mjs --output artifacts/hf-export');
+  assert.equal(sourceStep?.id, 'source');
+  assert.equal(sourceStep?.env?.DISPATCH_SHA, '${{ github.sha }}');
+  assert.match(sourceStep?.run ?? '', /git rev-parse HEAD/);
+  assert.match(sourceStep?.run ?? '', /source-manifest\.json/);
+  assert.match(sourceStep?.run ?? '', /DISPATCH_SHA/);
+  assert.match(sourceStep?.run ?? '', /GITHUB_OUTPUT/);
+
+  assert.equal(upload?.with?.path, 'artifacts/hf-export');
+  assert.equal(upload?.with?.['if-no-files-found'], 'error');
+  assert.equal(publish?.if, 'inputs.publish == true');
+  assert.equal(publish?.env?.SOURCE_COMMIT, '${{ steps.source.outputs.source_commit }}');
+  assert.match(publish?.run ?? '', /git fetch origin main/);
+  assert.match(publish?.run ?? '', /git merge-base --is-ancestor "\$SOURCE_COMMIT" origin\/main/);
+  assert.match(publish?.run ?? '', /source-manifest\.json/);
+  assert.match(publish?.run ?? '', /--directory artifacts\/hf-export/);
+
+  assert.doesNotMatch(source, /ref:\s*main(?:\s|$)/);
+  assert.doesNotMatch(source, /git\s+(?:switch|checkout)\b/);
+});
+
+test('dataset publication cannot be reached from a privileged pull-request checkout', () => {
+  const { workflow, source } = readDatasetWorkflow();
+  assert.equal(workflow.on?.pull_request, undefined);
+  assert.equal(workflow.on?.pull_request_target, undefined);
+  assert.equal(workflow.on?.push, undefined);
+  assert.equal(workflow.on?.schedule, undefined);
+  assert.doesNotMatch(source, /pull_request_target|github\.event\.pull_request\.head\.sha|refs\/pull\//);
+  assert.doesNotMatch(source, /actions\/checkout@v6[\s\S]*ref:\s*main/);
+});
+
+test('release shell binds dispatch versions and rejects missing or moved tags before writes', () => {
+  const workflow = readYaml(resolve(REPO_ROOT, '.github/workflows/release.yml'));
+  const verify = workflow.jobs.npm.steps.find(step => step.name === 'Verify downloaded release tarballs');
+  const publish = workflow.jobs.npm.steps.find(step => step.name === 'Publish verified release tarballs with recovery');
+  assert.equal(verify.env.RELEASE_VERSION, '${{ needs.verify.outputs.version }}');
+  assert.equal(publish.env.RELEASE_VERSION, verify.env.RELEASE_VERSION);
+  assert.equal(workflow.jobs.verify.outputs.version, '${{ steps.artifacts.outputs.version }}');
+  const release = workflow.jobs['github-release'].steps.find(step => step.name === 'Create or update GitHub release without stale latest promotion');
+  const directory = mkdtempSync(join(tmpdir(), 'patina-release-workflow-'));
+  const log = join(directory, 'calls.jsonl');
+  const executable = name => join(directory, name);
+  const run = (script, extra = {}) => {
+    writeFileSync(log, '');
+    const result = spawnSync('bash', ['-e', '-o', 'pipefail', '-c', script], {
+      cwd: REPO_ROOT, encoding: 'utf8', timeout: 15000,
+      env: { ...process.env, PATH: `${directory}:${process.env.PATH}`, MOCK_LOG: log,
+        GITHUB_REF: 'refs/tags/v8.6.0', GITHUB_REF_NAME: 'v8.6.0', GITHUB_SHA: 'a'.repeat(40),
+        GITHUB_REPOSITORY: 'fixture/patina', RELEASE_VERSION: '8.6.0', ...extra },
+    });
+    assert.ifError(result.error);
+    const calls = readFileSync(log, 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse);
+    return { result, calls };
+  };
+  try {
+    writeFileSync(executable('node'), `#!${process.execPath}
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+if (args[0] === 'scripts/release-artifacts.mjs') {
+  fs.appendFileSync(process.env.MOCK_LOG, JSON.stringify(args) + '\\n');
+} else {
+  const result = require('node:child_process').spawnSync(${JSON.stringify(process.execPath)}, args, { stdio: 'inherit' });
+  process.exit(result.status ?? 1);
+}
+`, { mode: 0o755 });
+    writeFileSync(executable('gh'), `#!${process.execPath}
+const fs = require('node:fs'); const args = process.argv.slice(2);
+fs.appendFileSync(process.env.MOCK_LOG, JSON.stringify(args) + '\\n');
+if (args[0] !== 'api') process.exit(0);
+const latest = args.at(-1).endsWith('/latest');
+const status = latest || process.env.EXISTING === '1' ? 200 : 404;
+process.stdout.write('HTTP/2.0 ' + status + ' Test\\r\\n\\r\\n' + JSON.stringify({tag_name:'v8.5.0'}));
+process.exit(status === 404 ? 1 : 0);
+`, { mode: 0o755 });
+    writeFileSync(executable('git'), `#!${process.execPath}
+const fs = require('node:fs'); const args = process.argv.slice(2);
+fs.appendFileSync(process.env.MOCK_LOG, JSON.stringify(['git', ...args]) + '\\n');
+if (args[0] === 'fetch') process.exit(process.env.TAG_STATE === 'missing' ? 1 : 0);
+if (args[0] === 'rev-parse') process.stdout.write((process.env.TAG_STATE === 'moved' ? 'b'.repeat(40) : process.env.GITHUB_SHA) + '\\n');
+`, { mode: 0o755 });
+
+    const dispatch = run(verify.run, { GITHUB_REF: 'refs/heads/main', GITHUB_REF_NAME: 'main' });
+    assert.equal(dispatch.result.status, 0, dispatch.result.stderr);
+    assert.equal(dispatch.calls[0].at(-1), '8.6.0');
+    const mismatch = run(verify.run, { GITHUB_REF_NAME: 'v8.5.0' });
+    assert.notEqual(mismatch.result.status, 0);
+    assert.equal(mismatch.calls.length, 0);
+
+    for (const existing of ['0', '1']) {
+      for (const tagState of ['matching', 'moved', 'missing']) {
+        const { result, calls } = run(release.run, { EXISTING: existing, TAG_STATE: tagState });
+        const writes = calls.filter(args => args[0] === 'release');
+        if (tagState === 'matching') {
+          assert.equal(result.status, 0, result.stderr);
+          assert.equal(writes.length, 1);
+          assert.equal(writes[0][1], existing === '1' ? 'edit' : 'create');
+          if (existing === '0') assert.ok(writes[0].includes('--verify-tag'));
+          assert.ok(calls.some(args => args[0] === 'git' && args[2] === 'refs/patina/release-check^{commit}'));
+        } else {
+          assert.notEqual(result.status, 0, tagState);
+          assert.equal(writes.length, 0, tagState);
+        }
+      }
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/release-artifacts.test.js
+++ b/tests/unit/release-artifacts.test.js
@@ -1,0 +1,557 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import {
+  buildReleaseArtifacts,
+  ReleaseArtifactError,
+  canPromoteLatest,
+  classifyGithubReleaseLookup,
+  compareSemver,
+  createIntegrityManifest,
+  decideGithubReleaseAction,
+  hashBytes,
+  main,
+  parseGithubApiJson,
+  parseGithubApiStatus,
+  parseGithubReleaseTag,
+  parseSemver,
+  publishWithRecovery,
+  createNpmTransport,
+  runLocalInstallSmoke,
+  verifyReleaseArtifacts,
+} from '../../scripts/release-artifacts.mjs';
+
+const ROOT = {
+  key: 'root',
+  name: 'patina-cli',
+  file: 'patina-cli-8.6.0.tgz',
+  size: 10,
+  sha256: 'root-sha256',
+  sha512: 'root-sha512',
+  integrity: 'sha512-cm9vdC1zaGE1MTI=',
+  files: [{ path: 'package.json', size: 100 }],
+};
+const ALIAS = {
+  key: 'alias',
+  name: 'patina-humanizer',
+  file: 'patina-humanizer-8.6.0.tgz',
+  size: 11,
+  sha256: 'alias-sha256',
+  sha512: 'alias-sha512',
+  integrity: 'sha512-YWxpYXM=',
+  files: [{ path: 'package.json', size: 100 }],
+};
+
+test('build refuses a nonempty caller output directory', () => {
+  const outputDir = mkdtempSync(join(tmpdir(), 'patina-release-output-'));
+  try {
+    writeFileSync(join(outputDir, 'caller-owned.txt'), 'do not delete');
+    assert.throws(
+      () => buildReleaseArtifacts({ outputDir, sourceSHA: 'test-source-sha' }),
+      (error) => error?.code === 'ERR_OUTPUT_DIR_NOT_EMPTY'
+    );
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+test('CLI rejects contradictory publish and dry-run modes', async () => {
+  await assert.rejects(
+    main(['--publish', '--dry-run'], { stdout: { write() {} } }),
+    (error) => error?.code === 'ERR_USAGE'
+  );
+});
+
+test('local smoke refuses a nonempty caller fixture directory', () => {
+  const outputDir = mkdtempSync(join(tmpdir(), 'patina-release-output-'));
+  const fixtureDir = mkdtempSync(join(tmpdir(), 'patina-release-fixture-'));
+  try {
+    writeFileSync(join(fixtureDir, 'caller-owned.txt'), 'do not delete');
+    assert.throws(
+      () => runLocalInstallSmoke({
+        outputDir,
+        fixtureDir,
+        artifacts: [
+          { ...ROOT, path: join(outputDir, ROOT.file) },
+          { ...ALIAS, path: join(outputDir, ALIAS.file) },
+        ],
+      }),
+      (error) => error?.code === 'ERR_SMOKE_DIR_NOT_EMPTY'
+    );
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true });
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test('release verification rejects symlinked manifest and tarball paths', () => {
+  const outputDir = mkdtempSync(join(tmpdir(), 'patina-release-paths-'));
+  const outsideDir = mkdtempSync(join(tmpdir(), 'patina-release-outside-'));
+  try {
+    const manifestPath = join(outputDir, 'release-manifest.json');
+    writeFileSync(join(outsideDir, 'release-manifest.json'), '{}\n');
+    symlinkSync(join(outsideDir, 'release-manifest.json'), manifestPath);
+    assert.throws(
+      () => verifyReleaseArtifacts({ outputDir, sourceSHA: 'unit-source-sha' }),
+      (error) => error?.code === 'ERR_MANIFEST'
+    );
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test('integrity helpers produce both hashes and SRI', () => {
+  const actual = hashBytes('release bytes');
+  assert.equal(actual.sha256.length, 64);
+  assert.equal(actual.sha512.length, 128);
+  assert.match(actual.integrity, /^sha512-[A-Za-z0-9+/]+=*$/);
+  const manifest = createIntegrityManifest({
+    sourceSHA: 'abc123',
+    version: '8.6.0',
+    artifacts: [ROOT, ALIAS],
+  });
+  assert.equal(manifest.sourceSHA, 'abc123');
+  assert.equal(manifest.version, '8.6.0');
+  assert.deepEqual(Object.keys(manifest.packages).sort(), ['alias', 'root']);
+  assert.equal(manifest.files.length, 2);
+});
+
+test('semantic version comparison handles numeric and prerelease ordering', () => {
+  assert.equal(compareSemver('1.10.0', '1.9.0'), 1);
+  assert.equal(compareSemver('2.0.0-rc.2', '2.0.0-rc.10'), -1);
+  assert.equal(compareSemver('2.0.0', '2.0.0-rc.10'), 1);
+  assert.equal(parseSemver('v8.6.0+build.1'), '8.6.0');
+  assert.equal(canPromoteLatest({ candidateVersion: '8.5.0', currentLatestVersion: '8.6.0' }), false);
+  assert.equal(canPromoteLatest({ candidateVersion: '8.6.0', currentLatestVersion: '8.6.0' }), true);
+});
+
+test('GitHub release action preserves existing releases and guards latest monotonicity', () => {
+  assert.equal(decideGithubReleaseAction({
+    candidateVersion: '8.6.0',
+    currentLatestVersion: '8.7.0',
+    existingRelease: true,
+  }), 'edit');
+  assert.equal(decideGithubReleaseAction({
+    candidateVersion: '8.6.0',
+    currentLatestVersion: '8.7.0',
+  }), 'create-not-latest');
+  assert.equal(decideGithubReleaseAction({
+    candidateVersion: '8.7.0',
+    currentLatestVersion: '8.7.0',
+  }), 'create-latest');
+  assert.equal(decideGithubReleaseAction({ candidateVersion: '8.8.0' }), 'create-latest');
+  assert.throws(
+    () => decideGithubReleaseAction({ candidateVersion: 'release-head' }),
+    (error) => error?.code === 'ERR_INVALID_VERSION'
+  );
+});
+
+test('GitHub API release lookups accept only explicit 404 as absence', () => {
+  assert.equal(classifyGithubReleaseLookup({ httpStatus: 404, commandStatus: 1 }), 'absent');
+  assert.equal(classifyGithubReleaseLookup({ httpStatus: 200, commandStatus: 0 }), 'present');
+  for (const failure of [
+    { httpStatus: undefined, commandStatus: 1 },
+    { httpStatus: 401, commandStatus: 1 },
+    { httpStatus: 500, commandStatus: 0 },
+    { httpStatus: 200, commandStatus: 1 },
+  ]) {
+    assert.throws(
+      () => classifyGithubReleaseLookup(failure),
+      (error) => error?.code === 'ERR_GITHUB_RELEASE_LOOKUP'
+    );
+  }
+});
+
+test('GitHub API response helpers parse latest tag and reject malformed bodies', () => {
+  const response = [
+    'HTTP/2 200 OK',
+    'content-type: application/json',
+    '',
+    JSON.stringify({ tag_name: 'v8.7.0' }),
+  ].join('\n');
+  assert.equal(parseGithubApiStatus(response), 200);
+  assert.deepEqual(parseGithubApiJson(response), { tag_name: 'v8.7.0' });
+  assert.equal(parseGithubReleaseTag('v8.7.0'), '8.7.0');
+  assert.throws(
+    () => parseGithubApiJson('HTTP/2 200 OK\n\nnot-json'),
+    (error) => error?.code === 'ERR_GITHUB_RELEASE_RESPONSE'
+  );
+  assert.throws(
+    () => parseGithubReleaseTag('latest'),
+    (error) => error?.code === 'ERR_INVALID_VERSION'
+  );
+
+  const crlfResponse = [
+    'HTTP/2 200 OK',
+    'content-type: application/json',
+    '',
+    JSON.stringify({ tag_name: 'v8.8.0' }),
+  ].join('\r\n');
+  assert.equal(parseGithubApiStatus(crlfResponse), 200);
+  assert.deepEqual(parseGithubApiJson(crlfResponse), { tag_name: 'v8.8.0' });
+  assert.throws(
+    () => parseGithubApiStatus([
+      'HTTP/2 302 Found',
+      '',
+      'HTTP/2 200 OK',
+      '',
+      JSON.stringify({ tag_name: 'v8.8.0' }),
+    ].join('\r\n')),
+    (error) => error?.code === 'ERR_GITHUB_RELEASE_RESPONSE'
+  );
+});
+
+test('root success and alias timeout retry only the alias', async () => {
+  const registry = new Map();
+  const calls = [];
+  let aliasAttempts = 0;
+  const transport = {
+    async inspect({ name }) {
+      return registry.get(name) || null;
+    },
+    async latest() {
+      return null;
+    },
+    async publish({ name, artifact }) {
+      calls.push(name);
+      if (name === 'patina-humanizer' && aliasAttempts++ === 0) {
+        const error = new Error('registry timeout');
+        error.code = 'ETIMEDOUT';
+        throw error;
+      }
+      registry.set(name, {
+        integrity: artifact.integrity,
+        sha256: artifact.sha256,
+        sha512: artifact.sha512,
+      });
+    },
+  };
+  const result = await publishWithRecovery({
+    version: '8.6.0',
+    expectedVersion: '8.6.0',
+    sourceSHA: 'unit-source-sha',
+    artifacts: [ROOT, ALIAS],
+    transport,
+  });
+  assert.deepEqual(result.states, { root: 'done', alias: 'done' });
+  assert.deepEqual(result.attempts, { root: 1, alias: 2 });
+  assert.deepEqual(result.retries, { root: 0, alias: 1 });
+  assert.deepEqual(calls, ['patina-cli', 'patina-humanizer', 'patina-humanizer']);
+});
+
+test('timeout registry inspection fails closed on mismatched bytes', async () => {
+  const registry = new Map();
+  let aliasPublishAttempts = 0;
+  const transport = {
+    async inspect({ name }) {
+      return registry.get(name) || null;
+    },
+    async latest() {
+      return null;
+    },
+    async publish({ name, artifact }) {
+      if (name === 'patina-cli') {
+        registry.set(name, artifact);
+        return;
+      }
+      if (aliasPublishAttempts++ > 0) return;
+      const error = new Error('timeout');
+      error.timedOut = true;
+      throw error;
+    },
+  };
+  let aliasInspections = 0;
+  const originalInspect = transport.inspect;
+  transport.inspect = async (request) => {
+    if (request.name === 'patina-humanizer') {
+      aliasInspections += 1;
+      if (aliasInspections === 2) return { integrity: 'sha512-wrong' };
+    }
+    return originalInspect(request);
+  };
+  await assert.rejects(
+    publishWithRecovery({
+      version: '8.6.0',
+      expectedVersion: '8.6.0',
+      sourceSHA: 'unit-source-sha',
+      artifacts: [ROOT, ALIAS],
+      transport,
+    }),
+    (error) => error instanceof ReleaseArtifactError
+      && error.code === 'ERR_REGISTRY_INTEGRITY_MISMATCH'
+      && error.details?.states?.root === 'done'
+      && error.details?.states?.alias === 'failed'
+  );
+});
+
+test('timeout with exact registry integrity is treated as completed', async () => {
+  let aliasInspections = 0;
+  const transport = {
+    async inspect({ name }) {
+      if (name === 'patina-cli') {
+        return {
+          integrity: ROOT.integrity,
+          sha256: ROOT.sha256,
+          sha512: ROOT.sha512,
+        };
+      }
+      aliasInspections += 1;
+      if (aliasInspections === 2) {
+        return {
+          integrity: ALIAS.integrity,
+          sha256: ALIAS.sha256,
+          sha512: ALIAS.sha512,
+        };
+      }
+      return null;
+    },
+    async latest() {
+      return null;
+    },
+    async publish({ name }) {
+      if (name === 'patina-cli') return;
+      const error = new Error('request timeout');
+      error.code = 'ETIMEDOUT';
+      throw error;
+    },
+  };
+  const result = await publishWithRecovery({
+    version: '8.6.0',
+    expectedVersion: '8.6.0',
+    sourceSHA: 'unit-source-sha',
+    artifacts: [ROOT, ALIAS],
+    transport,
+  });
+  assert.deepEqual(result.states, { root: 'done', alias: 'done' });
+  assert.equal(result.attempts.alias, 1);
+});
+
+test('an existing exact version is recognized as done without republishing', async () => {
+  const calls = [];
+  const transport = {
+    async inspect({ name }) {
+      const artifact = name === ROOT.name ? ROOT : ALIAS;
+      return {
+        integrity: artifact.integrity,
+        sha256: artifact.sha256,
+        sha512: artifact.sha512,
+      };
+    },
+    async latest() {
+      return null;
+    },
+    async publish(request) {
+      calls.push(request.name);
+    },
+  };
+  const result = await publishWithRecovery({
+    version: '8.6.0',
+    expectedVersion: '8.6.0',
+    sourceSHA: 'unit-source-sha',
+    artifacts: [ROOT, ALIAS],
+    transport,
+  });
+  assert.deepEqual(result.states, { root: 'done', alias: 'done' });
+  assert.deepEqual(calls, []);
+});
+
+test('stale versions cannot promote latest', async () => {
+  let publishes = 0;
+  await assert.rejects(
+    publishWithRecovery({
+      version: '8.5.0',
+      expectedVersion: '8.5.0',
+      sourceSHA: 'unit-source-sha',
+      artifacts: [ROOT, ALIAS],
+      transport: {
+        async inspect() {
+          return null;
+        },
+        async latest() {
+          return '8.6.0';
+        },
+        async publish() {
+          publishes += 1;
+        },
+      },
+    }),
+    (error) => error?.code === 'ERR_STALE_LATEST'
+  );
+  assert.equal(publishes, 0);
+});
+
+test('latest inspection is per package before each publish', async () => {
+  const latestCalls = [];
+  const published = [];
+  const registry = new Map();
+  const transport = {
+    async inspect({ name }) {
+      return registry.get(name) || null;
+    },
+    async latest({ name }) {
+      latestCalls.push(name);
+      return name === ROOT.name ? '8.6.0' : '8.5.0';
+    },
+    async publish({ name, artifact }) {
+      published.push(name);
+      registry.set(name, {
+        integrity: artifact.integrity,
+        sha256: artifact.sha256,
+        sha512: artifact.sha512,
+      });
+    },
+  };
+  const result = await publishWithRecovery({
+    version: '8.6.0',
+    expectedVersion: '8.6.0',
+    sourceSHA: 'unit-source-sha',
+    artifacts: [ROOT, ALIAS],
+    transport,
+  });
+  assert.deepEqual(result.states, { root: 'done', alias: 'done' });
+  assert.deepEqual(latestCalls, [ROOT.name, ALIAS.name]);
+  assert.deepEqual(published, [ROOT.name, ALIAS.name]);
+});
+
+test('npm transport maps wrapped exec timeout and passes a bounded timeout', async () => {
+  const calls = [];
+  const transport = createNpmTransport({
+    npmTimeoutMs: 1234,
+    command(_command, args, options) {
+      calls.push({ args, timeout: options.timeout });
+      if (args[0] === 'view') return 'null';
+      const error = new Error('spawnSync npm ETIMEDOUT');
+      error.signal = 'SIGTERM';
+      error.killed = true;
+      throw error;
+    },
+  });
+  await assert.rejects(
+    publishWithRecovery({
+      version: '8.6.0',
+      expectedVersion: '8.6.0',
+      sourceSHA: 'unit-source-sha',
+      artifacts: [ROOT, ALIAS],
+      transport,
+    }),
+    (error) => error?.code === 'ERR_COMMAND_TIMEOUT'
+      && error.details?.cause?.signal === 'SIGTERM'
+      && error.details?.cause?.killed === true
+  );
+  assert.ok(calls.every(({ timeout }) => timeout === 1234));
+});
+
+test('npm E404 is the only missing-package response accepted by registry transport', async () => {
+  const notFound = createNpmTransport({
+    command(_command, args) {
+      if (args[0] === 'view') {
+        const error = new Error('registry response');
+        error.code = 'E404';
+        throw error;
+      }
+      return '';
+    },
+  });
+  assert.equal(await notFound.inspect({ name: ROOT.name, version: '8.6.0' }), null);
+  assert.equal(await notFound.latest({ name: ROOT.name }), null);
+
+  const ambiguous = createNpmTransport({
+    command() {
+      throw new Error('package not found in local mirror');
+    },
+  });
+  await assert.rejects(
+    ambiguous.inspect({ name: ROOT.name, version: '8.6.0' }),
+    (error) => error?.code === 'ERR_COMMAND'
+  );
+});
+
+test('malformed latest inspection fails closed', async () => {
+  await assert.rejects(
+    publishWithRecovery({
+      version: '8.6.0',
+      expectedVersion: '8.6.0',
+      sourceSHA: 'unit-source-sha',
+      artifacts: [ROOT, ALIAS],
+      transport: {
+        async inspect() {
+          return null;
+        },
+        async latest() {
+          return {};
+        },
+        async publish() {
+          assert.fail('malformed latest must prevent publish');
+        },
+      },
+    }),
+    (error) => error?.code === 'ERR_LATEST_RESPONSE'
+  );
+});
+
+test('publication requires trusted source and expected version anchors', async () => {
+  const transport = {
+    async inspect() { return null; },
+    async latest() { return null; },
+    async publish() { assert.fail('missing anchors must fail before publish'); },
+  };
+  await assert.rejects(
+    publishWithRecovery({ version: '8.6.0', expectedVersion: '8.6.0', artifacts: [ROOT, ALIAS], transport }),
+    (error) => error?.code === 'ERR_SOURCE_SHA'
+  );
+  await assert.rejects(
+    publishWithRecovery({ version: '8.6.0', sourceSHA: 'unit-source-sha', artifacts: [ROOT, ALIAS], transport }),
+    (error) => error?.code === 'ERR_VERSION'
+  );
+  await assert.rejects(
+    publishWithRecovery({
+      version: '8.6.0',
+      expectedVersion: '8.5.0',
+      sourceSHA: 'unit-source-sha',
+      artifacts: [ROOT, ALIAS],
+      transport,
+    }),
+    (error) => error?.code === 'ERR_VERSION_MISMATCH'
+  );
+});
+
+test('verification requires a trusted source anchor', () => {
+  const outputDir = mkdtempSync(join(tmpdir(), 'patina-release-source-'));
+  try {
+    assert.throws(
+      () => verifyReleaseArtifacts({ outputDir }),
+      (error) => error?.code === 'ERR_SOURCE_SHA'
+    );
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+test('registry inspection failures preserve publication state details', async () => {
+  let inspections = 0;
+  await assert.rejects(
+    publishWithRecovery({
+      version: '8.6.0',
+      expectedVersion: '8.6.0',
+      sourceSHA: 'unit-source-sha',
+      artifacts: [ROOT, ALIAS],
+      transport: {
+        async inspect() {
+          inspections += 1;
+          if (inspections === 1) return null;
+          throw Object.assign(new Error('registry unavailable'), { code: 'ECONNRESET' });
+        },
+        async latest() { return null; },
+        async publish() {},
+      },
+    }),
+    (error) => error?.code === 'ECONNRESET'
+      && error.details?.registryInspectionPhase === 'post-publish inspection'
+      && error.details?.states?.root === 'failed'
+      && error.details?.attempts?.root === 1
+      && error.details?.retries?.root === 0
+  );
+});

--- a/tests/unit/retired-concepts.test.js
+++ b/tests/unit/retired-concepts.test.js
@@ -11,6 +11,10 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  LIFECYCLE_MARKER_PATH,
+  REQUIRED_LIFECYCLE_ID,
+  scanLifecycleRecord,
+  scanLifecycleText,
   scanPaths,
   scanRoot,
   scanText,
@@ -27,6 +31,75 @@ function relocateFirstMatch(source) {
   [lines[from], lines[to]] = [lines[to], lines[from]];
   return lines.join('\n');
 }
+
+const lifecycleMarker = '<!-- maintenance-lifecycle: npm-token-publishing; owner=repository-maintainer; review=2026-10-09; remove-after=root-and-alias-trusted-publishing-verified -->';
+
+test('temporary publication lifecycle marker requires owner, review, and removal condition', () => {
+  const clean = scanLifecycleText(`before\n${lifecycleMarker}\nafter\n`);
+  assert.equal(clean.errors.length, 0);
+  assert.equal(clean.records.length, 1);
+  assert.equal(clean.records[0].id, REQUIRED_LIFECYCLE_ID);
+  assert.equal(clean.records[0].owner, 'repository-maintainer');
+  assert.equal(clean.records[0].review, '2026-10-09');
+  assert.equal(clean.records[0]['remove-after'], 'root-and-alias-trusted-publishing-verified');
+
+  const missing = scanLifecycleText(
+    '<!-- maintenance-lifecycle: npm-token-publishing; owner=; review=; remove-after= -->'
+  );
+  assert.equal(missing.records.length, 1);
+  assert.deepEqual(
+    missing.errors.map((error) => error.field),
+    ['owner', 'review', 'remove-after']
+  );
+
+  const malformedDate = scanLifecycleText(
+    '<!-- maintenance-lifecycle: npm-token-publishing; owner=maintainer; review=next-month; remove-after=verified -->'
+  );
+  assert.ok(malformedDate.errors.some((error) => error.field === 'review'));
+  const impossibleDate = scanLifecycleText(
+    '<!-- maintenance-lifecycle: npm-token-publishing; owner=maintainer; review=2023-02-29; remove-after=verified -->'
+  );
+  assert.ok(impossibleDate.errors.some((error) => error.field === 'review'));
+
+  const duplicateField = scanLifecycleText(
+    '<!-- maintenance-lifecycle: npm-token-publishing; owner=maintainer; owner=another-maintainer; review=2026-10-09; remove-after=verified -->'
+  );
+  assert.ok(duplicateField.errors.some((error) => error.field === 'owner' && /duplicated/.test(error.reason)));
+
+  const malformedField = scanLifecycleText(
+    '<!-- maintenance-lifecycle: npm-token-publishing; owner; review=2026-10-09; remove-after=verified -->'
+  );
+  assert.ok(malformedField.errors.some((error) => error.segment === 'owner'));
+  // The checker records lifecycle metadata; it never makes a date-based
+  // deletion or pass decision.
+});
+
+test('root lifecycle pilot checks the tracked release policy path only', () => {
+  const root = mkdtempSync(join(tmpdir(), 'patina-lifecycle-scan-'));
+  try {
+    mkdirSync(resolve(root, 'docs/integrations'), { recursive: true });
+    writeFileSync(resolve(root, LIFECYCLE_MARKER_PATH), lifecycleMarker);
+    const files = [LIFECYCLE_MARKER_PATH];
+    const report = scanLifecycleRecord(root, files, new Map([
+      [LIFECYCLE_MARKER_PATH, lifecycleMarker],
+    ]));
+    assert.equal(report.errors.length, 0);
+    assert.equal(report.records.length, 1);
+
+    const missing = scanLifecycleRecord(root, files, new Map([
+      [LIFECYCLE_MARKER_PATH, '<!-- maintenance-lifecycle: npm-token-publishing; owner=maintainer -->'],
+    ]));
+    assert.ok(missing.errors.some((error) => error.field === 'review'));
+
+    writeFileSync(resolve(root, LIFECYCLE_MARKER_PATH), Buffer.from(`${lifecycleMarker}\n\0`, 'utf8'));
+    const binary = scanPaths(root, files, { requireLifecycleRecords: true });
+    assert.equal(binary.filesSkipped.binary, 1);
+    assert.equal(binary.lifecycleRecordCount, 0);
+    assert.ok(binary.lifecycleDrift.some((error) => /unavailable/.test(error.reason)));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 
 test('current product references are forbidden case-insensitively', () => {


### PR DESCRIPTION
Refs #783. Focused release domain in the maintenance delivery stack. Base bot/maintenance-browser-delivery-20260909; retarget to dev only after prerequisite units integrate.

Owner approved coherent per-domain size exceptions, not aggregate approval. Regression tests and required docs remain together. No version bump, scoring change, publication or account writes. Local integrated tests/lint/release/private gates passed; current clean hosted CI and independent review required before Ready/merge.

Rollback: revert this domain commit, considering dependent units before reversal. Existing registry/production state remains untouched. Historical local receipts are not current hosted acceptance. Applicable unavailable client/OS/backend/account checks remain inconclusive, not passed.