### PR TITLE
test(backends): complete P17b — kimi/gemini-cli/agy verified, codex/claude re-smoked on current versions

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -182,6 +182,28 @@ moves from version-only to verified. Still not exercised: gemini-cli
 (api-key mode would spend the product key), kimi-cli, `agy` (no adapter),
 quota behavior, other operating systems.
 
+### P17b completion: every local CLI backend verified on current versions (2026-09-13)
+
+`backend-compat-kimi-gemini-agy-20260913.json` closes the P17b remainder of
+the 2026-09-10 record above. The maintainer first refreshed the CLIs (kimi
+0.29.1→0.42.0 via the official installer, agy 1.2.0→1.2.2, codex
+0.153.4→0.154.0, claude 2.1.267→2.1.269; gemini 0.59.0 was already latest) and
+resolved the two open auth decisions: kimi verifies over the Kimi Code OAuth
+session with `KIMI_API_KEY`/`MOONSHOT_API_KEY` unset, and gemini-cli over
+personal Google OAuth (`selectedAuthType=oauth-personal`) with `GEMINI_API_KEY`
+unset, so the product key was never read and the loopback OpenCodex fallback
+was not needed. All five local CLI backends then passed the same surface —
+auth ping, strict scoring JSON parse, `--verify` rewrite with
+`verification.verified=true`, a 1500 ms timeout kill with clean owned-process
+and temp-workspace checks, and the invalid in-family model error paths — plus
+a live codex foreign-model fallback re-check on 0.154.0. New fixtures:
+`backend-kimi-contract.json`, `backend-gemini-contract.json`,
+`backend-agy-contract.json`; the codex and claude fixtures re-point at the new
+record with their 2026-09-10 verdicts retained as history. Still not covered:
+quota/rate-limit behavior, other operating systems (P16b), other CLI
+versions/models, and gemini-cli's API-key mode (deliberately unexercised:
+product-key policy).
+
 P09 was closed on 2026-09-10 by maintainer decision: native Codex GitHub
 review is not used (a repository-wide search for `chatgpt-codex-connector[bot]`
 comments and a five-PR spot check found no evidence of use; no workflow

--- a/docs/operations/backend-compat-kimi-gemini-agy-20260913.json
+++ b/docs/operations/backend-compat-kimi-gemini-agy-20260913.json
@@ -1,0 +1,109 @@
+{
+  "schemaVersion": 1,
+  "recordType": "maintenance-backend-compatibility-pilot",
+  "observedDate": "2026-09-13",
+  "repository": "devswha/patina",
+  "plan": "patina-repo-development-maintenance-plan-final-2026-09-09",
+  "planIds": ["P17b"],
+  "trackingIssue": 783,
+  "supersedes": {
+    "record": "docs/operations/backend-compat-claude-gemini-20260910.json",
+    "field": "notExercised",
+    "entries": ["gemini-cli", "antigravity-cli (agy 1.1.26)", "kimi-cli"],
+    "note": "All three move to verified on 2026-09-13 against updated CLI versions. The 2026-09-10 record's codex 0.153.4 and claude 2.1.261 verdicts are also superseded for version coverage by re-smokes on codex 0.154.0 and claude 2.1.269; its openai-http-over-OpenCodex verdict is unaffected."
+  },
+  "authority": {
+    "approval": "Maintainer directed the CLI refresh and the P17b remainder on 2026-09-13 and resolved the two open auth decisions: (1) kimi must verify over the Kimi Code OAuth session, not the env API key; (2) gemini-cli should use personal Google OAuth, with the loopback OpenCodex route as fallback only if personal OAuth were impossible. Personal OAuth was possible and was used; the OpenCodex proxy was not running and was not needed.",
+    "credentialPolicy": "OPENAI_API_KEY, GEMINI_API_KEY, ANTHROPIC_API_KEY, KIMI_API_KEY and MOONSHOT_API_KEY were unset in every pilot shell. gemini-cli ran on selectedAuthType=oauth-personal; no product or provider API key was read by any leg.",
+    "budget": {
+      "kimiOauthInvocations": 10,
+      "geminiOauthInvocations": 8,
+      "agyPlanInvocations": 7,
+      "codexOauthInvocations": 8,
+      "claudeOauthInvocations": 7,
+      "note": "Per backend: 1 auth ping, A=1 scorer, B=1 rewrite + 2 scorers per candidate (kimi's passed-on-retry adds 1 rewrite + 2 scorers), C=1 killed at 1500 ms, E=1 rejected before generation (gemini E ran twice: once truncated in the console log, once to read the full error class). codex adds 1 foreign-model fallback check (a claude-* id passed to codex-cli resolves to the backend default and succeeds). An earlier pre-decision kimi ping had used the KIMI_API_KEY env path; it is not counted here and is not evidence for the OAuth verdict."
+    }
+  },
+  "environment": {
+    "os": "Linux 6.8.0-139-generic x64",
+    "node": "v24.18.0",
+    "patina": "8.6.0 at dev 9f9c7b6 (branch bot/backend-compat-p17b-20260913)",
+    "clis": {
+      "kimi": "Kimi Code 0.29.1 -> 0.42.0 (refreshed 2026-09-13 via the official install.sh; prior binary kept at ~/.kimi-code/bin/kimi.bak)",
+      "gemini": "0.59.0 (already latest; unchanged)",
+      "agy": "Antigravity CLI 1.2.0 -> 1.2.2 (agy update)",
+      "codex": "0.153.4 -> 0.154.0 (npm)",
+      "claude": "Claude Code 2.1.267 -> 2.1.269 (claude update)"
+    },
+    "inputs": [
+      "body of tests/fixtures/suspect-zones/en/ai/en-ai-01.md without frontmatter (423 bytes)",
+      "body of tests/fixtures/suspect-zones/ko/ai/ko-ai-01.md without frontmatter (174 bytes)"
+    ]
+  },
+  "scenarios": {
+    "kimi-cli": {
+      "status": "verified",
+      "model": "kimi-code/kimi-for-coding (backend default)",
+      "authPath": "Kimi Code OAuth session in ~/.kimi-code; both env key names unset",
+      "A-score": {"exitCode": 0, "observed": "Strict scoring JSON parsed and rendered; overall 1.1 on the no-catalogued-pattern EN fixture (one low-severity vague attribution)."},
+      "B-rewrite-verify": {"exitCode": 0, "observed": "verification.verified=true, mps 100, fidelity 100, reason passed-on-retry (one conservative retry), outputHash present; JSON envelope shape matches the CLI contract."},
+      "C-timeout": {"wallMs": 1540, "exitCode": 1, "observed": "`kimi-cli backend: timed out after 1500ms`; leak check found no /tmp/patina-* workspace and no process cwd-bound to one."},
+      "E-invalid-in-family-model": {"wallMs": 1104, "exitCode": 1, "observed": "kimi exited 1 with its unknown-model catalog message (Model \"kimi-nonexistent-model\" is not co[nfigured...]); surfaced as a backend error; cleanup clean."}
+    },
+    "gemini-cli": {
+      "status": "verified",
+      "model": "gemini-2.5-pro (backend default)",
+      "authPath": "oauth-personal (~/.gemini/gemini-credentials.json, settings selectedAuthType=oauth-personal); GEMINI_API_KEY unset so the product key was never a candidate",
+      "A-score": {"exitCode": 0, "observed": "Strict scoring JSON parsed and rendered; overall 0.0 on the no-pattern EN fixture."},
+      "B-rewrite-verify": {"exitCode": 0, "observed": "verification.verified=true, mps 100, fidelity 100, reason passed (no retry), outputHash present."},
+      "C-timeout": {"wallMs": 1522, "exitCode": 1, "observed": "`gemini-cli backend: timed out after 1500ms`; leak check clean."},
+      "E-invalid-in-family-model": {"wallMs": 1783, "exitCode": 1, "observed": "gemini exited 1 with `ModelNotFoundError: models/gemini-nonexistent-model is not found ... or is not supported for generateContent` after its usual terminal/ripgrep warnings, which stripGeminiNoise handles; surfaced as a backend error; cleanup clean."}
+    },
+    "agy-cli": {
+      "status": "verified",
+      "model": "gemini-3.7-flash-medium (backend default; Antigravity catalog id)",
+      "authPath": "Antigravity OAuth token (~/.gemini/antigravity-cli/antigravity-oauth-token); the adapter's pre-launch settings gate (assertAgySettingsSafe) passed on the host's default permissions",
+      "A-score": {"exitCode": 0, "observed": "Strict scoring JSON parsed and rendered; overall 0.0 on the no-pattern EN fixture. First live verification of the agy-cli adapter (#802): custom-agent definition, stdin NDJSON turn, and final-response extraction all worked on 1.2.2."},
+      "B-rewrite-verify": {"exitCode": 0, "observed": "verification.verified=true, mps 100, fidelity 100, reason passed (no retry), outputHash present."},
+      "C-timeout": {"wallMs": 1521, "exitCode": 1, "observed": "`agy-cli backend: timed out after 1500ms`; leak check clean."},
+      "E-invalid-in-family-model": {"wallMs": 4724, "exitCode": 1, "observed": "agy exited 1 with `invalid model selection ... model gemini-nonexistent-model is not recognized as a known model or custom model in settings` plus its catalog listing; surfaced as a backend error; cleanup clean."}
+    },
+    "codex-cli-resmoke": {
+      "status": "verified",
+      "model": "gpt-5.5 (backend default)",
+      "authPath": "ChatGPT OAuth session (~/.codex/auth.json); OPENAI_API_KEY unset",
+      "A-score": {"exitCode": 0, "observed": "Strict scoring JSON parsed; overall 1.1."},
+      "B-rewrite-verify": {"exitCode": 0, "observed": "verification.verified=true, mps 100, fidelity 91.7 (floor 70), reason passed, outputHash present."},
+      "C-timeout": {"wallMs": 1527, "exitCode": 1, "observed": "`codex-cli backend: timed out after 1500ms`; leak check clean."},
+      "E-invalid-in-family-model": {"wallMs": 3151, "exitCode": 1, "observed": "codex 0.154.0 exited 1 after warning that model metadata for `gpt-nonexistent-model` was not found; surfaced as a backend error; cleanup clean. Codex stderr includes its banner/session header; no such raw output is retained in this record."},
+      "F-foreign-model-fallback": {"wallMs": 5440, "exitCode": 0, "observed": "Passing a claude-* model id to codex-cli resolved to the backend default and returned normally (OK), re-confirming the resolveLocalCliModel family filter live on 0.154.0."}
+    },
+    "claude-cli-resmoke": {
+      "status": "verified",
+      "model": "claude-sonnet-4-6 (backend default)",
+      "authPath": "Claude Code subscription OAuth session; ANTHROPIC_API_KEY unset",
+      "A-score": {"exitCode": 0, "observed": "Strict scoring JSON parsed; overall 2.2 (same value as the 2.1.261 pilot on this fixture)."},
+      "B-rewrite-verify": {"exitCode": 0, "observed": "verification.verified=true, mps 100, fidelity 100, reason passed, outputHash present."},
+      "C-timeout": {"wallMs": 1523, "exitCode": 1, "observed": "`claude-cli backend: timed out after 1500ms`; leak check clean."},
+      "E-invalid-in-family-model": {"wallMs": 1708, "exitCode": 1, "observed": "claude exited 1 with this version's unknown-model catalog message (\"claude-nonexistent-model\" isn't described by this version's model catalog...); surfaced as a backend error; cleanup clean."}
+    }
+  },
+  "acceptance": {
+    "P17b": "passed for kimi-cli 0.42.0 (OAuth), gemini-cli 0.59.0 (oauth-personal), agy-cli 1.2.2 (plan OAuth), and re-verified on current versions codex-cli 0.154.0 and claude-cli 2.1.269. Together with the 2026-09-10 records, every Patina local CLI backend now has a real-invocation verification on its current version.",
+    "fixtures": [
+      "tests/fixtures/backend-kimi-contract.json",
+      "tests/fixtures/backend-gemini-contract.json",
+      "tests/fixtures/backend-agy-contract.json",
+      "tests/fixtures/backend-codex-contract.json",
+      "tests/fixtures/backend-claude-contract.json"
+    ],
+    "notCovered": ["quota/rate-limit behavior", "other operating systems (P16b)", "other CLI versions or models", "kimi's `--agent-file` tool-restriction surface beyond the adapter's zero-tool profile", "gemini-cli API-key mode (deliberately not exercised: product-key policy)"]
+  },
+  "boundaries": {
+    "productSourceChanged": false,
+    "versionBumped": false,
+    "publication": "none",
+    "researchRevived": false,
+    "credentialsRecorded": "none; auth mode names, exit codes, and error classes only. Raw CLI output, prompts, and model responses are not retained (scenario logs lived in /tmp during the run)."
+  }
+}

--- a/tests/fixtures/backend-agy-contract.json
+++ b/tests/fixtures/backend-agy-contract.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "backend": "agy-cli",
+  "cli": "agy",
+  "observedVersion": "1.2.2",
+  "observedAt": "2026-09-13",
+  "status": "verified",
+  "evidence": {
+    "kind": "real-invocation",
+    "record": "docs/operations/backend-compat-kimi-gemini-agy-20260913.json",
+    "realInvocation": true,
+    "outputParsingVerified": true,
+    "errorsVerified": true,
+    "authVerified": true,
+    "quotaVerified": false,
+    "timeoutVerified": true
+  },
+  "syntheticFixture": false,
+  "rawOutputIncluded": false,
+  "history": {
+    "2026-09-10": "not exercised: agy 1.1.26 was present with an OAuth token but Patina had no adapter for it yet (the adapter shipped in #802)."
+  },
+  "scope": {
+    "platform": "linux-x64",
+    "node": "24.18.0",
+    "patina": "8.6.0 at dev 9f9c7b6",
+    "model": "gemini-3.7-flash-medium",
+    "authPath": "Antigravity OAuth token (~/.gemini/antigravity-cli/antigravity-oauth-token); the backend has no API-key path; the pre-launch settings gate (assertAgySettingsSafe) passed on default permissions",
+    "invocations": 7,
+    "scenarios": ["auth ping", "score", "rewrite --verify", "timeout", "invalid in-family model"]
+  },
+  "requiredContracts": {
+    "output": "Headless agy -p= with --input-format/--output-format stream-json, the workspace-local custom-agent definition, and the NDJSON final-response extraction all work on 1.2.2; strict scoring JSON and the [BODY]/[SELF_AUDIT] rewrite framing both parsed.",
+    "errors": "A non-zero agy exit is reported as a backend error with the child's stderr (the invalid-model-selection catalog message); the owned temp workspace is removed and no agy process survives.",
+    "auth": "Authentication is the non-empty Antigravity OAuth token file; the verified run used the plan-backed OAuth session and no API key (none exists for this backend).",
+    "quota": "No quota or rate-limit failure occurred in the pilot budget; quota behavior is not verified by this record.",
+    "timeout": "Patina's bounded child timer rejected a live invocation at 1500 ms, SIGKILLed the owned child, and left no temp workspace or process behind."
+  },
+  "limitations": [
+    "No credential, prompt, model response, or raw CLI output is recorded.",
+    "Verified only for Antigravity CLI 1.2.2 on Linux with gemini-3.7-flash-medium; other versions, platforms, and catalog models are unverified.",
+    "Quota and rate-limit handling were not exercised.",
+    "Tool denial relies on headless ask-mode auto-deny plus the post-hoc tool-step rejection; only the zero-tool rewrite/score profile was exercised.",
+    "This is a connectivity/contract check, not a rewrite-quality experiment."
+  ]
+}

--- a/tests/fixtures/backend-claude-contract.json
+++ b/tests/fixtures/backend-claude-contract.json
@@ -2,12 +2,12 @@
   "schemaVersion": 1,
   "backend": "claude-cli",
   "cli": "claude",
-  "observedVersion": "2.1.261",
-  "observedAt": "2026-09-10",
+  "observedVersion": "2.1.269",
+  "observedAt": "2026-09-13",
   "status": "verified",
   "evidence": {
     "kind": "real-invocation",
-    "record": "docs/operations/backend-compat-claude-gemini-20260910.json",
+    "record": "docs/operations/backend-compat-kimi-gemini-agy-20260913.json",
     "realInvocation": true,
     "outputParsingVerified": true,
     "errorsVerified": true,
@@ -18,12 +18,13 @@
   "syntheticFixture": false,
   "rawOutputIncluded": false,
   "history": {
-    "2026-09-09": "version-only / unverified record from `claude --version` (P17a)."
+    "2026-09-09": "version-only / unverified record from `claude --version` (P17a).",
+    "2026-09-10": "verified on Claude Code 2.1.261 (docs/operations/backend-compat-claude-gemini-20260910.json, 7 invocations)."
   },
   "scope": {
     "platform": "linux-x64",
     "node": "24.18.0",
-    "patina": "8.6.0 at dev 0ec1376 (agent tools removed, #798)",
+    "patina": "8.6.0 at dev 9f9c7b6",
     "model": "claude-sonnet-4-6",
     "authPath": "Claude Code OAuth session (~/.claude/.credentials.json claudeAiOauth, subscription); no ANTHROPIC_API_KEY in the environment",
     "invocations": 7,
@@ -38,7 +39,7 @@
   },
   "limitations": [
     "No credential, prompt, model response, or raw CLI output is recorded.",
-    "Verified only for Claude Code 2.1.261 on Linux with claude-sonnet-4-6; other versions, platforms, and models are unverified.",
+    "Verified only for Claude Code 2.1.269 on Linux with claude-sonnet-4-6; other versions, platforms, and models are unverified.",
     "Quota and rate-limit handling were not exercised.",
     "This is a connectivity/contract check, not a rewrite-quality experiment."
   ]

--- a/tests/fixtures/backend-codex-contract.json
+++ b/tests/fixtures/backend-codex-contract.json
@@ -2,12 +2,12 @@
   "schemaVersion": 1,
   "backend": "codex-cli",
   "cli": "codex",
-  "observedVersion": "0.153.4",
-  "observedAt": "2026-09-10",
+  "observedVersion": "0.154.0",
+  "observedAt": "2026-09-13",
   "status": "verified",
   "evidence": {
     "kind": "real-invocation",
-    "record": "docs/operations/backend-compat-codex-20260910.json",
+    "record": "docs/operations/backend-compat-kimi-gemini-agy-20260913.json",
     "realInvocation": true,
     "outputParsingVerified": true,
     "errorsVerified": true,
@@ -20,11 +20,14 @@
   "scope": {
     "platform": "linux-x64",
     "node": "24.18.0",
-    "patina": "8.6.0",
+    "patina": "8.6.0 at dev 9f9c7b6",
     "model": "gpt-5.5",
     "authPath": "ChatGPT OAuth (~/.codex/auth.json auth_mode=chatgpt, API-key field null)",
-    "invocations": 10,
+    "invocations": 8,
     "scenarios": ["score", "rewrite --verify", "timeout", "foreign-model fallback", "invalid in-family model"]
+  },
+  "history": {
+    "2026-09-10": "verified on codex 0.153.4 (docs/operations/backend-compat-codex-20260910.json, 10 invocations including two scorer retries)."
   },
   "requiredContracts": {
     "output": "codex exec --output-last-message file is read after a zero exit; strict scoring JSON and the [BODY]/[SELF_AUDIT] rewrite framing both parsed on this version.",
@@ -35,7 +38,7 @@
   },
   "limitations": [
     "No credential, prompt, model response, or raw CLI output is recorded.",
-    "Verified only for codex 0.153.4 on Linux with model gpt-5.5; other versions, platforms, and models are unverified.",
+    "Verified only for codex 0.154.0 on Linux with model gpt-5.5; other versions, platforms, and models are unverified.",
     "Quota and rate-limit handling were not exercised.",
     "This is a connectivity/contract check, not a rewrite-quality experiment."
   ]

--- a/tests/fixtures/backend-gemini-contract.json
+++ b/tests/fixtures/backend-gemini-contract.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "backend": "gemini-cli",
+  "cli": "gemini",
+  "observedVersion": "0.59.0",
+  "observedAt": "2026-09-13",
+  "status": "verified",
+  "evidence": {
+    "kind": "real-invocation",
+    "record": "docs/operations/backend-compat-kimi-gemini-agy-20260913.json",
+    "realInvocation": true,
+    "outputParsingVerified": true,
+    "errorsVerified": true,
+    "authVerified": true,
+    "quotaVerified": false,
+    "timeoutVerified": true
+  },
+  "syntheticFixture": false,
+  "rawOutputIncluded": false,
+  "history": {
+    "2026-09-10": "not exercised: the configured auth type was gemini-api-key, which would consume the product-only GEMINI_API_KEY; only the --policy flag surface was checked offline."
+  },
+  "scope": {
+    "platform": "linux-x64",
+    "node": "24.18.0",
+    "patina": "8.6.0 at dev 9f9c7b6",
+    "model": "gemini-2.5-pro",
+    "authPath": "oauth-personal (~/.gemini/gemini-credentials.json, selectedAuthType=oauth-personal); GEMINI_API_KEY was unset in the pilot shell, so the product key was never a candidate",
+    "invocations": 8,
+    "scenarios": ["auth ping", "score", "rewrite --verify", "timeout", "invalid in-family model"]
+  },
+  "requiredContracts": {
+    "output": "gemini -p with stdin prompt and --output-format text works on 0.59.0 with --skip-trust, the no-MCP allowlist entry, and the deny-all --policy file; leading terminal/ripgrep warnings are stripped and strict scoring JSON and the [BODY]/[SELF_AUDIT] rewrite framing both parsed.",
+    "errors": "A non-zero gemini exit is reported as a backend error with the child's stderr (ModelNotFoundError for an unknown model); the owned temp directory is removed and no gemini process survives.",
+    "auth": "Authentication accepts the OAuth credentials file or GEMINI_API_KEY; the verified run unset the env key and used personal Google OAuth (Code Assist), so no provider API key was read.",
+    "quota": "No quota or rate-limit failure occurred in the pilot budget; quota behavior is not verified by this record.",
+    "timeout": "Patina's bounded child timer rejected a live invocation at 1500 ms, SIGKILLed the owned child, and left no temp directory or process behind."
+  },
+  "limitations": [
+    "No credential, prompt, model response, or raw CLI output is recorded.",
+    "Verified only for gemini-cli 0.59.0 on Linux with gemini-2.5-pro over personal OAuth; other versions, platforms, models, and the API-key auth mode are unverified (API-key mode is deliberately not exercised: product-key policy).",
+    "Quota and rate-limit handling were not exercised.",
+    "This is a connectivity/contract check, not a rewrite-quality experiment."
+  ]
+}

--- a/tests/fixtures/backend-kimi-contract.json
+++ b/tests/fixtures/backend-kimi-contract.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "backend": "kimi-cli",
+  "cli": "kimi",
+  "observedVersion": "0.42.0",
+  "observedAt": "2026-09-13",
+  "status": "verified",
+  "evidence": {
+    "kind": "real-invocation",
+    "record": "docs/operations/backend-compat-kimi-gemini-agy-20260913.json",
+    "realInvocation": true,
+    "outputParsingVerified": true,
+    "errorsVerified": true,
+    "authVerified": true,
+    "quotaVerified": false,
+    "timeoutVerified": true
+  },
+  "syntheticFixture": false,
+  "rawOutputIncluded": false,
+  "history": {
+    "2026-09-10": "not exercised: would have needed KIMI_API_KEY or the Kimi OAuth session; not authorized in that pilot."
+  },
+  "scope": {
+    "platform": "linux-x64",
+    "node": "24.18.0",
+    "patina": "8.6.0 at dev 9f9c7b6",
+    "model": "kimi-code/kimi-for-coding",
+    "authPath": "Kimi Code OAuth session in ~/.kimi-code; KIMI_API_KEY and MOONSHOT_API_KEY were unset in the pilot shell",
+    "invocations": 10,
+    "scenarios": ["auth ping", "score", "rewrite --verify (one conservative retry)", "timeout", "invalid in-family model"]
+  },
+  "requiredContracts": {
+    "output": "kimi --prompt <text> --output-format stream-json NDJSON final-message extraction works on Kimi Code 0.42.0; strict scoring JSON and the [BODY]/[SELF_AUDIT] rewrite framing both parsed on this version.",
+    "errors": "A non-zero kimi exit is reported as a backend error with the child's stderr (the unknown-model catalog message); the owned temp directory is removed and no kimi process survives.",
+    "auth": "Authentication checks the ~/.kimi-code|~/.kimi credential/config paths or the env keys; the verified run unset both env key names and used the Kimi Code OAuth session, not an API key.",
+    "quota": "No quota or rate-limit failure occurred in the pilot budget; quota behavior is not verified by this record.",
+    "timeout": "Patina's bounded child timer rejected a live invocation at 1500 ms, SIGKILLed the owned child, and left no temp directory or process behind."
+  },
+  "limitations": [
+    "No credential, prompt, model response, or raw CLI output is recorded.",
+    "Verified only for Kimi Code 0.42.0 on Linux with kimi-code/kimi-for-coding; other versions, platforms, and models are unverified. 0.29.1 -> 0.42.0 was a large jump verified only through this smoke surface.",
+    "Quota and rate-limit handling were not exercised.",
+    "kimi's --agent-file tool-restriction surface was exercised only through the adapter's zero-tool profile.",
+    "This is a connectivity/contract check, not a rewrite-quality experiment."
+  ]
+}

--- a/tests/unit/backend-contract.test.js
+++ b/tests/unit/backend-contract.test.js
@@ -177,11 +177,12 @@ test('Claude CLI compatibility record is a real-invocation verification without 
   assertVerifiedBackendRecord(fixture, {
     backend: 'claude-cli',
     cli: 'claude',
-    version: '2.1.261',
-    record: 'docs/operations/backend-compat-claude-gemini-20260910.json',
+    version: '2.1.269',
+    record: 'docs/operations/backend-compat-kimi-gemini-agy-20260913.json',
   });
-  // The earlier version-only status is retained as history, not erased.
+  // Earlier statuses are retained as history, not erased.
   assert.match(fixture.history['2026-09-09'], /version-only/);
+  assert.match(fixture.history['2026-09-10'], /2\.1\.261/);
 });
 
 test('Codex CLI compatibility record is a real-invocation verification without raw output', () => {
@@ -192,9 +193,57 @@ test('Codex CLI compatibility record is a real-invocation verification without r
   assertVerifiedBackendRecord(fixture, {
     backend: 'codex-cli',
     cli: 'codex',
-    version: '0.153.4',
-    record: 'docs/operations/backend-compat-codex-20260910.json',
+    version: '0.154.0',
+    record: 'docs/operations/backend-compat-kimi-gemini-agy-20260913.json',
   });
+  assert.match(fixture.history['2026-09-10'], /0\.153\.4/);
+});
+
+test('Kimi CLI compatibility record is a real-invocation verification without raw output', () => {
+  const fixture = JSON.parse(readFileSync(
+    new URL('../fixtures/backend-kimi-contract.json', import.meta.url),
+    'utf8',
+  ));
+  assertVerifiedBackendRecord(fixture, {
+    backend: 'kimi-cli',
+    cli: 'kimi',
+    version: '0.42.0',
+    record: 'docs/operations/backend-compat-kimi-gemini-agy-20260913.json',
+  });
+  // The OAuth-path verification is what upgraded this record from not-exercised.
+  assert.match(fixture.scope.authPath, /OAuth session/);
+  assert.match(fixture.scope.authPath, /KIMI_API_KEY and MOONSHOT_API_KEY were unset/);
+});
+
+test('Gemini CLI compatibility record is a real-invocation verification without raw output', () => {
+  const fixture = JSON.parse(readFileSync(
+    new URL('../fixtures/backend-gemini-contract.json', import.meta.url),
+    'utf8',
+  ));
+  assertVerifiedBackendRecord(fixture, {
+    backend: 'gemini-cli',
+    cli: 'gemini',
+    version: '0.59.0',
+    record: 'docs/operations/backend-compat-kimi-gemini-agy-20260913.json',
+  });
+  // Verified over personal OAuth with the product env key unset, per policy.
+  assert.match(fixture.scope.authPath, /oauth-personal/);
+  assert.match(fixture.scope.authPath, /GEMINI_API_KEY was unset/);
+});
+
+test('Antigravity CLI compatibility record is a real-invocation verification without raw output', () => {
+  const fixture = JSON.parse(readFileSync(
+    new URL('../fixtures/backend-agy-contract.json', import.meta.url),
+    'utf8',
+  ));
+  assertVerifiedBackendRecord(fixture, {
+    backend: 'agy-cli',
+    cli: 'agy',
+    version: '1.2.2',
+    record: 'docs/operations/backend-compat-kimi-gemini-agy-20260913.json',
+  });
+  // This backend has no API-key path at all; the verdict is plan-backed OAuth.
+  assert.match(fixture.scope.authPath, /no API-key path/);
 });
 
 test('isRetryableBackendError honors message status even when err.status is null (#445)', () => {


### PR DESCRIPTION
## Purpose / linked Issue

Closes the P17b remainder of the backend compatibility pilot.

Refs #783 (tracking Issue).

## Scope / non-goals

One unit: the P17b real-invocation verification record set for the five local CLI backends on their current versions, on top of the maintainer-directed CLI refresh (kimi 0.42.0, agy 1.2.2, codex 0.154.0, claude 2.1.269, gemini 0.59.0) and the two maintainer auth decisions (kimi over OAuth with env keys unset; gemini-cli over personal OAuth with `GEMINI_API_KEY` unset — no product key read, OpenCodex fallback not needed).

- New: `docs/operations/backend-compat-kimi-gemini-agy-20260913.json`, `backend-{kimi,gemini,agy}-contract.json` fixtures, README P17b completion paragraph.
- Updated: codex/claude fixtures re-point to the new record with 2026-09-10 verdicts kept as history; `backend-contract.test.js` extended to five records.

Not changed by this PR: product source, backend adapters, prompts, thresholds, CI workflows, versions.

## Contract / risk / size

- Contract: `not-applicable` (evidence records + fixture/test additions only; no public contract touched)
- Risk: `low`
- Raw diff: +338/−17 across 8 files
- Reviewable diff: same (all hand-written JSON/MD/test)
- Generated/lockfile/rename/move evidence: none
- Size exception: none (under budget)

## Verification evidence

- head `5dc0007` on base `dev` @ `9f9c7b6`
- Live pilot (2026-09-13, Linux x64, Node 24.18.0, provider env keys unset): per backend — auth ping, A score parse (kimi 1.1 / gemini 0.0 / agy 0.0 / codex 1.1 / claude 2.2), B `--verify` (all `verified=true`; mps 100 everywhere, fidelity 100 except codex 91.7), C 1500 ms timeout kill, E invalid in-family model error path; owned-process/temp leak checks CLEAN after every C/E; live codex foreign-model fallback PASS on 0.154.0.
- Commands: `node --test tests/unit/backend-contract.test.js` → 16 pass / 0 fail (exit 0); `npm run lint` → exit 0 (cSpell 0 issues, architecture 0 violations); `npm run check:no-private-assets` → exit 0.
- QA profile: deterministic unit + lint + asset gates; the live calls are auth/transport evidence only, not rewrite-quality evidence (per P17b discipline).
- Stale results: none.

## Integration / delivery / rollback

- Integration target: `dev`; P17b acceptance-criteria closure owner: maintainer (quota behavior, other OSes via P16b, and gemini-cli API-key mode remain explicitly uncovered).
- User delivery status by channel: `not-applicable` (internal evidence).
- Semver impact: none (no version bump; belongs to release PR).
- External writes requested and authorized: live model calls against the maintainer's own OAuth/plan sessions (kimi OAuth ×10, gemini oauth-personal ×8, agy plan ×7, codex OAuth ×8, claude subscription ×7); no publication, no account changes.
- Rollback: revert this commit; no product behavior depends on it.