### PR TITLE
feat(doctor): probe the default HTTP key instead of trusting its presence

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -58,7 +58,7 @@ in a stable envelope:
 - Score JSON may include `scores.llm`, `scores.deterministic`, and `scores.preference` when deterministic shadow scoring is available.
 - `mps` is populated when the underlying mode emits it.
 - `gateResult` is `null` unless `--exit-on` is used.
-- `patina doctor --json` emits setup diagnostics for CI without making an LLM call.
+- `patina doctor --json` emits setup diagnostics for CI without making an LLM call. It does make two small network requests by default — one `GET /models` against the configured HTTP base URL to confirm the key is accepted (a 401/403 downgrades `openai-http` to `authenticated=no`), and one npm registry lookup for updates. `--no-probe`, `--no-update-check`, or `--offline` skip them; network failures are informational, never blockers.
 
 
 ## Meaning verification: `--verify`

--- a/docs/operations/backend-compat-claude-gemini-20260910.json
+++ b/docs/operations/backend-compat-claude-gemini-20260910.json
@@ -35,7 +35,7 @@
       {"id": "E-invalid-in-family-model", "exitCode": 1, "wallMs": 2179, "observed": "claude exited 1 with its model-catalog message; Patina surfaced it as a backend error and cleaned up."}
     ],
     "sessionLog": "~/.claude/projects/*patina-claude* sessions for the pilot window: 0 tool_use blocks and 0 mcp__ references in every session, confirming #798's --tools \"\" --strict-mcp-config on a live run. Score prompt cache read ~75k tokens (Claude Code system prompt + Patina score prompt); rewrite/verification ~18-25k.",
-    "sideObservation": "32 stale /tmp/patina-claude-* directories dated 2026-09-05 pre-date this pilot (earlier research runs); the pilot added none. Candidate cleanup, outside this record."
+    "sideObservation": "Correction (2026-09-10, later the same day): the '32 stale /tmp/patina-claude-* directories' first noted here were research scratch files named patina-claude-*.log/.mjs from 2026-09-05, not adapter temp directories. A pattern-exact scan for mkdtemp-style patina-{claude,codex,gemini,kimi,agy}-XXXXXX directories found exactly one orphan, /tmp/patina-codex-AkCVBR (empty, 2026-09-06 02:30, a run killed before cleanup), which was removed. The pilot itself left none; no adapter cleanup defect is indicated."
   },
   "geminiViaOpenCodex": {
     "backend": "openai-http",

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
-import { HTTP_KEY_ENV_VARS, inspectHttpApiKeySource, providerHttpKeyEnvVars } from '../auth.js';
+import { HTTP_KEY_ENV_VARS, inspectHttpApiKeySource, providerHttpKeyEnvVars, resolveHttpApiKey } from '../auth.js';
 import { listBackends } from '../backends/index.js';
-import { PROVIDERS } from '../providers.js';
+import { PROVIDERS, resolveProviderConfig } from '../providers.js';
 import { inputError } from '../errors.js';
 
 const MIN_NODE_MAJOR = 18;
@@ -14,6 +14,11 @@ export async function runDoctor(args = [], { version, fetchImpl } = {}) {
   }
 
   const report = buildDoctorReport({ version });
+  if (parsed.probe) {
+    await appendApiKeyProbe(report, { fetchImpl });
+  } else {
+    report.apiKeyProbe = { attempted: false, host: null, status: null, ok: null, error: null };
+  }
   if (parsed.updateCheck) {
     await appendUpdateCheck(report, { version, fetchImpl });
   }
@@ -30,6 +35,106 @@ export async function runDoctor(args = [], { version, fetchImpl } = {}) {
 
 export const NPM_LATEST_URL = 'https://registry.npmjs.org/patina-cli/latest';
 const UPDATE_CHECK_TIMEOUT_MS = 3000;
+const API_KEY_PROBE_TIMEOUT_MS = 3000;
+
+/**
+ * Ask the default HTTP endpoint whether the configured key is actually
+ * accepted, and fold the answer into the report.
+ *
+ * `api-key-env` only proves a key is present. A revoked or mistyped key
+ * still reads `authenticated=yes` and fails on the first real call
+ * (observed 2026-09-10: OPENAI_API_KEY set, provider answering 401). The
+ * probe is one `GET {baseURL}/models` with the same bearer header a rewrite
+ * would send, so nothing is sent anywhere the key would not go anyway.
+ *
+ * Outcomes: 2xx = accepted (ok); 401/403 = rejected (warning, and the
+ * openai-http backend stops counting as authenticated so `usable-backend`
+ * tells the truth); anything else (timeout, DNS, 5xx, odd status) =
+ * inconclusive (informational ok, never a blocker). Never throws.
+ */
+export async function appendApiKeyProbe(report, { fetchImpl = globalThis.fetch, timeoutMs = API_KEY_PROBE_TIMEOUT_MS } = {}) {
+  const backend = report.backends.find((b) => b.name === 'openai-http');
+  let apiKey = null;
+  try {
+    apiKey = resolveHttpApiKey() || null;
+  } catch {
+    apiKey = null;
+  }
+  if (!apiKey || !backend) {
+    report.apiKeyProbe = { attempted: false, host: null, status: null, ok: null, error: null };
+    return report;
+  }
+
+  const { baseURL } = resolveProviderConfig({});
+  const url = `${String(baseURL).replace(/\/+$/, '')}/models`;
+  let host;
+  try {
+    host = new URL(url).host;
+  } catch {
+    host = String(baseURL);
+  }
+
+  let status = null;
+  let error = null;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      method: 'GET',
+      signal: controller.signal,
+      headers: { authorization: `Bearer ${apiKey}`, accept: 'application/json' },
+    });
+    status = Number(response.status) || null;
+  } catch (err) {
+    error = err?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : String(err?.message ?? err);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const accepted = status !== null && status >= 200 && status < 300;
+  const rejected = status === 401 || status === 403;
+  const ok = accepted ? true : (rejected ? false : null);
+  report.apiKeyProbe = { attempted: true, host, status, ok, error };
+  backend.keyProbe = ok === null ? 'inconclusive' : (ok ? 'accepted' : 'rejected');
+
+  if (rejected) {
+    // Presence is not validity: a key the provider refuses cannot run a
+    // rewrite, so the backend is not usable and the aggregate check must
+    // recount rather than keep the presence-based verdict.
+    backend.authenticated = false;
+    backend.authHint = `The provider at ${host} rejected the configured key (HTTP ${status}). Replace the key or point PATINA_API_BASE at the right endpoint.`;
+    recountUsableBackends(report);
+  }
+
+  report.checks.push({
+    name: 'api-key-probe',
+    status: rejected ? 'warning' : 'ok',
+    summary: accepted
+      ? `default HTTP key accepted by ${host}`
+      : (rejected ? `default HTTP key rejected by ${host} (HTTP ${status})` : 'default HTTP key not verified'),
+    detail: accepted
+      ? 'GET /models answered 2xx with the configured bearer key'
+      : (rejected
+        ? 'presence alone is not authentication; replace the key or select a working backend'
+        : `could not probe ${host} (${error || `HTTP ${status}`}); the key may still work`),
+  });
+  return report;
+}
+
+function recountUsableBackends(report) {
+  const usable = report.backends.filter((b) => b.available && b.authenticated);
+  const check = report.checks.find((c) => c.name === 'usable-backend');
+  if (check) {
+    check.status = usable.length > 0 ? 'ok' : 'blocker';
+    check.summary = usable.length > 0 ? `${usable.length} authenticated backend(s)` : 'no authenticated backend';
+    check.detail = usable.length > 0
+      ? usable.map((b) => b.name).join(', ')
+      : 'Set a working API key or authenticate one local backend (`codex login`, `claude`, `gemini`, or `agy`).';
+  }
+  const blockers = report.checks.filter((c) => c.status === 'blocker');
+  report.ok = blockers.length === 0;
+  report.blockers = blockers.map((c) => ({ name: c.name, summary: c.summary, detail: c.detail }));
+}
 
 /** Numeric x.y.z compare; returns 1/0/-1, or null when either side is unparseable. */
 export function compareSemver(a, b) {
@@ -183,7 +288,7 @@ export function buildDoctorReport({ version } = {}) {
 }
 
 function parseDoctorArgs(args) {
-  const parsed = { format: 'text', updateCheck: true };
+  const parsed = { format: 'text', updateCheck: true, probe: true };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     switch (arg) {
@@ -196,6 +301,13 @@ function parseDoctorArgs(args) {
         break;
       case '--no-update-check':
         parsed.updateCheck = false;
+        break;
+      case '--no-probe':
+        parsed.probe = false;
+        break;
+      case '--offline':
+        parsed.updateCheck = false;
+        parsed.probe = false;
         break;
       case '--format': {
         const value = args[++i];
@@ -212,7 +324,7 @@ function parseDoctorArgs(args) {
       default:
         throw inputError(
           `unknown doctor option ${arg}`,
-          'The doctor command only accepts --json, --format, --no-update-check, and --help.',
+          'The doctor command only accepts --json, --format, --no-update-check, --no-probe, --offline, and --help.',
           'Run `patina doctor --help` for usage.'
         );
     }
@@ -258,8 +370,9 @@ function formatDoctorText(report) {
   for (const backend of report.backends) {
     const ok = backend.available && backend.authenticated;
     const images = backend.supportsImages ? ', images=yes' : '';
+    const probe = backend.keyProbe ? `, key=${backend.keyProbe}` : '';
     lines.push(
-      `  ${ok ? '✓' : '!'} ${backend.name}: available=${yesNo(backend.available)}, authenticated=${yesNo(backend.authenticated)}${images}`
+      `  ${ok ? '✓' : '!'} ${backend.name}: available=${yesNo(backend.available)}, authenticated=${yesNo(backend.authenticated)}${probe}${images}`
     );
     if (!ok && backend.authHint) lines.push(`    → ${backend.authHint}`);
   }
@@ -289,12 +402,15 @@ function yesNo(value) {
 function printDoctorHelp() {
   console.log(`patina doctor — check local CLI readiness
 
-Usage: patina doctor [--json] [--no-update-check]
+Usage: patina doctor [--json] [--no-update-check] [--no-probe] [--offline]
 
 Checks Node version, patina CLI version, backend availability/authentication,
-tmux, PATINA/provider API key environment variables, and whether a newer
-patina-cli is on npm (skip with --no-update-check; offline failures are
-informational, never blockers). Exits 0 when no blockers are found, or 1 when
-a blocking setup issue is detected.
+tmux, PATINA/provider API key environment variables, whether the default HTTP
+key is actually accepted (one GET /models against the configured base URL;
+skip with --no-probe), and whether a newer patina-cli is on npm (skip with
+--no-update-check). --offline skips both network checks. Network failures are
+informational, never blockers; a key the provider rejects with 401/403 is a
+warning and no longer counts as an authenticated backend. Exits 0 when no
+blockers are found, or 1 when a blocking setup issue is detected.
 `);
 }

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -158,10 +158,13 @@ export async function appendApiKeyProbe(report, { fetchImpl = globalThis.fetch, 
 
 // Strip the key value and any `scheme://user:pass@` userinfo from text that
 // may be printed or serialised. Fetch and URL errors can echo the request URL.
+// The userinfo match is greedy up to the LAST `@` before the path, matching
+// how URL parsers split `user:p@ss@host`; a first-`@` match would leave the
+// password tail behind.
 export function redactSecrets(text, apiKey) {
   let out = String(text ?? '');
   if (apiKey) out = out.split(apiKey).join('***');
-  return out.replace(/(\w+:\/\/)[^/@\s]+@/g, '$1***@');
+  return out.replace(/(\w+:\/\/)[^/\s]*@/g, '$1***@');
 }
 
 function recountUsableBackends(report) {

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,7 +1,10 @@
 import { spawnSync } from 'node:child_process';
 import { HTTP_KEY_ENV_VARS, inspectHttpApiKeySource, providerHttpKeyEnvVars, resolveHttpApiKey } from '../auth.js';
 import { listBackends } from '../backends/index.js';
-import { PROVIDERS, resolveProviderConfig } from '../providers.js';
+import { loadConfig } from '../config.js';
+import { PROVIDERS, resolveProviderConfig, selectProvider } from '../providers.js';
+import { validateBaseURL } from '../security.js';
+import { nativeAnthropicEnabled, nativeHeaders } from '../anthropic-native.js';
 import { inputError } from '../errors.js';
 
 const MIN_NODE_MAJOR = 18;
@@ -45,34 +48,60 @@ const API_KEY_PROBE_TIMEOUT_MS = 3000;
  * still reads `authenticated=yes` and fails on the first real call
  * (observed 2026-09-10: OPENAI_API_KEY set, provider answering 401). The
  * probe is one `GET {baseURL}/models` with the same bearer header a rewrite
- * would send, so nothing is sent anywhere the key would not go anyway.
+ * would send, resolved exactly the way a rewrite resolves it (config file
+ * provider/base URL, provider key env order, PATINA_* env) and gated by the
+ * same validateBaseURL guard, so the key goes nowhere a rewrite would not
+ * send it and never to a destination a rewrite would refuse.
  *
  * Outcomes: 2xx = accepted (ok); 401/403 = rejected (warning, and the
  * openai-http backend stops counting as authenticated so `usable-backend`
- * tells the truth); anything else (timeout, DNS, 5xx, odd status) =
- * inconclusive (informational ok, never a blocker). Never throws.
+ * tells the truth); anything else (timeout, DNS, 5xx, 404 from a proxy
+ * without /models, refused base URL) = inconclusive (informational ok, never
+ * a blocker). Never throws. Error text is redacted of the key value and of
+ * any credentials embedded in the base URL.
  */
-export async function appendApiKeyProbe(report, { fetchImpl = globalThis.fetch, timeoutMs = API_KEY_PROBE_TIMEOUT_MS } = {}) {
+export async function appendApiKeyProbe(report, { fetchImpl = globalThis.fetch, timeoutMs = API_KEY_PROBE_TIMEOUT_MS, config = null } = {}) {
   const backend = report.backends.find((b) => b.name === 'openai-http');
-  let apiKey = null;
-  try {
-    apiKey = resolveHttpApiKey() || null;
-  } catch {
-    apiKey = null;
-  }
-  if (!apiKey || !backend) {
-    report.apiKeyProbe = { attempted: false, host: null, status: null, ok: null, error: null };
+  const notAttempted = { attempted: false, host: null, status: null, ok: null, error: null };
+  if (!backend) {
+    report.apiKeyProbe = notAttempted;
     return report;
   }
 
-  const { baseURL } = resolveProviderConfig({});
-  const url = `${String(baseURL).replace(/\/+$/, '')}/models`;
-  let host;
+  let resolved;
+  let apiKey = null;
   try {
-    host = new URL(url).host;
-  } catch {
-    host = String(baseURL);
+    const effective = config || loadConfig();
+    const provider = selectProvider(effective.provider);
+    apiKey = resolveHttpApiKey({ envVars: providerHttpKeyEnvVars(provider?.apiKeyEnv) }) || null;
+    if (!apiKey) {
+      report.apiKeyProbe = notAttempted;
+      return report;
+    }
+    resolved = resolveProviderConfig({ provider, apiKey, baseURL: effective.baseURL ?? effective['base-url'] });
+    validateBaseURL(resolved.baseURL);
+  } catch (err) {
+    // Unknown provider, unreadable key file, or a base URL a rewrite would
+    // refuse: nothing is sent, and the reason is reported without the key.
+    report.apiKeyProbe = { attempted: false, host: null, status: null, ok: null, error: redactSecrets(String(err?.message ?? err), apiKey) };
+    backend.keyProbe = 'inconclusive';
+    report.checks.push({
+      name: 'api-key-probe',
+      status: 'ok',
+      summary: 'default HTTP key not verified',
+      detail: `probe skipped (${report.apiKeyProbe.error}); the key may still work`,
+    });
+    return report;
   }
+
+  const url = `${String(resolved.baseURL).replace(/\/+$/, '')}/models`;
+  // host excludes any userinfo; validateBaseURL already proved the URL parses.
+  const host = new URL(url).host;
+  // Same authentication headers a rewrite would send on this base URL: the
+  // opt-in native Anthropic mode uses x-api-key, everything else a bearer.
+  const authHeaders = nativeAnthropicEnabled({ baseURL: resolved.baseURL })
+    ? nativeHeaders(apiKey)
+    : { authorization: `Bearer ${apiKey}` };
 
   let status = null;
   let error = null;
@@ -82,12 +111,18 @@ export async function appendApiKeyProbe(report, { fetchImpl = globalThis.fetch, 
     const response = await fetchImpl(url, {
       method: 'GET',
       signal: controller.signal,
-      headers: { authorization: `Bearer ${apiKey}`, accept: 'application/json' },
+      headers: { ...authHeaders, accept: 'application/json' },
     });
     status = Number(response.status) || null;
+    // fetch resolves at headers; only the status matters, so drop the body
+    // instead of leaving a streaming catalog response open past the budget.
+    try { await response.body?.cancel?.(); } catch {}
   } catch (err) {
-    error = err?.name === 'AbortError' ? `timed out after ${timeoutMs}ms` : String(err?.message ?? err);
+    error = err?.name === 'AbortError'
+      ? `timed out after ${timeoutMs}ms`
+      : redactSecrets(String(err?.message ?? err), apiKey);
   } finally {
+    controller.abort();
     clearTimeout(timer);
   }
 
@@ -119,6 +154,14 @@ export async function appendApiKeyProbe(report, { fetchImpl = globalThis.fetch, 
         : `could not probe ${host} (${error || `HTTP ${status}`}); the key may still work`),
   });
   return report;
+}
+
+// Strip the key value and any `scheme://user:pass@` userinfo from text that
+// may be printed or serialised. Fetch and URL errors can echo the request URL.
+export function redactSecrets(text, apiKey) {
+  let out = String(text ?? '');
+  if (apiKey) out = out.split(apiKey).join('***');
+  return out.replace(/(\w+:\/\/)[^/@\s]+@/g, '$1***@');
 }
 
 function recountUsableBackends(report) {

--- a/tests/e2e/cli-adoption.test.js
+++ b/tests/e2e/cli-adoption.test.js
@@ -74,9 +74,12 @@ describe('CLI adoption commands', () => {
     process.exitCode = undefined;
     try {
       await withEnv({ PATINA_API_KEY: 'test-key', PATINA_API_KEY_FILE: undefined }, async () => {
-        const { logs } = await captureConsole(() => main(['doctor', '--json']));
+        // --no-probe: the fake key must not be sent to a real provider, and
+        // the presence-based verdict is what this test pins.
+        const { logs } = await captureConsole(() => main(['doctor', '--json', '--no-probe']));
         const report = JSON.parse(logs.join('\n'));
         assert.strictEqual(report.ok, true);
+        assert.deepEqual(report.apiKeyProbe, { attempted: false, host: null, status: null, ok: null, error: null });
         assert.ok(report.node.ok);
         assert.ok(report.backends.some((backend) => backend.name === 'openai-http'));
         assert.ok(report.providers.some((provider) => provider.name === 'openai'));
@@ -101,7 +104,7 @@ describe('CLI adoption commands', () => {
         KIMI_API_KEY: undefined,
         MOONSHOT_API_KEY: undefined,
       }, async () => {
-        const { logs } = await captureConsole(() => main(['doctor']));
+        const { logs } = await captureConsole(() => main(['doctor', '--offline']));
         const output = logs.join('\n');
         assert.strictEqual(process.exitCode, 1);
         assert.match(output, /^patina doctor — blockers found/);
@@ -131,7 +134,7 @@ describe('CLI adoption commands', () => {
         MOONSHOT_API_KEY: undefined,
         PATINA_API_KEY_FILE: keyFile,
       }, async () => {
-        const { logs } = await captureConsole(() => main(['doctor', '--json']));
+        const { logs } = await captureConsole(() => main(['doctor', '--json', '--no-probe']));
         const report = JSON.parse(logs.join('\n'));
         const http = report.backends.find((backend) => backend.name === 'openai-http');
         const usable = report.checks.find((check) => check.name === 'usable-backend');

--- a/tests/unit/doctor-api-key-probe.test.js
+++ b/tests/unit/doctor-api-key-probe.test.js
@@ -210,6 +210,11 @@ test('redactSecrets strips the key value and URL userinfo from error text', () =
   assert.equal(redactSecrets('fetch failed for https://user:pw@proxy.example/v1/models', 'sk-abc'), 'fetch failed for https://***@proxy.example/v1/models');
   assert.equal(redactSecrets('bad key sk-abc in header', 'sk-abc'), 'bad key *** in header');
   assert.equal(redactSecrets('plain message', null), 'plain message');
+  // Passwords containing `@` are userinfo up to the last `@` before the path.
+  assert.equal(redactSecrets('x https://user:p@ss@proxy.example/v1 y', null), 'x https://***@proxy.example/v1 y');
+  assert.equal(redactSecrets('https://a@b@c@host/p', null), 'https://***@host/p');
+  assert.equal(redactSecrets('mailto-like a@b text and https://h/p', null), 'mailto-like a@b text and https://h/p');
+  assert.equal(redactSecrets('two https://u:p@h1/a https://u2:p2@h2/b', null), 'two https://***@h1/a https://***@h2/b');
   // An error that echoes a URL with embedded credentials never reaches the report unredacted.
   return withEnv({ PATINA_API_KEY: 'sk-abc', PATINA_API_BASE: 'https://user:pw@proxy.example/v1' }, async () => {
     const report = reportWithHttpKey();

--- a/tests/unit/doctor-api-key-probe.test.js
+++ b/tests/unit/doctor-api-key-probe.test.js
@@ -1,17 +1,17 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { appendApiKeyProbe } from '../../src/commands/doctor.js';
+import { appendApiKeyProbe, redactSecrets } from '../../src/commands/doctor.js';
 
-const KEY_ENV = ['PATINA_API_KEY', 'PATINA_API_KEY_FILE', 'OPENAI_API_KEY', 'PATINA_API_BASE'];
+const KEY_ENV = ['PATINA_API_KEY', 'PATINA_API_KEY_FILE', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'PATINA_API_BASE', 'PATINA_ALLOW_INSECURE_BASE_URL', 'PATINA_ANTHROPIC_NATIVE_CACHE'];
 
-function withEnv(values, body) {
+async function withEnv(values, body) {
   const saved = {};
   for (const key of KEY_ENV) saved[key] = process.env[key];
   try {
     for (const key of KEY_ENV) delete process.env[key];
     Object.assign(process.env, values);
-    return body();
+    return await body();
   } finally {
     for (const [key, value] of Object.entries(saved)) {
       if (value === undefined) delete process.env[key];
@@ -46,6 +46,7 @@ test('accepted key -> ok probe check, bearer sent only to the configured base UR
     const report = reportWithHttpKey();
     let seen = null;
     await appendApiKeyProbe(report, {
+      config: {},
       fetchImpl: respond(200, (url, init) => { seen = { url, init }; }),
     });
     assert.equal(seen.url, 'https://example.test/v1/models');
@@ -66,7 +67,7 @@ test('rejected key (401/403) -> warning, backend no longer authenticated, usable
   for (const status of [401, 403]) {
     await withEnv({ OPENAI_API_KEY: 'sk-dead' }, async () => {
       const report = reportWithHttpKey();
-      await appendApiKeyProbe(report, { fetchImpl: respond(status) });
+      await appendApiKeyProbe(report, { config: {}, fetchImpl: respond(status) });
       assert.equal(report.apiKeyProbe.ok, false);
       assert.equal(report.apiKeyProbe.host, 'api.openai.com');
       assert.equal(report.backends[0].keyProbe, 'rejected');
@@ -87,7 +88,7 @@ test('rejected key does not flip the aggregate when another backend is authentic
   await withEnv({ OPENAI_API_KEY: 'sk-dead' }, async () => {
     const report = reportWithHttpKey();
     report.backends[1].authenticated = true;
-    await appendApiKeyProbe(report, { fetchImpl: respond(401) });
+    await appendApiKeyProbe(report, { config: {}, fetchImpl: respond(401) });
     const usable = report.checks.find((c) => c.name === 'usable-backend');
     assert.equal(usable.status, 'ok');
     assert.equal(usable.detail, 'codex-cli');
@@ -104,7 +105,7 @@ test('network failure, timeout, or odd status -> inconclusive, informational, ne
   for (const c of cases) {
     await withEnv({ PATINA_API_KEY: 'sk-x' }, async () => {
       const report = reportWithHttpKey();
-      await appendApiKeyProbe(report, { fetchImpl: c.fetchImpl, timeoutMs: c.timeoutMs });
+      await appendApiKeyProbe(report, { config: {}, fetchImpl: c.fetchImpl, timeoutMs: c.timeoutMs });
       assert.equal(report.apiKeyProbe.ok, null);
       if (c.expectError) assert.match(report.apiKeyProbe.error, c.expectError);
       if (c.expectStatus) assert.equal(report.apiKeyProbe.status, c.expectStatus);
@@ -116,6 +117,107 @@ test('network failure, timeout, or odd status -> inconclusive, informational, ne
       assert.equal(report.ok, true);
     });
   }
+});
+
+test('probe resolves provider, key order and base URL the way a rewrite does', async () => {
+  // Config-file provider: key comes from the provider env var, URL from the preset.
+  await withEnv({ GEMINI_API_KEY: 'g-key', OPENAI_API_KEY: 'o-key' }, async () => {
+    const report = reportWithHttpKey();
+    let seen = null;
+    await appendApiKeyProbe(report, { config: { provider: 'gemini' }, fetchImpl: respond(200, (url, init) => { seen = { url, init }; }) });
+    assert.match(seen.url, /^https:\/\/generativelanguage\.googleapis\.com\/.*\/models$/);
+    assert.equal(seen.init.headers.authorization, 'Bearer g-key');
+  });
+  // Config-file base URL wins over the OpenAI default.
+  await withEnv({ PATINA_API_KEY: 'k' }, async () => {
+    const report = reportWithHttpKey();
+    let seen = null;
+    await appendApiKeyProbe(report, { config: { baseURL: 'https://proxy.example/v1' }, fetchImpl: respond(200, (url) => { seen = url; }) });
+    assert.equal(seen, 'https://proxy.example/v1/models');
+    assert.equal(report.apiKeyProbe.host, 'proxy.example');
+  });
+});
+
+test('probe refuses destinations a rewrite would refuse and sends nothing', async () => {
+  for (const base of ['http://proxy.example/v1', 'https://169.254.169.254/v1', 'not a url']) {
+    await withEnv({ PATINA_API_KEY: 'sk-never-sent', PATINA_API_BASE: base }, async () => {
+      const report = reportWithHttpKey();
+      let called = false;
+      await appendApiKeyProbe(report, { config: {}, fetchImpl: async () => { called = true; return { status: 200, ok: true }; } });
+      assert.equal(called, false, base);
+      assert.equal(report.apiKeyProbe.attempted, false);
+      assert.match(report.apiKeyProbe.error, /refusing|Invalid base URL/);
+      assert.equal(report.backends[0].keyProbe, 'inconclusive');
+      assert.equal(report.backends[0].authenticated, true);
+      assert.equal(report.checks.find((c) => c.name === 'api-key-probe').status, 'ok');
+      assert.doesNotMatch(JSON.stringify(report), /sk-never-sent/);
+    });
+  }
+});
+
+test('probe uses native Anthropic headers when a rewrite would, and cancels the response body', async () => {
+  await withEnv({ PATINA_API_KEY: 'ant-key', PATINA_API_BASE: 'https://api.anthropic.com/v1', PATINA_ANTHROPIC_NATIVE_CACHE: '1' }, async () => {
+    const report = reportWithHttpKey();
+    let seen = null;
+    let cancelled = false;
+    await appendApiKeyProbe(report, {
+      config: {},
+      fetchImpl: async (url, init) => {
+        seen = { url, init };
+        return { status: 200, ok: true, body: { cancel: async () => { cancelled = true; } } };
+      },
+    });
+    assert.equal(seen.url, 'https://api.anthropic.com/v1/models');
+    assert.equal(seen.init.headers['x-api-key'], 'ant-key');
+    assert.equal(seen.init.headers.authorization, undefined);
+    assert.equal(cancelled, true);
+    assert.equal(report.apiKeyProbe.ok, true);
+  });
+  // Without the opt-in the same host gets a bearer, like a rewrite.
+  await withEnv({ PATINA_API_KEY: 'ant-key', PATINA_API_BASE: 'https://api.anthropic.com/v1' }, async () => {
+    const report = reportWithHttpKey();
+    let seen = null;
+    await appendApiKeyProbe(report, { config: {}, fetchImpl: respond(200, (url, init) => { seen = init; }) });
+    assert.equal(seen.headers.authorization, 'Bearer ant-key');
+    assert.equal(seen.headers['x-api-key'], undefined);
+  });
+});
+
+test('explicit inconclusive statuses and unrelated blockers survive the probe', async () => {
+  for (const status of [404, 405, 429]) {
+    await withEnv({ PATINA_API_KEY: 'k' }, async () => {
+      const report = reportWithHttpKey();
+      report.checks.unshift({ name: 'node', status: 'blocker', summary: 'Node 16', detail: 'requires Node >=18' });
+      report.ok = false;
+      report.blockers = [{ name: 'node', summary: 'Node 16', detail: 'requires Node >=18' }];
+      await appendApiKeyProbe(report, { config: {}, fetchImpl: respond(status) });
+      assert.equal(report.apiKeyProbe.ok, null, String(status));
+      assert.equal(report.backends[0].authenticated, true);
+      assert.equal(report.ok, false);
+      assert.equal(report.blockers[0].name, 'node');
+    });
+  }
+  // A rejection recount keeps the unrelated blocker as well.
+  await withEnv({ PATINA_API_KEY: 'k' }, async () => {
+    const report = reportWithHttpKey();
+    report.checks.unshift({ name: 'node', status: 'blocker', summary: 'Node 16', detail: 'requires Node >=18' });
+    await appendApiKeyProbe(report, { config: {}, fetchImpl: respond(401) });
+    assert.deepEqual(report.blockers.map((b) => b.name), ['node', 'usable-backend']);
+  });
+});
+
+test('redactSecrets strips the key value and URL userinfo from error text', () => {
+  assert.equal(redactSecrets('fetch failed for https://user:pw@proxy.example/v1/models', 'sk-abc'), 'fetch failed for https://***@proxy.example/v1/models');
+  assert.equal(redactSecrets('bad key sk-abc in header', 'sk-abc'), 'bad key *** in header');
+  assert.equal(redactSecrets('plain message', null), 'plain message');
+  // An error that echoes a URL with embedded credentials never reaches the report unredacted.
+  return withEnv({ PATINA_API_KEY: 'sk-abc', PATINA_API_BASE: 'https://user:pw@proxy.example/v1' }, async () => {
+    const report = reportWithHttpKey();
+    await appendApiKeyProbe(report, { config: {}, fetchImpl: async (url) => { throw new Error(`ECONNRESET ${url} Bearer sk-abc`); } });
+    assert.equal(report.apiKeyProbe.host, 'proxy.example');
+    assert.doesNotMatch(report.apiKeyProbe.error, /user:pw|sk-abc/);
+    assert.doesNotMatch(JSON.stringify(report), /user:pw|sk-abc/);
+  });
 });
 
 test('no HTTP key configured -> probe not attempted and nothing is fetched', async () => {

--- a/tests/unit/doctor-api-key-probe.test.js
+++ b/tests/unit/doctor-api-key-probe.test.js
@@ -1,0 +1,131 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { appendApiKeyProbe } from '../../src/commands/doctor.js';
+
+const KEY_ENV = ['PATINA_API_KEY', 'PATINA_API_KEY_FILE', 'OPENAI_API_KEY', 'PATINA_API_BASE'];
+
+function withEnv(values, body) {
+  const saved = {};
+  for (const key of KEY_ENV) saved[key] = process.env[key];
+  try {
+    for (const key of KEY_ENV) delete process.env[key];
+    Object.assign(process.env, values);
+    return body();
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+// A report shaped like buildDoctorReport() output, with the presence-based
+// verdict already in place so the probe's recount is observable.
+function reportWithHttpKey() {
+  return {
+    ok: true,
+    checks: [
+      { name: 'usable-backend', status: 'ok', summary: '1 authenticated backend(s)', detail: 'openai-http' },
+    ],
+    backends: [
+      { name: 'openai-http', available: true, authenticated: true, authHint: 'Authenticated via PATINA_API_KEY.' },
+      { name: 'codex-cli', available: true, authenticated: false, authHint: 'Run `codex login`.' },
+    ],
+    blockers: [],
+  };
+}
+
+const respond = (status, expect) => async (url, init) => {
+  if (expect) expect(url, init);
+  return { status, ok: status >= 200 && status < 300 };
+};
+
+test('accepted key -> ok probe check, bearer sent only to the configured base URL', async () => {
+  await withEnv({ PATINA_API_KEY: 'sk-test-accept', PATINA_API_BASE: 'https://example.test/v1/' }, async () => {
+    const report = reportWithHttpKey();
+    let seen = null;
+    await appendApiKeyProbe(report, {
+      fetchImpl: respond(200, (url, init) => { seen = { url, init }; }),
+    });
+    assert.equal(seen.url, 'https://example.test/v1/models');
+    assert.equal(seen.init.method, 'GET');
+    assert.equal(seen.init.headers.authorization, 'Bearer sk-test-accept');
+    assert.deepEqual(report.apiKeyProbe, { attempted: true, host: 'example.test', status: 200, ok: true, error: null });
+    assert.equal(report.backends[0].keyProbe, 'accepted');
+    assert.equal(report.backends[0].authenticated, true);
+    const check = report.checks.find((c) => c.name === 'api-key-probe');
+    assert.equal(check.status, 'ok');
+    assert.match(check.summary, /accepted by example\.test/);
+    // The secret never lands in the report.
+    assert.doesNotMatch(JSON.stringify(report), /sk-test-accept/);
+  });
+});
+
+test('rejected key (401/403) -> warning, backend no longer authenticated, usable-backend recounted', async () => {
+  for (const status of [401, 403]) {
+    await withEnv({ OPENAI_API_KEY: 'sk-dead' }, async () => {
+      const report = reportWithHttpKey();
+      await appendApiKeyProbe(report, { fetchImpl: respond(status) });
+      assert.equal(report.apiKeyProbe.ok, false);
+      assert.equal(report.apiKeyProbe.host, 'api.openai.com');
+      assert.equal(report.backends[0].keyProbe, 'rejected');
+      assert.equal(report.backends[0].authenticated, false);
+      assert.match(report.backends[0].authHint, new RegExp(`HTTP ${status}`));
+      assert.equal(report.checks.find((c) => c.name === 'api-key-probe').status, 'warning');
+      // openai-http was the only authenticated backend, so the aggregate flips.
+      const usable = report.checks.find((c) => c.name === 'usable-backend');
+      assert.equal(usable.status, 'blocker');
+      assert.equal(report.ok, false);
+      assert.equal(report.blockers[0].name, 'usable-backend');
+      assert.doesNotMatch(JSON.stringify(report), /sk-dead/);
+    });
+  }
+});
+
+test('rejected key does not flip the aggregate when another backend is authenticated', async () => {
+  await withEnv({ OPENAI_API_KEY: 'sk-dead' }, async () => {
+    const report = reportWithHttpKey();
+    report.backends[1].authenticated = true;
+    await appendApiKeyProbe(report, { fetchImpl: respond(401) });
+    const usable = report.checks.find((c) => c.name === 'usable-backend');
+    assert.equal(usable.status, 'ok');
+    assert.equal(usable.detail, 'codex-cli');
+    assert.equal(report.ok, true);
+  });
+});
+
+test('network failure, timeout, or odd status -> inconclusive, informational, never throws', async () => {
+  const cases = [
+    { fetchImpl: async () => { throw new Error('getaddrinfo ENOTFOUND'); }, expectError: /ENOTFOUND/ },
+    { fetchImpl: respond(503), expectError: null, expectStatus: 503 },
+    { fetchImpl: (url, init) => new Promise((_, reject) => init.signal.addEventListener('abort', () => reject(Object.assign(new Error('aborted'), { name: 'AbortError' })))), expectError: /timed out after 5ms/, timeoutMs: 5 },
+  ];
+  for (const c of cases) {
+    await withEnv({ PATINA_API_KEY: 'sk-x' }, async () => {
+      const report = reportWithHttpKey();
+      await appendApiKeyProbe(report, { fetchImpl: c.fetchImpl, timeoutMs: c.timeoutMs });
+      assert.equal(report.apiKeyProbe.ok, null);
+      if (c.expectError) assert.match(report.apiKeyProbe.error, c.expectError);
+      if (c.expectStatus) assert.equal(report.apiKeyProbe.status, c.expectStatus);
+      assert.equal(report.backends[0].keyProbe, 'inconclusive');
+      assert.equal(report.backends[0].authenticated, true);
+      const check = report.checks.find((c2) => c2.name === 'api-key-probe');
+      assert.equal(check.status, 'ok');
+      assert.match(check.summary, /not verified/);
+      assert.equal(report.ok, true);
+    });
+  }
+});
+
+test('no HTTP key configured -> probe not attempted and nothing is fetched', async () => {
+  await withEnv({}, async () => {
+    const report = reportWithHttpKey();
+    report.backends[0].authenticated = false;
+    let called = false;
+    await appendApiKeyProbe(report, { fetchImpl: async () => { called = true; return { status: 200, ok: true }; } });
+    assert.equal(called, false);
+    assert.equal(report.apiKeyProbe.attempted, false);
+    assert.equal(report.checks.find((c) => c.name === 'api-key-probe'), undefined);
+  });
+});


### PR DESCRIPTION
## 목적 / 연결 Issue
Refs #783 (P17b side observations). `patina doctor` reported `openai-http: authenticated=yes` for a key the provider answers 401 to — presence was mistaken for validity. Adds a real key probe.

## 범위 / 비목표
- `appendApiKeyProbe`: when a default HTTP key resolves, one `GET {baseURL}/models` with the same bearer header a rewrite would send, 3 s timeout. 2xx → `api-key-probe` ok; 401/403 → warning, `openai-http.authenticated=false`, `keyProbe: rejected`, and `usable-backend` recounted (so a dead key alone is now a blocker, while other authenticated backends keep the report ok); anything else (timeout, DNS, 5xx) → inconclusive, informational, never a blocker, never throws.
- New flags: `--no-probe`, `--offline` (= `--no-probe --no-update-check`). JSON gains `apiKeyProbe {attempted, host, status, ok, error}` and per-backend `keyProbe`. The key value never enters the report.
- e2e doctor tests use fake keys and now pass `--no-probe` / `--offline` so CI never sends them anywhere.
- Correction to `docs/operations/backend-compat-claude-gemini-20260910.json`: the "32 stale /tmp/patina-claude-* directories" were research scratch *files* (`patina-claude-*.log/.mjs`, 2026-09-05), not adapter temp dirs. A pattern-exact scan found one real orphan (`/tmp/patina-codex-AkCVBR`, empty, 2026-09-06, killed run) which was removed; no adapter cleanup defect, so no sweeper was added.

Not in scope: probing per-provider keys (`--provider gemini` etc.); local CLI auth validation (already file/expiry based).

## 검증
- Unit `tests/unit/doctor-api-key-probe.test.js` (5 tests): accepted key + exact URL/header, 401 and 403 rejection with recount to blocker, rejection without flip when another backend is authenticated, ENOTFOUND/503/timeout inconclusive, no-key → no fetch. Secret never serialised.
- Real host: `patina doctor --no-update-check` now prints `! openai-http: available=yes, authenticated=no, key=rejected` with the 401 hint, `api-key-probe` warning, aggregate still ok via the five CLI backends. `--offline --json` skips both network checks with a stable `apiKeyProbe` shape. Unknown option message updated.
- `npm run lint` clean; `npm test` 2447 / 2445 pass / 0 fail / 2 pre-existing skips.

## 계약 / 위험 / 크기
contract: compatible — existing JSON fields unchanged; two additive fields; `authenticated` can now be false for a rejected key (that is the fix). risk: low. 6 files.

## 릴리스 / 되돌리기
semver: patch. Rollback: revert.
