### PR TITLE
fix(backends): strip agent tools from local CLI rewrite calls

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -48,6 +48,14 @@ patina --backend codex-cli --lang ko input.txt
 patina --model codex --lang ko input.txt   # routes to codex-cli, uses gpt-5.5 default
 ```
 
+Notes: `codex exec` runs from a fresh temp directory with `--sandbox read-only`
+and with the `shell_tool`, `unified_exec` and `multi_agent` features disabled.
+A rewrite needs no tools, and with them enabled codex behaves as an agent —
+measured on 2026-09-10 it ran 3–13 shell commands per rewrite prompt, re-sending
+the ~20k-token prompt every turn (up to ~500k tokens for one Korean rewrite).
+With the tools removed the same rewrite is one turn, ~20k tokens, ~20 s. Reasoning
+effort is not overridden; it follows your `~/.codex/config.toml`.
+
 ## claude-cli backend
 
 Spawns local [`claude`](https://docs.anthropic.com/en/docs/claude-code) `-p` with the patina prompt on stdin. Free for anyone with a Claude subscription. Claude Code is an agent runtime, so patina treats it conservatively in batch mode: compact prompt mode, default max concurrency `1`, and default retries `0`. The default model passed to Claude Code is `claude-sonnet-4-6`; Claude Code may still apply its own model/session policy outside patina's control.
@@ -58,6 +66,10 @@ patina auth login claude-cli               # same, with confirmation
 patina --backend claude-cli --lang ko input.txt
 patina --model claude-sonnet-4-6 --lang ko input.txt   # auto-routes
 ```
+
+Notes: patina passes `--tools ""` and `--strict-mcp-config`, so the call carries
+no built-in tools and starts none of your configured MCP servers. The `--ocr`
+image route is the only exception and keeps `Read` for the staged image files.
 
 Auth file: `~/.claude/.credentials.json` (created by the OAuth flow). `patina
 doctor`, `patina auth status`, and automatic `--ocr` backend selection read
@@ -78,7 +90,7 @@ patina --backend gemini-cli --lang ko input.txt
 patina --model gemini-3-flash-preview --lang ko input.txt   # auto-routes
 ```
 
-Notes: patina passes `--skip-trust` because the prompt runs from a fresh temp directory (containment for prompt-injection in user text). Default timeout is higher than other CLIs because gemini's startup latency is longer.
+Notes: patina passes `--skip-trust` because the prompt runs from a fresh temp directory (containment for prompt-injection in user text), disables MCP servers, and passes a per-call `--policy` file that denies every tool (`toolName = "*"`), so the model receives no tool definitions and cannot spend turns on `run_shell_command` or `write_file`; image input uses `@file` includes, which the CLI resolves itself. Default timeout is higher than other CLIs because gemini's startup latency is longer.
 
 ## kimi-cli backend
 

--- a/docs/AUTHENTICATION_KR.md
+++ b/docs/AUTHENTICATION_KR.md
@@ -49,10 +49,10 @@ patina --model codex --lang ko input.txt   # codex-cli로 라우팅하고 gpt-5.
 ```
 
 참고: `codex exec`는 새 임시 디렉터리에서 `--sandbox read-only`로 실행되며
-`shell_tool`, `unified_exec`, `multi_agent` 기능을 끔니다. 재작성에는 도구가 필요 없는데,
+`shell_tool`, `unified_exec`, `multi_agent` 기능을 끕니다. 재작성에는 도구가 필요 없는데,
 켜 두면 codex가 에이전트처럼 동작합니다 — 2026-09-10 측정에서 재작성 프롬프트 하나에
 셸 명령 3–13회를 실행하며 턴마다 약 20k 토큰 프롬프트를 다시 보냈습니다(한국어 재작성 한 건에
-최대 약 500k 토큰). 도구를 끕 뒤 같은 재작성은 1턴, 약 20k 토큰, 약 20초입니다. reasoning
+최대 약 500k 토큰). 도구를 끈 뒤 같은 재작성은 1턴, 약 20k 토큰, 약 20초입니다. reasoning
 effort는 덮어쓰지 않고 `~/.codex/config.toml` 설정을 따릅니다.
 
 ## claude-cli backend

--- a/docs/AUTHENTICATION_KR.md
+++ b/docs/AUTHENTICATION_KR.md
@@ -48,6 +48,13 @@ patina --backend codex-cli --lang ko input.txt
 patina --model codex --lang ko input.txt   # codex-cli로 라우팅하고 gpt-5.5 기본값 사용
 ```
 
+참고: `codex exec`는 새 임시 디렉터리에서 `--sandbox read-only`로 실행되며
+`shell_tool`, `unified_exec`, `multi_agent` 기능을 끔니다. 재작성에는 도구가 필요 없는데,
+켜 두면 codex가 에이전트처럼 동작합니다 — 2026-09-10 측정에서 재작성 프롬프트 하나에
+셸 명령 3–13회를 실행하며 턴마다 약 20k 토큰 프롬프트를 다시 보냈습니다(한국어 재작성 한 건에
+최대 약 500k 토큰). 도구를 끕 뒤 같은 재작성은 1턴, 약 20k 토큰, 약 20초입니다. reasoning
+effort는 덮어쓰지 않고 `~/.codex/config.toml` 설정을 따릅니다.
+
 ## claude-cli backend
 
 로컬 [`claude`](https://docs.anthropic.com/en/docs/claude-code) `-p`에 patina 프롬프트를 stdin으로 넘겨 실행합니다. Claude 구독이 있으면 추가 API 키 없이 쓸 수 있습니다. Claude Code는 agent runtime이므로 batch 모드에서는 보수적으로 다룹니다: compact prompt mode, 기본 동시성 `1`, 기본 retry `0`. 기본 모델은 `claude-sonnet-4-6`이지만, Claude Code 자체의 모델/세션 정책은 patina가 완전히 통제하지 못할 수 있습니다.
@@ -58,6 +65,10 @@ patina auth login claude-cli               # same, with confirmation
 patina --backend claude-cli --lang ko input.txt
 patina --model claude-sonnet-4-6 --lang ko input.txt   # auto-routes
 ```
+
+참고: patina는 `--tools ""`과 `--strict-mcp-config`를 넘기므로 호출에 내장 도구가 실리지
+않고 사용자가 설정한 MCP 서버도 시작하지 않습니다. `--ocr` 이미지 경로만 예외로, 스테이징된
+이미지 파일을 읽기 위해 `Read`를 유지합니다.
 
 인증 파일: `~/.claude/.credentials.json` (OAuth 로그인 뒤 생성됩니다). `patina
 doctor`, `patina auth status`, 그리고 `--ocr`의 자동 백엔드 선택은 이 파일의 `claudeAiOauth` 토큰과 만료 시각을 읽습니다.
@@ -76,6 +87,11 @@ export GEMINI_API_KEY="..."                # AI Studio key
 patina --backend gemini-cli --lang ko input.txt
 patina --model gemini-3-flash-preview --lang ko input.txt   # auto-routes
 ```
+
+참고: 프롬프트는 새 임시 디렉터리에서 실행되므로 `--skip-trust`를 넘기고, MCP 서버를 끄며,
+모든 도구를 거부하는 호출별 `--policy` 파일(`toolName = "*"`)을 넘깁니다. 모델은 도구 정의를
+아예 받지 않으므로 `run_shell_command`나 `write_file`에 턴을 쓰지 못합니다. 이미지 입력은 CLI가
+직접 해석하는 `@file` include를 씁니다. gemini는 시작 지연이 길어 기본 timeout이 다른 CLI보다 깁니다.
 
 ## kimi-cli backend
 

--- a/src/backends/claude-cli.js
+++ b/src/backends/claude-cli.js
@@ -105,8 +105,17 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
   // Vision input: images are staged INTO the temp cwd — claude's in-cwd Read
   // tool is auto-allowed in print mode, while paths outside cwd would be
   // permission-denied (and granting them would weaken the containment above).
+  //
+  // A rewrite or score is a pure text transform, so the built-in tool set is
+  // emptied (`--tools ""`) and the user's configured MCP servers are skipped
+  // (`--strict-mcp-config` with no --mcp-config): source text that contains
+  // instructions gets no tool to act on, no third-party MCP process starts
+  // per call, and the request carries no tool definitions. Only the image
+  // route keeps the Read tool, which is how claude ingests staged files.
   let effectivePrompt = prompt;
-  if (Array.isArray(images) && images.length > 0) {
+  const hasImages = Array.isArray(images) && images.length > 0;
+  const tools = hasImages ? 'Read' : '';
+  if (hasImages) {
     try {
       const staged = stageCliImages(dir, images);
       effectivePrompt = `${prompt}\n\nAttached image file(s) in the working directory: ${staged.map((f) => `./${f}`).join(', ')} — read them before answering.`;
@@ -121,7 +130,7 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
   return new Promise((resolve, reject) => {
     const { proc, terminate, waitForClose } = spawnOwnedCliProcess(
       'claude',
-      ['-p', '--model', cliModel],
+      ['-p', '--model', cliModel, '--tools', tools, '--strict-mcp-config'],
       { stdio: ['pipe', 'pipe', 'pipe'], cwd: dir },
     );
 

--- a/src/backends/codex-cli.js
+++ b/src/backends/codex-cli.js
@@ -13,6 +13,15 @@ import { resolveLocalCliModel } from '../model-defaults.js';
 export const name = 'codex-cli';
 export const supportsImages = true;
 export const loginCommand = 'codex login';
+
+// Codex feature flags that expose agent tools. A rewrite or score is a pure
+// text transform, yet with these enabled `codex exec` behaves as an agent:
+// on the 2026-09-10 P17b pilot it issued 3-13 shell tool calls per prompt
+// inside the read-only sandbox, re-sending the prompt on every turn (one KO
+// rewrite reached 11 turns, ~500k cumulative input tokens). Disabling them
+// removes the tool definitions from the request and leaves a single turn.
+// Images still arrive through `-i`, which is model input, not a tool.
+export const CODEX_DISABLED_FEATURES = Object.freeze(['shell_tool', 'unified_exec', 'multi_agent']);
 export const installHint = 'Install it from https://github.com/openai/codex, then run `patina auth login codex-cli` again.';
 
 export function isAvailable() {
@@ -81,6 +90,7 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
       '--sandbox', 'read-only',
       '-C', dir,
       '--model', cliModel,
+      ...CODEX_DISABLED_FEATURES.flatMap((feature) => ['--disable', feature]),
       '--output-last-message', outFile,
       ...imageArgs,
       // stdout is discarded, not piped: `codex exec` streams session/progress

--- a/src/backends/gemini-cli.js
+++ b/src/backends/gemini-cli.js
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -18,6 +18,11 @@ export const installHint = 'Install Gemini CLI first, then run `patina auth logi
 // `--allowed-mcp-server-names` is an allowlist; naming one server that cannot
 // exist is how the CLI expresses "no MCP servers".
 const NO_MCP_SERVERS = '__patina_no_mcp__';
+
+// Policy-engine rule passed per invocation via --policy. `*` matches every
+// built-in and MCP tool; a global deny excludes them from the model's tool
+// list entirely. 999 is the highest TOML priority within the User tier.
+export const GEMINI_NO_TOOLS_POLICY = '[[rule]]\ntoolName = "*"\ndecision = "deny"\npriority = 999\n';
 
 export function isAvailable() {
   try {
@@ -74,9 +79,24 @@ export async function invoke({ prompt, model, modelSource, signal, timeout = DEF
   // the backend timeout (observed 2026-07-27: one scoring call sat for the
   // full 600s budget while sibling calls finished in ~30s). Same containment
   // rationale as the temp cwd — the agent gets nothing it does not need.
+  //
+  // Built-in tools are removed the same way through the policy engine: a
+  // global `deny` for `*` drops every tool definition from the request (the
+  // documented behaviour for rules without argsPattern), so the model cannot
+  // spend turns on run_shell_command/write_file and source text that contains
+  // instructions has nothing to act on. Earlier sessions (2026-08-18/19) show
+  // the model doing exactly that on rewrite prompts. Image input uses
+  // @-includes, which the CLI resolves before the model runs, not a tool.
   const dir = mkdtempSync(join(tmpdir(), 'patina-gemini-'));
+  const policyFile = join(dir, 'patina-no-tools.toml');
+  try {
+    writeFileSync(policyFile, GEMINI_NO_TOOLS_POLICY, { mode: 0o600 });
+  } catch (err) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch {}
+    throw new Error(`gemini-cli backend: failed to write tool policy (${err.message})`);
+  }
   const cliModel = resolveLocalCliModel({ backendName: name, model, modelSource });
-  const args = ['-p', '', '--output-format', 'text', '--skip-trust', '--allowed-mcp-server-names', NO_MCP_SERVERS, '-m', cliModel];
+  const args = ['-p', '', '--output-format', 'text', '--skip-trust', '--allowed-mcp-server-names', NO_MCP_SERVERS, '--policy', policyFile, '-m', cliModel];
 
   // Vision input: gemini's @-includes are confined to the workspace root, so
   // images are staged into the temp cwd and referenced as @<filename>.

--- a/tests/unit/backend-model-defaults.test.js
+++ b/tests/unit/backend-model-defaults.test.js
@@ -142,6 +142,59 @@ test('local CLI backends pass default best-model flags to child processes', asyn
   });
 });
 
+// A fake CLI that also captures the gemini --policy file body before the
+// adapter removes its temp directory.
+const FAKE_CLI_WITH_POLICY = FAKE_CLI.replace(
+  "  const payload = JSON.stringify({ command: basename(process.argv[1]), args, stdin, isolation });",
+  "  const policyIndex = args.indexOf('--policy');\n" +
+  "  const policy = policyIndex >= 0 ? readFileSync(args[policyIndex + 1], 'utf8') : null;\n" +
+  "  const payload = JSON.stringify({ command: basename(process.argv[1]), args, stdin, isolation, policy });",
+);
+
+test('local CLI backends strip agent tools from every text invocation', async () => {
+  await withFakeCli(async () => {
+    const codex = JSON.parse(await codexCli.invoke({ prompt: 'rewrite this' }));
+    for (const feature of codexCli.CODEX_DISABLED_FEATURES) {
+      const index = codex.args.indexOf('--disable');
+      assert.notStrictEqual(index, -1);
+      assert.ok(codex.args.some((arg, i) => arg === '--disable' && codex.args[i + 1] === feature), `codex should disable ${feature}`);
+    }
+    assert.deepEqual(codexCli.CODEX_DISABLED_FEATURES, ['shell_tool', 'unified_exec', 'multi_agent']);
+    // Sandbox containment stays in place alongside the feature switches.
+    assertArgValue(codex.args, '--sandbox', 'read-only');
+
+    const claude = JSON.parse(await claudeCli.invoke({ prompt: 'rewrite this' }));
+    assertArgValue(claude.args, '--tools', '');
+    assert.ok(claude.args.includes('--strict-mcp-config'));
+    assert.ok(!claude.args.includes('--mcp-config'));
+
+    const gemini = JSON.parse(await geminiCli.invoke({ prompt: 'rewrite this' }));
+    assert.strictEqual(gemini.policy, geminiCli.GEMINI_NO_TOOLS_POLICY);
+    assert.match(gemini.policy, /toolName = "\*"/);
+    assert.match(gemini.policy, /decision = "deny"/);
+    assertArgValue(gemini.args, '--allowed-mcp-server-names', '__patina_no_mcp__');
+  }, FAKE_CLI_WITH_POLICY);
+});
+
+test('claude keeps only the Read tool when images are attached; gemini stays tool-free', async () => {
+  const imageDir = mkdtempSync(join(tmpdir(), 'patina-tool-image-'));
+  const image = join(imageDir, 'shot.png');
+  writeFileSync(image, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  try {
+    await withFakeCli(async () => {
+      const claude = JSON.parse(await claudeCli.invoke({ prompt: 'read the image', images: [image] }));
+      assertArgValue(claude.args, '--tools', 'Read');
+      assert.ok(claude.args.includes('--strict-mcp-config'));
+
+      const gemini = JSON.parse(await geminiCli.invoke({ prompt: 'read the image', images: [image] }));
+      assert.strictEqual(gemini.policy, geminiCli.GEMINI_NO_TOOLS_POLICY);
+      assert.match(gemini.stdin, /^@ocr-image-0\.png\n/);
+    }, FAKE_CLI_WITH_POLICY);
+  } finally {
+    rmSync(imageDir, { recursive: true, force: true });
+  }
+});
+
 test('local CLI backends pass explicit non-alias model ids', async () => {
   await withFakeCli(async () => {
     const codex = JSON.parse(await codexCli.invoke({


### PR DESCRIPTION
## 목적 / 연결 Issue
Refs #783 (P17b side observation). Maintainer asked whether the codex token blow-up was codex-only. It is not: three of four local CLI backends hand the model an agent tool set for what is a pure text transform.

**Evidence from session logs on this machine**
| backend | evidence | before |
|---|---|---|
| codex-cli 0.153.4 | P17b pilot, 10 sessions | 3–13 shell tool calls per rewrite/score prompt; KO rewrite = 11 turns, ~500k cumulative input tokens, 237 s |
| gemini-cli | `~/.gemini/tmp/patina-gemini-*` chats, 2026-08-18/19 | 6 sessions with `run_shell_command`, `write_file`, `invoke_agent`, `update_topic`; up to 7 turns |
| claude-cli | last 40 `~/.claude/projects/*patina-claude*` sessions | 0 tool calls, but full tool set + user MCP servers loaded per call |
| kimi-cli | adapter | already `tools: []` / `subagents: []` — the pattern this PR copies |

## 범위 / 비목표
사용자가 관찰하는 변경: local CLI rewrites no longer run shell commands, write files, spawn sub-agents, or start MCP servers. codex rewrites become single-turn.
- codex-cli: `--disable shell_tool --disable unified_exec --disable multi_agent` (feature flags listed by `codex features list`, all `stable`)
- claude-cli: `--tools ""` + `--strict-mcp-config`; `--ocr` image route keeps `--tools Read`
- gemini-cli: per-call `--policy <tmp>/patina-no-tools.toml` with `toolName = "*"`, `decision = "deny"` (documented: global deny removes the tool definitions from the request)

이번 PR에서 하지 않는 것: no reasoning-effort override (that is a quality decision and follows the user's CLI config); no prompt change; openai-http untouched.

## 계약 / 위험 / 크기
contract: compatible — same inputs/outputs; only child argv changes. Risk: a CLI version that rejects a flag would fail the call; flag acceptance is verified below on the installed versions.
risk: standard. 6 files.

## 검증
base: dev `2e54c4e`.
- **codex live re-check (authorized backend):** same KO rewrite after the change → exit 0, **1 turn, 0 tool calls, 19,859 input tokens (14,720 cached), 1,301 output, 20.5 s** (was 11 turns / ~500k / 237 s).
- **claude offline flag check:** `HOME=<empty> claude -p --tools "" --strict-mcp-config --model … --bogus-flag` → `unknown option '--bogus-flag'`; without the bogus flag → `Not logged in` (parse OK, auth is the only failure). No call made.
- **gemini offline flag check:** `HOME=<empty> gemini … --policy bad.toml` → `Policy file error … TOML parsing failed`; with the real policy → auth-method error (parse OK, no call, product key never read).
- Unit: two new tests in `tests/unit/backend-model-defaults.test.js` assert the argv/policy body for text and image invocations via the fake-CLI harness.
- `npm run lint`; `npm test` 2435 tests / 2433 pass / 0 fail / 2 pre-existing skips.

미실행: claude/gemini live rewrite (expired OAuth; product-only Gemini key). Flag acceptance is verified; tool-count reduction on those two is inferred from the documented CLI behaviour.

## 릴리스 / 되돌리기
semver 영향: patch (behavioural fix, no interface change). 롤백: revert this commit.
