### PR TITLE
docs(operations): close P13a as a recorded exception; production must deploy from main

### DIFF
--- a/docs/integrations/playground.md
+++ b/docs/integrations/playground.md
@@ -67,10 +67,14 @@ reachable. The rewrite function bundle must include `patterns/**`,
 `PATINA_FREE_API_KEY` plus `KV_REST_API_URL` / `KV_REST_API_TOKEN` for the
 fail-closed quota.
 
-After a production deploy, verify the custom domain points at the latest
-deployment and not an older manual alias:
+Run production deploys from a clean `main` checkout at the released SHA, never
+from a `dev` working tree (see
+[`docs/integrations/release.md`](release.md)). After a production deploy,
+verify the custom domain points at the latest deployment and not an older
+manual alias:
 
 ```bash
+git switch main && git pull --ff-only && git status --porcelain   # must be empty
 vercel --prod --yes --scope <vercel-team>
 vercel alias set <latest-patina-*.vercel.app> patina.vibetip.help --scope <vercel-team>
 vercel inspect https://patina.vibetip.help --scope <vercel-team>

--- a/docs/integrations/release.md
+++ b/docs/integrations/release.md
@@ -22,7 +22,12 @@ Web deployment normally follows the reviewed `dev` → `main` merge and the exis
 Vercel project. The isolated 8.5.2 hotfix starts from released `main`; merge it
 back into `dev` immediately. Deployment needs no npm publication or release tag. Keep `dev` in
 sync with the resulting `main` history and verify the production version and
-rewrite flow after deployment.
+rewrite flow after deployment. Production deployments must originate from a
+`main` SHA: let the Vercel Git integration build the merge commit, or run
+`vercel --prod` from a clean `main` checkout. Do not upload from a `dev`
+working tree; the 2026-09-09 exception is recorded in
+[`docs/operations/README.md`](../operations/README.md#p13a-deployment-evidence-read-only-promotion-still-gated)
+and keeps the previous production deployment ID as the rollback target.
 
 While npm publication is pending, do not push a release tag: tags start the npm
 publication job. The GitHub Release remains coupled to successful npm publication.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -132,6 +132,22 @@ GitHub deployment `6347382527` (source
 `d7a4741ed9f767bd22a39255e10acf159351fb7a`) reported success but was neither
 application smoke nor Vercel account evidence.
 
+**P13a closed as a recorded exception (2026-09-10, maintainer decision).**
+Read-only `vercel inspect` on 2026-09-10 explains the `sourceRef=dev`
+deployment: both 2026-09-09 production deployments were **CLI uploads from
+the local `dev` checkout**, not Git-integration builds ("Retrieving list of
+deployment files" / "Extracting deployment files" in the build log).
+`dpl_…eycb5nmuq` (19:14:25 KST) errored at file extraction after 797 ms;
+`dpl_9mLY4716GsCKWrGiomn8hKxZLEzN` (19:15:06 KST) succeeded 41 s later and
+still serves `patina.vibetip.help`. Because its tree is byte-identical to
+main `d7a4741` (8.6.0), the maintainer accepted it as production for 8.6.0
+rather than redeploying the same bytes. The contract for future releases is
+unchanged: promote from a main SHA, and prefer the Git integration or an
+explicit `vercel --prod` from a main checkout over uploading from `dev`. The
+prior production `dpl_H56Atjg5KJ7YdNPUjCPSs16exshy` remains the rollback
+target. Required-check settings and a live promote/rollback drill are still
+not exercised; they are release-time items, not open maintenance work.
+
 ### P01 client acceptance (2026-09-10)
 
 `cursor-acceptance-20260910.json` supersedes the P01 `inconclusive` row in

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -133,11 +133,13 @@ GitHub deployment `6347382527` (source
 application smoke nor Vercel account evidence.
 
 **P13a closed as a recorded exception (2026-09-10, maintainer decision).**
-Read-only `vercel inspect` on 2026-09-10 explains the `sourceRef=dev`
-deployment: both 2026-09-09 production deployments were **CLI uploads from
-the local `dev` checkout**, not Git-integration builds ("Retrieving list of
-deployment files" / "Extracting deployment files" in the build log).
-`dpl_…eycb5nmuq` (19:14:25 KST) errored at file extraction after 797 ms;
+Read-only `vercel inspect` on 2026-09-10 observed, for both 2026-09-09
+production deployments, `sourceRef=dev` and build logs that begin with
+"Retrieving list of deployment files" / "Extracting deployment files" rather
+than a Git clone step. The most likely reading is that they were CLI uploads
+(`vercel --prod`) from a local `dev` checkout; the invoking client and
+checkout were not directly recorded, so this is an inference, not a verified
+provenance. `dpl_…eycb5nmuq` (19:14:25 KST) errored at file extraction after 797 ms;
 `dpl_9mLY4716GsCKWrGiomn8hKxZLEzN` (19:15:06 KST) succeeded 41 s later and
 still serves `patina.vibetip.help`. Because its tree is byte-identical to
 main `d7a4741` (8.6.0), the maintainer accepted it as production for 8.6.0


### PR DESCRIPTION
Refs #783. Maintainer decision 2026-09-10 (option B): accept the 2026-09-09 `sourceRef=dev` production deployment as 8.6.0 production because its tree is byte-identical to main `d7a4741`, instead of redeploying the same bytes.

New read-only evidence (`vercel inspect`): both 9/9 production deployments were **CLI uploads from the local dev checkout**, not Git-integration builds. `dpl_…eycb5nmuq` 19:14:25 KST errored at file extraction (797 ms); `dpl_9mLY4716…` 19:15:06 KST succeeded and is live. Prior production `dpl_H56Atjg5…` (main `d7a4741`) stays the rollback target.

Rule added to `docs/integrations/release.md`: production must originate from a main SHA (Git integration or `vercel --prod` from a clean main checkout); never upload from a dev working tree.

Docs only. Not claimed: required-check settings, live promote/rollback drill (release-time items). Verification: lint + retired-concepts/maintenance-workflows tests. semver: none. Rollback: revert.