### PR TITLE
fix(backends): launch .cmd-shimmed local CLIs on win32

### DIFF
--- a/src/backends/agy-cli.js
+++ b/src/backends/agy-cli.js
@@ -1,10 +1,10 @@
-import { spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   DEFAULT_BACKEND_TIMEOUT_MS,
   runInteractiveCommand,
+  probeCliAvailability,
   spawnOwnedCliProcess,
 } from './contract.js';
 import { resolveLocalCliModel } from '../model-defaults.js';
@@ -44,12 +44,7 @@ Do not call any tool; answer directly with only the requested result.
 `;
 
 export function isAvailable() {
-  try {
-    const result = spawnSync('agy', ['--version'], { stdio: 'ignore' });
-    return result.status === 0;
-  } catch {
-    return false;
-  }
+  return probeCliAvailability('agy');
 }
 
 function antigravityDir() {

--- a/src/backends/claude-cli.js
+++ b/src/backends/claude-cli.js
@@ -1,10 +1,10 @@
-import { spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   DEFAULT_BACKEND_TIMEOUT_MS,
   runInteractiveCommand,
+  probeCliAvailability,
   spawnOwnedCliProcess,
   stageCliImages,
 } from './contract.js';
@@ -16,12 +16,7 @@ export const loginCommand = 'claude auth login';
 export const installHint = 'Install Claude Code first, then run `patina auth login claude-cli` again.';
 
 export function isAvailable() {
-  try {
-    const result = spawnSync('claude', ['--version'], { stdio: 'ignore' });
-    return result.status === 0;
-  } catch {
-    return false;
-  }
+  return probeCliAvailability('claude');
 }
 
 function credentialsPath() {

--- a/src/backends/codex-cli.js
+++ b/src/backends/codex-cli.js
@@ -1,10 +1,10 @@
-import { spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   DEFAULT_BACKEND_TIMEOUT_MS,
   runInteractiveCommand,
+  probeCliAvailability,
   spawnOwnedCliProcess,
   stageCliImages,
 } from './contract.js';
@@ -25,12 +25,7 @@ export const CODEX_DISABLED_FEATURES = Object.freeze(['shell_tool', 'unified_exe
 export const installHint = 'Install it from https://github.com/openai/codex, then run `patina auth login codex-cli` again.';
 
 export function isAvailable() {
-  try {
-    const result = spawnSync('codex', ['--version'], { stdio: 'ignore' });
-    return result.status === 0;
-  } catch {
-    return false;
-  }
+  return probeCliAvailability('codex');
 }
 
 export function isAuthenticated() {

--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -31,7 +31,7 @@ import { join } from 'node:path';
  * without a shell (Node refuses since the CVE-2024-27980 fix), while a real
  * `.exe` spawns bare. Walk PATH in order and return the first PATHEXT match;
  * batch shims come back flagged so callers launch them through cmd.exe (see
- * spawnWindowsBatch). Real executables and unknown names keep the bare name
+ * windowsBatchSpawn). Real executables and unknown names keep the bare name
  * so the existing not-installed error path is unchanged.
  *
  * @param {string} command Bare CLI name (e.g. 'gemini').
@@ -63,6 +63,12 @@ export function resolveCliSpawnCommand(command, { platform = process.platform, e
  * pair because cmd /s strips one outer pair, and windowsVerbatimArguments
  * keeps Node's own quoting out of the way. Verified on Windows 11 with a
  * space in the batch path, an empty-string arg and a space in an arg.
+ *
+ * Arg domain: backend flags, model ids and temp paths only — user prose
+ * always travels via stdin, never argv. cmd still expands %var% inside
+ * quotes and the ""/doubling is lossy for embedded double quotes, so values
+ * containing `%` or `"` are NOT safe here; the backends above never produce
+ * them.
  */
 export function windowsBatchSpawn(command, args, options = {}) {
   const quote = (value) => `"${String(value).replace(/"/g, '""')}"`;
@@ -534,6 +540,8 @@ export function runInteractiveCommand({
   env = process.env,
   stdio = 'inherit',
   notFoundHint,
+  platform = process.platform,
+  spawnImpl = spawn,
 } = {}) {
   if (!backendName || !command) {
     throw new Error('interactive backend command requires backendName and command');
@@ -545,11 +553,11 @@ export function runInteractiveCommand({
     let settled = false;
     const settle = (fn) => { if (settled) return; settled = true; fn(); };
 
-    const resolved = resolveCliSpawnCommand(command);
+    const resolved = resolveCliSpawnCommand(command, { platform });
     const [spawnCommand, spawnArgs, spawnOptions] = resolved.batch
       ? windowsBatchSpawn(resolved.command, args, { cwd, env, stdio })
-      : [command, args, { cwd, env, stdio }];
-    const proc = spawn(spawnCommand, spawnArgs, spawnOptions);
+      : [resolved.command, args, { cwd, env, stdio }];
+    const proc = spawnImpl(spawnCommand, spawnArgs, spawnOptions);
 
     proc.on('error', (err) => {
       if (err.code === 'ENOENT') {

--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -29,31 +29,45 @@ import { join } from 'node:path';
  *
  * win32 only: a CLI installed as an npm `.cmd`/`.bat` shim cannot be spawned
  * without a shell (Node refuses since the CVE-2024-27980 fix), while a real
- * `.exe` spawns bare. Walk PATH in order and return the first matching
- * candidate with the shell flag a batch shim needs. Anything else (a real
- * executable, or nothing found) keeps the bare name so the existing
- * not-installed error path is unchanged. Node quotes shell-spawn args only
- * since 18.20.2/20.12.2 — older win32 Nodes may mis-split paths with spaces.
+ * `.exe` spawns bare. Walk PATH in order and return the first PATHEXT match;
+ * batch shims come back flagged so callers launch them through cmd.exe (see
+ * spawnWindowsBatch). Real executables and unknown names keep the bare name
+ * so the existing not-installed error path is unchanged.
  *
  * @param {string} command Bare CLI name (e.g. 'gemini').
  * @param {object} [deps]
  * @param {string} [deps.platform]
  * @param {NodeJS.ProcessEnv} [deps.env]
  * @param {(path: string) => boolean} [deps.exists]
- * @returns {{ command: string, shell: boolean }}
+ * @returns {{ command: string, batch: boolean }}
  */
 export function resolveCliSpawnCommand(command, { platform = process.platform, env = process.env, exists = existsSync } = {}) {
-  if (platform !== 'win32') return { command, shell: false };
+  if (platform !== 'win32') return { command, batch: false };
   const extensions = String(env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').map((ext) => ext.toUpperCase());
   for (const dir of String(env.PATH || '').split(';')) {
     if (!dir) continue;
     for (const ext of extensions) {
       const candidate = join(dir, command + ext);
       if (!exists(candidate)) continue;
-      return { command: candidate, shell: ext === '.CMD' || ext === '.BAT' };
+      return { command: candidate, batch: ext === '.CMD' || ext === '.BAT' };
     }
   }
-  return { command, shell: false };
+  return { command, batch: false };
+}
+
+/**
+ * Build the spawn triple for a win32 batch shim. `shell: true` is not used:
+ * Node merely concatenates args with it (dropping empty strings, splitting
+ * on spaces, DEP0190). Instead cmd.exe gets one fully-quoted command line:
+ * every token is double-quoted, the whole line is wrapped in a second quote
+ * pair because cmd /s strips one outer pair, and windowsVerbatimArguments
+ * keeps Node's own quoting out of the way. Verified on Windows 11 with a
+ * space in the batch path, an empty-string arg and a space in an arg.
+ */
+export function windowsBatchSpawn(command, args, options = {}) {
+  const quote = (value) => `"${String(value).replace(/"/g, '""')}"`;
+  const line = [command, ...args].map(quote).join(' ');
+  return ['cmd.exe', ['/d', '/s', '/c', `"${line}"`], { ...options, windowsVerbatimArguments: true }];
 }
 
 /**
@@ -63,16 +77,15 @@ export function resolveCliSpawnCommand(command, { platform = process.platform, e
 export function probeCliAvailability(command, { platform = process.platform, env = process.env, exists = existsSync, spawnSyncImpl = spawnSync } = {}) {
   try {
     const resolved = resolveCliSpawnCommand(command, { platform, env, exists });
-    const result = spawnSyncImpl(resolved.command, ['--version'], {
-      stdio: 'ignore',
-      ...(resolved.shell ? { shell: true } : {}),
-    });
+    const [spawnCommand, spawnArgs, spawnOptions] = resolved.batch
+      ? windowsBatchSpawn(resolved.command, ['--version'], { stdio: 'ignore' })
+      : [resolved.command, ['--version'], { stdio: 'ignore' }];
+    const result = spawnSyncImpl(spawnCommand, spawnArgs, spawnOptions);
     return result.status === 0;
   } catch {
     return false;
   }
 }
-
 export const DEFAULT_BACKEND_TIMEOUT_MS = 600_000;
 export const DEFAULT_HTTP_MAX_RETRIES = 2;
 export const PROMPT_SIZE_WARNING_CHARS = 20_000;
@@ -442,9 +455,11 @@ export function spawnOwnedCliProcess(command, args = [], options = {}, {
 } = {}) {
   const ownsProcessGroup = supportsOwnedProcessGroup(platform);
   const resolved = resolveCliSpawnCommand(command, { platform });
-  const spawnOptions = ownsProcessGroup ? { ...options, detached: true } : { ...options };
-  if (resolved.shell) spawnOptions.shell = true;
-  const proc = spawnImpl(resolved.command, args, spawnOptions);
+  const baseOptions = ownsProcessGroup ? { ...options, detached: true } : { ...options };
+  const [spawnCommand, spawnArgs, spawnOptions] = resolved.batch
+    ? windowsBatchSpawn(resolved.command, args, baseOptions)
+    : [resolved.command, args, baseOptions];
+  const proc = spawnImpl(spawnCommand, spawnArgs, spawnOptions);
   let closeResult;
   let resolveClose;
   const closePromise = new Promise((resolve) => {

--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -19,10 +19,59 @@
 //
 // Defaults are intentionally stable; changing a retry path means changing its
 // single owner here or in the file named above, never adding a parallel one.
-import { spawn } from 'node:child_process';
-import { copyFileSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { spawn, spawnSync } from 'node:child_process';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir, userInfo } from 'node:os';
 import { join } from 'node:path';
+
+/**
+ * Resolve how a bare CLI name must be spawned on the current platform.
+ *
+ * win32 only: a CLI installed as an npm `.cmd`/`.bat` shim cannot be spawned
+ * without a shell (Node refuses since the CVE-2024-27980 fix), while a real
+ * `.exe` spawns bare. Walk PATH in order and return the first matching
+ * candidate with the shell flag a batch shim needs. Anything else (a real
+ * executable, or nothing found) keeps the bare name so the existing
+ * not-installed error path is unchanged. Node quotes shell-spawn args only
+ * since 18.20.2/20.12.2 — older win32 Nodes may mis-split paths with spaces.
+ *
+ * @param {string} command Bare CLI name (e.g. 'gemini').
+ * @param {object} [deps]
+ * @param {string} [deps.platform]
+ * @param {NodeJS.ProcessEnv} [deps.env]
+ * @param {(path: string) => boolean} [deps.exists]
+ * @returns {{ command: string, shell: boolean }}
+ */
+export function resolveCliSpawnCommand(command, { platform = process.platform, env = process.env, exists = existsSync } = {}) {
+  if (platform !== 'win32') return { command, shell: false };
+  const extensions = String(env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').map((ext) => ext.toUpperCase());
+  for (const dir of String(env.PATH || '').split(';')) {
+    if (!dir) continue;
+    for (const ext of extensions) {
+      const candidate = join(dir, command + ext);
+      if (!exists(candidate)) continue;
+      return { command: candidate, shell: ext === '.CMD' || ext === '.BAT' };
+    }
+  }
+  return { command, shell: false };
+}
+
+/**
+ * Availability probe shared by every local CLI backend: `<cli> --version`
+ * with the platform's spawn shape (see resolveCliSpawnCommand).
+ */
+export function probeCliAvailability(command, { platform = process.platform, env = process.env, exists = existsSync, spawnSyncImpl = spawnSync } = {}) {
+  try {
+    const resolved = resolveCliSpawnCommand(command, { platform, env, exists });
+    const result = spawnSyncImpl(resolved.command, ['--version'], {
+      stdio: 'ignore',
+      ...(resolved.shell ? { shell: true } : {}),
+    });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
 
 export const DEFAULT_BACKEND_TIMEOUT_MS = 600_000;
 export const DEFAULT_HTTP_MAX_RETRIES = 2;
@@ -392,9 +441,10 @@ export function spawnOwnedCliProcess(command, args = [], options = {}, {
   killImpl = (pid, signal) => process.kill(pid, signal),
 } = {}) {
   const ownsProcessGroup = supportsOwnedProcessGroup(platform);
-  const proc = spawnImpl(command, args, ownsProcessGroup
-    ? { ...options, detached: true }
-    : options);
+  const resolved = resolveCliSpawnCommand(command, { platform });
+  const spawnOptions = ownsProcessGroup ? { ...options, detached: true } : { ...options };
+  if (resolved.shell) spawnOptions.shell = true;
+  const proc = spawnImpl(resolved.command, args, spawnOptions);
   let closeResult;
   let resolveClose;
   const closePromise = new Promise((resolve) => {

--- a/src/backends/contract.js
+++ b/src/backends/contract.js
@@ -545,7 +545,11 @@ export function runInteractiveCommand({
     let settled = false;
     const settle = (fn) => { if (settled) return; settled = true; fn(); };
 
-    const proc = spawn(command, args, { cwd, env, stdio });
+    const resolved = resolveCliSpawnCommand(command);
+    const [spawnCommand, spawnArgs, spawnOptions] = resolved.batch
+      ? windowsBatchSpawn(resolved.command, args, { cwd, env, stdio })
+      : [command, args, { cwd, env, stdio }];
+    const proc = spawn(spawnCommand, spawnArgs, spawnOptions);
 
     proc.on('error', (err) => {
       if (err.code === 'ENOENT') {

--- a/src/backends/gemini-cli.js
+++ b/src/backends/gemini-cli.js
@@ -1,10 +1,10 @@
-import { spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   DEFAULT_BACKEND_TIMEOUT_MS,
   runInteractiveCommand,
+  probeCliAvailability,
   spawnOwnedCliProcess,
   stageCliImages,
 } from './contract.js';
@@ -25,12 +25,7 @@ const NO_MCP_SERVERS = '__patina_no_mcp__';
 export const GEMINI_NO_TOOLS_POLICY = '[[rule]]\ntoolName = "*"\ndecision = "deny"\npriority = 999\n';
 
 export function isAvailable() {
-  try {
-    const result = spawnSync('gemini', ['--version'], { stdio: 'ignore' });
-    return result.status === 0;
-  } catch {
-    return false;
-  }
+  return probeCliAvailability('gemini');
 }
 
 export function isAuthenticated() {

--- a/src/backends/kimi-cli.js
+++ b/src/backends/kimi-cli.js
@@ -1,10 +1,10 @@
-import { spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   DEFAULT_BACKEND_TIMEOUT_MS,
   runInteractiveCommand,
+  probeCliAvailability,
   spawnOwnedCliProcess,
 } from './contract.js';
 import { resolveLocalCliModel } from '../model-defaults.js';
@@ -16,12 +16,7 @@ export const installHint = 'Install Kimi Code CLI first, then run `patina auth l
 const KIMI_ENV_KEYS = ['KIMI_API_KEY', 'MOONSHOT_API_KEY'];
 
 export function isAvailable() {
-  try {
-    const result = spawnSync('kimi', ['--version'], { stdio: 'ignore' });
-    return result.status === 0;
-  } catch {
-    return false;
-  }
+  return probeCliAvailability('kimi');
 }
 
 export function isAuthenticated() {

--- a/tests/unit/backend-cli-spawn.test.js
+++ b/tests/unit/backend-cli-spawn.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { EventEmitter } from 'node:events';
 
-import { probeCliAvailability, resolveCliSpawnCommand, spawnOwnedCliProcess } from '../../src/backends/contract.js';
+import { probeCliAvailability, resolveCliSpawnCommand, runInteractiveCommand, spawnOwnedCliProcess, windowsBatchSpawn } from '../../src/backends/contract.js';
 
 const WIN_ENV = { PATH: 'C:\\tools;C:\\other', PATHEXT: '.COM;.EXE;.BAT;.CMD' };
 
@@ -59,7 +59,7 @@ test('resolveCliSpawnCommand keeps the bare name when nothing is found', () => {
   );
 });
 
-test('probeCliAvailability spawns a .cmd shim with a shell and reports status', () => {
+test('probeCliAvailability routes a .cmd shim through cmd.exe and reports status', () => {
   const seen = [];
   const spawnSyncImpl = (command, args, options) => {
     seen.push({ command, args, options });
@@ -87,7 +87,7 @@ test('probeCliAvailability spawns a .cmd shim with a shell and reports status', 
   assert.equal(boom, false);
 });
 
-test('spawnOwnedCliProcess passes shell:true through for a .cmd-only CLI on win32', () => {
+test('spawnOwnedCliProcess routes a .cmd-only CLI through cmd.exe on win32', () => {
   // Uses the real env/exists seams: a .cmd fixture in a real temp PATH dir,
   // with only the platform injected — so this runs on any host OS.
   const dir = mkdtempSync(join(tmpdir(), 'patina-cli-spawn-'));
@@ -126,4 +126,38 @@ test('spawnOwnedCliProcess keeps the bare name for unknown CLIs on win32', () =>
   spawnOwnedCliProcess('definitely-not-a-real-cli-xyz', [], {}, { platform: 'win32', spawnImpl });
   assert.equal(seen.command, 'definitely-not-a-real-cli-xyz');
   assert.equal(seen.options.windowsVerbatimArguments, undefined);
+});
+
+test('windowsBatchSpawn pins the empty-string arg and space args in one quoted line', () => {
+  const [command, args, options] = windowsBatchSpawn('C:\\tools dir\\gemini.CMD', ['-p', '', '--output-format', 'text with space'], { stdio: 'ignore' });
+  assert.equal(command, 'cmd.exe');
+  assert.deepEqual(args.slice(0, 3), ['/d', '/s', '/c']);
+  // The line must quote every token (empty string becomes "") and wrap the
+  // whole line in a second quote pair for cmd /s stripping.
+  assert.equal(args[3], '""C:\\tools dir\\gemini.CMD" "-p" "" "--output-format" "text with space""');
+  assert.deepEqual(options, { stdio: 'ignore', windowsVerbatimArguments: true });
+});
+
+test('runInteractiveCommand routes a .cmd-only CLI through cmd.exe on win32', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'patina-cli-login-'));
+  const oldPath = process.env.PATH;
+  let seen = null;
+  const child = new EventEmitter();
+  try {
+    writeFileSync(join(dir, 'login-cli.CMD'), '@echo off\r\n');
+    process.env.PATH = `${dir};${oldPath || ''}`;
+    const spawnImpl = (command, args, options) => {
+      seen = { command, args, options };
+      process.nextTick(() => child.emit('close', 0));
+      return child;
+    };
+    await runInteractiveCommand({ backendName: 'test-cli', command: 'login-cli', platform: 'win32', spawnImpl });
+    assert.equal(seen.command, 'cmd.exe');
+    assert.deepEqual(seen.args, ['/d', '/s', '/c', `"${[`"${join(dir, 'login-cli.CMD')}"`].join(' ')}"`]);
+    assert.equal(seen.options.windowsVerbatimArguments, true);
+  } finally {
+    if (oldPath === undefined) delete process.env.PATH;
+    else process.env.PATH = oldPath;
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/tests/unit/backend-cli-spawn.test.js
+++ b/tests/unit/backend-cli-spawn.test.js
@@ -16,7 +16,7 @@ test('resolveCliSpawnCommand is a no-op off win32', () => {
   for (const platform of ['linux', 'darwin']) {
     assert.deepEqual(
       resolveCliSpawnCommand('gemini', { platform, env: WIN_ENV, exists: () => true }),
-      { command: 'gemini', shell: false }
+      { command: 'gemini', batch: false }
     );
   }
 });
@@ -25,7 +25,7 @@ test('resolveCliSpawnCommand on win32 spawns a real executable bare', () => {
   const exists = withFiles(new Set([join('C:\\tools', 'claude.EXE')]));
   assert.deepEqual(
     resolveCliSpawnCommand('claude', { platform: 'win32', env: WIN_ENV, exists }),
-    { command: join('C:\\tools', 'claude.EXE'), shell: false }
+    { command: join('C:\\tools', 'claude.EXE'), batch: false }
   );
 });
 
@@ -33,7 +33,7 @@ test('resolveCliSpawnCommand on win32 gives batch shims a shell', () => {
   const exists = withFiles(new Set([join('C:\\tools', 'gemini.CMD')]));
   assert.deepEqual(
     resolveCliSpawnCommand('gemini', { platform: 'win32', env: WIN_ENV, exists }),
-    { command: join('C:\\tools', 'gemini.CMD'), shell: true }
+    { command: join('C:\\tools', 'gemini.CMD'), batch: true }
   );
 });
 
@@ -42,20 +42,20 @@ test('resolveCliSpawnCommand respects PATH order before PATHEXT order', () => {
   const pathOrder = withFiles(new Set([join('C:\\other', 'x.EXE'), join('C:\\tools', 'x.CMD')]));
   assert.deepEqual(
     resolveCliSpawnCommand('x', { platform: 'win32', env: { ...WIN_ENV, PATH: 'C:\\tools;C:\\other' }, exists: pathOrder }),
-    { command: join('C:\\tools', 'x.CMD'), shell: true }
+    { command: join('C:\\tools', 'x.CMD'), batch: true }
   );
   // Within one dir, PATHEXT order wins: .EXE before .CMD.
   const extOrder = withFiles(new Set([join('C:\\tools', 'x.EXE'), join('C:\\tools', 'x.CMD')]));
   assert.deepEqual(
     resolveCliSpawnCommand('x', { platform: 'win32', env: WIN_ENV, exists: extOrder }),
-    { command: join('C:\\tools', 'x.EXE'), shell: false }
+    { command: join('C:\\tools', 'x.EXE'), batch: false }
   );
 });
 
 test('resolveCliSpawnCommand keeps the bare name when nothing is found', () => {
   assert.deepEqual(
     resolveCliSpawnCommand('missing', { platform: 'win32', env: WIN_ENV, exists: () => false }),
-    { command: 'missing', shell: false }
+    { command: 'missing', batch: false }
   );
 });
 
@@ -67,10 +67,12 @@ test('probeCliAvailability spawns a .cmd shim with a shell and reports status', 
   };
   const exists = withFiles(new Set([join('C:\\tools', 'gemini.CMD')]));
   assert.equal(probeCliAvailability('gemini', { platform: 'win32', env: WIN_ENV, exists, spawnSyncImpl }), true);
+  const quote = (v) => `"${v}"`;
+  const line = [join('C:\\tools', 'gemini.CMD'), '--version'].map(quote).join(' ');
   assert.deepEqual(seen, [{
-    command: join('C:\\tools', 'gemini.CMD'),
-    args: ['--version'],
-    options: { stdio: 'ignore', shell: true },
+    command: 'cmd.exe',
+    args: ['/d', '/s', '/c', `"${line}"`],
+    options: { stdio: 'ignore', windowsVerbatimArguments: true },
   }]);
 
   const fail = probeCliAvailability('gemini', {
@@ -104,8 +106,9 @@ test('spawnOwnedCliProcess passes shell:true through for a .cmd-only CLI on win3
       return child;
     };
     spawnOwnedCliProcess('probe-cli', ['--version'], { stdio: 'ignore' }, { platform: 'win32', spawnImpl });
-    assert.equal(seen.command, join(dir, 'probe-cli.CMD'));
-    assert.equal(seen.options.shell, true);
+    assert.equal(seen.command, 'cmd.exe');
+    assert.deepEqual(seen.args, ['/d', '/s', '/c', `"${[`"${join(dir, 'probe-cli.CMD')}"`, '"--version"'].join(' ')}"`]);
+    assert.equal(seen.options.windowsVerbatimArguments, true);
   } finally {
     if (oldPath === undefined) delete process.env.PATH;
     else process.env.PATH = oldPath;
@@ -122,5 +125,5 @@ test('spawnOwnedCliProcess keeps the bare name for unknown CLIs on win32', () =>
   };
   spawnOwnedCliProcess('definitely-not-a-real-cli-xyz', [], {}, { platform: 'win32', spawnImpl });
   assert.equal(seen.command, 'definitely-not-a-real-cli-xyz');
-  assert.equal(seen.options.shell, undefined);
+  assert.equal(seen.options.windowsVerbatimArguments, undefined);
 });

--- a/tests/unit/backend-cli-spawn.test.js
+++ b/tests/unit/backend-cli-spawn.test.js
@@ -1,0 +1,126 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { EventEmitter } from 'node:events';
+
+import { probeCliAvailability, resolveCliSpawnCommand, spawnOwnedCliProcess } from '../../src/backends/contract.js';
+
+const WIN_ENV = { PATH: 'C:\\tools;C:\\other', PATHEXT: '.COM;.EXE;.BAT;.CMD' };
+
+// A lookup table double for the exists() seam: exact path set membership.
+const withFiles = (files) => (candidate) => files.has(candidate);
+
+test('resolveCliSpawnCommand is a no-op off win32', () => {
+  for (const platform of ['linux', 'darwin']) {
+    assert.deepEqual(
+      resolveCliSpawnCommand('gemini', { platform, env: WIN_ENV, exists: () => true }),
+      { command: 'gemini', shell: false }
+    );
+  }
+});
+
+test('resolveCliSpawnCommand on win32 spawns a real executable bare', () => {
+  const exists = withFiles(new Set([join('C:\\tools', 'claude.EXE')]));
+  assert.deepEqual(
+    resolveCliSpawnCommand('claude', { platform: 'win32', env: WIN_ENV, exists }),
+    { command: join('C:\\tools', 'claude.EXE'), shell: false }
+  );
+});
+
+test('resolveCliSpawnCommand on win32 gives batch shims a shell', () => {
+  const exists = withFiles(new Set([join('C:\\tools', 'gemini.CMD')]));
+  assert.deepEqual(
+    resolveCliSpawnCommand('gemini', { platform: 'win32', env: WIN_ENV, exists }),
+    { command: join('C:\\tools', 'gemini.CMD'), shell: true }
+  );
+});
+
+test('resolveCliSpawnCommand respects PATH order before PATHEXT order', () => {
+  // First PATH dir wins even when a later dir has an earlier-PATHEXT match.
+  const pathOrder = withFiles(new Set([join('C:\\other', 'x.EXE'), join('C:\\tools', 'x.CMD')]));
+  assert.deepEqual(
+    resolveCliSpawnCommand('x', { platform: 'win32', env: { ...WIN_ENV, PATH: 'C:\\tools;C:\\other' }, exists: pathOrder }),
+    { command: join('C:\\tools', 'x.CMD'), shell: true }
+  );
+  // Within one dir, PATHEXT order wins: .EXE before .CMD.
+  const extOrder = withFiles(new Set([join('C:\\tools', 'x.EXE'), join('C:\\tools', 'x.CMD')]));
+  assert.deepEqual(
+    resolveCliSpawnCommand('x', { platform: 'win32', env: WIN_ENV, exists: extOrder }),
+    { command: join('C:\\tools', 'x.EXE'), shell: false }
+  );
+});
+
+test('resolveCliSpawnCommand keeps the bare name when nothing is found', () => {
+  assert.deepEqual(
+    resolveCliSpawnCommand('missing', { platform: 'win32', env: WIN_ENV, exists: () => false }),
+    { command: 'missing', shell: false }
+  );
+});
+
+test('probeCliAvailability spawns a .cmd shim with a shell and reports status', () => {
+  const seen = [];
+  const spawnSyncImpl = (command, args, options) => {
+    seen.push({ command, args, options });
+    return { status: 0 };
+  };
+  const exists = withFiles(new Set([join('C:\\tools', 'gemini.CMD')]));
+  assert.equal(probeCliAvailability('gemini', { platform: 'win32', env: WIN_ENV, exists, spawnSyncImpl }), true);
+  assert.deepEqual(seen, [{
+    command: join('C:\\tools', 'gemini.CMD'),
+    args: ['--version'],
+    options: { stdio: 'ignore', shell: true },
+  }]);
+
+  const fail = probeCliAvailability('gemini', {
+    platform: 'win32', env: WIN_ENV, exists,
+    spawnSyncImpl: () => ({ status: 1 }),
+  });
+  assert.equal(fail, false);
+  const boom = probeCliAvailability('gemini', {
+    platform: 'win32', env: WIN_ENV, exists,
+    spawnSyncImpl: () => { throw new Error('EINVAL'); },
+  });
+  assert.equal(boom, false);
+});
+
+test('spawnOwnedCliProcess passes shell:true through for a .cmd-only CLI on win32', () => {
+  // Uses the real env/exists seams: a .cmd fixture in a real temp PATH dir,
+  // with only the platform injected — so this runs on any host OS.
+  const dir = mkdtempSync(join(tmpdir(), 'patina-cli-spawn-'));
+  const oldPath = process.env.PATH;
+  let seen = null;
+  const child = new EventEmitter();
+  try {
+    // Uppercase extension: the lookup tries PATHEXT spellings verbatim and a
+    // case-sensitive host FS only matches the exact name.
+    writeFileSync(join(dir, 'probe-cli.CMD'), '@echo off\r\n');
+    // win32 PATH entries are ';'-separated regardless of the host running
+    // this test — the resolver under test splits on ';' by design.
+    process.env.PATH = `${dir};${oldPath || ''}`;
+    const spawnImpl = (command, args, options) => {
+      seen = { command, args, options };
+      return child;
+    };
+    spawnOwnedCliProcess('probe-cli', ['--version'], { stdio: 'ignore' }, { platform: 'win32', spawnImpl });
+    assert.equal(seen.command, join(dir, 'probe-cli.CMD'));
+    assert.equal(seen.options.shell, true);
+  } finally {
+    if (oldPath === undefined) delete process.env.PATH;
+    else process.env.PATH = oldPath;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('spawnOwnedCliProcess keeps the bare name for unknown CLIs on win32', () => {
+  let seen = null;
+  const child = new EventEmitter();
+  const spawnImpl = (command, args, options) => {
+    seen = { command, args, options };
+    return child;
+  };
+  spawnOwnedCliProcess('definitely-not-a-real-cli-xyz', [], {}, { platform: 'win32', spawnImpl });
+  assert.equal(seen.command, 'definitely-not-a-real-cli-xyz');
+  assert.equal(seen.options.shell, undefined);
+});


### PR DESCRIPTION
## Summary

Fixes #807 item 2. On win32, every local CLI backend spawned its CLI by bare name; a CLI installed as an npm `.cmd`/`.bat` shim cannot be spawned that way (CVE-2024-27980), so those backends were **unusable on Windows even when the CLI was installed**.

Verified on the maintainer's Windows 11 host (before → after):

- `claude` is a real `claude.exe` → always worked.
- `gemini` is an npm `gemini.cmd` shim → bare spawn `ENOENT`; `patina doctor` reported `gemini-cli available=false` despite the installed CLI. After the fix: `available=true`, and a real rewrite reaches the CLI (progresses through spawn + arg parsing to the CLI's own auth check — that host's gemini OAuth needs an interactive refresh, exit 41; a host auth state, not a launch failure).

## Fix

- `resolveCliSpawnCommand` (contract.js): on win32, walk PATH in order, return the first PATHEXT match, flag `.cmd`/`.bat` candidates. No-op off win32.
- `windowsBatchSpawn`: launches the shim through `cmd.exe /d /s /c` with **one fully-quoted command line** — every token double-quoted, the line wrapped in a second quote pair (cmd `/s` strips exactly one), `windowsVerbatimArguments` keeping Node's quoting out. `shell: true` was tried first and rejected on live evidence: Node merely concatenates args with it (DEP0190), silently dropping the empty `-p` value gemini requires; and naive `cmd /c` breaks when the batch path contains spaces (/s quote stripping). The final construction was verified on the host with a space in the batch path, an empty-string arg and a space in an arg.
- Applied at all three spawn surfaces: `spawnOwnedCliProcess` (invoke), `probeCliAvailability` (availability — replaces five per-backend `spawnSync` copies), `runInteractiveCommand` (`patina auth login <backend>`).
- Arg domain documented: flags, model ids, temp paths only — user prose always rides stdin. Values containing `%` or `"` are explicitly out of contract (cmd expands `%var%` even inside quotes).

## Evidence

- Live host probes in the commit history: bare-spawn ENOENT on `gemini.cmd`, `shell:true` dropping `''`, `/s` quote-strip failure with a spaced path, then the working construction.
- `tests/unit/backend-cli-spawn.test.js` (10 tests, run on all host OSes): resolution (exe vs cmd, PATH/PATHEXT order, miss), probe, invoke pass-through, the quoted line (empty-arg regression driver), login flow.
- Full suite 2463 tests / 2461 pass / 0 fail / 2 pre-existing skips; full lint green.
- Review lane: architect pass (approve-with-comments; all findings addressed in the last commit).

## Notes

- Remaining #807 item 1 (libuv teardown abort in the unverified batch path) is separate and still open.
- Side observation recorded on #807: this host's `gemini` OAuth creds exist but need interactive re-auth, while patina's `isAuthenticated` reports true from the creds file — an auth-fidelity nuance, not a launch issue.