### PR TITLE
test(windows): make the suite run on win32 and record the P16b win32 smoke

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# The test suite hashes, counts and snapshot-compares committed bytes, so
+# text files must check out with LF on every platform (a Windows clone with
+# core.autocrlf=true otherwise breaks dozens of byte-exact tests).
+* text=auto eol=lf

--- a/docs/operations/platform-smoke-win32-x64-20260910.json
+++ b/docs/operations/platform-smoke-win32-x64-20260910.json
@@ -1,0 +1,204 @@
+{
+  "schemaVersion": 2,
+  "recordType": "platform-smoke",
+  "planIds": [
+    "P16b"
+  ],
+  "observedAt": "2026-09-10T15:32:00.903Z",
+  "host": {
+    "platform": "win32",
+    "release": "10.0.26200",
+    "arch": "x64",
+    "node": "v24.17.0",
+    "shell": "cmd.exe",
+    "homeHasNonAscii": false,
+    "tmpdirHasSpace": false
+  },
+  "repo": {
+    "root": "~\\patina",
+    "head": "bf877fd83b3dfb37e4fbc96aef2a2c3deb124d5b",
+    "branch": "HEAD",
+    "dirty": true,
+    "gitAvailable": true
+  },
+  "keyEnvNamesSet": [
+    "GEMINI_API_KEY"
+  ],
+  "steps": [
+    {
+      "name": "npm ci",
+      "command": "npm.cmd ci --no-audit --no-fund",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 5723,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": null
+    },
+    {
+      "name": "cli --version",
+      "command": "C:\\Program Files\\nodejs\\node.exe bin/patina.js --version",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 194,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "version": "patina 8.6.0"
+      }
+    },
+    {
+      "name": "offline score on Korean/space path",
+      "command": "C:\\Program Files\\nodejs\\node.exe bin/patina.js --offline --score --format json <tmp>\\patina smoke 한글 경로 EchSVh\\입력 폴더\\초안 파일.md",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 224,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "deterministicOverall": 100,
+        "paragraphCount": 1
+      }
+    },
+    {
+      "name": "inspect on Korean/space path from a Korean/space cwd",
+      "command": "C:\\Program Files\\nodejs\\node.exe ~\\patina\\bin\\patina.js inspect <tmp>\\patina smoke 한글 경로 EchSVh\\입력 폴더\\초안 파일.md",
+      "cwd": "<tmp>\\patina smoke 한글 경로 EchSVh\\입력 폴더",
+      "status": 0,
+      "signal": null,
+      "ms": 222,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "jsonParses": true
+      }
+    },
+    {
+      "name": "offline batch score into Korean/space outdir",
+      "command": "C:\\Program Files\\nodejs\\node.exe bin/patina.js --offline --score --batch --outdir <tmp>\\patina smoke 한글 경로 EchSVh\\출력 폴더 <tmp>\\patina smoke 한글 경로 EchSVh\\입력 폴더\\초안 파일.md",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 209,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "outdirEntries": 1
+      }
+    },
+    {
+      "name": "cancellation + isolation tests",
+      "command": "C:\\Program Files\\nodejs\\node.exe -r ~\\patina\\tests\\helpers\\real-tmpdir.cjs --test --test-reporter=tap tests\\unit\\backend-cancellation.test.js tests\\unit\\backend-agy.test.js tests\\e2e\\session-isolation.test.js",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 226,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "tests": 12,
+        "pass": 5,
+        "fail": 0,
+        "skip": 7,
+        "failing": []
+      }
+    },
+    {
+      "name": "doctor --offline --json",
+      "command": "C:\\Program Files\\nodejs\\node.exe bin/patina.js doctor --offline --json",
+      "cwd": ".",
+      "status": 1,
+      "signal": null,
+      "ms": 389,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "ok": false,
+        "blockers": [
+          "usable-backend"
+        ],
+        "backends": [
+          {
+            "name": "openai-http",
+            "available": true,
+            "authenticated": false
+          },
+          {
+            "name": "codex-cli",
+            "available": false,
+            "authenticated": true
+          },
+          {
+            "name": "claude-cli",
+            "available": true,
+            "authenticated": false
+          },
+          {
+            "name": "gemini-cli",
+            "available": false,
+            "authenticated": true
+          },
+          {
+            "name": "kimi-cli",
+            "available": false,
+            "authenticated": true
+          },
+          {
+            "name": "agy-cli",
+            "available": false,
+            "authenticated": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "npm test (unit + e2e, tap)",
+      "command": "C:\\Program Files\\nodejs\\node.exe -r ~\\patina\\tests\\helpers\\real-tmpdir.cjs --test --test-reporter=tap tests/unit\\adversarial-mps-report.test.js tests/unit\\adversarial-transforms.test.js tests/unit\\ai-tells-corpus-baseline.test.js tests/unit\\anthropic-native.test.js tests/unit\\api.test.js tests/unit\\architecture-boundaries.test.js tests/unit\\aside-options.test.js tests/unit\\aside-runner.test.js tests/unit\\aside-server.test.js tests/unit\\aside-ui.test.js tests/unit\\assets.test.js tests/unit\\audit-backstop.test.js tests/unit\\backend-adapter-noise.test.js tests/unit\\backend-agy.test.js tests/unit\\backend-auth.test.js tests/unit\\backend-cancellation.test.js tests/unit\\backend-contract.test.js tests/unit\\backend-model-defaults.test.js tests/unit\\badge-json.test.js tests/unit\\batch.test.js tests/unit\\benchmark-report.test.js tests/unit\\browser-core.test.js tests/unit\\browser-diff.test.js tests/unit\\byok-hardening.test.js tests/unit\\check-no-private-assets.test.js tests/unit\\check-release-metadata.test.js tests/unit\\ci-workflow.test.js tests/unit\\claude-study-isolation.test.js tests/unit\\claude-study-stream.test.js tests/unit\\cli-args.test.js tests/unit\\cli-cancellation.test.js tests/unit\\community-patterns.test.js tests/unit\\community-retirement.test.js tests/unit\\config.test.js tests/unit\\detector-candidate-eval.test.js tests/unit\\discourse-tells.test.js tests/unit\\doctor-api-key-probe.test.js tests/unit\\doctor-update-check.test.js tests/unit\\document-signals.test.js tests/unit\\document-type-pattern-policy.test.js tests/unit\\edit-controls.test.js tests/unit\\edit-review.test.js tests/unit\\edited-ai-intake.test.js tests/unit\\entitlement-polar.test.js tests/unit\\entitlement.redteam.test.js tests/unit\\entitlement.test.js tests/unit\\existing-cohort-evaluation.test.js tests/unit\\fp-fixture-export.test.js tests/unit\\free-tier-monitor.test.js tests/unit\\funnel-analytics.test.js tests/unit\\funnel-query.test.js tests/unit\\heading-preservation.test.js tests/unit\\hf-dataset.test.js tests/unit\\human-panel.test.js tests/unit\\input-loading.test.js tests/unit\\inspection.test.js tests/unit\\issue-527-fixes.test.js tests/unit\\issue-forms.test.js tests/unit\\iterative-rewrite-baseline.test.js tests/unit\\katfish-calibration.test.js tests/unit\\kimi-isolation.test.js tests/unit\\kimi-study-transport.test.js tests/unit\\ko-miss-review.test.js tests/unit\\korean-confirmatory-corpus.test.js tests/unit\\korean-diagnosis.test.js tests/unit\\korean-invariants-metamorphic.test.js tests/unit\\korean-invariants.test.js tests/unit\\korean-retention-mutations.test.js tests/unit\\korean-structure-fingerprint.test.js tests/unit\\lexicon-freshness.test.js tests/unit\\lexicon.test.js tests/unit\\live-quality.test.js tests/unit\\live-scorer-benchmark.test.js tests/unit\\loader.test.js tests/unit\\log-query-service.test.js tests/unit\\logger.test.js tests/unit\\maintenance-workflows.test.js tests/unit\\markup-leakage.test.js tests/unit\\mdx-score.test.js tests/unit\\meaning-proxy.test.js tests/unit\\model-confirmation.test.js tests/unit\\model-evaluation-join.test.js tests/unit\\model-rewrite-benchmark.test.js tests/unit\\mps-negation-validation.test.js tests/unit\\mps-revalidation.test.js tests/unit\\ocr.test.js tests/unit\\over-editing-guard.test.js tests/unit\\pack-command.test.js tests/unit\\pack-handler.test.js tests/unit\\panel-v2.test.js tests/unit\\pattern-docs.test.js tests/unit\\pattern-overlap.test.js tests/unit\\pay-b-cost-receipt.test.js tests/unit\\perf-report.test.js tests/unit\\persona-ablation-live.test.js tests/unit\\persona-args.test.js tests/unit\\persona-calibration.test.js tests/unit\\persona-command.test.js tests/unit\\persona-gates.test.js tests/unit\\persona-match.test.js tests/unit\\persona-natural-ko.test.js tests/unit\\persona-packaging.test.js tests/unit\\persona-resolver.test.js tests/unit\\persona-schema.test.js tests/unit\\persona-seed.test.js tests/unit\\playground-a11y.test.js tests/unit\\playground-analytics.test.js tests/unit\\playground-examples.test.js tests/unit\\playground-experience.test.js tests/unit\\playground-module-graph.test.js tests/unit\\playground-preferences.test.js tests/unit\\playground-pro.test.js tests/unit\\polar-webhook.test.js tests/unit\\pr-policy.test.js tests/unit\\preparation-replay.test.js tests/unit\\preview.test.js tests/unit\\pro-monitor-api.test.js tests/unit\\pro-monitor-e2e.test.js tests/unit\\pro-monitor.test.js tests/unit\\prompt-builder.persona.test.js tests/unit\\prompt-builder.snapshot.test.js tests/unit\\prose-score.test.js tests/unit\\protected-input.test.js tests/unit\\public-showcase.test.js tests/unit\\quota-redis.test.js tests/unit\\quota-reservation.test.js tests/unit\\ranking-metrics.test.js tests/unit\\rate-limit.redteam.test.js tests/unit\\rate-limit.test.js tests/unit\\rebaseline-build-claim-manifest.test.js tests/unit\\rebaseline-generate-modern.test.js tests/unit\\rebaseline-intake.test.js tests/unit\\rebaseline-low-fpr-report.test.js tests/unit\\rebaseline-score-collection.test.js tests/unit\\rebaseline-score.test.js tests/unit\\rebaseline-summary.test.js tests/unit\\rebaseline-web-collect.test.js tests/unit\\redos-mattr-evidence.test.js tests/unit\\register.test.js tests/unit\\release-artifacts.test.js tests/unit\\retired-concepts.test.js tests/unit\\rewrite-ab.test.js tests/unit\\rewrite-api.test.js tests/unit\\rewrite-client.test.js tests/unit\\rewrite-handler.test.js tests/unit\\score-overall-coercion.test.js tests/unit\\scorer-path-corpus.test.js tests/unit\\scorer-public-report.test.js tests/unit\\scoring.test.js tests/unit\\security.test.js tests/unit\\share-card.test.js tests/unit\\short-form.test.js tests/unit\\shortform-collection.test.js tests/unit\\signal-impact.test.js tests/unit\\slice-metadata.test.js tests/unit\\slice-metrics.test.js tests/unit\\streaming-api.test.js tests/unit\\structural-classifier.test.js tests/unit\\structural-model-loader.test.js tests/unit\\study-completion-persistence.test.js tests/unit\\study-family.test.js tests/unit\\study-persistence.test.js tests/unit\\study-transport-process.test.js tests/unit\\study-validation.test.js tests/unit\\stylometry-ko.test.js tests/unit\\stylometry.test.js tests/unit\\threshold-parity.test.js tests/unit\\transform-options.test.js tests/unit\\translationese.test.js tests/unit\\verification-schema.test.js tests/unit\\verify.test.js tests/unit\\web-config.test.js tests/unit\\web-deploy-invariants.test.js tests/unit\\web-edit-controls.test.js tests/unit\\web-observability.test.js tests/unit\\web-rewrite-contract.redteam.test.js tests/unit\\web-rewrite-contract.test.js tests/unit\\web-rewrite-stream.redteam.test.js tests/unit\\web-rewrite-stream.test.js tests/unit\\web-rewrite.redteam.test.js tests/unit\\web-rewrite.test.js tests/unit\\xliff-cli.redteam.test.js tests/unit\\xliff-cli.test.js tests/unit\\xliff-crossfile-dedup.test.js tests/unit\\xliff-writeback.redteam.test.js tests/unit\\xliff-writeback.test.js tests/unit\\xliff.redteam.test.js tests/unit\\xliff.test.js tests/e2e\\aside-cli.test.js tests/e2e\\auth-login.test.js tests/e2e\\backends.test.js tests/e2e\\check-no-private-assets.test.js tests/e2e\\cli-adoption.test.js tests/e2e\\cli-api.test.js tests/e2e\\cli-cancellation.test.js tests/e2e\\cli-persona.test.js tests/e2e\\cli-verification.test.js tests/e2e\\cli.test.js tests/e2e\\dev-server.test.js tests/e2e\\precommit-score.test.js tests/e2e\\providers.test.js tests/e2e\\public-contracts.test.js tests/e2e\\release-artifacts.test.js tests/e2e\\security.test.js tests/e2e\\session-isolation.test.js tests/e2e\\skill-install.test.js tests/e2e\\skill-invocation.test.js",
+      "cwd": ".",
+      "status": 0,
+      "signal": null,
+      "ms": 73822,
+      "ok": true,
+      "spawnError": null,
+      "parseError": null,
+      "parsed": {
+        "tests": 2453,
+        "pass": 2370,
+        "fail": 0,
+        "skip": 83,
+        "failing": []
+      }
+    }
+  ],
+  "summary": {
+    "stepsRun": 8,
+    "stepsSkipped": [],
+    "stepsFailed": [],
+    "suite": {
+      "tests": 2453,
+      "pass": 2370,
+      "fail": 0,
+      "skip": 83,
+      "failing": []
+    },
+    "lifecycle": {
+      "tests": 12,
+      "pass": 5,
+      "fail": 0,
+      "skip": 7,
+      "failing": []
+    },
+    "verdict": "recorded; interpretation belongs to the maintenance record, not this script"
+  },
+  "diagnostics": "docs/internal/<stem>.diagnostics.json (gitignored; raw child output, operator-only)"
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import js from '@eslint/js';
 
 const nodeGlobals = {
   AbortController: 'readonly',
+  AbortSignal: 'readonly',
   Buffer: 'readonly',
   URL: 'readonly',
   console: 'readonly',

--- a/scripts/check-no-private-assets.mjs
+++ b/scripts/check-no-private-assets.mjs
@@ -169,10 +169,13 @@ export function runGate({ packedFiles = [], trackedFiles = [] } = {}) {
  * @throws {Error} When `npm pack` fails or emits unparseable JSON.
  */
 export function collectPackedFiles(cwd, prefix = '', { spawn = spawnSync } = {}) {
+  // npm is npm.cmd on Windows, which Node refuses to spawn without a shell
+  // since the CVE-2024-27980 fix.
   const result = spawn(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
     cwd,
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
+    shell: process.platform === 'win32',
   });
   if (result.error) {
     const code = result.error.code ? ` (${result.error.code})` : '';

--- a/scripts/platform-smoke.mjs
+++ b/scripts/platform-smoke.mjs
@@ -28,11 +28,10 @@ const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const WIN = process.platform === 'win32';
 const NPM = WIN ? 'npm.cmd' : 'npm';
 const STEP_TIMEOUT_MS = 20 * 60 * 1000;
-// The full suite is spawn-heavy, which Windows process creation (plus
-// real-time AV scanning) makes an order of magnitude slower than Linux:
-// measured 67 s on Linux, 72 s on macOS, and past the 20-minute default on a
-// Windows 11 host. The suite gets its own bound so a genuinely hung run is
-// still recorded as a timed-out step instead of passing silently.
+// Hang guard for the full-suite step: a genuinely wedged run (leaked server,
+// deadlocked child) must still be recorded as a timed-out step instead of
+// hanging the smoke forever. Far above the measured suite durations
+// (~70 s on Linux/macOS/Windows once teardown leaks are fixed).
 const SUITE_TIMEOUT_MS = 90 * 60 * 1000;
 const DIAG_CAP = 20_000;
 const KEY_ENV_NAMES = ['PATINA_API_KEY', 'PATINA_API_KEY_FILE', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'ANTHROPIC_API_KEY', 'KIMI_API_KEY', 'MOONSHOT_API_KEY', 'GROQ_API_KEY', 'TOGETHER_API_KEY', 'MINIMAX_API_KEY'];

--- a/scripts/platform-smoke.mjs
+++ b/scripts/platform-smoke.mjs
@@ -28,6 +28,12 @@ const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const WIN = process.platform === 'win32';
 const NPM = WIN ? 'npm.cmd' : 'npm';
 const STEP_TIMEOUT_MS = 20 * 60 * 1000;
+// The full suite is spawn-heavy, which Windows process creation (plus
+// real-time AV scanning) makes an order of magnitude slower than Linux:
+// measured 67 s on Linux, 72 s on macOS, and past the 20-minute default on a
+// Windows 11 host. The suite gets its own bound so a genuinely hung run is
+// still recorded as a timed-out step instead of passing silently.
+const SUITE_TIMEOUT_MS = 90 * 60 * 1000;
 const DIAG_CAP = 20_000;
 const KEY_ENV_NAMES = ['PATINA_API_KEY', 'PATINA_API_KEY_FILE', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'ANTHROPIC_API_KEY', 'KIMI_API_KEY', 'MOONSHOT_API_KEY', 'GROQ_API_KEY', 'TOGETHER_API_KEY', 'MINIMAX_API_KEY'];
 
@@ -113,13 +119,13 @@ const diagnostics = { stem, steps: [] };
  * Run one child process and record it. `okWhen(result, parsed)` decides the
  * verdict once; the default is exit status 0 with no spawn error.
  */
-function run(name, command, argv, { cwd = REPO_ROOT, env = {}, parse = null, okWhen = null } = {}) {
+function run(name, command, argv, { cwd = REPO_ROOT, env = {}, parse = null, okWhen = null, timeout = STEP_TIMEOUT_MS } = {}) {
   const started = Date.now();
   const result = spawnSync(command, argv, {
     cwd,
     env: { ...process.env, ...env },
     encoding: 'utf8',
-    timeout: STEP_TIMEOUT_MS,
+    timeout,
     maxBuffer: 64 * 1024 * 1024,
     shell: WIN && command.endsWith('.cmd'),
   });
@@ -260,7 +266,7 @@ try {
 
   // 6. Full suite, files enumerated here so no shell glob expansion is needed.
   if (!flag('--skip-suite')) {
-    run('npm test (unit + e2e, tap)', process.execPath, ['-r', join(REPO_ROOT, 'tests', 'helpers', 'real-tmpdir.cjs'), '--test', '--test-reporter=tap', ...listTests('tests/unit'), ...listTests('tests/e2e')], { parse: parseTap });
+    run('npm test (unit + e2e, tap)', process.execPath, ['-r', join(REPO_ROOT, 'tests', 'helpers', 'real-tmpdir.cjs'), '--test', '--test-reporter=tap', ...listTests('tests/unit'), ...listTests('tests/e2e')], { parse: parseTap, timeout: SUITE_TIMEOUT_MS });
   } else {
     receipt.steps.push({ name: 'npm test (unit + e2e, tap)', ok: null, skipped: '--skip-suite' });
   }

--- a/scripts/release-artifacts.mjs
+++ b/scripts/release-artifacts.mjs
@@ -358,7 +358,9 @@ function runCommand(command, args, options = {}, execute = execFileSync) {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
       // .cmd shims on win32 cannot be spawned without a shell
-      // (CVE-2024-27980).
+      // (CVE-2024-27980). Node quotes args for shell spawns only since
+      // 18.20.2/20.12.2; release tooling runs on the Linux runner, and win32
+      // use on older Nodes risks mis-split paths with spaces.
       ...(command.endsWith('.cmd') ? { shell: true } : {}),
       ...options,
     });

--- a/scripts/release-artifacts.mjs
+++ b/scripts/release-artifacts.mjs
@@ -44,7 +44,7 @@ export const PACKAGE_ARTIFACTS = Object.freeze([
   }),
 ]);
 
-const DEFAULT_NPM_COMMAND = process.env.NPM_COMMAND || 'npm';
+const DEFAULT_NPM_COMMAND = process.env.NPM_COMMAND || (process.platform === 'win32' ? 'npm.cmd' : 'npm');
 const DEFAULT_NPM_TIMEOUT_MS = 120_000;
 const NPM_REGISTRY = 'https://registry.npmjs.org';
 
@@ -357,6 +357,9 @@ function runCommand(command, args, options = {}, execute = execFileSync) {
     return execute(command, args, {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      // .cmd shims on win32 cannot be spawned without a shell
+      // (CVE-2024-27980).
+      ...(command.endsWith('.cmd') ? { shell: true } : {}),
       ...options,
     });
   } catch (error) {

--- a/tests/e2e/aside-cli.test.js
+++ b/tests/e2e/aside-cli.test.js
@@ -40,7 +40,21 @@ test('aside CLI discovers its skill and detached options session persists to sta
   const session = JSON.parse(launched.stdout);
   const url = new URL(session.url);
   const headers = { 'X-Patina-Session': url.hash.slice(1), Origin: url.origin, 'Content-Type': 'application/json' };
-  t.after(async () => { await fetch(`${url.origin}/api/close`, { method: 'POST', headers, body: '{}' }).catch(() => {}); });
+  t.after(async () => {
+    await fetch(`${url.origin}/api/close`, { method: 'POST', headers, body: '{}' }).catch(() => {});
+    // The detached server exits asynchronously, and win32 cannot remove the
+    // workspace while the process still holds it as its cwd (EBUSY). Wait
+    // for the port to stop answering before the workspace rm runs.
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+      try {
+        await fetch(`${url.origin}/api/options`, { headers, signal: AbortSignal.timeout(500) });
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      } catch {
+        return;
+      }
+    }
+  });
   const state = await (await fetch(`${url.origin}/api/options`, { headers })).json();
   const settings = { ...state.settings, language: 'ko', register: 'professional' };
   assert.equal((await fetch(`${url.origin}/api/options`, { method: 'POST', headers, body: JSON.stringify({ settings, baseHash: state.settingsHash }) })).status, 200);

--- a/tests/e2e/aside-cli.test.js
+++ b/tests/e2e/aside-cli.test.js
@@ -20,14 +20,18 @@ function command(args, cwd, env = process.env) {
     child.once('close', code => { clearTimeout(timer); resolve({ code, stdout, stderr }); });
   });
 }
-async function workspace(t) {
+async function workspace(t, { autoClean = true } = {}) {
   const dir = await mkdtemp(join(tmpdir(), 'patina-aside-cli-'));
-  t.after(() => rm(dir, { recursive: true, force: true }));
+  if (autoClean) t.after(() => rm(dir, { recursive: true, force: true }));
   return dir;
 }
 
 test('aside CLI discovers its skill and detached options session persists to status', async (t) => {
-  const dir = await workspace(t);
+  // No autoClean: the session-close hook and the rm must run in that order.
+  // t.after hooks run in registration order and a failed hook skips the
+  // rest, so the rm is registered after the close below; on win32 an rm
+  // racing the live detached server fails EBUSY and would skip the close.
+  const dir = await workspace(t, { autoClean: false });
   const skill = await command(['skill'], dir);
   assert.equal(skill.code, 0);
   const bundle = JSON.parse(skill.stdout);
@@ -55,6 +59,7 @@ test('aside CLI discovers its skill and detached options session persists to sta
       }
     }
   });
+  t.after(() => rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 300 }));
   const state = await (await fetch(`${url.origin}/api/options`, { headers })).json();
   const settings = { ...state.settings, language: 'ko', register: 'professional' };
   assert.equal((await fetch(`${url.origin}/api/options`, { method: 'POST', headers, body: JSON.stringify({ settings, baseHash: state.settingsHash }) })).status, 200);

--- a/tests/e2e/auth-login.test.js
+++ b/tests/e2e/auth-login.test.js
@@ -94,6 +94,14 @@ function makeFakeCliEnv() {
   };
 }
 
+// The fake CLIs are extensionless POSIX shebang scripts. On win32 a PATH shim
+// like that cannot intercept a spawn, so these tests would launch the REAL
+// host CLIs instead — and an interactive `claude auth login` never returns.
+// Skipping is absent coverage on Windows, not a pass.
+const FAKE_LOGIN_SKIP = process.platform === 'win32'
+  ? 'fake login CLIs require POSIX shebang PATH shims; would launch real host CLIs on Windows'
+  : false;
+
 describe('patina auth login <backend>', () => {
   it('keeps no-arg login as a per-backend instruction listing', async () => {
     const output = await captureConsole(async () => {
@@ -107,7 +115,7 @@ describe('patina auth login <backend>', () => {
     assert.match(output, /kimi-cli/);
   });
 
-  it('launches codex login and re-checks authentication', async () => {
+  it('launches codex login and re-checks authentication', { skip: FAKE_LOGIN_SKIP }, async () => {
     const env = makeFakeCliEnv();
     const output = await withEnv(env, () => captureConsole(async () => {
       await main(['auth', 'login', 'codex-cli', '--yes']);
@@ -118,7 +126,7 @@ describe('patina auth login <backend>', () => {
     assert.match(output, /codex-cli: authenticated/);
   });
 
-  it('launches claude, gemini, and kimi interactive login flows', async () => {
+  it('launches claude, gemini, and kimi interactive login flows', { skip: FAKE_LOGIN_SKIP }, async () => {
     const env = makeFakeCliEnv();
     const output = await withEnv(env, () => captureConsole(async () => {
       await main(['auth', 'login', 'claude-cli', '--yes']);

--- a/tests/e2e/check-no-private-assets.test.js
+++ b/tests/e2e/check-no-private-assets.test.js
@@ -28,11 +28,12 @@ describe('leak gate (end to end): real npm pack + git enumeration', () => {
     const planted = resolve(REPO_ROOT, 'src/AGENTS.md');
     writeFileSync(planted, '# fixture-only scoped development rule\n');
     try {
-      const pack = spawnSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
-        cwd: REPO_ROOT,
-        encoding: 'utf8',
-        maxBuffer: 64 * 1024 * 1024,
-      });
+      // Bare npm is npm.cmd on win32 (needs a shell; CVE-2024-27980).
+      const pack = process.platform === 'win32'
+        ? spawnSync('npm.cmd', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+            cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, shell: true })
+        : spawnSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+            cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
       assert.strictEqual(pack.status, 0, `npm pack should succeed:\n${pack.stdout}\n${pack.stderr}`);
       const packed = JSON.parse(pack.stdout)[0].files.map((file) => file.path);
       assert.ok(packed.includes('SKILL.md'), 'product SKILL.md must remain packaged');

--- a/tests/e2e/cli-api.test.js
+++ b/tests/e2e/cli-api.test.js
@@ -283,7 +283,7 @@ describe('CLI End-to-End with Mock API', () => {
 
       assert.ok(previewRun.logs.join('\n').includes('First paragraph rewritten by the mock backend'));
       assert.strictEqual(mock.callCount, 2);
-      assert.ok(previewRun.errors.some((line) => line.includes('Preview page saved at /tmp/patina-preview-456/browser-diff-456.html')));
+      assert.ok(previewRun.errors.some((line) => line.includes(`Preview page saved at ${join('/tmp', 'patina-preview-456', 'browser-diff-456.html')}`)));
       assert.ok(previewRun.errors.some((line) => line.includes('Browser open failed: browser opener exited with code 1')));
     } finally {
       resetBrowserDiffRuntimeForTests();
@@ -420,7 +420,7 @@ describe('CLI End-to-End with Mock API', () => {
       await mainPromise;
 
       assert.deepStrictEqual(spawns, [], 'serve mode must not spawn a window opener');
-      assert.ok(errors.some((line) => line.includes('Preview page saved at /tmp/patina-preview-serve/browser-diff-999.html')));
+      assert.ok(errors.some((line) => line.includes(`Preview page saved at ${join('/tmp', 'patina-preview-serve', 'browser-diff-999.html')}`)));
       assert.ok(errors.some((line) => line.includes('Stops after 10 idle minutes')));
       assert.ok(logs.join('\n').includes('First paragraph rewritten by the mock backend'));
       assert.strictEqual(mock.callCount, 2);
@@ -513,8 +513,8 @@ describe('CLI End-to-End with Mock API', () => {
       // Document-brief stage: the rewrite request primes a global frame.
       assert.ok(mock.requestBodies[0].messages[0].content.includes('Phase 0: Document Brief'));
       assert.ok(previewRun.logs.join('\n').includes('First paragraph rewritten by the mock backend'));
-      assert.ok(previewRun.errors.some((line) => line.includes('Preview page saved at /tmp/patina-preview-77/browser-diff-77.html (2 of 2 blocks rewritten)')));
-      assert.deepStrictEqual(spawns, [{ command: 'xdg-open', args: ['/tmp/patina-preview-77/browser-diff-77.html'] }]);
+      assert.ok(previewRun.errors.some((line) => line.includes(`Preview page saved at ${join('/tmp', 'patina-preview-77', 'browser-diff-77.html')} (2 of 2 blocks rewritten)`)));
+      assert.deepStrictEqual(spawns, [{ command: 'xdg-open', args: [resolve(join('/tmp', 'patina-preview-77', 'browser-diff-77.html'))] }]);
 
       const page = writes[0].data;
       assert.ok(page.includes('<span class="ptna-after">First paragraph rewritten by the mock backend for the preview test.</span>'));

--- a/tests/e2e/cli-cancellation.test.js
+++ b/tests/e2e/cli-cancellation.test.js
@@ -11,7 +11,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../..');
 const BIN = resolve(REPO_ROOT, 'bin/patina.js');
 
-test('SIGINT cancels an in-flight HTTP backend request and exits 130', async () => {
+// win32 cannot deliver SIGINT to a child: Node terminates the process
+// unconditionally, so the exit-130 cancellation path has no coverage there.
+test('SIGINT cancels an in-flight HTTP backend request and exits 130', { skip: process.platform === 'win32' && 'win32 has no SIGINT delivery to children' }, async () => {
   const dir = mkdtempSync(join(tmpdir(), 'patina-sigint-'));
   const inputPath = join(dir, 'input.txt');
   writeFileSync(inputPath, 'This draft should wait on the mock backend.\n');

--- a/tests/e2e/cli-verification.test.js
+++ b/tests/e2e/cli-verification.test.js
@@ -97,7 +97,13 @@ async function runMeaningSafetyBatch(scenario, {
 }
 
 for (const scenario of ['hard-fail', 'malformed', 'nested-body', 'dropped-number', 'dropped-number-unverified']) {
-  test(`CLI batch in-place preserves failed ${scenario} input and still writes the next valid file`, async () => {
+  // win32: the unverified scenario's CLI child completes all batch work
+  // correctly, then aborts at process teardown with a libuv assertion
+  // (exit 0xC0000409, src\win\async.c:94, Node 24.17.0). That is a runtime-
+  // level crash, absent coverage here — tracked as a win32 follow-up.
+  const skip = process.platform === 'win32' && scenario === 'dropped-number-unverified'
+    && 'libuv async-handle abort at CLI teardown on win32 (Node 24.17.0)';
+  test(`CLI batch in-place preserves failed ${scenario} input and still writes the next valid file`, { skip }, async () => {
     for (const format of ['text', 'json']) {
       const { result, counts, first, second, original, validCandidate, firstAfter, secondAfter } =
         await runMeaningSafetyBatch(scenario, { format });

--- a/tests/e2e/cli-verification.test.js
+++ b/tests/e2e/cli-verification.test.js
@@ -100,9 +100,9 @@ for (const scenario of ['hard-fail', 'malformed', 'nested-body', 'dropped-number
   // win32: the unverified scenario's CLI child completes all batch work
   // correctly, then aborts at process teardown with a libuv assertion
   // (exit 0xC0000409, src\win\async.c:94, Node 24.17.0). That is a runtime-
-  // level crash, absent coverage here — tracked as a win32 follow-up.
+  // level crash, absent coverage here — tracked as issue #807.
   const skip = process.platform === 'win32' && scenario === 'dropped-number-unverified'
-    && 'libuv async-handle abort at CLI teardown on win32 (Node 24.17.0)';
+    && 'libuv async-handle abort at CLI teardown on win32 (Node 24.17.0); see issue #807';
   test(`CLI batch in-place preserves failed ${scenario} input and still writes the next valid file`, { skip }, async () => {
     for (const format of ['text', 'json']) {
       const { result, counts, first, second, original, validCandidate, firstAfter, secondAfter } =

--- a/tests/e2e/cli.test.js
+++ b/tests/e2e/cli.test.js
@@ -12,6 +12,6 @@ describe('CLI Entry Point', () => {
     const binPath = resolve(REPO_ROOT, 'bin/patina.js');
     const stats = fs.statSync(binPath);
     assert.ok(stats.isFile());
-    assert.ok(stats.mode & 0o111, 'Should be executable');
+    if (process.platform !== 'win32') assert.ok(stats.mode & 0o111, 'Should be executable');
   });
 });

--- a/tests/e2e/dev-server.test.js
+++ b/tests/e2e/dev-server.test.js
@@ -230,7 +230,11 @@ test('loopback preview serves the browser dependency graph and completes a real 
 test('public-root symlinks cannot expose private or hidden files', { timeout: 15000 }, async (t) => {
   // All filesystem probes live in a disposable replica, never in the shared playground.
   const root = await mkdtemp(path.join(tmpdir(), 'patina-preview-static-'));
-  await mkdir(path.join(root, 'scripts'));
+  // If setup or startPreview throws before the rm hook below is registered,
+  // still remove the replica.
+  let replicaCleanupArmed = false;
+  try {
+    await mkdir(path.join(root, 'scripts'));
   await cp(path.join(ROOT, 'scripts/dev-server.mjs'), path.join(root, 'scripts/dev-server.mjs'));
   await mkdir(path.join(root, 'api'));
   await cp(path.join(ROOT, 'api/funnel.js'), path.join(root, 'api/funnel.js'));
@@ -247,13 +251,18 @@ test('public-root symlinks cannot expose private or hidden files', { timeout: 15
   // rest: the replica rm must be registered AFTER startPreview's kill hook,
   // or a win32 EBUSY (the child still holds root as cwd) would leak the
   // server and hang the worker. maxRetries absorbs the handle-release lag.
-  t.after(() => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 300 }));
-  for (const route of ['/outside.js', '/hidden.js', '/.secret.js']) {
-    const response = await request(base, route);
-    assert.equal(response.status, 403, route);
-    assert.doesNotMatch(response.body, /sentinel/);
+    t.after(() => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 300 }));
+    replicaCleanupArmed = true;
+    for (const route of ['/outside.js', '/hidden.js', '/.secret.js']) {
+      const response = await request(base, route);
+      assert.equal(response.status, 403, route);
+      assert.doesNotMatch(response.body, /sentinel/);
+    }
+    assert.equal((await request(base, '/public-alias.js')).body, (await request(base, '/preferences.js')).body);
+  } catch (err) {
+    if (!replicaCleanupArmed) await rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 300 });
+    throw err;
   }
-  assert.equal((await request(base, '/public-alias.js')).body, (await request(base, '/preferences.js')).body);
 });
 
 test('DEV_LLM transport uses preview fixtures only when real scoring is disabled', { timeout: 30000 }, async (t) => {

--- a/tests/e2e/dev-server.test.js
+++ b/tests/e2e/dev-server.test.js
@@ -230,7 +230,6 @@ test('loopback preview serves the browser dependency graph and completes a real 
 test('public-root symlinks cannot expose private or hidden files', { timeout: 15000 }, async (t) => {
   // All filesystem probes live in a disposable replica, never in the shared playground.
   const root = await mkdtemp(path.join(tmpdir(), 'patina-preview-static-'));
-  t.after(() => rm(root, { recursive: true, force: true }));
   await mkdir(path.join(root, 'scripts'));
   await cp(path.join(ROOT, 'scripts/dev-server.mjs'), path.join(root, 'scripts/dev-server.mjs'));
   await mkdir(path.join(root, 'api'));
@@ -244,6 +243,11 @@ test('public-root symlinks cannot expose private or hidden files', { timeout: 15
   await symlink('.secret.js', path.join(root, 'playground', 'hidden.js'));
   await symlink('preferences.js', path.join(root, 'playground', 'public-alias.js'));
   const base = await startPreview(t, { root });
+  // t.after hooks run in registration order and a failed hook skips the
+  // rest: the replica rm must be registered AFTER startPreview's kill hook,
+  // or a win32 EBUSY (the child still holds root as cwd) would leak the
+  // server and hang the worker. maxRetries absorbs the handle-release lag.
+  t.after(() => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 300 }));
   for (const route of ['/outside.js', '/hidden.js', '/.secret.js']) {
     const response = await request(base, route);
     assert.equal(response.status, 403, route);

--- a/tests/e2e/skill-install.test.js
+++ b/tests/e2e/skill-install.test.js
@@ -4,7 +4,15 @@ import { cpSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, re
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { test } from 'node:test';
+import { test as nodeTest } from 'node:test';
+
+// install.sh/uninstall.sh and every fixture shim are POSIX shell (/bin/sh,
+// extensionless shebang PATH shims); QA.md declares the installer POSIX-only.
+// None of it can run on win32, so every test in this file registers as
+// skipped there — absent coverage, not a pass.
+const test = process.platform === 'win32'
+  ? (name, ..._rest) => nodeTest(name, { skip: 'POSIX-only installer fixtures (/bin/sh, shebang PATH shims)' }, () => {})
+  : nodeTest;
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const AGENTS = ['CLAUDE', 'CODEX', 'CURSOR', 'OPCODE'];

--- a/tests/e2e/skill-invocation.test.js
+++ b/tests/e2e/skill-invocation.test.js
@@ -7,12 +7,15 @@ import { createHash } from 'node:crypto';
 import { chmod, cp, mkdtemp, mkdir, readFile, readdir, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { mpsResult } from '../fixtures/verification-results.js';
 import { DEFAULT_BEST_MODELS } from '../../src/model-defaults.js';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const HELPER = join(ROOT, 'bin/patina-skill.js');
+// ESM imports of absolute paths must be file:// URLs on win32 ('C:\...' is
+// parsed as the URL scheme 'c:'), while POSIX absolute paths import as-is.
+const HELPER_URL = pathToFileURL(HELPER).href;
 const SOURCE = 'The service retains 12 audit logs.';
 const hash = value => createHash('sha256').update(value).digest('hex');
 
@@ -130,7 +133,7 @@ test('captured config remains authoritative through the real CLI after ambient m
   const capturedPath = join(f.root, 'captured.json');
   const envelopePath = join(f.root, 'child-envelope.json');
   const result = await command(f, [], { program: `
-    import { runSkill } from ${JSON.stringify(HELPER)};
+    import { runSkill } from ${JSON.stringify(HELPER_URL)};
     import { spawn } from 'node:child_process';
     import { readFileSync, writeFileSync } from 'node:fs';
     const result = await runSkill(${JSON.stringify(['--input', f.input])}, { spawnImpl(command, argv, options) {
@@ -256,7 +259,7 @@ function seam(f, { output = SOURCE, verification, stdout, script, inspect = '', 
     mpsFloor: 70, fidelityFloor: 70, outputHash: hash(output) } : verification;
   const body = stdout ?? JSON.stringify({ mode: 'rewrite', format: 'json', output, verification: proof });
   return command(f, [], { program: `
-    import { runSkill } from ${JSON.stringify(HELPER)};
+    import { runSkill } from ${JSON.stringify(HELPER_URL)};
     import { spawn } from 'node:child_process';
     import { readFileSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
     import { dirname, join } from 'node:path';
@@ -431,7 +434,9 @@ test('final receipt write failure never advertises or retains accepted output', 
   assert.deepEqual(names.sort(), ['initial.json', 'receipt.json']);
 });
 
-test('public cancellation waits for the exact real provider request and cleans snapshots', async t => {
+// win32 cannot deliver SIGINT to a child, so the exit-130 cancellation path
+// has no coverage there (see cli-cancellation.test.js).
+test('public cancellation waits for the exact real provider request and cleans snapshots', { skip: process.platform === 'win32' && 'win32 has no SIGINT delivery to children' }, async t => {
   const f = await fixture(t);
   let ready;
   const requested = new Promise(resolve => { ready = resolve; });
@@ -459,7 +464,7 @@ test('output is bounded by the child byte cap, not the source character limit', 
 test('failed spawn records invocationStarted=false rather than a planned invocation', async t => {
   const f = await fixture(t);
   const result = await command(f, [], { program: `
-    import { runSkill } from ${JSON.stringify(HELPER)};
+    import { runSkill } from ${JSON.stringify(HELPER_URL)};
     import { spawn } from 'node:child_process';
     const result = await runSkill(${JSON.stringify(['--input', f.input])}, { spawnImpl(command, argv, options) {
       if (argv.includes('--version')) return spawn(command, argv, options);
@@ -475,7 +480,7 @@ test('unsupported Node and broken actual CLI version never read or send draft by
   for (const kind of ['node', 'cli']) {
     const f = await fixture(t);
     const result = await command(f, [], { program: `
-      import { runSkill } from ${JSON.stringify(HELPER)};
+      import { runSkill } from ${JSON.stringify(HELPER_URL)};
       import { spawn } from 'node:child_process';
       ${kind === 'node' ? "Object.defineProperty(process.versions, 'node', { value: '18.0.0' });" : ''}
       const result = await runSkill(${JSON.stringify(['--input', f.input])}, { spawnImpl(command, _argv, options) {

--- a/tests/e2e/skill-invocation.test.js
+++ b/tests/e2e/skill-invocation.test.js
@@ -368,12 +368,17 @@ test('missing selected backend and missing selected authentication never fall ba
   const unavailable = await command(f, ['--backend', 'codex-cli']).done;
   assert.equal(unavailable.summary.code, 'backend_unavailable');
   assert.equal((await privateArtifacts(unavailable, ['receipt.json'])).invocationStarted, false);
-  const codex = join(executables, 'codex');
-  await writeFile(codex, '#!/bin/sh\nexit 0\n');
-  await chmod(codex, 0o700);
-  const unauthenticated = await command(f, ['--backend', 'codex-cli']).done;
-  assert.equal(unauthenticated.summary.code, 'backend_auth_missing');
-  assert.equal((await privateArtifacts(unauthenticated, ['receipt.json'])).selection.backend, 'codex-cli');
+  // The unauthenticated-CLI case needs an executable PATH shim: an
+  // extensionless POSIX script is never resolved through PATHEXT on win32, so
+  // only the unavailable-backend case is covered there.
+  if (process.platform !== 'win32') {
+    const codex = join(executables, 'codex');
+    await writeFile(codex, '#!/bin/sh\nexit 0\n');
+    await chmod(codex, 0o700);
+    const unauthenticated = await command(f, ['--backend', 'codex-cli']).done;
+    assert.equal(unauthenticated.summary.code, 'backend_auth_missing');
+    assert.equal((await privateArtifacts(unauthenticated, ['receipt.json'])).selection.backend, 'codex-cli');
+  }
   f.env.PATINA_API_KEY = '';
   const http = await command(f, ['--backend', 'openai-http']).done;
   assert.equal(http.summary.code, 'backend_auth_missing');

--- a/tests/unit/aside-runner.test.js
+++ b/tests/unit/aside-runner.test.js
@@ -22,7 +22,9 @@ const NESTED_GRADED = 'The service does not store drafts. [BODY]It runs locally.
 
 async function fixture(t, { source = SOURCE, settings } = {}) {
   const root = await mkdtemp(join(tmpdir(), 'aside-runner-test-'));
-  t.after(() => rm(root, { recursive: true, force: true }));
+  // maxRetries absorbs win32 EBUSY: the OS releases directory handles a beat
+  // after the child that held the workspace as cwd has already exited.
+  t.after(() => rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 }));
   const workspace = join(root, 'workspace with spaces');
   const temporary = join(root, 'temporary');
   await mkdir(workspace);

--- a/tests/unit/backend-agy.test.js
+++ b/tests/unit/backend-agy.test.js
@@ -73,7 +73,15 @@ function hostSettingsProblem() {
     return err.message;
   }
 }
-const launchSkip = hostSettingsProblem();
+// The fake `agy` is an extensionless POSIX shebang script joined to PATH with
+// ':'. Windows never resolves an extensionless name through PATHEXT and (since
+// the Node CVE-2024-27980 fix) refuses to spawn a .cmd shim without a shell,
+// so the fake cannot intercept the launch there. Skipping is absent coverage
+// of the live Windows launch path, not a pass; everything else (argv building,
+// stream parsing, settings guard) still runs on win32.
+const launchSkip = process.platform === 'win32'
+  ? 'fake agy CLI shim requires POSIX shebang semantics; live Windows launch unverified'
+  : hostSettingsProblem();
 
 function argValue(args, flag) {
   const index = args.indexOf(flag);

--- a/tests/unit/backend-model-defaults.test.js
+++ b/tests/unit/backend-model-defaults.test.js
@@ -29,6 +29,12 @@ const FAKE_CLI = [
   '});',
   '',
 ].join('\n');
+// The fake CLIs are extensionless POSIX shebang scripts; on win32 they cannot
+// intercept a spawn, so the fake-dependent tests below would invoke the REAL
+// host CLIs. Skipping is absent coverage on Windows, not a pass.
+const FAKE_CLI_SKIP = process.platform === 'win32'
+  ? 'fake CLI PATH shims require POSIX shebang semantics'
+  : false;
 
 async function withFakeCli(fn, script = FAKE_CLI) {
   const binDir = mkdtempSync(join(tmpdir(), 'patina-model-cli-'));
@@ -112,7 +118,7 @@ test('drops foreign-family models from env/provider sources for local CLI backen
   );
 });
 
-test('local CLI backends pass default best-model flags to child processes', async () => {
+test('local CLI backends pass default best-model flags to child processes', { skip: FAKE_CLI_SKIP }, async () => {
   await withFakeCli(async () => {
     const codex = JSON.parse(await codexCli.invoke({ prompt: 'rewrite this', modelSource: 'default' }));
     assert.strictEqual(basename(codex.command), 'codex');
@@ -151,7 +157,7 @@ const FAKE_CLI_WITH_POLICY = FAKE_CLI.replace(
   "  const payload = JSON.stringify({ command: basename(process.argv[1]), args, stdin, isolation, policy });",
 );
 
-test('local CLI backends strip agent tools from every text invocation', async () => {
+test('local CLI backends strip agent tools from every text invocation', { skip: FAKE_CLI_SKIP }, async () => {
   await withFakeCli(async () => {
     const codex = JSON.parse(await codexCli.invoke({ prompt: 'rewrite this' }));
     for (const feature of codexCli.CODEX_DISABLED_FEATURES) {
@@ -176,7 +182,7 @@ test('local CLI backends strip agent tools from every text invocation', async ()
   }, FAKE_CLI_WITH_POLICY);
 });
 
-test('claude keeps only the Read tool when images are attached; gemini stays tool-free', async () => {
+test('claude keeps only the Read tool when images are attached; gemini stays tool-free', { skip: FAKE_CLI_SKIP }, async () => {
   const imageDir = mkdtempSync(join(tmpdir(), 'patina-tool-image-'));
   const image = join(imageDir, 'shot.png');
   writeFileSync(image, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
@@ -195,7 +201,7 @@ test('claude keeps only the Read tool when images are attached; gemini stays too
   }
 });
 
-test('local CLI backends pass explicit non-alias model ids', async () => {
+test('local CLI backends pass explicit non-alias model ids', { skip: FAKE_CLI_SKIP }, async () => {
   await withFakeCli(async () => {
     const codex = JSON.parse(await codexCli.invoke({
       prompt: 'rewrite this',
@@ -220,7 +226,7 @@ test('local CLI backends pass explicit non-alias model ids', async () => {
   });
 });
 
-test('Kimi detailed output preserves validated private session identities', async () => {
+test('Kimi detailed output preserves validated private session identities', { skip: FAKE_CLI_SKIP }, async () => {
   const uuid = '04698749-1e50-4b73-a5a8-6d3f3c61f4c9';
   const script = `#!/usr/bin/env node
 const args = process.argv.slice(2);
@@ -241,7 +247,7 @@ console.log(JSON.stringify({ role: 'meta', type: 'session.resume_hint', session_
   }, script);
 });
 
-test('Kimi clients lacking explicit tool restrictions never fall back to unrestricted mode', async () => {
+test('Kimi clients lacking explicit tool restrictions never fall back to unrestricted mode', { skip: FAKE_CLI_SKIP }, async () => {
   const script = `#!/usr/bin/env node
 if (process.argv.includes('--agent-file')) {
   process.stderr.write('unknown option: --agent-file');

--- a/tests/unit/browser-diff.test.js
+++ b/tests/unit/browser-diff.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import { EventEmitter } from 'node:events';
-
+import { join, resolve as resolvePath } from 'node:path';
 import {
   buildBrowserDiffPromptInput,
   htmlEscape,
@@ -65,11 +65,13 @@ test('writeBrowserDiffPage uses a patina-scoped temp dir and restrictive permiss
     now: () => 42,
   });
 
-  assert.strictEqual(path, '/tmp/patina-browser-diff-abc/browser-diff-42.html');
-  assert.deepStrictEqual(writes, [{ filePath: '/tmp/patina-browser-diff-abc/browser-diff-42.html', content: '<html/>', encoding: 'utf8' }]);
+  const expectedDir = join('/tmp', 'patina-browser-diff-abc');
+  const expectedFile = join(expectedDir, 'browser-diff-42.html');
+  assert.strictEqual(path, expectedFile);
+  assert.deepStrictEqual(writes, [{ filePath: expectedFile, content: '<html/>', encoding: 'utf8' }]);
   assert.deepStrictEqual(chmods, [
-    { filePath: '/tmp/patina-browser-diff-abc', mode: 0o700 },
-    { filePath: '/tmp/patina-browser-diff-abc/browser-diff-42.html', mode: 0o600 },
+    { filePath: expectedDir, mode: 0o700 },
+    { filePath: expectedFile, mode: 0o600 },
   ]);
 });
 
@@ -104,7 +106,7 @@ test('openBrowserDiffPage selects the platform opener and propagates close failu
   };
 
   await openBrowserDiffPage('/tmp/demo.html', { platform: 'linux', spawn: successSpawn });
-  assert.deepStrictEqual(seen, { command: 'xdg-open', args: ['/tmp/demo.html'] });
+  assert.deepStrictEqual(seen, { command: 'xdg-open', args: [resolvePath('/tmp/demo.html')] });
   assert.strictEqual(unrefCalled, false);
 
   await assert.rejects(

--- a/tests/unit/browser-diff.test.js
+++ b/tests/unit/browser-diff.test.js
@@ -65,7 +65,9 @@ test('writeBrowserDiffPage uses a patina-scoped temp dir and restrictive permiss
     now: () => 42,
   });
 
-  const expectedDir = join('/tmp', 'patina-browser-diff-abc');
+  // The dir chmod receives the mkdtemp return value verbatim; only the file
+  // path goes through join().
+  const expectedDir = '/tmp/patina-browser-diff-abc';
   const expectedFile = join(expectedDir, 'browser-diff-42.html');
   assert.strictEqual(path, expectedFile);
   assert.deepStrictEqual(writes, [{ filePath: expectedFile, content: '<html/>', encoding: 'utf8' }]);

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -19,15 +19,21 @@ function tempWorkspace() {
 
 async function withEnv({ home, cwd }, fn) {
   const oldHome = process.env.HOME;
+  const oldUserProfile = process.env.USERPROFILE;
   const oldCwd = process.cwd();
+  // os.homedir() reads HOME on POSIX but USERPROFILE on win32; redirect both
+  // so the fixture home is the home directory on every platform.
   process.env.HOME = home;
+  process.env.USERPROFILE = home;
   process.chdir(cwd);
   try {
-    await fn();
+    return await fn();
   } finally {
     process.chdir(oldCwd);
     if (oldHome === undefined) delete process.env.HOME;
     else process.env.HOME = oldHome;
+    if (oldUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = oldUserProfile;
   }
 }
 

--- a/tests/unit/lexicon-freshness.test.js
+++ b/tests/unit/lexicon-freshness.test.js
@@ -26,10 +26,10 @@ test('repo lexicons have exact per-entry provenance sidecars', () => {
   assert.deepEqual(
     result.files.map((file) => [file.file, file.entries, file.provenanceRows]),
     [
-      ['lexicon/ai-en.md', 88, 88],
-      ['lexicon/ai-ko.md', 33, 33],
-      ['lexicon/ai-zh.md', 60, 60],
-      ['lexicon/ai-ja.md', 60, 60],
+      [join('lexicon', 'ai-en.md'), 88, 88],
+      [join('lexicon', 'ai-ko.md'), 33, 33],
+      [join('lexicon', 'ai-zh.md'), 60, 60],
+      [join('lexicon', 'ai-ja.md'), 60, 60],
     ]
   );
 });

--- a/tests/unit/lexicon.test.js
+++ b/tests/unit/lexicon.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { computeDensity, phraseToRegex, loadLexicon } from '../../src/features/lexicon.js';
 import { tokenize } from '../../src/features/segment.js';
 import { analyzeText } from '../../src/features/index.js';
@@ -13,7 +13,7 @@ const REPO_ROOT = resolve(__dirname, '../..');
 test('loads zh and ja AI lexicons with at least 50 entries each', () => {
   for (const lang of ['zh', 'ja']) {
     const lexicon = loadLexicon(lang, REPO_ROOT);
-    assert.ok(lexicon.path?.endsWith(`lexicon/ai-${lang}.md`));
+    assert.ok(lexicon.path?.endsWith(join('lexicon', `ai-${lang}.md`)), lexicon.path);
     assert.strictEqual(lexicon.strict.length, 0);
     assert.ok(lexicon.phrases.length >= 50, `${lang} lexicon should have at least 50 phrases`);
   }

--- a/tests/unit/maintenance-workflows.test.js
+++ b/tests/unit/maintenance-workflows.test.js
@@ -96,7 +96,7 @@ test('dataset publication cannot be reached from a privileged pull-request check
   assert.doesNotMatch(source, /actions\/checkout@v6[\s\S]*ref:\s*main/);
 });
 
-test('release shell binds dispatch versions and rejects missing or moved tags before writes', () => {
+test('release shell binds dispatch versions and rejects missing or moved tags before writes', { skip: process.platform === 'win32' && 'runs the workflow steps through bash and POSIX PATH shims' }, () => {
   const workflow = readYaml(resolve(REPO_ROOT, '.github/workflows/release.yml'));
   const verify = workflow.jobs.npm.steps.find(step => step.name === 'Verify downloaded release tarballs');
   const publish = workflow.jobs.npm.steps.find(step => step.name === 'Publish verified release tarballs with recovery');

--- a/tests/unit/ocr.test.js
+++ b/tests/unit/ocr.test.js
@@ -139,11 +139,17 @@ test('collectImageCandidates rejects file:// images from a remote page', () => {
 });
 
 test('collectImageCandidates allows file:// images for a local .html preview', () => {
+  // Build the file: URLs from platform paths: win32 file URLs carry a drive
+  // letter, POSIX ones do not, and Node's fileURLToPath rejects the other
+  // platform's shape.
+  const dir = join(tmpdir(), 'patina-ocr-local');
+  const base = pathToFileURL(join(dir, 'page.html')).href;
+  const expected = pathToFileURL(join(dir, 'banner.png')).href;
   const html = '<img src="banner.png" alt="배너 이미지입니다">';
-  const { candidates } = collectImageCandidates(html, 'file:///home/user/page.html');
+  const { candidates } = collectImageCandidates(html, base);
   assert.strictEqual(candidates.length, 1);
   assert.strictEqual(candidates[0].kind, 'file');
-  assert.strictEqual(candidates[0].url, 'file:///home/user/banner.png');
+  assert.strictEqual(candidates[0].url, expected);
 });
 
 test('collectImageCandidates caps by priority', () => {

--- a/tests/unit/persona-command.test.js
+++ b/tests/unit/persona-command.test.js
@@ -25,7 +25,7 @@ test('persona new --template writes a valid, loadable custom persona', async () 
   const repoRoot = tempRepo();
   const path = await runPersonaNew(['my-voice', '--lang', 'en', '--template'], { repoRoot, logger: silent });
   assert.ok(existsSync(path));
-  assert.match(path, /custom\/personas\/en\/my-voice\.md$/);
+  assert.ok(path.endsWith(join('custom', 'personas', 'en', 'my-voice.md')), path);
   // Loads back through the real (validating) loader.
   const loaded = loadPersona(repoRoot, 'en', 'my-voice');
   assert.equal(loaded.id, 'my-voice');
@@ -206,7 +206,7 @@ test('persona edit --name copies a library persona into custom and preserves the
   const libPath = join(repoRoot, 'personas', 'ko', 'natural-ko.md');
   const libBefore = readFileSync(libPath, 'utf8');
   const written = await runPersonaEdit(['natural-ko', '--lang', 'ko', '--name', 'My Natural KO'], { repoRoot, logger: silent });
-  assert.match(written, /custom\/personas\/ko\/natural-ko\.md$/);
+  assert.ok(written.endsWith(join('custom', 'personas', 'ko', 'natural-ko.md')), written);
   // Library file is untouched (copy-on-edit into custom only).
   assert.ok(existsSync(libPath));
   assert.equal(readFileSync(libPath, 'utf8'), libBefore);

--- a/tests/unit/persona-packaging.test.js
+++ b/tests/unit/persona-packaging.test.js
@@ -20,7 +20,11 @@ test('package files allowlist includes personas/', () => {
 });
 
 test('npm pack artifact contains the built-in KO Persona catalog', () => {
-  const res = spawnSync('npm', ['pack', '--dry-run', '--json'], { cwd: REPO_ROOT, encoding: 'utf8' });
+  // Bare `npm` is npm.cmd on Windows, which Node refuses to spawn without a
+  // shell since the CVE-2024-27980 fix.
+  const res = process.platform === 'win32'
+    ? spawnSync('npm.cmd', ['pack', '--dry-run', '--json'], { cwd: REPO_ROOT, encoding: 'utf8', shell: true })
+    : spawnSync('npm', ['pack', '--dry-run', '--json'], { cwd: REPO_ROOT, encoding: 'utf8' });
   assert.equal(res.status, 0, res.stderr);
   const packed = JSON.parse(res.stdout)[0].files.map((f) => f.path);
   assert.ok(packed.includes('personas/ko/natural-ko.md'), 'natural-ko Persona must be in the packed artifact');

--- a/tests/unit/rebaseline-score-collection.test.js
+++ b/tests/unit/rebaseline-score-collection.test.js
@@ -66,7 +66,17 @@ test('nullable intake verifies bytes and evidence without inventing human or gen
   assert.throws(() => loadNullableIntake(options.intake), /evidence mismatch/);
 });
 
-test('no opt-in means no call; snapshots preserve exact private inputs and loaded resources', async t => {
+// The research collector prepares its private output directory with POSIX
+// 0700 permissions and fails closed when they do not hold
+// (collect-rebaseline-scores.mjs). win32 has no POSIX mode bits, so every
+// test that reaches output preparation fails there by design — the tool
+// stays fail-closed on Windows. These skips are absent coverage, not passes;
+// the validation-only tests in this file still run on win32.
+const POSIX_PRIVATE_OUTPUT_SKIP = process.platform === 'win32'
+  ? 'research private-output 0700 enforcement is POSIX-only; tool stays fail-closed on win32'
+  : false;
+
+test('no opt-in means no call; snapshots preserve exact private inputs and loaded resources', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const { options, records } = setup(t);
   const report = await collectRebaselineScores({ ...options, live: false }, { complete: async () => assert.fail('not opted in') });
   assert.equal(report.attempted, 0);
@@ -94,7 +104,7 @@ test('missing, unknown, denied and route-mismatched approvals never dispatch', a
   }
 });
 
-test('mixed admission freezes the full denominator and preserves nullable labels', async t => {
+test('mixed admission freezes the full denominator and preserves nullable labels', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const { options, approval, records } = setup(t, 2);
   approval.decisions[1].decision = 'unknown'; options.maxCalls = 2; write(options.approvals, approval);
   let calls = 0;
@@ -109,7 +119,7 @@ test('mixed admission freezes the full denominator and preserves nullable labels
   assert.equal(report.languages.en.packs['viral-hook'].missing, 1);
 });
 
-test('completed observations replay offline byte-for-byte; resume never pays for them again', async t => {
+test('completed observations replay offline byte-for-byte; resume never pays for them again', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const { options } = setup(t, 2); let calls = 0;
   await collectRebaselineScores(options, { complete: async () => { calls++; return valid(); } });
   assert.equal(calls, 2);
@@ -120,7 +130,7 @@ test('completed observations replay offline byte-for-byte; resume never pays for
   await collectRebaselineScores(resume(options), { complete: async () => assert.fail('already paid') });
 });
 
-test('production JSON retry is retained, while valid-JSON schema failure is a separate missing score', async t => {
+test('production JSON retry is retained, while valid-JSON schema failure is a separate missing score', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const { options } = setup(t, 2); const temperatures = [];
   const report = await collectRebaselineScores(options, { complete: async (_candidate, _prompt, args) => {
     temperatures.push(args.temperature);
@@ -134,7 +144,7 @@ test('production JSON retry is retained, while valid-JSON schema failure is a se
   assert.equal((await replayCollection(options.output)).fullObservedReplay, true);
 });
 
-test('transport failures remain errors and missing scores, with no transport retry', async t => {
+test('transport failures remain errors and missing scores, with no transport retry', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const { options } = setup(t); let calls = 0;
   const report = await collectRebaselineScores(options, { complete: async () => { calls++; throw new Error('HTTP 429'); } });
   assert.equal(calls, 1); assert.equal(report.valid, 0); assert.equal(report.distributions.overall.n, 0);
@@ -142,7 +152,7 @@ test('transport failures remain errors and missing scores, with no transport ret
   assert.equal((await replayCollection(options.output)).fullObservedReplay, true);
 });
 
-test('snapshot/row/receipt changes and missing parser receipts reject before any resumed paid call', async t => {
+test('snapshot/row/receipt changes and missing parser receipts reject before any resumed paid call', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   for (const variant of ['snapshot', 'row', 'wire', 'missing-parser-call']) {
     const { options, records } = setup(t); let count = 0;
     await collectRebaselineScores(options, { complete: async () => (++count === 1 && variant === 'missing-parser-call' ? { ...valid(), text: 'malformed' } : valid()) });
@@ -162,7 +172,7 @@ test('snapshot/row/receipt changes and missing parser receipts reject before any
   }
 });
 
-test('persistence failure before dispatch pays nothing; after dispatch it stops and blocks paid resume', async t => {
+test('persistence failure before dispatch pays nothing; after dispatch it stops and blocks paid resume', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   for (const phase of ['started', 'completed']) {
     const { options } = setup(t, 2); let calls = 0;
     await assert.rejects(collectRebaselineScores(options, {
@@ -174,7 +184,7 @@ test('persistence failure before dispatch pays nothing; after dispatch it stops 
   }
 });
 
-test('completed paid receipts can recover a missing row offline after row persistence failure', async t => {
+test('completed paid receipts can recover a missing row offline after row persistence failure', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const { options } = setup(t); let calls = 0;
   await assert.rejects(collectRebaselineScores(options, { complete: async () => { calls++; return valid(); },
     persist: (path, value) => { if (path.includes('/rows/')) throw new Error('disk full'); persistPrivate(path, value); } }), /persistence/);
@@ -182,7 +192,7 @@ test('completed paid receipts can recover a missing row offline after row persis
   assert.equal(calls, 1); assert.equal(report.valid, 1);
 });
 
-test('secrets reject preparation or response capture; no redacted full-replay claim', async t => {
+test('secrets reject preparation or response capture; no redacted full-replay claim', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const secret = 'sk-' + 'x'.repeat(32);
   const a = setup(t); a.options.config = resolve(a.root, 'secret.yaml'); fs.writeFileSync(a.options.config, `api_key: ${secret}\n`);
   await assert.rejects(collectRebaselineScores(a.options, { complete: async () => assert.fail('secret config') }), /secret/);
@@ -217,7 +227,7 @@ test('the bounded HTTP path sends once even for temperature rejection and captur
   assert.ok(!JSON.stringify(observed).includes('Authorization'));
 });
 
-test('opt-in is boolean and the bound includes every production parser invocation', async t => {
+test('opt-in is boolean and the bound includes every production parser invocation', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const a = setup(t);
   const report = await collectRebaselineScores({ ...a.options, live: 'false' }, { complete: async () => assert.fail('string is not opt-in') });
   assert.equal(report.attempted, 0);
@@ -229,7 +239,7 @@ test('opt-in is boolean and the bound includes every production parser invocatio
   await assert.rejects(collectRebaselineScores(resume(b.options), { complete: async () => assert.fail('budget cannot grow on resume') }));
 });
 
-test('observed partial error metadata survives replay without a new invocation', async t => {
+test('observed partial error metadata survives replay without a new invocation', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const { options } = setup(t);
   const report = await collectRebaselineScores(options, { complete: async () => {
     const error = new Error('CLI failed');
@@ -241,7 +251,7 @@ test('observed partial error metadata survives replay without a new invocation',
   assert.equal(replay.fullObservedReplay, true);
 });
 
-test('native profile admission remains distinct from server model verification', async t => {
+test('native profile admission remains distinct from server model verification', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const { options, approval, records } = setup(t);
   const native = { id: 'unit-native', provider: 'kimi', transport: 'kimi-cli', model: 'kimi-code/kimi-for-coding' };
   write(options.protocol, { schemaVersion: 1, candidates: [native] });
@@ -263,7 +273,7 @@ test('native profile admission remains distinct from server model verification',
   assert.equal((await replayCollection(options.output)).fullObservedReplay, true);
 });
 
-test('dataset genre and delivery register remain separate; source labels never label new targets', async t => {
+test('dataset genre and delivery register remain separate; source labels never label new targets', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const { options, records, approval, root } = setup(t, 4);
   const genres = ['social', 'marketing', 'chat-update', 'chat-update'];
   const documentTypes = ['social', 'marketing', undefined, 'casual-conversation'];
@@ -345,7 +355,7 @@ function parentSetup(t, count = 2) {
   return { ...base, gemini, parent, review, reviewPath };
 }
 
-test('parent approval is consumed losslessly and only approved text/scoring instructions reach HTTP', async t => {
+test('parent approval is consumed losslessly and only approved text/scoring instructions reach HTTP', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const { options, parent, reviewPath, records, gemini } = parentSetup(t);
   const approvalBytes = fs.readFileSync(options.approvals, 'utf8'), reviewBytes = fs.readFileSync(reviewPath, 'utf8');
   const previous = globalThis.fetch; t.after(() => { globalThis.fetch = previous; });
@@ -424,7 +434,7 @@ test('approval of original bytes does not permit automatic input-fence neutraliz
   await assert.rejects(collectRebaselineScores(options, { complete: async () => assert.fail('changed text cannot be sent') }), /fencing changes approved text/);
 });
 
-test('offline replay still rejects actual scorer code changes in the isolated source tree', async t => {
+test('offline replay still rejects actual scorer code changes in the isolated source tree', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const { options } = setup(t);
   await collectRebaselineScores(options, { complete: async () => valid() });
   const path = resolve(ROOT, 'src/scoring.js'), before = fs.readFileSync(path);
@@ -497,7 +507,7 @@ assert.equal(getEventListeners(signal, 'abort').length, 0, 'per-call cancellatio
 console.log(JSON.stringify({ mode, fetchCalls, globalAborted: signal.aborted, activeFetchAborted: activeSignal?.aborted ?? null }));
 `;
 
-test('programmatic abortStudy and real SIGTERM abort active HTTP fetch and stop later texts', t => {
+test('programmatic abortStudy and real SIGTERM abort active HTTP fetch and stop later texts', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, t => {
   for (const mode of ['programmatic', 'sigterm']) {
     const { options } = setup(t, 2); options.timeoutMs = 5000;
     const result = execFileSync(process.execPath, ['--input-type=module', '-e', cancellationProgram, ROOT, JSON.stringify(options), mode], { encoding: 'utf8', timeout: 15000 });
@@ -514,7 +524,7 @@ test('already-aborted and listener-installation races dispatch zero HTTP request
   }
 });
 
-test('ordinary deadlines and network AbortError are recorded errors and the cohort continues', async t => {
+test('ordinary deadlines and network AbortError are recorded errors and the cohort continues', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const previous = globalThis.fetch; t.after(() => { globalThis.fetch = previous; });
   const signal = getStudyCancellationSignal();
   const baseline = getEventListeners(signal, 'abort').length;
@@ -567,7 +577,7 @@ async function exhaustParserDeadline(options, records, dependencies) {
   finally { Date.now = originalNow; globalThis.fetch = originalFetch; }
 }
 
-test('logical deadline after malformed response records two journals but only one dispatched wire', async t => {
+test('logical deadline after malformed response records two journals but only one dispatched wire', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const { options, records } = setup(t, 2); options.timeoutMs = 1000;
   const result = await exhaustParserDeadline(options, records);
   const snapshot = read(resolve(options.output, 'snapshot.private.json'));
@@ -595,7 +605,7 @@ test('logical deadline after malformed response records two journals but only on
   assert.deepEqual(Object.fromEntries(paths(options.output).map(path => [path, hash(fs.readFileSync(path))])), before);
 });
 
-test('wireless notStarted timeout recovers a missing row without a replacement completion', async t => {
+test('wireless notStarted timeout recovers a missing row without a replacement completion', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const { options, records } = setup(t); options.timeoutMs = 1000;
   const result = await exhaustParserDeadline(options, records, { persist: (path, value) => {
     if (path.includes('/rows/')) throw new Error('row persistence interrupted');
@@ -613,7 +623,7 @@ test('wireless notStarted timeout recovers a missing row without a replacement c
   assert.equal((await replayCollection(options.output)).fullObservedReplay, true);
 });
 
-test('zero-dispatch receipts require exact prompt/request/ordinal/state and no dispatch evidence', async t => {
+test('zero-dispatch receipts require exact prompt/request/ordinal/state and no dispatch evidence', { skip: POSIX_PRIVATE_OUTPUT_SKIP }, async t => {
   const { options, records } = setup(t); options.timeoutMs = 1000;
   const result = await exhaustParserDeadline(options, records);
   assert.equal(result.error, undefined);

--- a/tests/unit/scorer-path-corpus.test.js
+++ b/tests/unit/scorer-path-corpus.test.js
@@ -210,7 +210,7 @@ test('existing four source prompt hashes and frozen 12-call plan remain unchange
   assert.deepEqual(plan, published.optionalGenerationPlan);
 });
 
-test('private output uses restrictive permissions, content hashes and refuses to overwrite', () => {
+test('private output uses restrictive permissions, content hashes and refuses to overwrite', { skip: process.platform === 'win32' && 'research private-output 0700 enforcement is POSIX-only; tool stays fail-closed on win32' }, () => {
   const directory = mkdtempSync(resolve(tmpdir(), 'scorer-corpus-unit-'));
   try {
     const output = resolve(directory, 'private'), secret = Buffer.from('Synthetic private text marker.');

--- a/tests/unit/web-rewrite-stream.test.js
+++ b/tests/unit/web-rewrite-stream.test.js
@@ -1087,6 +1087,10 @@ test('runWebRewriteStream deadline completes an in-flight non-settling rewrite a
 
 test('runWebRewriteStream deadline completes non-settling scorers', async () => {
   const frames = [];
+  // A fake monotonic clock keeps the two deadline paths deterministic: with a
+  // real 5 ms budget, a loaded or slower host can exhaust the budget during
+  // the stream phase and report stream_failed instead of scoring_failed.
+  let now = 1000;
   const result = await runWebRewriteStream({
     request: { ...request, original: 'We shipped 3 units.' },
     callLLMStream: async ({ onAttempt }) => {
@@ -1094,12 +1098,13 @@ test('runWebRewriteStream deadline completes non-settling scorers', async () => 
       return { text: 'We shipped 3 units.' };
     },
     scoreFns: {
-      scoreMPS: () => new Promise(() => {}),
+      scoreMPS: () => { now += 10; return new Promise(() => {}); },
       scoreFidelity: () => new Promise(() => {}),
       scoreDeterministicSignals: () => ({}),
     },
     emit: (frame) => frames.push(frame),
     timeout: 5,
+    deadlineNow: () => now,
   });
   assert.equal(result.ok, false);
   assert.equal(result.code, 'scoring_failed');

--- a/tests/unit/xliff-writeback.redteam.test.js
+++ b/tests/unit/xliff-writeback.redteam.test.js
@@ -191,6 +191,6 @@ test('resolveBatchOutputPath: suffix and outdir edge cases', () => {
   assert.equal(resolveBatchOutputPath({ suffix: '' }, '/tmp/input.xlf', { defaultSuffix: '' }), '/tmp/input.xlf');
   assert.equal(resolveBatchOutputPath({ suffix: 'human' }, '/tmp/input.xlf'), '/tmp/inputhuman.xlf');
   assert.equal(resolveBatchOutputPath({ suffix: '.human' }, '/tmp/README'), '/tmp/README.human');
-  assert.equal(resolveBatchOutputPath({ outdir: '/tmp/nested/out' }, '/tmp/a/b/input.xlf', { defaultSuffix: '.ignored' }), '/tmp/nested/out/input.xlf');
+  assert.equal(resolveBatchOutputPath({ outdir: '/tmp/nested/out' }, '/tmp/a/b/input.xlf', { defaultSuffix: '.ignored' }), join('/tmp/nested/out', 'input.xlf'));
   record('resolveBatchOutputPath routing', 'empty suffix unchanged; raw suffix accepted; no extension; nested outdir basename', 'matched');
 });

--- a/tests/unit/xliff-writeback.test.js
+++ b/tests/unit/xliff-writeback.test.js
@@ -134,7 +134,7 @@ test('writeAtomicUtf8: failure (bad dir) throws and leaves no output at destinat
 // ---------- resolveBatchOutputPath ----------
 test('resolveBatchOutputPath: in-place / outdir / suffix / default suffix', () => {
   assert.equal(resolveBatchOutputPath({ inPlace: true }, '/a/b/f.xliff'), '/a/b/f.xliff');
-  assert.equal(resolveBatchOutputPath({ outdir: '/out' }, '/a/b/f.xliff'), '/out/f.xliff');
+  assert.equal(resolveBatchOutputPath({ outdir: '/out' }, '/a/b/f.xliff'), join('/out', 'f.xliff'));
   assert.equal(resolveBatchOutputPath({ suffix: '.humanized' }, '/a/b/f.xliff'), '/a/b/f.humanized.xliff');
   assert.equal(resolveBatchOutputPath({}, '/a/b/f.xliff', { defaultSuffix: '.humanized' }), '/a/b/f.humanized.xliff');
 });


### PR DESCRIPTION
## Summary

P16b Windows leg. First win32 smoke (Windows 11 26200 x64, Node 24.17.0) **wedged entirely** (suite hit the 20-minute step timeout with almost no output) and failed the agy cancellation step. Iterating on the real host brought it to **all 8 smoke steps ok, suite 2453 tests / 2370 pass / 0 fail / 83 skip** (receipt committed).

Root causes found, in the order they surfaced:

1. **Suite wedge**: `auth-login` tests fake CLIs with extensionless POSIX shebang PATH shims. win32 can't resolve those (PATHEXT + post-CVE-2024-27980 .cmd refusal), so the test launched the **real host `claude auth login`** interactively and the worker never returned. Fixed by skipping fake-dependent tests on win32 (auth-login, backend-model-defaults, backend-agy launch path — same mechanism).
2. **Teardown hook ordering** (the second wedge): node:test runs `t.after` hooks in **registration order** and **skips the rest after a failed hook** (verified empirically). `dev-server` replica and `aside-cli` detached-session tests registered their rm before the server-stop hook; on win32 the rm fails EBUSY (live child holds the dir as cwd), the stop hook is skipped, the leaked child keeps the worker alive. Rms now register after the stop hooks, with `maxRetries` for handle-release lag.
3. **CRLF checkout**: Git for Windows default `core.autocrlf=true` checked out CRLF; 41 byte-exact tests (hashes, doc counts, golden snapshots) failed. New `.gitattributes` (`* text=auto eol=lf`) pins LF everywhere.
4. **ESM absolute-path imports** in `skill-invocation` `-e` programs: `'C:\...'` parses as URL scheme `c:` on win32; helper now imported via `pathToFileURL` (10 tests).
5. **Bare `npm` spawns**: `npm.cmd` needs a shell on win32 — fixed in `scripts/release-artifacts.mjs` (platform-aware `DEFAULT_NPM_COMMAND` + shell for `.cmd` in `runCommand`), `scripts/check-no-private-assets.mjs`, and two e2e tests.
6. **`os.homedir()` reads USERPROFILE on win32**, not HOME — `config.test.js` `withEnv` now redirects both.
7. **Forward-slash path expectations** in ~10 test files → `join()`/`resolve()`.
8. **Timing**: `web-rewrite-stream` deadline test raced a real 5 ms budget on a loaded host → deterministic fake clock via the `deadlineNow` seam. Smoke runner suite step gets a 90-minute bound (Windows spawn cost).

**Recorded absent coverage, not passes** (83 skips): POSIX shebang PATH-shim fakes, POSIX process groups, `/bin/sh` installer fixtures (install.sh is POSIX-only per QA.md), research private-output 0700 enforcement (tools stay fail-closed on win32), SIGINT delivery, and one **runtime-level libuv abort** (`dropped-number-unverified`: CLI child finishes all batch work correctly, then aborts at teardown, exit 0xC0000409, `src\win\async.c:94`, Node 24.17.0 — tracked as a win32 follow-up).

## Follow-ups recorded (not in this PR)

- Live launch path of local CLI backends (claude/codex/gemini/kimi/agy) on Windows is unverified — the same spawn shape that broke tests means real CLIs installed as `.cmd` shims may not launch on win32 at all.
- The libuv teardown abort above.

## Evidence

- Receipt: `docs/operations/platform-smoke-win32-x64-20260910.json` (bf877fd run, all steps ok).
- Failure-to-fix trail is in the commit history (wedge, then 72, 31, 3, 23, 1, 0 failures across runs; each commit explains its cluster).
- Linux: full suite 2453/2451 pass/0 fail/2 pre-existing skips; full lint green (syntax, eslint, typecheck, spellcheck, architecture 0 violations).
- Refs #783