### PR TITLE
fix(config): merge a symlinked user config once; preload real TMPDIR in tests (P16b darwin smoke)

### DIFF
--- a/docs/operations/platform-smoke-darwin-arm64-20260910-tmpdir-symlink-failure.json
+++ b/docs/operations/platform-smoke-darwin-arm64-20260910-tmpdir-symlink-failure.json
@@ -1,0 +1,300 @@
+{
+  "schemaVersion": 2,
+  "recordType": "platform-smoke",
+  "planIds": [
+    "P16b"
+  ],
+  "observedAt": "2026-09-10T12:11:25.734Z",
+  "host": {
+    "platform": "darwin",
+    "release": "25.6.0",
+    "arch": "arm64",
+    "node": "v22.23.1",
+    "shell": "zsh",
+    "homeHasNonAscii": false,
+    "tmpdirHasSpace": false
+  },
+  "repo": {
+    "root": "~/workspace/patina-smoke-darwin",
+    "head": "0afc07d16da7608eebf1aabbbddc09f4608c9f4c",
+    "branch": "HEAD",
+    "dirty": false,
+    "gitAvailable": true
+  },
+  "keyEnvNamesSet": [],
+  "steps": [
+    {
+      "name": "npm ci",
+      "command": "npm ci --no-audit --no-fund",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 828,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": null
+    },
+    {
+      "name": "cli --version",
+      "command": "/opt/homebrew/Cellar/node@22/22.23.1/bin/node bin/patina.js --version",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 84,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "version": "patina 8.6.0"
+      }
+    },
+    {
+      "name": "offline score on Korean/space path",
+      "command": "/opt/homebrew/Cellar/node@22/22.23.1/bin/node bin/patina.js --offline --score --format json <tmp>/patina smoke 한글 경로 vUUGq4/입력 폴더/초안 파일.md",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 97,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "deterministicOverall": 100,
+        "paragraphCount": 1
+      }
+    },
+    {
+      "name": "inspect on Korean/space path from a Korean/space cwd",
+      "command": "/opt/homebrew/Cellar/node@22/22.23.1/bin/node ~/workspace/patina-smoke-darwin/bin/patina.js inspect <tmp>/patina smoke 한글 경로 vUUGq4/입력 폴더/초안 파일.md",
+      "cwd": "<tmp>/patina smoke 한글 경로 vUUGq4/입력 폴더",
+      "status": 0,
+      "signal": null,
+      "ms": 101,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "jsonParses": true
+      }
+    },
+    {
+      "name": "offline batch score into Korean/space outdir",
+      "command": "/opt/homebrew/Cellar/node@22/22.23.1/bin/node bin/patina.js --offline --score --batch --outdir <tmp>/patina smoke 한글 경로 vUUGq4/출력 폴더 <tmp>/patina smoke 한글 경로 vUUGq4/입력 폴더/초안 파일.md",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 98,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "outdirEntries": 1
+      }
+    },
+    {
+      "name": "cancellation + isolation tests",
+      "command": "/opt/homebrew/Cellar/node@22/22.23.1/bin/node --test --test-reporter=tap tests/unit/backend-cancellation.test.js tests/unit/backend-agy.test.js tests/e2e/session-isolation.test.js",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 16634,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "tests": 12,
+        "pass": 12,
+        "fail": 0,
+        "skip": 0,
+        "failing": []
+      }
+    },
+    {
+      "name": "doctor --offline --json",
+      "command": "/opt/homebrew/Cellar/node@22/22.23.1/bin/node bin/patina.js doctor --offline --json",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 1887,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "ok": true,
+        "blockers": [],
+        "backends": [
+          {
+            "name": "openai-http",
+            "available": true,
+            "authenticated": false
+          },
+          {
+            "name": "codex-cli",
+            "available": true,
+            "authenticated": true
+          },
+          {
+            "name": "claude-cli",
+            "available": false,
+            "authenticated": true
+          },
+          {
+            "name": "gemini-cli",
+            "available": true,
+            "authenticated": false
+          },
+          {
+            "name": "kimi-cli",
+            "available": false,
+            "authenticated": false
+          },
+          {
+            "name": "agy-cli",
+            "available": false,
+            "authenticated": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "npm test (unit + e2e, tap)",
+      "command": "/opt/homebrew/Cellar/node@22/22.23.1/bin/node --test --test-reporter=tap tests/unit/adversarial-mps-report.test.js tests/unit/adversarial-transforms.test.js tests/unit/ai-tells-corpus-baseline.test.js tests/unit/anthropic-native.test.js tests/unit/api.test.js tests/unit/architecture-boundaries.test.js tests/unit/aside-options.test.js tests/unit/aside-runner.test.js tests/unit/aside-server.test.js tests/unit/aside-ui.test.js tests/unit/assets.test.js tests/unit/audit-backstop.test.js tests/unit/backend-adapter-noise.test.js tests/unit/backend-agy.test.js tests/unit/backend-auth.test.js tests/unit/backend-cancellation.test.js tests/unit/backend-contract.test.js tests/unit/backend-model-defaults.test.js tests/unit/badge-json.test.js tests/unit/batch.test.js tests/unit/benchmark-report.test.js tests/unit/browser-core.test.js tests/unit/browser-diff.test.js tests/unit/byok-hardening.test.js tests/unit/check-no-private-assets.test.js tests/unit/check-release-metadata.test.js tests/unit/ci-workflow.test.js tests/unit/claude-study-isolation.test.js tests/unit/claude-study-stream.test.js tests/unit/cli-args.test.js tests/unit/cli-cancellation.test.js tests/unit/community-patterns.test.js tests/unit/community-retirement.test.js tests/unit/config.test.js tests/unit/detector-candidate-eval.test.js tests/unit/discourse-tells.test.js tests/unit/doctor-api-key-probe.test.js tests/unit/doctor-update-check.test.js tests/unit/document-signals.test.js tests/unit/document-type-pattern-policy.test.js tests/unit/edit-controls.test.js tests/unit/edit-review.test.js tests/unit/edited-ai-intake.test.js tests/unit/entitlement-polar.test.js tests/unit/entitlement.redteam.test.js tests/unit/entitlement.test.js tests/unit/existing-cohort-evaluation.test.js tests/unit/fp-fixture-export.test.js tests/unit/free-tier-monitor.test.js tests/unit/funnel-analytics.test.js tests/unit/funnel-query.test.js tests/unit/heading-preservation.test.js tests/unit/hf-dataset.test.js tests/unit/human-panel.test.js tests/unit/input-loading.test.js tests/unit/inspection.test.js tests/unit/issue-527-fixes.test.js tests/unit/issue-forms.test.js tests/unit/iterative-rewrite-baseline.test.js tests/unit/katfish-calibration.test.js tests/unit/kimi-isolation.test.js tests/unit/kimi-study-transport.test.js tests/unit/ko-miss-review.test.js tests/unit/korean-confirmatory-corpus.test.js tests/unit/korean-diagnosis.test.js tests/unit/korean-invariants-metamorphic.test.js tests/unit/korean-invariants.test.js tests/unit/korean-retention-mutations.test.js tests/unit/korean-structure-fingerprint.test.js tests/unit/lexicon-freshness.test.js tests/unit/lexicon.test.js tests/unit/live-quality.test.js tests/unit/live-scorer-benchmark.test.js tests/unit/loader.test.js tests/unit/log-query-service.test.js tests/unit/logger.test.js tests/unit/maintenance-workflows.test.js tests/unit/markup-leakage.test.js tests/unit/mdx-score.test.js tests/unit/meaning-proxy.test.js tests/unit/model-confirmation.test.js tests/unit/model-evaluation-join.test.js tests/unit/model-rewrite-benchmark.test.js tests/unit/mps-negation-validation.test.js tests/unit/mps-revalidation.test.js tests/unit/ocr.test.js tests/unit/over-editing-guard.test.js tests/unit/pack-command.test.js tests/unit/pack-handler.test.js tests/unit/panel-v2.test.js tests/unit/pattern-docs.test.js tests/unit/pattern-overlap.test.js tests/unit/pay-b-cost-receipt.test.js tests/unit/perf-report.test.js tests/unit/persona-ablation-live.test.js tests/unit/persona-args.test.js tests/unit/persona-calibration.test.js tests/unit/persona-command.test.js tests/unit/persona-gates.test.js tests/unit/persona-match.test.js tests/unit/persona-natural-ko.test.js tests/unit/persona-packaging.test.js tests/unit/persona-resolver.test.js tests/unit/persona-schema.test.js tests/unit/persona-seed.test.js tests/unit/playground-a11y.test.js tests/unit/playground-analytics.test.js tests/unit/playground-examples.test.js tests/unit/playground-experience.test.js tests/unit/playground-module-graph.test.js tests/unit/playground-preferences.test.js tests/unit/playground-pro.test.js tests/unit/polar-webhook.test.js tests/unit/pr-policy.test.js tests/unit/preparation-replay.test.js tests/unit/preview.test.js tests/unit/pro-monitor-api.test.js tests/unit/pro-monitor-e2e.test.js tests/unit/pro-monitor.test.js tests/unit/prompt-builder.persona.test.js tests/unit/prompt-builder.snapshot.test.js tests/unit/prose-score.test.js tests/unit/protected-input.test.js tests/unit/public-showcase.test.js tests/unit/quota-redis.test.js tests/unit/quota-reservation.test.js tests/unit/ranking-metrics.test.js tests/unit/rate-limit.redteam.test.js tests/unit/rate-limit.test.js tests/unit/rebaseline-build-claim-manifest.test.js tests/unit/rebaseline-generate-modern.test.js tests/unit/rebaseline-intake.test.js tests/unit/rebaseline-low-fpr-report.test.js tests/unit/rebaseline-score-collection.test.js tests/unit/rebaseline-score.test.js tests/unit/rebaseline-summary.test.js tests/unit/rebaseline-web-collect.test.js tests/unit/redos-mattr-evidence.test.js tests/unit/register.test.js tests/unit/release-artifacts.test.js tests/unit/retired-concepts.test.js tests/unit/rewrite-ab.test.js tests/unit/rewrite-api.test.js tests/unit/rewrite-client.test.js tests/unit/rewrite-handler.test.js tests/unit/score-overall-coercion.test.js tests/unit/scorer-path-corpus.test.js tests/unit/scorer-public-report.test.js tests/unit/scoring.test.js tests/unit/security.test.js tests/unit/share-card.test.js tests/unit/short-form.test.js tests/unit/shortform-collection.test.js tests/unit/signal-impact.test.js tests/unit/slice-metadata.test.js tests/unit/slice-metrics.test.js tests/unit/streaming-api.test.js tests/unit/structural-classifier.test.js tests/unit/structural-model-loader.test.js tests/unit/study-completion-persistence.test.js tests/unit/study-family.test.js tests/unit/study-persistence.test.js tests/unit/study-transport-process.test.js tests/unit/study-validation.test.js tests/unit/stylometry-ko.test.js tests/unit/stylometry.test.js tests/unit/threshold-parity.test.js tests/unit/transform-options.test.js tests/unit/translationese.test.js tests/unit/verification-schema.test.js tests/unit/verify.test.js tests/unit/web-config.test.js tests/unit/web-deploy-invariants.test.js tests/unit/web-edit-controls.test.js tests/unit/web-observability.test.js tests/unit/web-rewrite-contract.redteam.test.js tests/unit/web-rewrite-contract.test.js tests/unit/web-rewrite-stream.redteam.test.js tests/unit/web-rewrite-stream.test.js tests/unit/web-rewrite.redteam.test.js tests/unit/web-rewrite.test.js tests/unit/xliff-cli.redteam.test.js tests/unit/xliff-cli.test.js tests/unit/xliff-crossfile-dedup.test.js tests/unit/xliff-writeback.redteam.test.js tests/unit/xliff-writeback.test.js tests/unit/xliff.redteam.test.js tests/unit/xliff.test.js tests/e2e/aside-cli.test.js tests/e2e/auth-login.test.js tests/e2e/backends.test.js tests/e2e/check-no-private-assets.test.js tests/e2e/cli-adoption.test.js tests/e2e/cli-api.test.js tests/e2e/cli-cancellation.test.js tests/e2e/cli-persona.test.js tests/e2e/cli-verification.test.js tests/e2e/cli.test.js tests/e2e/dev-server.test.js tests/e2e/precommit-score.test.js tests/e2e/providers.test.js tests/e2e/public-contracts.test.js tests/e2e/release-artifacts.test.js tests/e2e/security.test.js tests/e2e/session-isolation.test.js tests/e2e/skill-install.test.js tests/e2e/skill-invocation.test.js",
+      "cwd": ".",
+      "status": 1,
+      "signal": null,
+      "ms": 70697,
+      "ok": false,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "tests": 2452,
+        "pass": 2397,
+        "fail": 48,
+        "skip": 7,
+        "failing": [
+          "CLI batch continues after a blocked cross-input write without poisoning the valid item",
+          "real root and alias tarballs install together and run both CLIs",
+          "public helper rejects selected Kimi without exposing prose or invoking a rewrite",
+          "real helper -> shipped CLI -> loopback provider accepts exact bytes with private proof",
+          "captured config remains authoritative through the real CLI after ambient mutation",
+          "real CLI and adapter floors reject closest candidates without publishing output",
+          "source mutation is gated on the exact real provider request",
+          "audit, score, diff modes and root skill aliases publish unverified reports only",
+          "spawn-seam mutations reject malformed proof, mismatched hash, dropped numbers, invalid UTF-8 and bounds",
+          "configured floors cannot be lowered by a child proof",
+          "config precedence and custom persona remain native; implicit default model stays absent",
+          "BOM and multibyte input bytes survive the snapshot unchanged",
+          "invalid input and invalid floors fail before a rewrite is started",
+          "missing selected backend and missing selected authentication never fall back",
+          "missing installed CLI and dependency failure have a before-import receipt",
+          "final receipt write failure never advertises or retains accepted output",
+          "public cancellation waits for the exact real provider request and cleans snapshots",
+          "output is bounded by the child byte cap, not the source character limit",
+          "failed spawn records invocationStarted=false rather than a planned invocation",
+          "unsupported Node and broken actual CLI version never read or send draft bytes",
+          "Aside accepts valid forced CLI JSON, propagates options safely, and keeps source bytes unchanged",
+          "Aside unconfigured runs use blog/source defaults and a distinct default output path",
+          "loadConfig: when HOME equals cwd the shared .patina.yaml is applied once, not twice (G5)",
+          "nullable intake verifies bytes and evidence without inventing human or generator labels",
+          "no opt-in means no call; snapshots preserve exact private inputs and loaded resources",
+          "mixed admission freezes the full denominator and preserves nullable labels",
+          "completed observations replay offline byte-for-byte; resume never pays for them again",
+          "production JSON retry is retained, while valid-JSON schema failure is a separate missing score",
+          "transport failures remain errors and missing scores, with no transport retry",
+          "snapshot/row/receipt changes and missing parser receipts reject before any resumed paid call",
+          "persistence failure before dispatch pays nothing; after dispatch it stops and blocks paid resume",
+          "completed paid receipts can recover a missing row offline after row persistence failure",
+          "secrets reject preparation or response capture; no redacted full-replay claim",
+          "Gemini direct API candidates, protocol drift, unknown CLI flags and unsafe output paths reject",
+          "opt-in is boolean and the bound includes every production parser invocation",
+          "observed partial error metadata survives replay without a new invocation",
+          "native profile admission remains distinct from server model verification",
+          "dataset genre and delivery register remain separate; source labels never label new targets",
+          "a dataset genre in pinned config.register is rejected instead of treated as delivery register",
+          "parent approval is consumed losslessly and only approved text/scoring instructions reach HTTP",
+          "parent approval validation can run read-only without creating a cohort or mutating review decisions",
+          "approval of original bytes does not permit automatic input-fence neutralization",
+          "offline replay still rejects actual scorer code changes in the isolated source tree",
+          "programmatic abortStudy and real SIGTERM abort active HTTP fetch and stop later texts",
+          "ordinary deadlines and network AbortError are recorded errors and the cohort continues",
+          "logical deadline after malformed response records two journals but only one dispatched wire",
+          "wireless notStarted timeout recovers a missing row without a replacement completion",
+          "zero-dispatch receipts require exact prompt/request/ordinal/state and no dispatch evidence"
+        ]
+      }
+    }
+  ],
+  "summary": {
+    "stepsRun": 8,
+    "stepsSkipped": [],
+    "stepsFailed": [
+      "npm test (unit + e2e, tap)"
+    ],
+    "suite": {
+      "tests": 2452,
+      "pass": 2397,
+      "fail": 48,
+      "skip": 7,
+      "failing": [
+        "CLI batch continues after a blocked cross-input write without poisoning the valid item",
+        "real root and alias tarballs install together and run both CLIs",
+        "public helper rejects selected Kimi without exposing prose or invoking a rewrite",
+        "real helper -> shipped CLI -> loopback provider accepts exact bytes with private proof",
+        "captured config remains authoritative through the real CLI after ambient mutation",
+        "real CLI and adapter floors reject closest candidates without publishing output",
+        "source mutation is gated on the exact real provider request",
+        "audit, score, diff modes and root skill aliases publish unverified reports only",
+        "spawn-seam mutations reject malformed proof, mismatched hash, dropped numbers, invalid UTF-8 and bounds",
+        "configured floors cannot be lowered by a child proof",
+        "config precedence and custom persona remain native; implicit default model stays absent",
+        "BOM and multibyte input bytes survive the snapshot unchanged",
+        "invalid input and invalid floors fail before a rewrite is started",
+        "missing selected backend and missing selected authentication never fall back",
+        "missing installed CLI and dependency failure have a before-import receipt",
+        "final receipt write failure never advertises or retains accepted output",
+        "public cancellation waits for the exact real provider request and cleans snapshots",
+        "output is bounded by the child byte cap, not the source character limit",
+        "failed spawn records invocationStarted=false rather than a planned invocation",
+        "unsupported Node and broken actual CLI version never read or send draft bytes",
+        "Aside accepts valid forced CLI JSON, propagates options safely, and keeps source bytes unchanged",
+        "Aside unconfigured runs use blog/source defaults and a distinct default output path",
+        "loadConfig: when HOME equals cwd the shared .patina.yaml is applied once, not twice (G5)",
+        "nullable intake verifies bytes and evidence without inventing human or generator labels",
+        "no opt-in means no call; snapshots preserve exact private inputs and loaded resources",
+        "mixed admission freezes the full denominator and preserves nullable labels",
+        "completed observations replay offline byte-for-byte; resume never pays for them again",
+        "production JSON retry is retained, while valid-JSON schema failure is a separate missing score",
+        "transport failures remain errors and missing scores, with no transport retry",
+        "snapshot/row/receipt changes and missing parser receipts reject before any resumed paid call",
+        "persistence failure before dispatch pays nothing; after dispatch it stops and blocks paid resume",
+        "completed paid receipts can recover a missing row offline after row persistence failure",
+        "secrets reject preparation or response capture; no redacted full-replay claim",
+        "Gemini direct API candidates, protocol drift, unknown CLI flags and unsafe output paths reject",
+        "opt-in is boolean and the bound includes every production parser invocation",
+        "observed partial error metadata survives replay without a new invocation",
+        "native profile admission remains distinct from server model verification",
+        "dataset genre and delivery register remain separate; source labels never label new targets",
+        "a dataset genre in pinned config.register is rejected instead of treated as delivery register",
+        "parent approval is consumed losslessly and only approved text/scoring instructions reach HTTP",
+        "parent approval validation can run read-only without creating a cohort or mutating review decisions",
+        "approval of original bytes does not permit automatic input-fence neutralization",
+        "offline replay still rejects actual scorer code changes in the isolated source tree",
+        "programmatic abortStudy and real SIGTERM abort active HTTP fetch and stop later texts",
+        "ordinary deadlines and network AbortError are recorded errors and the cohort continues",
+        "logical deadline after malformed response records two journals but only one dispatched wire",
+        "wireless notStarted timeout recovers a missing row without a replacement completion",
+        "zero-dispatch receipts require exact prompt/request/ordinal/state and no dispatch evidence"
+      ]
+    },
+    "lifecycle": {
+      "tests": 12,
+      "pass": 12,
+      "fail": 0,
+      "skip": 0,
+      "failing": []
+    },
+    "verdict": "recorded; interpretation belongs to the maintenance record, not this script"
+  },
+  "diagnostics": "docs/internal/<stem>.diagnostics.json (gitignored; raw child output, operator-only)"
+}

--- a/docs/operations/platform-smoke-darwin-arm64-20260910.json
+++ b/docs/operations/platform-smoke-darwin-arm64-20260910.json
@@ -1,0 +1,200 @@
+{
+  "schemaVersion": 2,
+  "recordType": "platform-smoke",
+  "planIds": [
+    "P16b"
+  ],
+  "observedAt": "2026-09-10T12:35:22.142Z",
+  "host": {
+    "platform": "darwin",
+    "release": "25.6.0",
+    "arch": "arm64",
+    "node": "v22.23.1",
+    "shell": "zsh",
+    "homeHasNonAscii": false,
+    "tmpdirHasSpace": false
+  },
+  "repo": {
+    "root": "~/workspace/patina-smoke-darwin",
+    "head": "81375ee1df8d6ee13850d3de7d49b1e88a4468db",
+    "branch": "HEAD",
+    "dirty": true,
+    "gitAvailable": true
+  },
+  "keyEnvNamesSet": [],
+  "steps": [
+    {
+      "name": "npm ci",
+      "command": "npm ci --no-audit --no-fund",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 1001,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": null
+    },
+    {
+      "name": "cli --version",
+      "command": "/opt/homebrew/Cellar/node@22/22.23.1/bin/node bin/patina.js --version",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 88,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "version": "patina 8.6.0"
+      }
+    },
+    {
+      "name": "offline score on Korean/space path",
+      "command": "/opt/homebrew/Cellar/node@22/22.23.1/bin/node bin/patina.js --offline --score --format json <tmp>/patina smoke 한글 경로 e0rJ3h/입력 폴더/초안 파일.md",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 101,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "deterministicOverall": 100,
+        "paragraphCount": 1
+      }
+    },
+    {
+      "name": "inspect on Korean/space path from a Korean/space cwd",
+      "command": "/opt/homebrew/Cellar/node@22/22.23.1/bin/node ~/workspace/patina-smoke-darwin/bin/patina.js inspect <tmp>/patina smoke 한글 경로 e0rJ3h/입력 폴더/초안 파일.md",
+      "cwd": "<tmp>/patina smoke 한글 경로 e0rJ3h/입력 폴더",
+      "status": 0,
+      "signal": null,
+      "ms": 98,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "jsonParses": true
+      }
+    },
+    {
+      "name": "offline batch score into Korean/space outdir",
+      "command": "/opt/homebrew/Cellar/node@22/22.23.1/bin/node bin/patina.js --offline --score --batch --outdir <tmp>/patina smoke 한글 경로 e0rJ3h/출력 폴더 <tmp>/patina smoke 한글 경로 e0rJ3h/입력 폴더/초안 파일.md",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 97,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "outdirEntries": 1
+      }
+    },
+    {
+      "name": "cancellation + isolation tests",
+      "command": "/opt/homebrew/Cellar/node@22/22.23.1/bin/node -r ~/workspace/patina-smoke-darwin/tests/helpers/real-tmpdir.cjs --test --test-reporter=tap tests/unit/backend-cancellation.test.js tests/unit/backend-agy.test.js tests/e2e/session-isolation.test.js",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 16915,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "tests": 12,
+        "pass": 12,
+        "fail": 0,
+        "skip": 0,
+        "failing": []
+      }
+    },
+    {
+      "name": "doctor --offline --json",
+      "command": "/opt/homebrew/Cellar/node@22/22.23.1/bin/node bin/patina.js doctor --offline --json",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 1818,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "ok": true,
+        "blockers": [],
+        "backends": [
+          {
+            "name": "openai-http",
+            "available": true,
+            "authenticated": false
+          },
+          {
+            "name": "codex-cli",
+            "available": true,
+            "authenticated": true
+          },
+          {
+            "name": "claude-cli",
+            "available": false,
+            "authenticated": true
+          },
+          {
+            "name": "gemini-cli",
+            "available": true,
+            "authenticated": false
+          },
+          {
+            "name": "kimi-cli",
+            "available": false,
+            "authenticated": false
+          },
+          {
+            "name": "agy-cli",
+            "available": false,
+            "authenticated": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "npm test (unit + e2e, tap)",
+      "command": "/opt/homebrew/Cellar/node@22/22.23.1/bin/node -r ~/workspace/patina-smoke-darwin/tests/helpers/real-tmpdir.cjs --test --test-reporter=tap tests/unit/adversarial-mps-report.test.js tests/unit/adversarial-transforms.test.js tests/unit/ai-tells-corpus-baseline.test.js tests/unit/anthropic-native.test.js tests/unit/api.test.js tests/unit/architecture-boundaries.test.js tests/unit/aside-options.test.js tests/unit/aside-runner.test.js tests/unit/aside-server.test.js tests/unit/aside-ui.test.js tests/unit/assets.test.js tests/unit/audit-backstop.test.js tests/unit/backend-adapter-noise.test.js tests/unit/backend-agy.test.js tests/unit/backend-auth.test.js tests/unit/backend-cancellation.test.js tests/unit/backend-contract.test.js tests/unit/backend-model-defaults.test.js tests/unit/badge-json.test.js tests/unit/batch.test.js tests/unit/benchmark-report.test.js tests/unit/browser-core.test.js tests/unit/browser-diff.test.js tests/unit/byok-hardening.test.js tests/unit/check-no-private-assets.test.js tests/unit/check-release-metadata.test.js tests/unit/ci-workflow.test.js tests/unit/claude-study-isolation.test.js tests/unit/claude-study-stream.test.js tests/unit/cli-args.test.js tests/unit/cli-cancellation.test.js tests/unit/community-patterns.test.js tests/unit/community-retirement.test.js tests/unit/config.test.js tests/unit/detector-candidate-eval.test.js tests/unit/discourse-tells.test.js tests/unit/doctor-api-key-probe.test.js tests/unit/doctor-update-check.test.js tests/unit/document-signals.test.js tests/unit/document-type-pattern-policy.test.js tests/unit/edit-controls.test.js tests/unit/edit-review.test.js tests/unit/edited-ai-intake.test.js tests/unit/entitlement-polar.test.js tests/unit/entitlement.redteam.test.js tests/unit/entitlement.test.js tests/unit/existing-cohort-evaluation.test.js tests/unit/fp-fixture-export.test.js tests/unit/free-tier-monitor.test.js tests/unit/funnel-analytics.test.js tests/unit/funnel-query.test.js tests/unit/heading-preservation.test.js tests/unit/hf-dataset.test.js tests/unit/human-panel.test.js tests/unit/input-loading.test.js tests/unit/inspection.test.js tests/unit/issue-527-fixes.test.js tests/unit/issue-forms.test.js tests/unit/iterative-rewrite-baseline.test.js tests/unit/katfish-calibration.test.js tests/unit/kimi-isolation.test.js tests/unit/kimi-study-transport.test.js tests/unit/ko-miss-review.test.js tests/unit/korean-confirmatory-corpus.test.js tests/unit/korean-diagnosis.test.js tests/unit/korean-invariants-metamorphic.test.js tests/unit/korean-invariants.test.js tests/unit/korean-retention-mutations.test.js tests/unit/korean-structure-fingerprint.test.js tests/unit/lexicon-freshness.test.js tests/unit/lexicon.test.js tests/unit/live-quality.test.js tests/unit/live-scorer-benchmark.test.js tests/unit/loader.test.js tests/unit/log-query-service.test.js tests/unit/logger.test.js tests/unit/maintenance-workflows.test.js tests/unit/markup-leakage.test.js tests/unit/mdx-score.test.js tests/unit/meaning-proxy.test.js tests/unit/model-confirmation.test.js tests/unit/model-evaluation-join.test.js tests/unit/model-rewrite-benchmark.test.js tests/unit/mps-negation-validation.test.js tests/unit/mps-revalidation.test.js tests/unit/ocr.test.js tests/unit/over-editing-guard.test.js tests/unit/pack-command.test.js tests/unit/pack-handler.test.js tests/unit/panel-v2.test.js tests/unit/pattern-docs.test.js tests/unit/pattern-overlap.test.js tests/unit/pay-b-cost-receipt.test.js tests/unit/perf-report.test.js tests/unit/persona-ablation-live.test.js tests/unit/persona-args.test.js tests/unit/persona-calibration.test.js tests/unit/persona-command.test.js tests/unit/persona-gates.test.js tests/unit/persona-match.test.js tests/unit/persona-natural-ko.test.js tests/unit/persona-packaging.test.js tests/unit/persona-resolver.test.js tests/unit/persona-schema.test.js tests/unit/persona-seed.test.js tests/unit/playground-a11y.test.js tests/unit/playground-analytics.test.js tests/unit/playground-examples.test.js tests/unit/playground-experience.test.js tests/unit/playground-module-graph.test.js tests/unit/playground-preferences.test.js tests/unit/playground-pro.test.js tests/unit/polar-webhook.test.js tests/unit/pr-policy.test.js tests/unit/preparation-replay.test.js tests/unit/preview.test.js tests/unit/pro-monitor-api.test.js tests/unit/pro-monitor-e2e.test.js tests/unit/pro-monitor.test.js tests/unit/prompt-builder.persona.test.js tests/unit/prompt-builder.snapshot.test.js tests/unit/prose-score.test.js tests/unit/protected-input.test.js tests/unit/public-showcase.test.js tests/unit/quota-redis.test.js tests/unit/quota-reservation.test.js tests/unit/ranking-metrics.test.js tests/unit/rate-limit.redteam.test.js tests/unit/rate-limit.test.js tests/unit/rebaseline-build-claim-manifest.test.js tests/unit/rebaseline-generate-modern.test.js tests/unit/rebaseline-intake.test.js tests/unit/rebaseline-low-fpr-report.test.js tests/unit/rebaseline-score-collection.test.js tests/unit/rebaseline-score.test.js tests/unit/rebaseline-summary.test.js tests/unit/rebaseline-web-collect.test.js tests/unit/redos-mattr-evidence.test.js tests/unit/register.test.js tests/unit/release-artifacts.test.js tests/unit/retired-concepts.test.js tests/unit/rewrite-ab.test.js tests/unit/rewrite-api.test.js tests/unit/rewrite-client.test.js tests/unit/rewrite-handler.test.js tests/unit/score-overall-coercion.test.js tests/unit/scorer-path-corpus.test.js tests/unit/scorer-public-report.test.js tests/unit/scoring.test.js tests/unit/security.test.js tests/unit/share-card.test.js tests/unit/short-form.test.js tests/unit/shortform-collection.test.js tests/unit/signal-impact.test.js tests/unit/slice-metadata.test.js tests/unit/slice-metrics.test.js tests/unit/streaming-api.test.js tests/unit/structural-classifier.test.js tests/unit/structural-model-loader.test.js tests/unit/study-completion-persistence.test.js tests/unit/study-family.test.js tests/unit/study-persistence.test.js tests/unit/study-transport-process.test.js tests/unit/study-validation.test.js tests/unit/stylometry-ko.test.js tests/unit/stylometry.test.js tests/unit/threshold-parity.test.js tests/unit/transform-options.test.js tests/unit/translationese.test.js tests/unit/verification-schema.test.js tests/unit/verify.test.js tests/unit/web-config.test.js tests/unit/web-deploy-invariants.test.js tests/unit/web-edit-controls.test.js tests/unit/web-observability.test.js tests/unit/web-rewrite-contract.redteam.test.js tests/unit/web-rewrite-contract.test.js tests/unit/web-rewrite-stream.redteam.test.js tests/unit/web-rewrite-stream.test.js tests/unit/web-rewrite.redteam.test.js tests/unit/web-rewrite.test.js tests/unit/xliff-cli.redteam.test.js tests/unit/xliff-cli.test.js tests/unit/xliff-crossfile-dedup.test.js tests/unit/xliff-writeback.redteam.test.js tests/unit/xliff-writeback.test.js tests/unit/xliff.redteam.test.js tests/unit/xliff.test.js tests/e2e/aside-cli.test.js tests/e2e/auth-login.test.js tests/e2e/backends.test.js tests/e2e/check-no-private-assets.test.js tests/e2e/cli-adoption.test.js tests/e2e/cli-api.test.js tests/e2e/cli-cancellation.test.js tests/e2e/cli-persona.test.js tests/e2e/cli-verification.test.js tests/e2e/cli.test.js tests/e2e/dev-server.test.js tests/e2e/precommit-score.test.js tests/e2e/providers.test.js tests/e2e/public-contracts.test.js tests/e2e/release-artifacts.test.js tests/e2e/security.test.js tests/e2e/session-isolation.test.js tests/e2e/skill-install.test.js tests/e2e/skill-invocation.test.js",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 72381,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "tests": 2453,
+        "pass": 2446,
+        "fail": 0,
+        "skip": 7,
+        "failing": []
+      }
+    }
+  ],
+  "summary": {
+    "stepsRun": 8,
+    "stepsSkipped": [],
+    "stepsFailed": [],
+    "suite": {
+      "tests": 2453,
+      "pass": 2446,
+      "fail": 0,
+      "skip": 7,
+      "failing": []
+    },
+    "lifecycle": {
+      "tests": 12,
+      "pass": 12,
+      "fail": 0,
+      "skip": 0,
+      "failing": []
+    },
+    "verdict": "recorded; interpretation belongs to the maintenance record, not this script"
+  },
+  "diagnostics": "docs/internal/<stem>.diagnostics.json (gitignored; raw child output, operator-only)"
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,4 +39,16 @@ export default [
       'no-unused-vars': ['error', { argsIgnorePattern: '^_|^patterns$', varsIgnorePattern: '^_' }],
     },
   },
+  {
+    files: ['**/*.cjs'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'commonjs',
+      globals: { ...nodeGlobals, require: 'readonly', module: 'writable', __dirname: 'readonly' },
+    },
+    rules: {
+      'no-empty': ['error', { allowEmptyCatch: true }],
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_|^patterns$', varsIgnorePattern: '^_' }],
+    },
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "patina-score": "scripts/precommit-score.mjs"
   },
   "scripts": {
-    "test": "node --test tests/unit/*.test.js tests/e2e/*.test.js",
-    "test:unit": "node --test tests/unit/*.test.js",
+    "test": "node -r ./tests/helpers/real-tmpdir.cjs --test tests/unit/*.test.js tests/e2e/*.test.js",
+    "test:unit": "node -r ./tests/helpers/real-tmpdir.cjs --test tests/unit/*.test.js",
     "dataset:export": "node scripts/export-hf-dataset.mjs",
     "dataset:publish": "node scripts/publish-hf-dataset.mjs",
     "launch-config:generate": "node scripts/generate-launch-config.mjs",
-    "test:e2e": "node --test tests/e2e/*.test.js",
-    "test:browser": "node --test tests/browser/*.test.js",
+    "test:e2e": "node -r ./tests/helpers/real-tmpdir.cjs --test tests/e2e/*.test.js",
+    "test:browser": "node -r ./tests/helpers/real-tmpdir.cjs --test tests/browser/*.test.js",
     "smoke:platform": "node scripts/platform-smoke.mjs",
     "benchmark": "node tests/quality/benchmark.mjs",
     "benchmark:perf": "node scripts/perf-report.mjs",

--- a/scripts/platform-smoke.mjs
+++ b/scripts/platform-smoke.mjs
@@ -241,6 +241,7 @@ try {
   // skip for a different reason (unsafe host Antigravity settings), so skip
   // counts must be read with the failing/skipped names, not alone.
   run('cancellation + isolation tests', process.execPath, [
+    '-r', join(REPO_ROOT, 'tests', 'helpers', 'real-tmpdir.cjs'),
     '--test', '--test-reporter=tap',
     `tests${sep}unit${sep}backend-cancellation.test.js`, `tests${sep}unit${sep}backend-agy.test.js`, `tests${sep}e2e${sep}session-isolation.test.js`,
   ], { parse: parseTap });
@@ -259,7 +260,7 @@ try {
 
   // 6. Full suite, files enumerated here so no shell glob expansion is needed.
   if (!flag('--skip-suite')) {
-    run('npm test (unit + e2e, tap)', process.execPath, ['--test', '--test-reporter=tap', ...listTests('tests/unit'), ...listTests('tests/e2e')], { parse: parseTap });
+    run('npm test (unit + e2e, tap)', process.execPath, ['-r', join(REPO_ROOT, 'tests', 'helpers', 'real-tmpdir.cjs'), '--test', '--test-reporter=tap', ...listTests('tests/unit'), ...listTests('tests/e2e')], { parse: parseTap });
   } else {
     receipt.steps.push({ name: 'npm test (unit + e2e, tap)', ok: null, skipped: '--skip-suite' });
   }

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, realpathSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -48,8 +48,16 @@ export function loadConfig(path = resolve(REPO_ROOT, '.patina.default.yaml'), { 
 
   if (!snapshotPath) {
     // User config: ~/.patina.yaml (global), then ./.patina.yaml (project, takes precedence).
-    for (const userPath of [...new Set([resolve(homedir(), '.patina.yaml'), resolve(process.cwd(), '.patina.yaml')])]) {
+    const seenUserConfig = new Set();
+    for (const userPath of [resolve(homedir(), '.patina.yaml'), resolve(process.cwd(), '.patina.yaml')]) {
       if (!existsSync(userPath)) continue;
+      // The same file can be reached through symlinked directory spellings
+      // (macOS /var → /private/var, a symlinked HOME): dedupe on the real
+      // path, not the literal string, so one file is never merged twice.
+      let identity = userPath;
+      try { identity = realpathSync(userPath); } catch { /* keep the literal spelling */ }
+      if (seenUserConfig.has(identity)) continue;
+      seenUserConfig.add(identity);
       mergeYamlMapping(config, userPath, 'User config');
     }
 

--- a/tests/helpers/real-tmpdir.cjs
+++ b/tests/helpers/real-tmpdir.cjs
@@ -9,6 +9,11 @@
 // its realpath so every temp root a test creates is already canonical; child
 // processes (including npm) inherit the normalized value through the
 // environment. No-op on platforms whose temp root is not symlinked.
+//
+// Tradeoff by design: the suite runs under a canonical TMPDIR, so it cannot
+// detect a product-level literal-vs-real temp-path mismatch on macOS. Such a
+// defect would need its own product fix (like the src/config.js realpath
+// dedupe this helper was added alongside), not a harness change.
 const { realpathSync } = require('node:fs');
 const { tmpdir } = require('node:os');
 

--- a/tests/helpers/real-tmpdir.cjs
+++ b/tests/helpers/real-tmpdir.cjs
@@ -1,0 +1,22 @@
+'use strict';
+
+// Preloaded with `node --require` before any test module. macOS exposes the
+// temp root through symlinks (/var and /tmp point at /private/...): os.tmpdir()
+// keeps the literal spelling while process.cwd(), fs.realpathSync and npm
+// canonicalize to the real path. Temp roots created under the literal spelling
+// then compare unequal to the same locations reached through the symlink, and
+// npm writes lockfiles relativized against the real spelling. Point TMPDIR at
+// its realpath so every temp root a test creates is already canonical; child
+// processes (including npm) inherit the normalized value through the
+// environment. No-op on platforms whose temp root is not symlinked.
+const { realpathSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+
+try {
+  const literal = tmpdir();
+  const real = realpathSync(literal);
+  if (real && real !== literal) process.env.TMPDIR = real;
+} catch {
+  // Keep the platform default; a broken temp root fails loudly in the tests
+  // that need it.
+}

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -95,6 +95,26 @@ test('loadConfig: when HOME equals cwd the shared .patina.yaml is applied once, 
   await withEnv({ home: root, cwd: root }, async () => {
     const config = loadConfig(defaultPath);
     assert.strictEqual(config.blocklist.length, 1);
+    assert.deepStrictEqual(config.blocklist, [{ term: 'shared-entry' }]);
+  });
+});
+
+// Windows needs elevated privileges for directory symlinks; the literal-path
+// case above (G5) still covers the dedupe there.
+test('loadConfig: HOME reaching cwd through a symlink still merges .patina.yaml once', { skip: process.platform === 'win32' }, async () => {
+  const root = mkdtempSync(join(tmpdir(), 'patina-config-symlink-'));
+  const real = join(root, 'real');
+  const alias = join(root, 'alias');
+  mkdirSync(real);
+  symlinkSync(real, alias, 'dir');
+  const defaultPath = join(real, 'default.yaml');
+  writeFileSync(defaultPath, 'register: casual\n');
+  writeFileSync(join(real, '.patina.yaml'), 'blocklist:\n  - term: shared-entry\n');
+
+  // HOME keeps the symlink spelling while process.cwd() reports the real
+  // path, so the two candidate paths differ as strings but name one file.
+  await withEnv({ home: alias, cwd: real }, async () => {
+    const config = loadConfig(defaultPath);
     assert.deepStrictEqual(config.blocklist, [{ term: 'shared-entry' }]);
   });
 });

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -118,6 +118,7 @@ test('loadConfig: HOME reaching cwd through a symlink still merges .patina.yaml 
     assert.deepStrictEqual(config.blocklist, [{ term: 'shared-entry' }]);
   });
 });
+
 test('loadConfig preserves partial scoring defaults and explicit zero overrides', async () => {
   const { root, home, project } = tempWorkspace();
   const defaultPath = join(root, 'default.yaml');


### PR DESCRIPTION
## Summary

First P16b darwin smoke (macOS 26.6.2 arm64, Node 22.23.1, via SSH to a maintainer Mac) failed **48 tests that all pass on Linux**. Every failure traced to one root cause: macOS exposes the temp root through symlinks (`/var`, `/tmp` → `/private/...`), so `os.tmpdir()` keeps the literal spelling while `process.cwd()`, `fs.realpathSync` and npm canonicalize to the real path.

One real product bug and one test-environment assumption:

- **Product (`src/config.js`)** — `~/.patina.yaml` and `./.patina.yaml` can name one file through a symlinked HOME/cwd. The literal-string `Set` never matched, so additive object lists (blocklist) were merged **twice**. Now deduped on realpath. Regression test: HOME as a symlink to cwd (fails without the fix on any platform; skipped on win32 — directory symlinks need elevation, G5 still covers the literal case).
- **Harness (`tests/helpers/real-tmpdir.cjs`)** — `node -r` preload that points `TMPDIR` at its realpath before any test reads `os.tmpdir()`; children (npm) inherit it, so npm lockfiles are relativized against the real spelling (this was the release-artifacts `npm ci` "Missing: patina-cli from lock file" failure). No-op where the temp root is not symlinked. `-r` is used instead of `--import` because the supported minimum Node 18.1 lacks `--import`.
- Wired into `test`/`test:unit`/`test:e2e`/`test:browser` and the smoke runner's two `--test` invocations; `eslint.config.js` now lints `**/*.cjs` (first `.cjs` in the repo).

## Evidence

- Receipts (same host, before/after): `docs/operations/platform-smoke-darwin-arm64-20260910-tmpdir-symlink-failure.json` (0afc07d, suite fail 48) and `docs/operations/platform-smoke-darwin-arm64-20260910.json` (81375ee, **all 8 steps ok**, suite 2453 tests / 2446 pass / 0 fail / 7 skip — host-dependent skips: Gemini OAuth present, agy host settings, 2 pre-existing host-auth skips).
- Negative control: new symlink config test fails on the unfixed `src/config.js` (Linux), passes with the fix.
- Linux worktree: full suite 2453 / 2451 pass / 0 fail / 2 skip; `npm run lint` green (433 files syntax, eslint, typecheck, spellcheck, architecture 0 violations).
- Confirmed the suite root cause independently: full suite on macOS with `TMPDIR` preset to a non-symlinked path → 0 fail on the unfixed tree.

## Notes

- One unrelated flake observed once locally: `skill-install.test.js` "Cursor install and uninstall use the product adapter" fixture `ENOENT` under full-suite parallelism; passes standalone both with and without the preload, and passed in the macOS full-suite run. Recorded, not fixed here.
- Windows smoke remains open under P16b (no Windows host available); macOS leg is now green.
- Refs #783