### PR TITLE
docs(workflow): close P09 — native Codex review not used; review lane is architect pass + CI

### DIFF
--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -216,9 +216,10 @@ specific reason. If an applicable profile is unavailable, record
 ### Independent review lane
 
 **Decision (P09, 2026-09-10, maintainer):** native Codex GitHub review is not
-used for this repository. No `chatgpt-codex-connector[bot]` review or comment
-exists on any PR, no workflow requests one, and the maintainer chose not to
-enable it. The required review lane for a `bot/*` PR is one independent,
+used for this repository. A repository-wide GitHub search for
+`chatgpt-codex-connector[bot]` comments and a check of five recent PRs found
+no evidence of native Codex review use, no workflow requests one, and the
+maintainer chose not to enable it. Account-side settings were not inspected. The required review lane for a `bot/*` PR is one independent,
 read-only review pass (the session's `architect` agent or an equivalent
 reviewer that did not write the change) plus the full deterministic CI
 (lint, unit/e2e, quality, architecture boundaries). The `vercel` bot only

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -192,7 +192,7 @@ scope + acceptance criteria + isolated worktree
   → Draft PR + cheap targeted checks and normal deterministic CI
   → current size, risk, rollback, and SHA/tree evidence
   → Ready
-  → required expensive Codex review and/or browser/execution QA
+  → independent read-only review lane and/or browser/execution QA
   → maintainer decision and merge
 ```
 
@@ -213,17 +213,22 @@ The sole `not run` result is a documented non-applicability decision with a
 specific reason. If an applicable profile is unavailable, record
 `inconclusive`; `not run` is never a waiver.
 
-### Codex review requests
+### Independent review lane
 
-Use at most **one Codex code-review request per PR/head/diff**. Whether native
-Codex automation runs on Draft, Ready, or a new push is **unknown until P09
-confirms the repository's actual native settings**. Do not invent a label,
-Action, trigger, or external configuration and do not report one as enabled.
-Until that check is complete, no automatic path is assumed; use one explicit,
-authorized request path when review is needed. If native settings cannot
-enforce the Ready-plus-cheap-CI condition, disable automatic calls and keep
-the explicit single path. Never run GitHub Codex, an Action, and Desktop
-review against the same diff.
+**Decision (P09, 2026-09-10, maintainer):** native Codex GitHub review is not
+used for this repository. No `chatgpt-codex-connector[bot]` review or comment
+exists on any PR, no workflow requests one, and the maintainer chose not to
+enable it. The required review lane for a `bot/*` PR is one independent,
+read-only review pass (the session's `architect` agent or an equivalent
+reviewer that did not write the change) plus the full deterministic CI
+(lint, unit/e2e, quality, architecture boundaries). The `vercel` bot only
+builds a preview; it reads no code and is not a review.
+
+Use at most **one independent review per PR/head/diff** and record its
+verdict and findings in the PR body. Do not invent a label, Action, trigger,
+or external configuration and do not report one as enabled. Re-enabling native
+Codex review is a maintainer decision and would replace, not add to, the
+independent pass; never run two reviewers against the same diff.
 
 After a finding is fixed, keep it on the same PR and update the evidence.
 Automatic fix/review cycles stop after 2 retries; the owner then re-scopes the

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -165,7 +165,9 @@ moves from version-only to verified. Still not exercised: gemini-cli
 quota behavior, other operating systems.
 
 P09 was closed on 2026-09-10 by maintainer decision: native Codex GitHub
-review is not used (zero bot reviews on any PR, no workflow requests one);
+review is not used (a repository-wide search for `chatgpt-codex-connector[bot]`
+comments and a five-PR spot check found no evidence of use; no workflow
+requests one; account-side settings were not inspected);
 the review lane is the independent read-only pass plus full CI described in
 [`docs/WORKFLOW.md`](../WORKFLOW.md#independent-review-lane). Unexposed web
 account configuration remains unknown; no automation is inferred from a

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -164,8 +164,12 @@ moves from version-only to verified. Still not exercised: gemini-cli
 (api-key mode would spend the product key), kimi-cli, `agy` (no adapter),
 quota behavior, other operating systems.
 
-P09 native Codex settings and any unexposed web account configuration remain
-unknown; no automation is inferred from a deployment result. The recurring
+P09 was closed on 2026-09-10 by maintainer decision: native Codex GitHub
+review is not used (zero bot reviews on any PR, no workflow requests one);
+the review lane is the independent read-only pass plus full CI described in
+[`docs/WORKFLOW.md`](../WORKFLOW.md#independent-review-lane). Unexposed web
+account configuration remains unknown; no automation is inferred from a
+deployment result. The recurring
 maintenance owner is the repository maintainer. Repeated alerts for one
 repository/channel/tier/deployment/trigger/window are deduplicated into one
 incident record with a next-review date; retries are bounded and do not create


### PR DESCRIPTION
Refs #783. Maintainer decision 2026-09-10: native Codex GitHub review is not used. Evidence: zero `chatgpt-codex-connector[bot]` reviews/comments on any PR (checked #781–#799 and a repo-wide search), no workflow requests one, `dev` has no branch protection requiring reviews. The review lane stays what it has been in practice today: one independent read-only architect pass + full CI. `vercel` bot only builds previews.

Docs only: `docs/WORKFLOW.md` (section renamed to *Independent review lane*, decision recorded), `docs/operations/README.md` P09 line. Verification: `npm run lint`, workflow/pr-policy/retired-concepts unit tests pass. semver: none. Rollback: revert.