### PR TITLE
test(backends): verify claude-cli and Gemini-via-OpenCodex compatibility (P17b)

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -75,11 +75,17 @@ The normal `/patina` and `/patina --strict` routes remain CLI-first: a failed CL
 run is an error, never an inline rewrite or a silent fallback. The optional
 instruction-only route above is the only host-agent analysis path.
 
-`tests/fixtures/backend-claude-contract.json` records the observed
-`claude --version` result (`2.1.261`) as **version-only / unverified**. It is a
-synthetic contract fixture, not an invocation recording: it contains no
-credentials, prompts, model response, or raw CLI output. The evidence must stay
-separate from these runtime distinctions:
+`tests/fixtures/backend-claude-contract.json` was a **version-only /
+unverified** record of `claude --version` (`2.1.261`) on 2026-09-09; on
+2026-09-10 it became a **real-invocation / verified** record for that same
+version (`claude-sonnet-4-6`, subscription OAuth, `--tools ""
+--strict-mcp-config`) with per-scenario evidence in
+`docs/operations/backend-compat-claude-gemini-20260910.json`. The same receipt
+verifies the `openai-http` backend against the loopback OpenCodex proxy route
+`google-antigravity/gemini-3.7-flash`; that is transport evidence for the HTTP
+backend, not `gemini-cli` evidence. Neither fixture contains credentials,
+prompts, model responses, or raw CLI output. The evidence must stay separate
+from these runtime distinctions:
 
 - **Output parsing:** `claude-cli` captures `-p` stdout; Patina's output layer
   removes optional `[BODY]`/`[SELF_AUDIT]` scaffolding and returns the body. A

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -88,19 +88,22 @@ prompts, model responses, or raw CLI output. The evidence must stay separate
 from these runtime distinctions:
 
 - **Output parsing:** `claude-cli` captures `-p` stdout; Patina's output layer
-  removes optional `[BODY]`/`[SELF_AUDIT]` scaffolding and returns the body. A
-  version response does not exercise that parser.
+  removes optional `[BODY]`/`[SELF_AUDIT]` scaffolding and returns the body.
+  Verified on 2.1.261 by the 2026-09-10 score and rewrite scenarios; a version
+  response alone would not exercise that parser.
 - **Errors and cancellation:** non-zero exits, signal termination, spawn
   failures, `AbortError`, and local timeout errors are reported as failures.
   Cancellation/timeout tests also require the owned child, invocation
   directory, and concurrency slot to be gone before a later call succeeds.
-- **Authentication and quota:** the Claude credential-file check is not an
+- **Authentication and quota:** the Claude credential classification is not an
   invocation check. Account authentication or quota failures are external
   runtime outcomes and must not be promoted to compatibility or rewrite
-  success by a version-only record.
+  success. The 2026-09-10 run establishes that the recorded OAuth session
+  authenticated; quota behavior was not exercised and stays unverified.
 - **Timeout:** the adapter's bounded child-process timer is distinct from
-  caller cancellation and from account quota. The fixture does not verify any
-  of these paths.
+  caller cancellation and from account quota. The pilot verified the timer
+  path (kill plus temp-directory cleanup) for 2.1.261; caller cancellation and
+  quota remain covered only by the lifecycle fixtures, not by a live run.
 
 `tests/fixtures/backend-codex-contract.json` is the first **real-invocation /
 verified** record: codex `0.153.4` on Linux with `gpt-5.5` over a ChatGPT OAuth

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -153,10 +153,16 @@ invocations of codex 0.153.4 (gpt-5.5, ChatGPT OAuth, no provider API key
 read) verified score parsing, `--verify` retry, a 1.5 s timeout kill with
 process and temp-directory cleanup, the foreign-model fallback, and the
 invalid-model error path. The verdict lives in
-`tests/fixtures/backend-codex-contract.json`. claude-cli (expired OAuth),
-gemini-cli and openai-http (maintainer restricted those keys to product use),
-and kimi-cli were not exercised; quota behavior and other operating systems
-remain unverified.
+`tests/fixtures/backend-codex-contract.json`.
+
+`backend-compat-claude-gemini-20260910.json` (same day, after #798 removed
+agent tools) adds **claude-cli 2.1.261** (7 invocations, subscription OAuth,
+0 tool calls / 0 MCP references in the session log) and **openai-http over the
+loopback OpenCodex proxy** with `google-antigravity/gemini-3.7-flash` (6
+requests, placeholder key, no provider key). `backend-claude-contract.json`
+moves from version-only to verified. Still not exercised: gemini-cli
+(api-key mode would spend the product key), kimi-cli, `agy` (no adapter),
+quota behavior, other operating systems.
 
 P09 native Codex settings and any unexposed web account configuration remain
 unknown; no automation is inferred from a deployment result. The recurring

--- a/docs/operations/backend-compat-claude-gemini-20260910.json
+++ b/docs/operations/backend-compat-claude-gemini-20260910.json
@@ -1,0 +1,71 @@
+{
+  "schemaVersion": 1,
+  "recordType": "maintenance-backend-compatibility-pilot",
+  "observedDate": "2026-09-10",
+  "repository": "devswha/patina",
+  "plan": "patina-repo-development-maintenance-plan-final-2026-09-09",
+  "planIds": ["P17b"],
+  "trackingIssue": 783,
+  "supersedes": {
+    "record": "backend-compat-codex-20260910.json",
+    "field": "otherBackends",
+    "entries": ["claude-cli", "gemini-cli"],
+    "note": "claude-cli moves from not-runnable to verified. gemini-cli stays not-exercised; the Gemini model was verified through a different transport (openai-http against the loopback OpenCodex proxy), which is recorded as its own backend/transport pair, not as gemini-cli evidence."
+  },
+  "authority": {
+    "approval": "Maintainer re-authenticated Claude Code and, on 2026-09-10, pointed at the existing loopback OpenCodex proxy as the approved Gemini route (the same policy as docs/operations/remaining-work-20260905.md: loopback OpenCodex with an explicit google-antigravity/ model, no Gemini API key).",
+    "credentialPolicy": "OPENAI_API_KEY, GEMINI_API_KEY, ANTHROPIC_API_KEY and KIMI_API_KEY were unset in the pilot shell. Claude used the subscription OAuth session. The OpenCodex leg used PATINA_API_KEY=opencodex-local (a placeholder the proxy ignores) and PATINA_API_BASE=http://127.0.0.1:10100/v1; no provider key was read or sent.",
+    "budget": {"claudeInvocationsObserved": 7, "opencodexRequestsObserved": 6, "note": "Claude: A 1, B 4 (rewrite, verification, retry rewrite, verification), C 1 (killed), E 1 (rejected). OpenCodex: A 1, B 3 (rewrite + two verification calls), C 1 (aborted), E 1 (404)."}
+  },
+  "environment": {
+    "os": "Linux 6.8.0-138-generic x64",
+    "node": "v24.18.0",
+    "patina": "8.6.0 at dev 0ec1376 (after #798 removed agent tools from local CLI calls)",
+    "claude": "Claude Code 2.1.261, model claude-sonnet-4-6, invoked with --tools \"\" --strict-mcp-config",
+    "opencodex": "opencodex 2.33.0 listening on 127.0.0.1:10100, catalog of 38 routes including google-antigravity/gemini-3.1-pro, gemini-3.7-flash, gemini-3.8-flash-{low,medium,high}; route used: google-antigravity/gemini-3.7-flash",
+    "inputs": ["body of tests/fixtures/suspect-zones/en/ai/en-ai-01.md without frontmatter (EN, burstiness-only fixture)", "body of tests/fixtures/suspect-zones/ko/ai/ko-ai-01.md without frontmatter (424 bytes)"],
+    "inputNote": "Frontmatter was stripped because the earlier codex pilot showed the number-preservation gate rejecting rewrites that drop frontmatter statistics; that is a fixture-file artifact, not a backend property."
+  },
+  "claudeCli": {
+    "status": "verified",
+    "scenarios": [
+      {"id": "A-score", "exitCode": 0, "wallMs": 92076, "observed": "Strict scoring JSON parsed; LLM overall 2.2 (fixture is designed with no catalogued EN pattern)."},
+      {"id": "B-rewrite-verify", "exitCode": 0, "wallMs": 195137, "observed": "verified=true, mps 100, fidelity 100, reason passed-on-retry (one conservative retry)."},
+      {"id": "C-timeout", "exitCode": 1, "wallMs": 1640, "observed": "`claude-cli backend: timed out after 1499ms`; zero claude processes and no new temp directory one second later."},
+      {"id": "E-invalid-in-family-model", "exitCode": 1, "wallMs": 2179, "observed": "claude exited 1 with its model-catalog message; Patina surfaced it as a backend error and cleaned up."}
+    ],
+    "sessionLog": "~/.claude/projects/*patina-claude* sessions for the pilot window: 0 tool_use blocks and 0 mcp__ references in every session, confirming #798's --tools \"\" --strict-mcp-config on a live run. Score prompt cache read ~75k tokens (Claude Code system prompt + Patina score prompt); rewrite/verification ~18-25k.",
+    "sideObservation": "32 stale /tmp/patina-claude-* directories dated 2026-09-05 pre-date this pilot (earlier research runs); the pilot added none. Candidate cleanup, outside this record."
+  },
+  "geminiViaOpenCodex": {
+    "backend": "openai-http",
+    "transport": "loopback OpenCodex proxy",
+    "model": "google-antigravity/gemini-3.7-flash",
+    "status": "verified-for-this-transport",
+    "scenarios": [
+      {"id": "A-score", "exitCode": 0, "wallMs": 7095, "observed": "Strict scoring JSON parsed; LLM overall 0 on the no-pattern fixture."},
+      {"id": "B-rewrite-verify", "exitCode": 0, "wallMs": 12011, "observed": "verified=true, mps 100, fidelity 100, reason passed, no retry."},
+      {"id": "C-timeout", "exitCode": 1, "wallMs": 1611, "observed": "`LLM API deadline exceeded after attempt 1: This operation was aborted`; the HTTP client honoured --timeout-ms."},
+      {"id": "E-invalid-model", "exitCode": 1, "wallMs": 887, "observed": "HTTP 404 from the proxy (`Antigravity invalid request: Requested entity was not found`) surfaced as `LLM API failed after 1 attempts: HTTP 404`."}
+    ],
+    "identityCaveat": "OpenCodex echoes the requested alias as response.model; this record verifies Patina's HTTP contract against that route, not the upstream model identity (same caveat as docs/research/model-guide-20260905.md)."
+  },
+  "notExercised": [
+    {"backend": "gemini-cli", "version": "0.58.0", "reason": "Configured auth type is gemini-api-key, which would consume the product-only GEMINI_API_KEY. The #798 --policy deny-all was verified offline (flag parse) only."},
+    {"backend": "antigravity-cli (agy 1.1.26)", "reason": "Present on the host with an OAuth token, but Patina has no adapter for it; it is not a Patina backend today. Recorded as a candidate, not evidence."},
+    {"backend": "openai-http against api.openai.com", "reason": "Maintainer withdrew the OpenAI key from agent use."},
+    {"backend": "kimi-cli", "reason": "Would need KIMI_API_KEY or the Kimi OAuth session; not authorized in this pilot."}
+  ],
+  "acceptance": {
+    "P17b": "passed for codex-cli (prior record), claude-cli, and openai-http over loopback OpenCodex; gemini-cli and kimi-cli remain unverified",
+    "fixtures": ["tests/fixtures/backend-codex-contract.json", "tests/fixtures/backend-claude-contract.json"],
+    "notCovered": ["gemini-cli", "kimi-cli", "quota/rate-limit behavior", "other operating systems (P16b)", "other CLI versions or models"]
+  },
+  "boundaries": {
+    "productSourceChanged": false,
+    "versionBumped": false,
+    "publication": "none",
+    "researchRevived": false,
+    "credentialsRecorded": "none; auth mode names, placeholder key name, and HTTP status codes only"
+  }
+}

--- a/tests/fixtures/backend-claude-contract.json
+++ b/tests/fixtures/backend-claude-contract.json
@@ -3,30 +3,43 @@
   "backend": "claude-cli",
   "cli": "claude",
   "observedVersion": "2.1.261",
-  "observedAt": "2026-09-09",
-  "status": "unverified",
+  "observedAt": "2026-09-10",
+  "status": "verified",
   "evidence": {
-    "kind": "version-only",
-    "command": "claude --version",
-    "realInvocation": false,
-    "outputParsingVerified": false,
-    "errorsVerified": false,
-    "authVerified": false,
+    "kind": "real-invocation",
+    "record": "docs/operations/backend-compat-claude-gemini-20260910.json",
+    "realInvocation": true,
+    "outputParsingVerified": true,
+    "errorsVerified": true,
+    "authVerified": true,
     "quotaVerified": false,
-    "timeoutVerified": false
+    "timeoutVerified": true
   },
-  "syntheticFixture": true,
+  "syntheticFixture": false,
   "rawOutputIncluded": false,
+  "history": {
+    "2026-09-09": "version-only / unverified record from `claude --version` (P17a)."
+  },
+  "scope": {
+    "platform": "linux-x64",
+    "node": "24.18.0",
+    "patina": "8.6.0 at dev 0ec1376 (agent tools removed, #798)",
+    "model": "claude-sonnet-4-6",
+    "authPath": "Claude Code OAuth session (~/.claude/.credentials.json claudeAiOauth, subscription); no ANTHROPIC_API_KEY in the environment",
+    "invocations": 7,
+    "scenarios": ["score", "rewrite --verify", "timeout", "invalid in-family model"]
+  },
   "requiredContracts": {
-    "output": "claude -p stdout is passed to Patina's output parser; this version-only fixture does not exercise body framing or parsing.",
-    "errors": "Non-zero exits, signal termination, spawn failures, user aborts, and timeouts remain distinct runtime outcomes.",
-    "auth": "Authentication is the Claude credential-file check; a version response does not prove login or authorization.",
-    "quota": "Provider or account quota failures are external runtime failures, not successful output or compatibility evidence.",
-    "timeout": "Patina's bounded child-process timeout rejects and cleans the owned invocation; version output does not exercise this path."
+    "output": "claude -p stdout is parsed by Patina's output layer; strict scoring JSON and the [BODY]/[SELF_AUDIT] rewrite framing both parsed on this version with --tools \"\" --strict-mcp-config.",
+    "errors": "A non-zero claude exit is reported as a backend error with the child's stderr (the unknown-model catalog message); the owned temp directory is removed and no claude process survives.",
+    "auth": "Authentication is the claudeAiOauth token/expiry classification of ~/.claude/.credentials.json; the verified run used a live subscription session, not an API key.",
+    "quota": "No quota or rate-limit failure occurred in the pilot budget; quota behavior is not verified by this record.",
+    "timeout": "Patina's bounded child timer rejected a live invocation at the requested budget, SIGKILLed the owned child, and left no temp directory or process behind."
   },
   "limitations": [
     "No credential, prompt, model response, or raw CLI output is recorded.",
-    "This record does not verify invocation, output parsing, authentication, quota behavior, or timeout behavior.",
-    "No Windows coverage is claimed for POSIX process-lifecycle fixtures."
+    "Verified only for Claude Code 2.1.261 on Linux with claude-sonnet-4-6; other versions, platforms, and models are unverified.",
+    "Quota and rate-limit handling were not exercised.",
+    "This is a connectivity/contract check, not a rewrite-quality experiment."
   ]
 }

--- a/tests/unit/backend-contract.test.js
+++ b/tests/unit/backend-contract.test.js
@@ -142,48 +142,19 @@ test('backendSupportsStructuredOutput is true only for openai-http (#C2)', () =>
   assert.equal(backendSupportsStructuredOutput('mystery-backend'), false);
 });
 
-test('Claude CLI compatibility record remains version-only and unverified', () => {
-  const fixture = JSON.parse(readFileSync(
-    new URL('../fixtures/backend-claude-contract.json', import.meta.url),
-    'utf8',
-  ));
+// Shared shape check for a verified real-invocation compatibility record: the
+// fixture carries the verdict, the dated operations receipt carries the
+// per-scenario evidence, and neither may contain secrets or raw output.
+function assertVerifiedBackendRecord(fixture, { backend, cli, version, record }) {
   assert.equal(fixture.schemaVersion, 1);
-  assert.equal(fixture.backend, 'claude-cli');
-  assert.equal(fixture.cli, 'claude');
-  assert.equal(fixture.observedVersion, '2.1.261');
-  assert.equal(fixture.status, 'unverified');
-  assert.deepEqual(fixture.evidence, {
-    kind: 'version-only',
-    command: 'claude --version',
-    realInvocation: false,
-    outputParsingVerified: false,
-    errorsVerified: false,
-    authVerified: false,
-    quotaVerified: false,
-    timeoutVerified: false,
-  });
-  assert.equal(fixture.syntheticFixture, true);
-  assert.equal(fixture.rawOutputIncluded, false);
-  assert.deepEqual(Object.keys(fixture.requiredContracts), ['output', 'errors', 'auth', 'quota', 'timeout']);
-  assert.equal(Object.hasOwn(fixture, 'credentials'), false);
-});
-
-test('Codex CLI compatibility record is a real-invocation verification without raw output', () => {
-  const fixture = JSON.parse(readFileSync(
-    new URL('../fixtures/backend-codex-contract.json', import.meta.url),
-    'utf8',
-  ));
-  assert.equal(fixture.schemaVersion, 1);
-  assert.equal(fixture.backend, 'codex-cli');
-  assert.equal(fixture.cli, 'codex');
-  assert.equal(fixture.observedVersion, '0.153.4');
+  assert.equal(fixture.backend, backend);
+  assert.equal(fixture.cli, cli);
+  assert.equal(fixture.observedVersion, version);
   assert.equal(fixture.status, 'verified');
   assert.equal(fixture.evidence.kind, 'real-invocation');
   assert.equal(fixture.evidence.realInvocation, true);
-  // A verified record must point at the dated operations receipt that holds
-  // the per-scenario evidence; the fixture itself carries only the verdict.
-  assert.equal(fixture.evidence.record, 'docs/operations/backend-compat-codex-20260910.json');
-  assert.equal(existsSync(new URL(`../../${fixture.evidence.record}`, import.meta.url)), true);
+  assert.equal(fixture.evidence.record, record);
+  assert.equal(existsSync(new URL(`../../${record}`, import.meta.url)), true);
   for (const flag of ['outputParsingVerified', 'errorsVerified', 'authVerified', 'timeoutVerified']) {
     assert.equal(fixture.evidence[flag], true, flag);
   }
@@ -192,10 +163,38 @@ test('Codex CLI compatibility record is a real-invocation verification without r
   assert.equal(fixture.syntheticFixture, false);
   assert.equal(fixture.rawOutputIncluded, false);
   assert.deepEqual(Object.keys(fixture.requiredContracts), ['output', 'errors', 'auth', 'quota', 'timeout']);
-  assert.equal(Object.hasOwn(fixture, 'credentials'), false);
-  assert.equal(Object.hasOwn(fixture, 'prompt'), false);
-  assert.equal(Object.hasOwn(fixture, 'response'), false);
+  for (const key of ['credentials', 'prompt', 'response']) {
+    assert.equal(Object.hasOwn(fixture, key), false, key);
+  }
   assert.ok(Number.isInteger(fixture.scope.invocations) && fixture.scope.invocations > 0);
+}
+
+test('Claude CLI compatibility record is a real-invocation verification without raw output', () => {
+  const fixture = JSON.parse(readFileSync(
+    new URL('../fixtures/backend-claude-contract.json', import.meta.url),
+    'utf8',
+  ));
+  assertVerifiedBackendRecord(fixture, {
+    backend: 'claude-cli',
+    cli: 'claude',
+    version: '2.1.261',
+    record: 'docs/operations/backend-compat-claude-gemini-20260910.json',
+  });
+  // The earlier version-only status is retained as history, not erased.
+  assert.match(fixture.history['2026-09-09'], /version-only/);
+});
+
+test('Codex CLI compatibility record is a real-invocation verification without raw output', () => {
+  const fixture = JSON.parse(readFileSync(
+    new URL('../fixtures/backend-codex-contract.json', import.meta.url),
+    'utf8',
+  ));
+  assertVerifiedBackendRecord(fixture, {
+    backend: 'codex-cli',
+    cli: 'codex',
+    version: '0.153.4',
+    record: 'docs/operations/backend-compat-codex-20260910.json',
+  });
 });
 
 test('isRetryableBackendError honors message status even when err.status is null (#445)', () => {


### PR DESCRIPTION
## 목적 / 연결 Issue
Refs #783. Extends P17b to the remaining authorized routes after the maintainer re-authenticated Claude Code and confirmed the loopback OpenCodex proxy as the Gemini route (no Gemini API key). Runs were made on dev `0ec1376`, i.e. after #798 removed agent tools.

## 범위 / 비목표
Docs + fixture + test only. `tests/fixtures/backend-claude-contract.json` moves from version-only/unverified (P17a) to real-invocation/verified, with the old status kept under `history`. New receipt `docs/operations/backend-compat-claude-gemini-20260910.json`. The shared shape assertion in `backend-contract.test.js` now covers both verified fixtures.
Not claimed: gemini-cli (api-key mode would spend the product key), kimi-cli, `agy` (no adapter), quota, other OS.

## 계약 / 위험 / 크기
contract: not-applicable; risk: low; 5 files.

## 검증
**claude-cli 2.1.261** (claude-sonnet-4-6, subscription OAuth, keys unset), 7 invocations: score exit 0 (92 s); `--verify` passed on retry mps 100 / fidelity 100 (195 s); `--timeout-ms 1500` rejected at 1499 ms with 0 processes and no temp dir; bogus in-family model → claude exit 1 surfaced as backend error. Session log: 0 `tool_use`, 0 `mcp__` references — live confirmation of #798.
**openai-http over OpenCodex** (`PATINA_API_BASE=http://127.0.0.1:10100/v1`, placeholder key, `google-antigravity/gemini-3.7-flash`), 6 requests: score exit 0 (7 s); `--verify` passed first try mps 100 / fidelity 100 (12 s); timeout aborted at 1.6 s; bogus route → HTTP 404 surfaced. Identity caveat recorded (proxy echoes the alias).
Local: `node --test tests/unit/backend-contract.test.js`, `npm run lint`, `npm run check:no-private-assets`, `npm run release:check` — exit 0.

## 릴리스 / 되돌리기
semver: none. Rollback: revert.
