### PR TITLE
test(backends): record verified codex-cli 0.153.4 compatibility pilot (P17b)

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -96,6 +96,16 @@ separate from these runtime distinctions:
   caller cancellation and from account quota. The fixture does not verify any
   of these paths.
 
+`tests/fixtures/backend-codex-contract.json` is the first **real-invocation /
+verified** record: codex `0.153.4` on Linux with `gpt-5.5` over a ChatGPT OAuth
+session, exercised on 2026-09-10 through `--score`, `--verify`, a live
+`--timeout-ms` kill, the foreign-model fallback, and an invalid in-family model
+(per-scenario evidence in `docs/operations/backend-compat-codex-20260910.json`).
+It verifies output parsing, error reporting, authentication path, and timeout
+cleanup for that version only; quota behavior, other versions, other models,
+and other operating systems remain unverified, and the record still contains
+no credentials, prompts, responses, or raw CLI output.
+
 The lifecycle/session fixtures use POSIX executables, owned process-group
 probes, and `/proc` state where available (a zombie is not running). They
 verify that an independent-stdio worker dies with its leader while an

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -145,6 +145,19 @@ authentication failures, and wrote the result only after a `verified` receipt
 (mps 100 / fidelity 100, codex-cli). Cursor IDE desktop loading and other
 operating systems remain uncovered.
 
+### P17b backend compatibility pilot (2026-09-10)
+
+`backend-compat-codex-20260910.json` supersedes the P17b `inconclusive` row in
+`maintenance-delivery-20260910.json` for **codex-cli only**. Eight live
+invocations of codex 0.153.4 (gpt-5.5, ChatGPT OAuth, no provider API key
+read) verified score parsing, `--verify` retry, a 1.5 s timeout kill with
+process and temp-directory cleanup, the foreign-model fallback, and the
+invalid-model error path. The verdict lives in
+`tests/fixtures/backend-codex-contract.json`. claude-cli (expired OAuth),
+gemini-cli and openai-http (maintainer restricted those keys to product use),
+and kimi-cli were not exercised; quota behavior and other operating systems
+remain unverified.
+
 P09 native Codex settings and any unexposed web account configuration remain
 unknown; no automation is inferred from a deployment result. The recurring
 maintenance owner is the repository maintainer. Repeated alerts for one

--- a/docs/operations/backend-compat-codex-20260910.json
+++ b/docs/operations/backend-compat-codex-20260910.json
@@ -1,0 +1,94 @@
+{
+  "schemaVersion": 1,
+  "recordType": "maintenance-backend-compatibility-pilot",
+  "observedDate": "2026-09-10",
+  "repository": "devswha/patina",
+  "plan": "patina-repo-development-maintenance-plan-final-2026-09-09",
+  "planIds": ["P17b"],
+  "trackingIssue": 783,
+  "supersedes": {
+    "record": "maintenance-delivery-20260910.json",
+    "field": "remainingAcceptance",
+    "ids": ["P17b"],
+    "priorStatus": "inconclusive",
+    "note": "P16b (other operating systems) is not addressed by this record and stays inconclusive."
+  },
+  "authority": {
+    "approval": "Maintainer asked to proceed with P17b in session on 2026-09-10 after removing the OpenAI key and restricting the Gemini key to product use.",
+    "credentialPolicy": "OPENAI_API_KEY, GEMINI_API_KEY, ANTHROPIC_API_KEY and KIMI_API_KEY were unset in the pilot shell. Only the ChatGPT OAuth session behind the codex CLI was used; no provider API key was read or sent.",
+    "budget": {"maxInvocationsPlanned": 6, "invocationsObserved": 8, "note": "The --verify scenario retried once (rewrite + verify twice), which exceeded the planned count by two; recorded, not hidden."}
+  },
+  "environment": {
+    "os": "Linux 6.8.0-138-generic x64",
+    "node": "v24.18.0",
+    "patina": "8.6.0 at dev 73b2e7a",
+    "codex": "codex-cli 0.153.4",
+    "model": "gpt-5.5 (backend default; reasoning effort xhigh as reported by codex)",
+    "defaultTimeoutMs": "DEFAULT_BACKEND_TIMEOUT_MS from src/backends/contract.js",
+    "inputs": ["tests/fixtures/suspect-zones/en/ai/en-ai-01.md (1043 bytes)", "tests/fixtures/suspect-zones/ko/ai/ko-ai-01.md (942 bytes)"]
+  },
+  "scenarios": [
+    {
+      "id": "A-score",
+      "command": "patina --backend codex-cli --lang en --score --format json <en-ai-01>",
+      "exitCode": 0,
+      "wallMs": 55248,
+      "result": "verified",
+      "observed": "Strict scoring JSON parsed (no schema-failure). LLM overall 0 with 0 detections in every category; the fixture is designed so no catalogued EN pattern fires and burstiness is the only tell, so 0 is the expected pattern score. Deterministic overall 100 was skipped from reconciliation by the paragraphs<=2 rule. Minor: JSON category rows render `detected` as null because the markdown cell is a ratio string (0/6), a Patina rendering quirk unrelated to codex."
+    },
+    {
+      "id": "B-rewrite-verify",
+      "command": "patina --backend codex-cli --lang ko --verify --format json <ko-ai-01>",
+      "exitCode": 0,
+      "wallMs": 236908,
+      "result": "verified",
+      "observed": "First candidate failed a floor, one conservative retry passed: verified=true, mps 100, fidelity 100, reason passed-on-retry, floors 70/70. Rewrite body framing and verification JSON both parsed."
+    },
+    {
+      "id": "C-timeout",
+      "command": "patina --backend codex-cli --lang en --timeout-ms 1500 --format json <en-ai-01>",
+      "exitCode": 1,
+      "wallMs": 1633,
+      "result": "verified",
+      "observed": "Error `codex-cli backend: timed out after 1499ms`. One second later: zero `codex exec` processes, temp-directory count unchanged from baseline. Timeout, kill and cleanup behave as the adapter contract states."
+    },
+    {
+      "id": "D-foreign-model",
+      "command": "patina --backend codex-cli --model patina-nonexistent-model-zz <en-ai-01>",
+      "exitCode": 0,
+      "wallMs": 95026,
+      "result": "verified-as-designed",
+      "observed": "The id does not match the codex family regex, so resolveLocalCliModel substituted the backend default (#524) and the run succeeded. This is the documented foreign-model fallback, not an invalid-model error path; it cost one extra invocation."
+    },
+    {
+      "id": "E-invalid-in-family-model",
+      "command": "patina --backend codex-cli --model gpt-0-nonexistent-zz <en-ai-01>",
+      "exitCode": 1,
+      "wallMs": 2981,
+      "result": "verified",
+      "observed": "codex exited 1; Patina reported `codex-cli backend: codex exited with code 1` with the child's stderr, removed its temp directory and left no process. Observation: codex's stderr banner echoes the beginning of the prompt, so the surfaced error line contains the first words of the user's source text on the caller's terminal; receipts written by bin/patina-skill.js stayed content-free."
+    }
+  ],
+  "otherBackends": [
+    {"backend": "claude-cli", "version": "2.1.261", "status": "not-runnable", "reason": "Claude CLI OAuth session expired (observed 2026-09-10 through a cli_failed receipt). Not exercised; P17a fixture remains version-only."},
+    {"backend": "gemini-cli", "version": "0.58.0", "status": "not-exercised", "reason": "Configured with auth type gemini-api-key, i.e. it would consume GEMINI_API_KEY, which the maintainer restricted to product use."},
+    {"backend": "openai-http", "status": "not-exercised", "reason": "Maintainer removed the OpenAI key from agent use; the value still present in the shell returned HTTP 401 earlier the same day."},
+    {"backend": "kimi-cli", "status": "not-exercised", "reason": "bin/patina-skill.js refused it with backend_argv_exposes_input (helper guard, not a kimi failure); direct CLI use would need KIMI_API_KEY, which was not authorized."}
+  ],
+  "sideObservations": [
+    "One pre-existing /tmp/patina-codex-* directory dated 2026-09-06 was present before the pilot and untouched by it; the pilot itself left none.",
+    "`patina doctor` reports authenticated=yes for openai-http and claude-cli although both failed authentication on real calls; it checks credential presence, not validity. Candidate follow-up, outside this pilot."
+  ],
+  "acceptance": {
+    "P17b": "passed-for-codex-cli-0.153.4-linux",
+    "fixture": "tests/fixtures/backend-codex-contract.json",
+    "notCovered": ["claude-cli live check (P17a backend)", "quota/rate-limit behavior", "other operating systems (P16b)", "other codex versions or models"]
+  },
+  "boundaries": {
+    "productSourceChanged": false,
+    "versionBumped": false,
+    "publication": "none",
+    "researchRevived": false,
+    "credentialsRecorded": "none; auth mode names and HTTP status codes only"
+  }
+}

--- a/tests/fixtures/backend-codex-contract.json
+++ b/tests/fixtures/backend-codex-contract.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "backend": "codex-cli",
+  "cli": "codex",
+  "observedVersion": "0.153.4",
+  "observedAt": "2026-09-10",
+  "status": "verified",
+  "evidence": {
+    "kind": "real-invocation",
+    "record": "docs/operations/backend-compat-codex-20260910.json",
+    "realInvocation": true,
+    "outputParsingVerified": true,
+    "errorsVerified": true,
+    "authVerified": true,
+    "quotaVerified": false,
+    "timeoutVerified": true
+  },
+  "syntheticFixture": false,
+  "rawOutputIncluded": false,
+  "scope": {
+    "platform": "linux-x64",
+    "node": "24.18.0",
+    "patina": "8.6.0",
+    "model": "gpt-5.5",
+    "authPath": "ChatGPT OAuth (~/.codex/auth.json auth_mode=chatgpt, API-key field null)",
+    "invocations": 8,
+    "scenarios": ["score", "rewrite --verify", "timeout", "foreign-model fallback", "invalid in-family model"]
+  },
+  "requiredContracts": {
+    "output": "codex exec --output-last-message file is read after a zero exit; strict scoring JSON and the [BODY]/[SELF_AUDIT] rewrite framing both parsed on this version.",
+    "errors": "A non-zero codex exit is reported as a backend error with the child's stderr; the owned temp directory is removed and no codex process survives.",
+    "auth": "Authentication is the ~/.codex/auth.json existence check; the verified run used a ChatGPT OAuth session, not an API key.",
+    "quota": "No quota or rate-limit failure occurred in the pilot budget; quota behavior is not verified by this record.",
+    "timeout": "Patina's bounded child timer rejected a live invocation at the requested budget, SIGKILLed the owned child, and left no temp directory or process behind."
+  },
+  "limitations": [
+    "No credential, prompt, model response, or raw CLI output is recorded.",
+    "Verified only for codex 0.153.4 on Linux with model gpt-5.5; other versions, platforms, and models are unverified.",
+    "Quota and rate-limit handling were not exercised.",
+    "This is a connectivity/contract check, not a rewrite-quality experiment."
+  ]
+}

--- a/tests/unit/backend-contract.test.js
+++ b/tests/unit/backend-contract.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { EventEmitter } from 'node:events';
-import { mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir, userInfo } from 'node:os';
 import { join } from 'node:path';
 
@@ -166,6 +166,36 @@ test('Claude CLI compatibility record remains version-only and unverified', () =
   assert.equal(fixture.rawOutputIncluded, false);
   assert.deepEqual(Object.keys(fixture.requiredContracts), ['output', 'errors', 'auth', 'quota', 'timeout']);
   assert.equal(Object.hasOwn(fixture, 'credentials'), false);
+});
+
+test('Codex CLI compatibility record is a real-invocation verification without raw output', () => {
+  const fixture = JSON.parse(readFileSync(
+    new URL('../fixtures/backend-codex-contract.json', import.meta.url),
+    'utf8',
+  ));
+  assert.equal(fixture.schemaVersion, 1);
+  assert.equal(fixture.backend, 'codex-cli');
+  assert.equal(fixture.cli, 'codex');
+  assert.equal(fixture.observedVersion, '0.153.4');
+  assert.equal(fixture.status, 'verified');
+  assert.equal(fixture.evidence.kind, 'real-invocation');
+  assert.equal(fixture.evidence.realInvocation, true);
+  // A verified record must point at the dated operations receipt that holds
+  // the per-scenario evidence; the fixture itself carries only the verdict.
+  assert.equal(fixture.evidence.record, 'docs/operations/backend-compat-codex-20260910.json');
+  assert.equal(existsSync(new URL(`../../${fixture.evidence.record}`, import.meta.url)), true);
+  for (const flag of ['outputParsingVerified', 'errorsVerified', 'authVerified', 'timeoutVerified']) {
+    assert.equal(fixture.evidence[flag], true, flag);
+  }
+  // Quota was never exercised; a verified record must not imply it was.
+  assert.equal(fixture.evidence.quotaVerified, false);
+  assert.equal(fixture.syntheticFixture, false);
+  assert.equal(fixture.rawOutputIncluded, false);
+  assert.deepEqual(Object.keys(fixture.requiredContracts), ['output', 'errors', 'auth', 'quota', 'timeout']);
+  assert.equal(Object.hasOwn(fixture, 'credentials'), false);
+  assert.equal(Object.hasOwn(fixture, 'prompt'), false);
+  assert.equal(Object.hasOwn(fixture, 'response'), false);
+  assert.ok(Number.isInteger(fixture.scope.invocations) && fixture.scope.invocations > 0);
 });
 
 test('isRetryableBackendError honors message status even when err.status is null (#445)', () => {


### PR DESCRIPTION
## 목적 / 연결 Issue
Refs #783 — P17b (real backend compatibility pilot) was `inconclusive`. Maintainer approved running it on 2026-09-10 with the OpenAI key removed and the Gemini key restricted to product use, so the pilot used only the codex CLI's ChatGPT OAuth session.

## 범위 / 비목표
사용자가 관찰하는 변경: none. Adds `tests/fixtures/backend-codex-contract.json` (verdict), `docs/operations/backend-compat-codex-20260910.json` (per-scenario evidence), a fixture shape test, and doc links.
이번 PR에서 하지 않는 것: no adapter, prompt, scoring, or version change; no research revival; claude-cli/gemini-cli/openai-http/kimi-cli not exercised; quota and non-Linux unverified.

## 계약 / 위험 / 크기
contract: not-applicable
risk: low
5 files, tests + docs only.

## 검증
base: dev `73b2e7a`.
- Live: 8 codex 0.153.4 invocations (gpt-5.5) — score JSON parsed; `--verify` passed on retry (mps 100 / fidelity 100); `--timeout-ms 1500` rejected at 1499 ms with zero surviving `codex exec` processes and no temp dir; foreign model id fell back to default as documented (#524); in-family bogus model exited 1 with cleanup.
- Local: `node --test tests/unit/backend-contract.test.js` (new test passes), `npm run lint`, `npm run release:check`, `npm run check:no-private-assets` — all exit 0.
미실행 항목과 이유: full `npm test` left to CI; fixture/doc-only change.

## 릴리스 / 되돌리기
semver 영향: none. 롤백: revert this commit.

## 부수 관찰 (이 PR에서 안 고침)
- `patina doctor` reports `authenticated=yes` for openai-http/claude-cli while real calls fail auth — presence check, not validity.
- codex stderr banner echoes the prompt head, so a non-zero-exit error line shows the first words of the source text on the caller's terminal; skill receipts stay content-free.