### PR TITLE
docs(maintenance): record real Cursor Agent CLI acceptance for P01

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -132,6 +132,18 @@ GitHub deployment `6347382527` (source
 `d7a4741ed9f767bd22a39255e10acf159351fb7a`) reported success but was neither
 application smoke nor Vercel account evidence.
 
+### P01 client acceptance (2026-09-10)
+
+`cursor-acceptance-20260910.json` supersedes the P01 `inconclusive` row in
+`maintenance-delivery-20260910.json`. The real Cursor Agent CLI
+(2026.09.08, Linux) loaded the always-applied project rule and resolved
+`@AGENTS.md`, exposed the generated `~/.cursor/rules/patina.mdc` adapter as
+agent-requestable, fetched the canonical `SKILL.md` from the adapter's absolute
+path, ran `bin/patina-skill.js`, refused to write output on two backend
+authentication failures, and wrote the result only after a `verified` receipt
+(mps 100 / fidelity 100, codex-cli). Cursor IDE desktop loading and other
+operating systems remain uncovered.
+
 P09 native Codex settings and any unexposed web account configuration remain
 unknown; no automation is inferred from a deployment result. The recurring
 maintenance owner is the repository maintainer. Repeated alerts for one

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -137,7 +137,8 @@ application smoke nor Vercel account evidence.
 `cursor-acceptance-20260910.json` supersedes the P01 `inconclusive` row in
 `maintenance-delivery-20260910.json`. The real Cursor Agent CLI
 (2026.09.08, Linux) loaded the always-applied project rule and resolved
-`@AGENTS.md`, exposed the generated `~/.cursor/rules/patina.mdc` adapter as
+`@AGENTS.md` both in the maintainer checkout and in a fresh `--depth=1` clone
+of `dev` with no local files, exposed the generated `~/.cursor/rules/patina.mdc` adapter as
 agent-requestable, fetched the canonical `SKILL.md` from the adapter's absolute
 path, ran `bin/patina-skill.js`, refused to write output on two backend
 authentication failures, and wrote the result only after a `verified` receipt

--- a/docs/operations/cursor-acceptance-20260910.json
+++ b/docs/operations/cursor-acceptance-20260910.json
@@ -39,6 +39,17 @@
       ]
     },
     {
+      "id": "project-rule-loading-clean-clone",
+      "cwd": "fresh `git clone --depth=1 --branch dev` under /tmp at 46f5c4dcd29fbd9fe62ecefd1970f0ac4a6085f7; no CLAUDE.md, no local configuration, no node_modules",
+      "command": "cursor-agent -p --mode ask --trust --output-format text <context-inventory prompt>",
+      "result": "passed",
+      "observed": [
+        "Only two project rules were injected: .cursor/rules/patina.mdc (body `@AGENTS.md`) and the resolved AGENTS.md whose first heading is `# Repository development rules`.",
+        "No other workspace instruction file was loaded from the clean clone; the CLAUDE.md seen in the maintainer checkout was absent, as expected for a gitignored file.",
+        "The five injected user rules are the maintainer's personal Cursor rules and are unrelated to patina."
+      ]
+    },
+    {
       "id": "product-rule-end-to-end",
       "cwd": "fresh temporary git repository outside the checkout, one Korean AI-styled draft.md (432 bytes)",
       "command": "cursor-agent -p --trust --force --output-format text <humanize ./draft.md via Patina; --backend codex-cli>",
@@ -60,7 +71,7 @@
   "acceptance": {
     "P01": "passed-on-linux-cursor-agent-cli",
     "criteria": {
-      "publicRulesLoadFromCleanClone": "passed (project rule + AGENTS.md resolved by the real client)",
+      "publicRulesLoadFromCleanClone": "passed (probe project-rule-loading-clean-clone: fresh clone of dev, project rule + AGENTS.md resolved by the real client, no other workspace file loaded)",
       "productSkillBehaviorUnchanged": "passed (canonical SKILL.md fetched, helper invoked, verified receipt, unverified output refused)",
       "noDevelopmentGuidanceInProductAdapter": "passed (adapter body is SKILL.md; AGENTS.md was only loaded inside the repository checkout)"
     },

--- a/docs/operations/cursor-acceptance-20260910.json
+++ b/docs/operations/cursor-acceptance-20260910.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": 1,
+  "recordType": "maintenance-client-acceptance",
+  "observedDate": "2026-09-10",
+  "repository": "devswha/patina",
+  "plan": "patina-repo-development-maintenance-plan-final-2026-09-09",
+  "planIds": ["P01"],
+  "trackingIssue": 783,
+  "supersedes": {
+    "record": "maintenance-delivery-20260910.json",
+    "field": "remainingAcceptance",
+    "priorStatus": "inconclusive",
+    "priorReason": "Actual Cursor/client rule loading needs the client environment; installed generated content and helper paths are verified."
+  },
+  "environment": {
+    "os": "Linux 6.8.0-138-generic x64",
+    "client": "Cursor Agent CLI 2026.09.08-6caf4ff (cursor-agent; no Cursor IDE installation)",
+    "node": "v24.18.0",
+    "installedSkillCommit": "46f5c4dcd29fbd9fe62ecefd1970f0ac4a6085f7",
+    "installedSkillDir": "~/.claude/skills/patina",
+    "installCommand": "INSTALL_CLAUDE=false INSTALL_CODEX=false INSTALL_OPCODE=false PATINA_REF=46f5c4dcd29fbd9fe62ecefd1970f0ac4a6085f7 sh ./install.sh",
+    "generatedUserRule": {
+      "path": "~/.cursor/rules/patina.mdc",
+      "sha256": "c5dd74534be38ad14c76b5acee6d191825f1d9aa1056b4d5d01b1bb868c112df",
+      "lines": 788,
+      "frontmatter": {"description": "Apply Patina product instructions when humanizing text.", "alwaysApply": false}
+    }
+  },
+  "probes": [
+    {
+      "id": "project-rule-loading",
+      "cwd": "repository checkout at 46f5c4d",
+      "command": "cursor-agent -p --mode ask --trust --output-format text <context-inventory prompt>",
+      "result": "passed",
+      "observed": [
+        ".cursor/rules/patina.mdc reported as always-applied project rule; body `@AGENTS.md` resolved and AGENTS.md content present with first heading `# Repository development rules`.",
+        "~/.cursor/rules/patina.mdc reported as agent-requestable with only its description injected, as expected for alwaysApply:false.",
+        "Untracked, gitignored CLAUDE.md in the checkout was also injected by the client as a workspace rule. Not a tarball leak (gitignored, excluded from npm), but maintainers should expect Cursor to read it when present."
+      ]
+    },
+    {
+      "id": "product-rule-end-to-end",
+      "cwd": "fresh temporary git repository outside the checkout, one Korean AI-styled draft.md (432 bytes)",
+      "command": "cursor-agent -p --trust --force --output-format text <humanize ./draft.md via Patina; --backend codex-cli>",
+      "result": "passed",
+      "attempts": [
+        {"backend": "openai-http (default)", "outcome": "helper status=error code=cli_failed; provider returned HTTP 401 for the shell's OPENAI_API_KEY (confirmed dead with a direct curl). Agent correctly refused to write unverified output."},
+        {"backend": "claude-cli", "outcome": "helper status=error code=cli_failed; expired Claude CLI OAuth. Agent again refused to write output."},
+        {"backend": "codex-cli", "outcome": "helper status=verified; agent wrote ./draft.humanized.md."}
+      ],
+      "observed": [
+        "Agent fetched ~/.claude/skills/patina/SKILL.md (v8.6.0) through the generated adapter's absolute path, not the repository-development rule.",
+        "Agent ran exactly: node ~/.claude/skills/patina/bin/patina-skill.js --input <abs>/draft.md --backend codex-cli",
+        "Receipt ~/.patina/runs/run-rvDg7E/receipt.json: status=verified, mode=rewrite, exitCode=0, mps=100 (floor 70), fidelity=100 (floor 70), retried=false, reason=passed.",
+        "sourceHash fddf800bfdecde00c7a18d7a8ec17434ff84aee47d49b4f27aa1f0364cd61e43; outputHash d8f0b26c45f5126dce4b5ab92c86c3d299623d2b990adf595dd90f77fb61a256.",
+        "Both failed attempts produced error receipts and no output file; the agent surfaced the backend cause instead of pasting model text. This is the CLI-first refusal path behaving as documented in docs/agents.md."
+      ]
+    }
+  ],
+  "acceptance": {
+    "P01": "passed-on-linux-cursor-agent-cli",
+    "criteria": {
+      "publicRulesLoadFromCleanClone": "passed (project rule + AGENTS.md resolved by the real client)",
+      "productSkillBehaviorUnchanged": "passed (canonical SKILL.md fetched, helper invoked, verified receipt, unverified output refused)",
+      "noDevelopmentGuidanceInProductAdapter": "passed (adapter body is SKILL.md; AGENTS.md was only loaded inside the repository checkout)"
+    },
+    "notCovered": [
+      "Cursor IDE (desktop) rule loading; only the Cursor Agent CLI was available.",
+      "Other operating systems (P16b remains inconclusive).",
+      "openai-http and claude-cli backends were unauthenticated in this environment; that is environment state, not a product finding."
+    ]
+  },
+  "boundaries": {
+    "productSourceChanged": false,
+    "versionBumped": false,
+    "publication": "none",
+    "credentialsRecorded": "none; only key names and HTTP status codes"
+  }
+}


### PR DESCRIPTION
## 목적 / 연결 Issue
Refs #783 — P01 (Cursor client rule loading) was `inconclusive` in `docs/operations/maintenance-delivery-20260910.json` because no client environment was available. The real Cursor Agent CLI is now installed on the maintainer machine; this PR records the acceptance run.

## 범위 / 비목표
사용자가 관찰하는 변경: none (docs/operations only, excluded from the npm tarball).
이번 PR에서 하지 않는 것: no product source, SKILL, installer, version, or publication change. Cursor IDE desktop and non-Linux remain uncovered.

## 계약 / 위험 / 크기
contract: not-applicable
risk: low
2 files, +73/-0.

## 검증
head SHA: see PR head / base: dev `46f5c4d`.
- Real probes on `cursor-agent 2026.09.08-6caf4ff`: project rule + `@AGENTS.md` resolved; user adapter `~/.cursor/rules/patina.mdc` (788 lines, generated by `install.sh` at dev SHA) exposed as agent-requestable; end-to-end humanize in a clean temp repo fetched canonical `SKILL.md`, ran `bin/patina-skill.js`, refused output on openai-http 401 and expired claude-cli OAuth, wrote verified output on codex-cli (mps 100 / fidelity 100).
- Local: `npm run lint`, `npm run release:check`, `npm run check:no-private-assets`, `node --test tests/unit/retired-concepts.test.js tests/unit/check-no-private-assets.test.js` — all exit 0.
미실행 항목과 이유: full `npm test` not rerun for a docs-only change; it passed on the same base earlier today (2431/2429/2 skip).

## 릴리스 / 되돌리기
semver 영향: none. 롤백: revert this commit.