### PR TITLE
docs(maintenance): correct P17b invocation count and record codex token usage

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -148,7 +148,7 @@ operating systems remain uncovered.
 ### P17b backend compatibility pilot (2026-09-10)
 
 `backend-compat-codex-20260910.json` supersedes the P17b `inconclusive` row in
-`maintenance-delivery-20260910.json` for **codex-cli only**. Eight live
+`maintenance-delivery-20260910.json` for **codex-cli only**. Ten live
 invocations of codex 0.153.4 (gpt-5.5, ChatGPT OAuth, no provider API key
 read) verified score parsing, `--verify` retry, a 1.5 s timeout kill with
 process and temp-directory cleanup, the foreign-model fallback, and the

--- a/docs/operations/backend-compat-codex-20260910.json
+++ b/docs/operations/backend-compat-codex-20260910.json
@@ -16,7 +16,17 @@
   "authority": {
     "approval": "Maintainer asked to proceed with P17b in session on 2026-09-10 after removing the OpenAI key and restricting the Gemini key to product use.",
     "credentialPolicy": "OPENAI_API_KEY, GEMINI_API_KEY, ANTHROPIC_API_KEY and KIMI_API_KEY were unset in the pilot shell. Only the ChatGPT OAuth session behind the codex CLI was used; no provider API key was read or sent.",
-    "budget": {"maxInvocationsPlanned": 6, "invocationsObserved": 8, "note": "The --verify scenario retried once (rewrite + verify twice), which exceeded the planned count by two; recorded, not hidden."}
+    "budget": {"maxInvocationsPlanned": 6, "invocationsObserved": 10, "note": "Corrected after the run from the codex session log (~/.codex/sessions, 13:31-13:39 KST): A 1, B 6 (rewrite, two verification calls, retry rewrite, two verification calls), C 1 (killed), D 1, E 1 (rejected). The receipt first said 8 by assuming one verification call per candidate."},
+    "tokenUsage": {
+      "source": "codex rollout token_count events for the ten pilot sessions; ChatGPT subscription quota, not per-token billing",
+      "sessions": 10,
+      "modelTurns": 33,
+      "inputTokens": 1256282,
+      "cachedInputTokens": 944512,
+      "outputTokens": 23081,
+      "reasoningOutputTokens": 17383,
+      "observation": "Patina's own prompt is roughly 18-20k tokens for a rewrite or verification call and about 43k for --score (pattern packs). The multiple is codex exec behaving as an agent: on the rewrite/score prompts it issued 3-13 shell tool calls per session inside the read-only sandbox, re-sending the prompt each turn (the KO rewrite reached 11 turns), and the host config ran reasoning effort xhigh. A single-turn call would have cost roughly a third. Candidate follow-up: pass a codex config override that lowers reasoning effort and/or a prompt instruction not to run commands; outside this pilot."
+    }
   },
   "environment": {
     "os": "Linux 6.8.0-138-generic x64",

--- a/tests/fixtures/backend-codex-contract.json
+++ b/tests/fixtures/backend-codex-contract.json
@@ -23,7 +23,7 @@
     "patina": "8.6.0",
     "model": "gpt-5.5",
     "authPath": "ChatGPT OAuth (~/.codex/auth.json auth_mode=chatgpt, API-key field null)",
-    "invocations": 8,
+    "invocations": 10,
     "scenarios": ["score", "rewrite --verify", "timeout", "foreign-model fallback", "invalid in-family model"]
   },
   "requiredContracts": {


### PR DESCRIPTION
## 목적 / 연결 Issue
Refs #783, follows #795. The P17b receipt said 8 invocations; the codex session log shows 10 (each `--verify` candidate makes two verification calls). Also records measured token usage from the same log because the maintainer asked how expensive the pilot was.

## 범위 / 비목표
Docs/fixture numbers only. No product change. The token-usage cause (codex exec acting as an agent with shell tool calls; host reasoning effort xhigh) is recorded as a candidate follow-up, not fixed here.

## 계약 / 위험 / 크기
contract: not-applicable; risk: low; 3 files.

## 검증
`node --test tests/unit/backend-contract.test.js` pass; `npm run lint`, `npm run check:no-private-assets` exit 0. Numbers come from `~/.codex/sessions/2026/09/10` token_count events for the 13:31–13:39 KST sessions; no session content is copied.

## 릴리스 / 되돌리기
semver: none. Rollback: revert.