### PR TITLE
fix(backends): report an emptied Claude Code session as not authenticated

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -60,8 +60,8 @@ patina --model claude-sonnet-4-6 --lang ko input.txt   # auto-routes
 ```
 
 Auth file: `~/.claude/.credentials.json` (created by the OAuth flow). `patina
-doctor` and backend selection read its `claudeAiOauth` tokens and expiry
-timestamps: a file that Claude Code emptied after logout or a failed refresh
+doctor`, `patina auth status`, and automatic `--ocr` backend selection read
+its `claudeAiOauth` tokens and expiry timestamps: a file that Claude Code emptied after logout or a failed refresh
 reports `authenticated=no` with a hint to run `claude auth login` again. No
 network call is made; a token that is present but revoked server-side is only
 detected when the backend is invoked.

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -59,7 +59,12 @@ patina --backend claude-cli --lang ko input.txt
 patina --model claude-sonnet-4-6 --lang ko input.txt   # auto-routes
 ```
 
-Auth file: `~/.claude/.credentials.json` (created by the OAuth flow).
+Auth file: `~/.claude/.credentials.json` (created by the OAuth flow). `patina
+doctor` and backend selection read its `claudeAiOauth` tokens and expiry
+timestamps: a file that Claude Code emptied after logout or a failed refresh
+reports `authenticated=no` with a hint to run `claude auth login` again. No
+network call is made; a token that is present but revoked server-side is only
+detected when the backend is invoked.
 
 ## gemini-cli backend
 

--- a/docs/AUTHENTICATION_KR.md
+++ b/docs/AUTHENTICATION_KR.md
@@ -59,7 +59,11 @@ patina --backend claude-cli --lang ko input.txt
 patina --model claude-sonnet-4-6 --lang ko input.txt   # auto-routes
 ```
 
-인증 파일: `~/.claude/.credentials.json` (OAuth 로그인 뒤 생성됩니다).
+인증 파일: `~/.claude/.credentials.json` (OAuth 로그인 뒤 생성됩니다). `patina
+doctor`와 백엔드 선택은 이 파일의 `claudeAiOauth` 토큰과 만료 시각을 읽습니다.
+로그아웃이나 토큰 갱신 실패로 Claude Code가 비워 둔 파일은 `authenticated=no`로
+보고되고 `claude auth login` 재실행 안내가 붙습니다. 네트워크 호출은 하지 않으므로
+서버에서 폐기된 토큰은 실제 백엔드 호출 때에만 드러납니다.
 
 ## gemini-cli backend
 

--- a/docs/AUTHENTICATION_KR.md
+++ b/docs/AUTHENTICATION_KR.md
@@ -60,7 +60,7 @@ patina --model claude-sonnet-4-6 --lang ko input.txt   # auto-routes
 ```
 
 인증 파일: `~/.claude/.credentials.json` (OAuth 로그인 뒤 생성됩니다). `patina
-doctor`와 백엔드 선택은 이 파일의 `claudeAiOauth` 토큰과 만료 시각을 읽습니다.
+doctor`, `patina auth status`, 그리고 `--ocr`의 자동 백엔드 선택은 이 파일의 `claudeAiOauth` 토큰과 만료 시각을 읽습니다.
 로그아웃이나 토큰 갱신 실패로 Claude Code가 비워 둔 파일은 `authenticated=no`로
 보고되고 `claude auth login` 재실행 안내가 붙습니다. 네트워크 호출은 하지 않으므로
 서버에서 폐기된 토큰은 실제 백엔드 호출 때에만 드러납니다.

--- a/src/backends/claude-cli.js
+++ b/src/backends/claude-cli.js
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -24,14 +24,58 @@ export function isAvailable() {
   }
 }
 
-export function isAuthenticated() {
+function credentialsPath() {
   // Claude Code stores OAuth tokens in ~/.claude/.credentials.json after the
   // first interactive login. The path is consistent across platforms when the
   // CLI is installed via the standard installer.
-  return existsSync(join(homedir(), '.claude', '.credentials.json'));
+  return join(homedir(), '.claude', '.credentials.json');
+}
+
+/**
+ * Classify the Claude Code credentials file without touching the network.
+ *
+ * Claude Code keeps the file after a logout or a failed token refresh but
+ * blanks the tokens and sets `expiresAt` to 0, so file presence alone reported
+ * an expired session as authenticated (observed 2026-09-10 during the P17b
+ * pilot). A session is usable when the access token is live, or when a live
+ * refresh token lets the CLI mint a new one. Only positive, finite, past
+ * timestamps count as expired; 0 or a missing timestamp means "unknown", not
+ * "expired". An unrecognised layout keeps the old presence semantics so other
+ * credential stores are not misreported.
+ *
+ * @param {string} file Credentials file path.
+ * @param {number} [now=Date.now()] Comparison time in epoch milliseconds.
+ * @returns {'missing'|'unreadable'|'expired'|'ok'} Credential state.
+ */
+export function readClaudeCredentialState(file, now = Date.now()) {
+  if (!existsSync(file)) return 'missing';
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(file, 'utf8'));
+  } catch {
+    return 'unreadable';
+  }
+  const oauth = parsed?.claudeAiOauth;
+  if (!oauth || typeof oauth !== 'object') return 'ok';
+  const live = (token, expiresAt) => typeof token === 'string' && token.trim() !== ''
+    && !(Number.isFinite(expiresAt) && expiresAt > 0 && expiresAt <= now);
+  return live(oauth.accessToken, oauth.expiresAt) || live(oauth.refreshToken, oauth.refreshTokenExpiresAt)
+    ? 'ok'
+    : 'expired';
+}
+
+export function isAuthenticated() {
+  return readClaudeCredentialState(credentialsPath()) === 'ok';
 }
 
 export function authHint() {
+  const state = readClaudeCredentialState(credentialsPath());
+  if (state === 'expired') {
+    return `Claude Code session expired or logged out; run \`${loginCommand}\` again (uses your Claude subscription, no API key needed).`;
+  }
+  if (state === 'unreadable') {
+    return `Claude Code credentials file is not valid JSON; run \`${loginCommand}\` to recreate it.`;
+  }
   return `Run \`${loginCommand}\` and follow the OAuth prompt to authenticate (uses your Claude subscription, no API key needed).`;
 }
 

--- a/tests/unit/backend-auth.test.js
+++ b/tests/unit/backend-auth.test.js
@@ -5,6 +5,7 @@ import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { isAuthenticated as kimiAuthenticated } from '../../src/backends/kimi-cli.js';
+import { readClaudeCredentialState } from '../../src/backends/claude-cli.js';
 import {
   isAuthenticated as geminiAuthenticated,
   authHint as geminiAuthHint,
@@ -23,6 +24,48 @@ function withEnv(keys, body) {
     }
   }
 }
+
+// os.homedir() cannot be redirected here, so the classifier takes the file path
+// directly; isAuthenticated()/authHint() are thin wrappers over it.
+test('claude credential state distinguishes missing, unreadable, expired and live sessions', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'patina-claude-auth-'));
+  const file = join(dir, '.credentials.json');
+  const now = 1_800_000_000_000;
+  const write = (value) => writeFileSync(file, typeof value === 'string' ? value : JSON.stringify(value));
+  try {
+    assert.equal(readClaudeCredentialState(file, now), 'missing');
+
+    write('{not json');
+    assert.equal(readClaudeCredentialState(file, now), 'unreadable');
+
+    // Unknown layout (what the e2e fake login writes) keeps presence semantics.
+    write({});
+    assert.equal(readClaudeCredentialState(file, now), 'ok');
+
+    // Logged-out shape observed on disk: blank tokens, expiresAt 0, refresh
+    // expiry still in the future. Nothing usable remains.
+    write({ claudeAiOauth: { accessToken: '', refreshToken: '', expiresAt: 0, refreshTokenExpiresAt: now + 1 } });
+    assert.equal(readClaudeCredentialState(file, now), 'expired');
+
+    // Access token expired but a live refresh token lets the CLI renew it.
+    write({ claudeAiOauth: { accessToken: 'a', expiresAt: now - 1, refreshToken: 'r', refreshTokenExpiresAt: now + 1 } });
+    assert.equal(readClaudeCredentialState(file, now), 'ok');
+
+    // Both tokens past their timestamps.
+    write({ claudeAiOauth: { accessToken: 'a', expiresAt: now - 1, refreshToken: 'r', refreshTokenExpiresAt: now - 1 } });
+    assert.equal(readClaudeCredentialState(file, now), 'expired');
+
+    // Live access token with no timestamp is not treated as expired.
+    write({ claudeAiOauth: { accessToken: 'a' } });
+    assert.equal(readClaudeCredentialState(file, now), 'ok');
+
+    // Whitespace-only tokens are blank.
+    write({ claudeAiOauth: { accessToken: ' \t', refreshToken: '' } });
+    assert.equal(readClaudeCredentialState(file, now), 'expired');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 const KIMI_ENV = ['KIMI_API_KEY', 'MOONSHOT_API_KEY', 'KIMI_SHARE_DIR'];
 const GEMINI_ENV = ['GEMINI_API_KEY'];


### PR DESCRIPTION
## 목적 / 연결 Issue
Refs #783 (side observation from the P17b pilot, `docs/operations/backend-compat-codex-20260910.json` sideObservations[1]). `patina doctor` said `claude-cli: authenticated=yes` while every real call failed with an expired OAuth session, because the check was file presence only.

## 범위 / 비목표
사용자가 관찰하는 변경: `patina doctor`, `patina auth status`, and automatic `--ocr` backend selection now treat a logged-out/expired `~/.claude/.credentials.json` as not authenticated, with a hint naming the expired state. Explicit `--backend claude-cli` and rewrite fallback chains are unchanged; only OCR auto-selection skips it.
이번 PR에서 하지 않는 것: no network validation (a server-revoked token is still only caught on invoke); openai-http key validity is unchanged (presence check, needs a network probe — separate decision).

## 계약 / 위험 / 크기
contract: compatible — `doctor --json` shape unchanged; only the boolean value becomes accurate for the emptied-file case. Unknown file layouts keep the old presence semantics (the e2e fake login writes `{}` and still passes).
risk: low

## 검증
base: dev `bd882ef`; head `6e0ac2e`, run 34438733322 success.
- New unit test covers missing / unreadable / unknown-layout / logged-out shape / expired-access-with-live-refresh / both-expired / no-timestamp / whitespace tokens.
- Real host check: `patina doctor` now prints `claude-cli: available=yes, authenticated=no` + expired hint for the actual emptied credentials file on this machine (was `yes`).
- `npm run lint` and `npm test`: 2433 tests, 2431 pass, 0 fail, 2 pre-existing skips.
- Independent architect review: APPROVE; one doc nit (selection wording) fixed in the follow-up commit.

## 릴리스 / 되돌리기
semver 영향: patch (bug fix). 롤백: revert the squash commit ef5ba76.
